### PR TITLE
Remove skip_not_implemented marker

### DIFF
--- a/test/cqlpy/cassandra_tests/validation/operations/select_test.py
+++ b/test/cqlpy/cassandra_tests/validation/operations/select_test.py
@@ -2643,7 +2643,7 @@ def testTokenFctRejectsInvalidColumnCount(cql, test_keyspace):
 
 # UDF test skipped because of different languages in Scylla.
 # TODO: Finish translating this test.
-@pytest.mark.skip_not_implemented(reason="UDF tests not yet translated")
+@pytest.mark.skip_bug(link="https://scylladb.atlassian.net/browse/SCYLLADB-2799", reason="Function resolution isn't completely compatible with Cassandra")
 def testCreatingUDFWithSameNameAsBuiltin_PrefersCompatibleArgs_SameKeyspace(cql, test_keyspace):
     with create_table(cql, test_keyspace, f"(k1 uuid, k2 text, PRIMARY KEY ((k1, k2)))") as table:
         createFunctionOverload(KEYSPACE + ".token", "double",
@@ -2653,7 +2653,7 @@ def testCreatingUDFWithSameNameAsBuiltin_PrefersCompatibleArgs_SameKeyspace(cql,
 
 # UDF test skipped because of different languages in Scylla.
 # TODO: Finish translating this test.
-@pytest.mark.skip_not_implemented(reason="UDF tests not yet translated")
+@pytest.mark.skip_bug(link="https://scylladb.atlassian.net/browse/SCYLLADB-2799", reason="Function resolution isn't completely compatible with Cassandra")
 def testCreatingUDFWithSameNameAsBuiltin_FullyQualifiedFunctionNameWorks(cql, test_keyspace):
     with create_table(cql, test_keyspace, f"(k1 uuid, k2 text, PRIMARY KEY ((k1, k2)))") as table:
         createFunctionOverload(KEYSPACE + ".token", "double",
@@ -2663,7 +2663,7 @@ def testCreatingUDFWithSameNameAsBuiltin_FullyQualifiedFunctionNameWorks(cql, te
 
 # UDF test skipped because of different languages in Scylla.
 # TODO: Finish translating this test.
-@pytest.mark.skip_not_implemented(reason="UDF tests not yet translated")
+@pytest.mark.skip_bug(link="https://scylladb.atlassian.net/browse/SCYLLADB-2799", reason="Function resolution isn't completely compatible with Cassandra")
 def testCreatingUDFWithSameNameAsBuiltin_PrefersCompatibleArgs(cql, test_keyspace):
     with create_table(cql, test_keyspace, f"(k1 uuid, k2 text, PRIMARY KEY ((k1, k2)))") as table:
         createFunctionOverload(KEYSPACE + ".token", "double",
@@ -2673,7 +2673,7 @@ def testCreatingUDFWithSameNameAsBuiltin_PrefersCompatibleArgs(cql, test_keyspac
 
 # UDF test skipped because of different languages in Scylla.
 # TODO: Finish translating this test.
-@pytest.mark.skip_not_implemented(reason="UDF tests not yet translated")
+@pytest.mark.skip_bug(link="https://scylladb.atlassian.net/browse/SCYLLADB-2799", reason="Function resolution isn't completely compatible with Cassandra")
 def testCreatingUDFWithSameNameAsBuiltin_FullyQualifiedFunctionNameWorks_SystemKeyspace(cql, test_keyspace):
     with create_table(cql, test_keyspace, f"(k1 uuid, k2 text, PRIMARY KEY ((k1, k2)))") as table:
         createFunctionOverload(KEYSPACE + ".token", "double",

--- a/test/pylib/skip_reason_plugin.py
+++ b/test/pylib/skip_reason_plugin.py
@@ -15,7 +15,6 @@ Usage as decorator (after conftest.py registers the plugin)::
         link="https://github.com/scylladb/scylladb/issues/12345",
         reason="Known repair scheduler crash",
     )
-    @pytest.mark.skip_not_implemented(reason="no per tablet support yet")
 
 Usage at runtime (inside test body or fixture) — prefer the
 convenience wrappers from :mod:`test.pylib.skip_types`::

--- a/test/pylib/skip_types.py
+++ b/test/pylib/skip_types.py
@@ -45,7 +45,6 @@ def _is_valid_skip_bug_link(link: str) -> bool:
 # ``SKIP_BUG`` → ``@pytest.mark.skip_bug``, tag ``"bug"``.
 class SkipType(StrEnum):
     SKIP_BUG = "bug"
-    SKIP_NOT_IMPLEMENTED = "not_implemented"
     SKIP_ENV = "env"
 
     @staticmethod
@@ -93,11 +92,6 @@ def skip_bug(*, link: str, reason: str) -> None:
     context = "skip_bug()"
     msg = SkipType._validate_skip_bug_args(link, reason, context)
     skip(msg, skip_type=SkipType.SKIP_BUG)
-
-
-def skip_not_implemented(reason: str) -> None:
-    """Runtime skip for a feature that is not yet implemented."""
-    skip(reason, skip_type=SkipType.SKIP_NOT_IMPLEMENTED)
 
 
 def skip_env(reason: str) -> None:

--- a/test/pylib_test/test_skip_reason_plugin.py
+++ b/test/pylib_test/test_skip_reason_plugin.py
@@ -27,7 +27,6 @@ _BASE_CONFTEST = textwrap.dedent("""\
 
     class SkipType(enum.StrEnum):
         SKIP_BUG = "bug"
-        SKIP_NOT_IMPLEMENTED = "not_implemented"
         SKIP_SLOW = "slow"
         SKIP_ENV = "env"
 
@@ -76,7 +75,6 @@ def test_skip_bug_marker_skips_with_prefix(skippytest):
 
 
 @pytest.mark.parametrize("marker, skip_type, reason", [
-    ("skip_not_implemented", "not_implemented", "feature X not built yet"),
     ("skip_env", "env", "need --special-flag"),
 ])
 def test_non_bug_typed_marker_skips_with_prefix(skippytest, marker, skip_type, reason):
@@ -107,7 +105,6 @@ def test_skip_bug_positional_reason_rejected(skippytest):
 
 
 @pytest.mark.parametrize("marker, skip_type", [
-    ("skip_not_implemented", "not_implemented"),
     ("skip_env", "env"),
 ])
 def test_typed_marker_positional_reason_accepted(skippytest, marker, skip_type):
@@ -127,7 +124,7 @@ def test_typed_marker_positional_reason_accepted(skippytest, marker, skip_type):
 
 # -- Missing reason ---------------------------------------------------------
 
-@pytest.mark.parametrize("marker", ["skip_not_implemented", "skip_env"])
+@pytest.mark.parametrize("marker", ["skip_env"])
 def test_missing_reason_is_rejected(skippytest, marker):
     skippytest.makepyfile(f"""
         import pytest
@@ -178,8 +175,7 @@ def test_bare_skip_rejected_and_lists_alternatives(skippytest):
     result.stderr.fnmatch_lines(["*Untyped skip*some bare reason*"])
     assert result.ret != 0
     out = result.stderr.str()
-    for m in ("skip_bug", "skip_not_implemented",
-              "skip_env"):
+    for m in ("skip_bug", "skip_env"):
         assert m in out, f"expected '{m}' in error output"
 
 

--- a/test/pytest.ini
+++ b/test/pytest.ini
@@ -39,7 +39,6 @@ markers =
     nightly: for tests that are quite old, stable, and test functionality that rather not be changed or affected by other features, are partially covered in other tests, verify non-critical functionality, have not found any issues or regressions, too long to run on every PR,  and can be popped out from the CI run, but will continue run in Next/Nightly verification
     skip_mode(mode, reason, platform_key=None): Skip test in a specific build mode (e.g. dev, debug, release).
     skip_bug(link=..., reason=...): Skip due to a known bug (link = issue URL, reason = human-readable explanation).
-    skip_not_implemented(reason): Skip because the feature is not yet implemented.
     skip_env(reason): Skip due to a missing environment requirement.
 
 norecursedirs = manual perf lib pylib_test


### PR DESCRIPTION
Problem

skip_not_implemented was the one typed skip category that didn't point anywhere — no ticket, no owner, nothing that would cause the skip to be revisited. That's the failure mode typed skip markers were meant to eliminate: skip_bug requires a validated issue link, skip_env describes a reproducible condition, skip_not_implemented required only prose.

SCYLLADB-2720 migrated nearly all of them; four remained in test/cqlpy/cassandra_tests/validation/operations/select_test.py.

What changed

1) the four remaining UDF tests in select_test.py now use skip_bug pointing at SCYLLADB-2799. They don't fail from a missing feature, but because function resolution isn't completely compatible with Cassandra.

2) removed the category:
- skip_types.py — dropped the enum member and the skip_not_implemented() wrapper
- skip_reason_plugin.py — removed it from the docstring example
- pytest.ini — removed the marker registration; leaving it would let the marker pass --strict-markers while the test silently runs instead of skipping
- test_skip_reason_plugin.py — pytester enum and parametrized lists updated

Testing

./tools/toolchain/dbuild pytest test/pylib_test/test_skip_reason_plugin.py → 51 passed. Repo-wide grep for skip_not_implemented is clean (remaining not_implemented hits are unrelated C++ HTTP-501 code).

Backport

no backport - test-only change.

Refs https://scylladb.atlassian.net/browse/SCYLLADB-2720