### PR TITLE
sstables: improve min/max clustering-key metadata collection

### DIFF
--- a/sstables/metadata_collector.cc
+++ b/sstables/metadata_collector.cc
@@ -6,6 +6,8 @@
  * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
  */
 
+#include <seastar/core/on_internal_error.hh>
+
 #include "utils/log.hh"
 #include "metadata_collector.hh"
 #include "mutation/position_in_partition.hh"
@@ -25,23 +27,25 @@ void metadata_collector::convert(disk_array<uint32_t, disk_string<uint16_t>>& to
     }
 }
 
-void metadata_collector::update_min_max_components(position_in_partition_view pos) {
+void metadata_collector::update_min(position_in_partition_view pos) {
     if (pos.region() != partition_region::clustered) {
-        throw std::runtime_error(fmt::format("update_min_max_components() expects positions in the clustering region, got {}", pos));
+        on_internal_error(mdclogger, fmt::format("update_min() expects positions in the clustering region, got {}", pos));
     }
 
     const position_in_partition::tri_compare cmp(_schema);
-
-    // Positions are compared in natural order, prefix (non-full) keys included.
-    // Only the winner's key components are stored (see convert()); the reader
-    // extends them back to a range covering all prefixed keys, in
-    // sstable::set_min_max_position_range(), so prefixes need no special
-    // treatment here.
 
     if (!_min_clustering_pos || cmp(pos, *_min_clustering_pos) < 0) {
         mdclogger.trace("{}: setting min_clustering_key={}", _name, position_in_partition_view::printer(_schema, pos));
         _min_clustering_pos.emplace(pos);
     }
+}
+
+void metadata_collector::update_max(position_in_partition_view pos) {
+    if (pos.region() != partition_region::clustered) {
+        on_internal_error(mdclogger, fmt::format("update_max() expects positions in the clustering region, got {}", pos));
+    }
+
+    const position_in_partition::tri_compare cmp(_schema);
 
     if (!_max_clustering_pos || cmp(pos, *_max_clustering_pos) > 0) {
         mdclogger.trace("{}: setting max_clustering_key={}", _name, position_in_partition_view::printer(_schema, pos));

--- a/sstables/metadata_collector.cc
+++ b/sstables/metadata_collector.cc
@@ -26,8 +26,13 @@ void metadata_collector::convert(disk_array<uint32_t, disk_string<uint16_t>>& to
 }
 
 void metadata_collector::update_min_max_components(position_in_partition_view pos) {
+    update_min(pos);
+    update_max(pos);
+}
+
+void metadata_collector::update_min(position_in_partition_view pos) {
     if (pos.region() != partition_region::clustered) {
-        throw std::runtime_error(fmt::format("update_min_max_components() expects positions in the clustering region, got {}", pos));
+        throw std::runtime_error(fmt::format("update_min() expects positions in the clustering region, got {}", pos));
     }
 
     const position_in_partition::tri_compare cmp(_schema);
@@ -42,6 +47,14 @@ void metadata_collector::update_min_max_components(position_in_partition_view po
         mdclogger.trace("{}: setting min_clustering_key={}", _name, position_in_partition_view::printer(_schema, pos));
         _min_clustering_pos.emplace(pos);
     }
+}
+
+void metadata_collector::update_max(position_in_partition_view pos) {
+    if (pos.region() != partition_region::clustered) {
+        throw std::runtime_error(fmt::format("update_max() expects positions in the clustering region, got {}", pos));
+    }
+
+    const position_in_partition::tri_compare cmp(_schema);
 
     if (!_max_clustering_pos || cmp(pos, *_max_clustering_pos) > 0) {
         mdclogger.trace("{}: setting max_clustering_key={}", _name, position_in_partition_view::printer(_schema, pos));

--- a/sstables/metadata_collector.cc
+++ b/sstables/metadata_collector.cc
@@ -32,22 +32,20 @@ void metadata_collector::update_min_max_components(position_in_partition_view po
 
     const position_in_partition::tri_compare cmp(_schema);
 
-    // We need special treatment for non-full clustering row keys.
-    // We want to treat these like a range: {before_key(pos), after_key(pos)}
-    // for the purpose of calculating min and max respectively.
-    // This is how callers expect prefixes to be interpreted.
-    const auto is_prefix_row = pos.is_clustering_row() && !pos.key().is_full(_schema);
-    const auto min_pos = is_prefix_row ? position_in_partition_view::before_key(pos) : pos;
-    const auto max_pos = is_prefix_row ? position_in_partition_view::after_all_prefixed(pos) : pos;
+    // Positions are compared in natural order, prefix (non-full) keys included.
+    // Only the winner's key components are stored (see convert()); the reader
+    // extends them back to a range covering all prefixed keys, in
+    // sstable::set_min_max_position_range(), so prefixes need no special
+    // treatment here.
 
-    if (!_min_clustering_pos || cmp(min_pos, *_min_clustering_pos) < 0) {
-        mdclogger.trace("{}: setting min_clustering_key={}", _name, position_in_partition_view::printer(_schema, min_pos));
-        _min_clustering_pos.emplace(min_pos);
+    if (!_min_clustering_pos || cmp(pos, *_min_clustering_pos) < 0) {
+        mdclogger.trace("{}: setting min_clustering_key={}", _name, position_in_partition_view::printer(_schema, pos));
+        _min_clustering_pos.emplace(pos);
     }
 
-    if (!_max_clustering_pos || cmp(max_pos, *_max_clustering_pos) > 0) {
-        mdclogger.trace("{}: setting max_clustering_key={}", _name, position_in_partition_view::printer(_schema, max_pos));
-        _max_clustering_pos.emplace(max_pos);
+    if (!_max_clustering_pos || cmp(pos, *_max_clustering_pos) > 0) {
+        mdclogger.trace("{}: setting max_clustering_key={}", _name, position_in_partition_view::printer(_schema, pos));
+        _max_clustering_pos.emplace(pos);
     }
 }
 

--- a/sstables/metadata_collector.hh
+++ b/sstables/metadata_collector.hh
@@ -219,6 +219,12 @@ public:
     // pos must be in the clustered region
     void update_min_max_components(position_in_partition_view pos);
 
+    // pos must be in the clustered region.
+    void update_min(position_in_partition_view pos);
+
+    // pos must be in the clustered region.
+    void update_max(position_in_partition_view pos);
+
     void update(column_stats&& stats) {
         _timestamp_tracker.update(stats.timestamp_tracker);
         _min_live_timestamp_tracker.update(stats.min_live_timestamp_tracker);

--- a/sstables/metadata_collector.hh
+++ b/sstables/metadata_collector.hh
@@ -216,8 +216,11 @@ public:
         _has_legacy_counter_shards = _has_legacy_counter_shards || has_legacy_counter_shards;
     }
 
-    // pos must be in the clustered region
-    void update_min_max_components(position_in_partition_view pos);
+    // pos must be in the clustered region.
+    void update_min(position_in_partition_view pos);
+
+    // pos must be in the clustered region.
+    void update_max(position_in_partition_view pos);
 
     void update(column_stats&& stats) {
         _timestamp_tracker.update(stats.timestamp_tracker);

--- a/sstables/mx/writer.cc
+++ b/sstables/mx/writer.cc
@@ -560,6 +560,14 @@ private:
     std::unique_ptr<file_writer> _hashes_writer;
     bool _tombstone_written = false;
     bool _static_row_written = false;
+    // Positions within a partition are weakly monotonic, so the sstable-wide min is
+    // only checked on a partition's first clustering position and the max check is
+    // deferred to consume_end_of_partition(), using the last position seen.
+    // Reset in consume_new_partition().
+    bool _partition_min_checked = false;
+    // Deferred update_max() candidate - an owning copy of the partition's last
+    // clustering position; disengaged if the partition has none.
+    std::optional<position_in_partition> _partition_max_clustering_pos;
     // The length of partition header (partition key, partition deletion and static row, if present)
     // as written to the data file
     // Used for writing promoted index
@@ -800,6 +808,15 @@ private:
     void collect_range_tombstone_stats() {
         ++_c_stats.rows_count;
         ++_c_stats.range_tombstones_count;
+    }
+
+    // Track pos in _collector's sstable-wide min/max clustering positions.
+    void record_clustering_position(position_in_partition_view pos) {
+        if (!_partition_min_checked) {
+            _collector.update_min(pos);
+            _partition_min_checked = true;
+        }
+        _partition_max_clustering_pos = pos;
     }
 
     // Clustered is a term used to denote an entity that has a clustering key prefix
@@ -1121,6 +1138,9 @@ void writer::consume_new_partition(const dht::decorated_key& dk) {
 
     _tombstone_written = false;
     _static_row_written = false;
+
+    _partition_min_checked = false;
+    _partition_max_clustering_pos.reset();
 }
 
 void writer::consume(tombstone t) {
@@ -1135,8 +1155,11 @@ void writer::consume(tombstone t) {
     _tombstone_written = true;
 
     if (t) {
-        _collector.update_min_max_components(position_in_partition_view::before_all_clustered_rows());
-        _collector.update_min_max_components(position_in_partition_view::after_all_clustered_rows());
+        // The tombstone covers the whole clustered region; feed the sentinels to the
+        // collector directly - nothing in this partition can improve on them.
+        _collector.update_min(position_in_partition_view::before_all_clustered_rows());
+        _collector.update_max(position_in_partition_view::after_all_clustered_rows());
+        _partition_min_checked = true;
     }
 }
 
@@ -1568,7 +1591,7 @@ void writer::write_clustered(const clustering_row& clustered_row, uint64_t prev_
     flush_tmp_bufs();
 
     // Collect statistics
-    _collector.update_min_max_components(clustered_row.position());
+    record_clustering_position(clustered_row.position());
     collect_row_stats(_data_writer->offset() - current_pos, &clustered_row.key(), is_dead);
 }
 
@@ -1697,7 +1720,7 @@ void writer::write_clustered(const rt_marker& marker, uint64_t prev_row_size) {
     write_marker_body(_tmp_bufs);
     write_vint(*_data_writer, _tmp_bufs.size());
     flush_tmp_bufs();
-    _collector.update_min_max_components(marker.position());
+    record_clustering_position(marker.position());
 
     collect_range_tombstone_stats();
 }
@@ -1782,6 +1805,11 @@ stop_iteration writer::consume_end_of_partition() {
     _c_stats.partition_size = _data_writer->offset() - _c_stats.start_offset;
 
     maybe_record_large_partitions(_sst, *_partition_key, _c_stats.partition_size, _c_stats.rows_count, _c_stats.range_tombstones_count, _c_stats.dead_rows_count);
+
+    // Flush the deferred max update, if the partition had any clustering positions.
+    if (_partition_max_clustering_pos) {
+        _collector.update_max(*_partition_max_clustering_pos);
+    }
 
     // update is about merging column_stats with the data being stored by collector.
     _collector.update(std::move(_c_stats));

--- a/sstables/mx/writer.cc
+++ b/sstables/mx/writer.cc
@@ -560,6 +560,11 @@ private:
     std::unique_ptr<file_writer> _hashes_writer;
     bool _tombstone_written = false;
     bool _static_row_written = false;
+    // Positions within a partition are weakly monotonic, so the sstable-wide min is
+    // only checked on a partition's first clustering position; the max is checked
+    // unconditionally on every position, as before (cheap: no ownership/copy needed).
+    // Reset in consume_new_partition().
+    bool _partition_min_checked = false;
     // The length of partition header (partition key, partition deletion and static row, if present)
     // as written to the data file
     // Used for writing promoted index
@@ -800,6 +805,18 @@ private:
     void collect_range_tombstone_stats() {
         ++_c_stats.rows_count;
         ++_c_stats.range_tombstones_count;
+    }
+
+    // Track pos in _collector's sstable-wide min/max clustering positions.
+    // The min is only checked once per partition (on the first position seen);
+    // the max is checked on every position, which is cheap (view comparison,
+    // no ownership) and correct regardless of clustering-key row count.
+    void record_clustering_position(position_in_partition_view pos) {
+        if (!_partition_min_checked) {
+            _collector.update_min(pos);
+            _partition_min_checked = true;
+        }
+        _collector.update_max(pos);
     }
 
     // Clustered is a term used to denote an entity that has a clustering key prefix
@@ -1121,6 +1138,8 @@ void writer::consume_new_partition(const dht::decorated_key& dk) {
 
     _tombstone_written = false;
     _static_row_written = false;
+
+    _partition_min_checked = false;
 }
 
 void writer::consume(tombstone t) {
@@ -1135,8 +1154,11 @@ void writer::consume(tombstone t) {
     _tombstone_written = true;
 
     if (t) {
-        _collector.update_min_max_components(position_in_partition_view::before_all_clustered_rows());
-        _collector.update_min_max_components(position_in_partition_view::after_all_clustered_rows());
+        // The tombstone covers the whole clustered region; feed the sentinels to the
+        // collector directly - nothing in this partition can improve on them.
+        _collector.update_min(position_in_partition_view::before_all_clustered_rows());
+        _collector.update_max(position_in_partition_view::after_all_clustered_rows());
+        _partition_min_checked = true;
     }
 }
 
@@ -1568,7 +1590,7 @@ void writer::write_clustered(const clustering_row& clustered_row, uint64_t prev_
     flush_tmp_bufs();
 
     // Collect statistics
-    _collector.update_min_max_components(clustered_row.position());
+    record_clustering_position(clustered_row.position());
     collect_row_stats(_data_writer->offset() - current_pos, &clustered_row.key(), is_dead);
 }
 
@@ -1697,7 +1719,7 @@ void writer::write_clustered(const rt_marker& marker, uint64_t prev_row_size) {
     write_marker_body(_tmp_bufs);
     write_vint(*_data_writer, _tmp_bufs.size());
     flush_tmp_bufs();
-    _collector.update_min_max_components(marker.position());
+    record_clustering_position(marker.position());
 
     collect_range_tombstone_stats();
 }

--- a/test/boost/sstable_3_x_test.cc
+++ b/test/boost/sstable_3_x_test.cc
@@ -87,6 +87,10 @@ public:
         return &*_sst;
     }
 
+    const sstable_ptr& get_sstable() const noexcept {
+        return _sst;
+    }
+
     mutation_reader make_reader(
             const dht::partition_range& range,
             const query::partition_slice& slice,
@@ -3302,19 +3306,6 @@ static void do_validate_stats_metadata(schema_ptr s, sstable_assertions& written
     check_estimated_histogram(orig_stats.estimated_cells_count, written_stats.estimated_cells_count);
 }
 
-static void check_min_max_column_names(sstable_assertions& written_sst, std::vector<bytes> min_components, std::vector<bytes> max_components) {
-    const auto& st = written_sst->get_stats_metadata();
-    BOOST_TEST_MESSAGE(fmt::format("min {}/{} max {}/{}", st.min_column_names.elements.size(), min_components.size(), st.max_column_names.elements.size(), max_components.size()));
-    BOOST_REQUIRE(st.min_column_names.elements.size() == min_components.size());
-    for (auto i = 0U; i < st.min_column_names.elements.size(); i++) {
-        BOOST_REQUIRE(min_components[i] == st.min_column_names.elements[i].value);
-    }
-    BOOST_REQUIRE(st.max_column_names.elements.size() == max_components.size());
-    for (auto i = 0U; i < st.max_column_names.elements.size(); i++) {
-        BOOST_REQUIRE(max_components[i] == st.max_column_names.elements[i].value);
-    }
-}
-
 struct validate_stats_metadata_tag { };
 using validate_stats_metadata = bool_class<validate_stats_metadata_tag>;
 
@@ -3344,7 +3335,7 @@ static void write_mut_and_validate_version(test_env& env, schema_ptr s, const ss
     // complete and those version transforms are gone
     auto sst = make_sstable_containing(env.make_sstable(s, version), {mut}).get();
     auto written_sst = validate_read(env, sst, {mut});
-    check_min_max_column_names(written_sst, std::move(min_components), std::move(max_components));
+    check_min_max_column_names(written_sst.get_sstable(), std::move(min_components), std::move(max_components));
 }
 
 static void write_mut_and_validate(test_env& env, schema_ptr s, const sstring& table_name, mutation& mut,

--- a/test/boost/sstable_compaction_test.cc
+++ b/test/boost/sstable_compaction_test.cc
@@ -2286,19 +2286,6 @@ SEASTAR_FIXTURE_TEST_CASE(time_window_strategy_size_tiered_behavior_correctness_
                                    test_env_config{.storage = make_test_object_storage_options("GS")});
 }
 
-static void check_min_max_column_names(const sstable_ptr& sst, std::vector<bytes> min_components, std::vector<bytes> max_components) {
-    const auto& st = sst->get_stats_metadata();
-    BOOST_TEST_MESSAGE(fmt::format("min {}/{} max {}/{}", st.min_column_names.elements.size(), min_components.size(), st.max_column_names.elements.size(), max_components.size()));
-    BOOST_REQUIRE(st.min_column_names.elements.size() == min_components.size());
-    for (auto i = 0U; i < st.min_column_names.elements.size(); i++) {
-        BOOST_REQUIRE(min_components[i] == st.min_column_names.elements[i].value);
-    }
-    BOOST_REQUIRE(st.max_column_names.elements.size() == max_components.size());
-    for (auto i = 0U; i < st.max_column_names.elements.size(); i++) {
-        BOOST_REQUIRE(max_components[i] == st.max_column_names.elements[i].value);
-    }
-}
-
 future<> min_max_clustering_key_2(test_env& env) {
     for (const auto version : writable_sstable_versions) {
         auto s = schema_builder(this_smp_shard_count(), "ks", "cf")

--- a/test/boost/sstable_compaction_test.cc
+++ b/test/boost/sstable_compaction_test.cc
@@ -2315,19 +2315,6 @@ SEASTAR_FIXTURE_TEST_CASE(time_window_strategy_size_tiered_behavior_correctness_
                                    test_env_config{.storage = make_test_object_storage_options("GS")});
 }
 
-static void check_min_max_column_names(const sstable_ptr& sst, std::vector<bytes> min_components, std::vector<bytes> max_components) {
-    const auto& st = sst->get_stats_metadata();
-    BOOST_TEST_MESSAGE(fmt::format("min {}/{} max {}/{}", st.min_column_names.elements.size(), min_components.size(), st.max_column_names.elements.size(), max_components.size()));
-    BOOST_REQUIRE(st.min_column_names.elements.size() == min_components.size());
-    for (auto i = 0U; i < st.min_column_names.elements.size(); i++) {
-        BOOST_REQUIRE(min_components[i] == st.min_column_names.elements[i].value);
-    }
-    BOOST_REQUIRE(st.max_column_names.elements.size() == max_components.size());
-    for (auto i = 0U; i < st.max_column_names.elements.size(); i++) {
-        BOOST_REQUIRE(max_components[i] == st.max_column_names.elements[i].value);
-    }
-}
-
 future<> min_max_clustering_key_2(test_env& env) {
     for (const auto version : writable_sstable_versions) {
         auto s = schema_builder(this_smp_shard_count(), "ks", "cf")

--- a/test/boost/sstable_datafile_test.cc
+++ b/test/boost/sstable_datafile_test.cc
@@ -1478,6 +1478,31 @@ SEASTAR_TEST_CASE(sstable_partition_tombstone_with_rows_metadata_check) {
     });
 }
 
+// A static-row-only partition feeds no clustering positions into the collector,
+// so min/max_column_names must stay empty.
+SEASTAR_TEST_CASE(sstable_static_row_only_metadata_check) {
+    return test_env::do_with_async([] (test_env& env) {
+        for (const auto version : writable_sstable_versions) {
+            auto s = schema_builder(this_smp_shard_count(), "ks", "cf")
+                    .with_column("pk", utf8_type, column_kind::partition_key)
+                    .with_column("ck1", utf8_type, column_kind::clustering_key)
+                    .with_column("s1", int32_type, column_kind::static_column)
+                    .with_column("r1", int32_type)
+                    .build();
+            auto sst_gen = env.make_sst_factory(s, version);
+            auto key = partition_key::from_exploded(*s, {to_bytes("key1")});
+            const column_definition& s1_col = *s->get_column_definition("s1");
+
+            BOOST_TEST_MESSAGE(fmt::format("version {}", version));
+
+            mutation m(s, key);
+            m.set_static_cell(s1_col, make_atomic_cell(int32_type, int32_type->decompose(1)));
+            auto sst = make_sstable_containing(sst_gen, {std::move(m)}).get();
+            check_min_max_column_names(sst, {}, {});
+        }
+    });
+}
+
 SEASTAR_TEST_CASE(sstable_composite_reverse_tombstone_metadata_check) {
     return test_env::do_with_async([] (test_env& env) {
         for (const auto version : writable_sstable_versions) {

--- a/test/boost/sstable_datafile_test.cc
+++ b/test/boost/sstable_datafile_test.cc
@@ -1442,6 +1442,42 @@ SEASTAR_TEST_CASE(sstable_composite_tombstone_metadata_check) {
     });
 }
 
+// A partition tombstone seeds min/max tracking with the before_all/after_all
+// sentinels, which bound every real position and carry no key components, so
+// min/max_column_names must come out empty despite the rows.
+SEASTAR_TEST_CASE(sstable_partition_tombstone_with_rows_metadata_check) {
+    return test_env::do_with_async([] (test_env& env) {
+        for (const auto version : writable_sstable_versions) {
+            auto s = schema_builder(this_smp_shard_count(), "ks", "cf")
+                    .with_column("pk", utf8_type, column_kind::partition_key)
+                    .with_column("ck1", utf8_type, column_kind::clustering_key)
+                    .with_column("ck2", utf8_type, column_kind::clustering_key)
+                    .with_column("r1", int32_type)
+                    .build();
+            auto sst_gen = env.make_sst_factory(s, version);
+            auto key = partition_key::from_exploded(*s, {to_bytes("key1")});
+            const column_definition& r1_col = *s->get_column_definition("r1");
+
+            BOOST_TEST_MESSAGE(fmt::format("version {}", version));
+
+            mutation m(s, key);
+            tombstone tomb(api::new_timestamp(), gc_clock::now());
+            m.partition().apply(tomb);
+            // Rows inserted out of order on purpose; the partition tombstone must win.
+            for (auto& exploded_ck : std::vector<std::vector<bytes>>{
+                    {to_bytes("z1"), to_bytes("z2")},
+                    {to_bytes("a1"), to_bytes("a2")},
+                    {to_bytes("m1"), to_bytes("m2")}}) {
+                auto c_key = clustering_key_prefix::from_exploded(*s, exploded_ck);
+                m.set_clustered_cell(c_key, r1_col, make_atomic_cell(int32_type, int32_type->decompose(1)));
+            }
+            auto sst = make_sstable_containing(sst_gen, {std::move(m)}).get();
+            BOOST_REQUIRE(sst->get_stats_metadata().estimated_tombstone_drop_time.bin.size());
+            check_min_max_column_names(sst, {}, {});
+        }
+    });
+}
+
 SEASTAR_TEST_CASE(sstable_composite_reverse_tombstone_metadata_check) {
     return test_env::do_with_async([] (test_env& env) {
         for (const auto version : writable_sstable_versions) {

--- a/test/boost/sstable_datafile_test.cc
+++ b/test/boost/sstable_datafile_test.cc
@@ -926,19 +926,6 @@ SEASTAR_TEST_CASE(test_promoted_index_read) {
     });
 }
 
-static void check_min_max_column_names(const sstable_ptr& sst, std::vector<bytes> min_components, std::vector<bytes> max_components) {
-    const auto& st = sst->get_stats_metadata();
-    BOOST_TEST_MESSAGE(fmt::format("min {}/{} max {}/{}", st.min_column_names.elements.size(), min_components.size(), st.max_column_names.elements.size(), max_components.size()));
-    BOOST_REQUIRE(st.min_column_names.elements.size() == min_components.size());
-    for (auto i = 0U; i < st.min_column_names.elements.size(); i++) {
-        BOOST_REQUIRE(min_components[i] == st.min_column_names.elements[i].value);
-    }
-    BOOST_REQUIRE(st.max_column_names.elements.size() == max_components.size());
-    for (auto i = 0U; i < st.max_column_names.elements.size(); i++) {
-        BOOST_REQUIRE(max_components[i] == st.max_column_names.elements[i].value);
-    }
-}
-
 static void test_min_max_clustering_key(test_env& env, schema_ptr s, std::vector<bytes> exploded_pk, std::vector<std::vector<bytes>> exploded_cks,
         std::vector<bytes> min_components, std::vector<bytes> max_components, sstable_version_types version, bool remove = false) {
     auto mt = make_lw_shared<replica::memtable>(s);

--- a/test/boost/sstable_datafile_test.cc
+++ b/test/boost/sstable_datafile_test.cc
@@ -1064,8 +1064,23 @@ SEASTAR_TEST_CASE(min_max_clustering_key_test) {
                             .with_column("ck2", reversed_type_impl::get_instance(utf8_type), column_kind::clustering_key)
                             .with_column("r1", int32_type)
                             .build();
-                    BOOST_TEST_MESSAGE(fmt::format("min_max_clustering_key_test: reversed order: min={{\"a\"}} max={{\"a\"}} with compact storage version={}", version));
-                    test_min_max_clustering_key(env, s, {"key1"}, {{"a", "z"}, {"a"}}, {"a"}, {"a"}, version);
+                    BOOST_TEST_MESSAGE(fmt::format("min_max_clustering_key_test: reversed order: min={{\"a\"}} max={{\"a\", \"z\"}} with compact storage version={}", version));
+                    test_min_max_clustering_key(env, s, {"key1"}, {{"a", "z"}, {"a"}}, {"a"}, {"a", "z"}, version);
+                }
+                {
+                    auto s = schema_builder(this_smp_shard_count(), "ks", "cf")
+                            .with(schema_builder::compact_storage::yes)
+                            .with_column("pk", utf8_type, column_kind::partition_key)
+                            .with_column("ck1", utf8_type, column_kind::clustering_key)
+                            .with_column("ck2", utf8_type, column_kind::clustering_key)
+                            .with_column("r1", int32_type)
+                            .build();
+                    BOOST_TEST_MESSAGE(fmt::format("min_max_clustering_key_test: prefix row alone with compact storage version={}", version));
+                    test_min_max_clustering_key(env, s, {"key1"}, {{"a"}}, {"a"}, {"a"}, version);
+                    BOOST_TEST_MESSAGE(fmt::format("min_max_clustering_key_test: prefix row + full row sharing the prefix with compact storage version={}", version));
+                    test_min_max_clustering_key(env, s, {"key1"}, {{"a"}, {"a", "b"}}, {"a"}, {"a", "b"}, version);
+                    BOOST_TEST_MESSAGE(fmt::format("min_max_clustering_key_test: prefix row as max with compact storage version={}", version));
+                    test_min_max_clustering_key(env, s, {"key1"}, {{"a", "z"}, {"b"}}, {"a", "z"}, {"b"}, version);
                 }
             }
         }
@@ -1233,6 +1248,34 @@ SEASTAR_TEST_CASE(sstable_tombstone_metadata_check) {
                     auto sst = make_sstable_containing(sst_gen, {std::move(m)}).get();
                     BOOST_REQUIRE(sst->get_stats_metadata().estimated_tombstone_drop_time.bin.size());
                     check_min_max_column_names(sst, {}, {});
+                }
+
+                // Range tombstone with prefix bounds in a compact-storage table,
+                // together with a prefix row and a full-key row.
+                {
+                    auto s2 = schema_builder(this_smp_shard_count(), "ks", "cf2")
+                            .with(schema_builder::compact_storage::yes)
+                            .with_column("pk", utf8_type, column_kind::partition_key)
+                            .with_column("ck1", utf8_type, column_kind::clustering_key)
+                            .with_column("ck2", utf8_type, column_kind::clustering_key)
+                            .with_column("r1", int32_type)
+                            .build();
+                    auto sst_gen2 = env.make_sst_factory(s2, version);
+                    const column_definition& r1_col2 = *s2->get_column_definition("r1");
+                    mutation m(s2, partition_key::from_exploded(*s2, {to_bytes("key1")}));
+                    m.set_clustered_cell(clustering_key_prefix::from_single_value(*s2, bytes("b")), r1_col2,
+                            make_atomic_cell(int32_type, int32_type->decompose(1)));
+                    m.set_clustered_cell(clustering_key_prefix::from_exploded(*s2, {to_bytes("b"), to_bytes("c")}), r1_col2,
+                            make_atomic_cell(int32_type, int32_type->decompose(1)));
+                    tombstone tomb(api::new_timestamp(), gc_clock::now());
+                    range_tombstone rt(
+                            clustering_key_prefix::from_single_value(*s2, bytes("a")),
+                            clustering_key_prefix::from_single_value(*s2, bytes("a")),
+                            tomb);
+                    m.partition().apply_delete(*s2, std::move(rt));
+                    auto sst = make_sstable_containing(sst_gen2, {std::move(m)}).get();
+                    BOOST_REQUIRE(sst->get_stats_metadata().estimated_tombstone_drop_time.bin.size());
+                    check_min_max_column_names(sst, {"a"}, {"b", "c"});
                 }
             }
         }

--- a/test/boost/sstable_datafile_test.cc
+++ b/test/boost/sstable_datafile_test.cc
@@ -1082,6 +1082,17 @@ SEASTAR_TEST_CASE(min_max_clustering_key_test) {
                     BOOST_TEST_MESSAGE(fmt::format("min_max_clustering_key_test: prefix row as max with compact storage version={}", version));
                     test_min_max_clustering_key(env, s, {"key1"}, {{"a", "z"}, {"b"}}, {"a", "z"}, {"b"}, version);
                 }
+                {
+                    auto s = schema_builder(this_smp_shard_count(), "ks", "cf")
+                            .with(schema_builder::compact_storage::yes)
+                            .with_column("pk", utf8_type, column_kind::partition_key)
+                            .with_column("ck1", utf8_type, column_kind::clustering_key)
+                            .with_column("ck2", reversed_type_impl::get_instance(utf8_type), column_kind::clustering_key)
+                            .with_column("r1", int32_type)
+                            .build();
+                    BOOST_TEST_MESSAGE(fmt::format("min_max_clustering_key_test: prefix row as max, reversed order, with compact storage version={}", version));
+                    test_min_max_clustering_key(env, s, {"key1"}, {{"a", "z"}, {"b"}}, {"a", "z"}, {"b"}, version);
+                }
             }
         }
     });
@@ -1258,6 +1269,34 @@ SEASTAR_TEST_CASE(sstable_tombstone_metadata_check) {
                             .with_column("pk", utf8_type, column_kind::partition_key)
                             .with_column("ck1", utf8_type, column_kind::clustering_key)
                             .with_column("ck2", utf8_type, column_kind::clustering_key)
+                            .with_column("r1", int32_type)
+                            .build();
+                    auto sst_gen2 = env.make_sst_factory(s2, version);
+                    const column_definition& r1_col2 = *s2->get_column_definition("r1");
+                    mutation m(s2, partition_key::from_exploded(*s2, {to_bytes("key1")}));
+                    m.set_clustered_cell(clustering_key_prefix::from_single_value(*s2, bytes("b")), r1_col2,
+                            make_atomic_cell(int32_type, int32_type->decompose(1)));
+                    m.set_clustered_cell(clustering_key_prefix::from_exploded(*s2, {to_bytes("b"), to_bytes("c")}), r1_col2,
+                            make_atomic_cell(int32_type, int32_type->decompose(1)));
+                    tombstone tomb(api::new_timestamp(), gc_clock::now());
+                    range_tombstone rt(
+                            clustering_key_prefix::from_single_value(*s2, bytes("a")),
+                            clustering_key_prefix::from_single_value(*s2, bytes("a")),
+                            tomb);
+                    m.partition().apply_delete(*s2, std::move(rt));
+                    auto sst = make_sstable_containing(sst_gen2, {std::move(m)}).get();
+                    BOOST_REQUIRE(sst->get_stats_metadata().estimated_tombstone_drop_time.bin.size());
+                    check_min_max_column_names(sst, {"a"}, {"b", "c"});
+                }
+
+                // Same as above, but with a reversed clustering column, to make sure
+                // prefix-vs-full-key comparison doesn't get flipped by column order.
+                {
+                    auto s2 = schema_builder(this_smp_shard_count(), "ks", "cf3")
+                            .with(schema_builder::compact_storage::yes)
+                            .with_column("pk", utf8_type, column_kind::partition_key)
+                            .with_column("ck1", utf8_type, column_kind::clustering_key)
+                            .with_column("ck2", reversed_type_impl::get_instance(utf8_type), column_kind::clustering_key)
                             .with_column("r1", int32_type)
                             .build();
                     auto sst_gen2 = env.make_sst_factory(s2, version);
@@ -1473,6 +1512,31 @@ SEASTAR_TEST_CASE(sstable_partition_tombstone_with_rows_metadata_check) {
             }
             auto sst = make_sstable_containing(sst_gen, {std::move(m)}).get();
             BOOST_REQUIRE(sst->get_stats_metadata().estimated_tombstone_drop_time.bin.size());
+            check_min_max_column_names(sst, {}, {});
+        }
+    });
+}
+
+// A static-row-only partition feeds no clustering positions into the collector,
+// so min/max_column_names must stay empty.
+SEASTAR_TEST_CASE(sstable_static_row_only_metadata_check) {
+    return test_env::do_with_async([] (test_env& env) {
+        for (const auto version : writable_sstable_versions) {
+            auto s = schema_builder(this_smp_shard_count(), "ks", "cf")
+                    .with_column("pk", utf8_type, column_kind::partition_key)
+                    .with_column("ck1", utf8_type, column_kind::clustering_key)
+                    .with_column("s1", int32_type, column_kind::static_column)
+                    .with_column("r1", int32_type)
+                    .build();
+            auto sst_gen = env.make_sst_factory(s, version);
+            auto key = partition_key::from_exploded(*s, {to_bytes("key1")});
+            const column_definition& s1_col = *s->get_column_definition("s1");
+
+            BOOST_TEST_MESSAGE(fmt::format("version {}", version));
+
+            mutation m(s, key);
+            m.set_static_cell(s1_col, make_atomic_cell(int32_type, int32_type->decompose(1)));
+            auto sst = make_sstable_containing(sst_gen, {std::move(m)}).get();
             check_min_max_column_names(sst, {}, {});
         }
     });

--- a/test/boost/sstable_test.hh
+++ b/test/boost/sstable_test.hh
@@ -58,6 +58,19 @@ public:
 
 namespace sstables {
 
+inline void check_min_max_column_names(const sstable_ptr& sst, std::vector<bytes> min_components, std::vector<bytes> max_components) {
+    const auto& st = sst->get_stats_metadata();
+    BOOST_TEST_MESSAGE(fmt::format("min {}/{} max {}/{}", st.min_column_names.elements.size(), min_components.size(), st.max_column_names.elements.size(), max_components.size()));
+    BOOST_REQUIRE(st.min_column_names.elements.size() == min_components.size());
+    for (auto i = 0U; i < st.min_column_names.elements.size(); i++) {
+        BOOST_REQUIRE(min_components[i] == st.min_column_names.elements[i].value);
+    }
+    BOOST_REQUIRE(st.max_column_names.elements.size() == max_components.size());
+    for (auto i = 0U; i < st.max_column_names.elements.size(); i++) {
+        BOOST_REQUIRE(max_components[i] == st.max_column_names.elements[i].value);
+    }
+}
+
 inline sstring get_test_dir(const sstring& name, const sstring& ks, const sstring& cf)
 {
     return seastar::format("test/resource/sstables/{}/{}/{}-1c6ace40fad111e7b9cf000000000002", name, ks, cf);


### PR DESCRIPTION
Motivation:
`metadata_collector::update_min_max_components()` did two `position_in_partition::tri_compare` calls (against the running min and the running max) per clustering row/range-tombstone marker written by the mx sstable writer, even though fragment positions within a partition are only weakly monotonically increasing - only the first position in a partition can ever lower the running min, only the last can ever raise the running max.

Changes:
1. `metadata_collector` now compares min/max candidate positions in natural order, instead of extending prefix (non-full) clustering keys to `{before_key(pos), after_all_prefixed(pos)}` during collection. That extension was a representation concern: stats metadata stores only key components, and the reader already re-extends them to an inclusive position range in `sstable::set_min_max_position_range()`. Comparing raw positions makes stream order and comparison order coincide, and the stored max becomes tighter (a full key extending a prefix row now wins over it) while still covering every position present.
2. `update_min_max_components()` is split into `update_min()`/`update_max()`. The mx writer checks the min once, on the first clustering position of a partition, and defers the max check to `consume_end_of_partition()`, using the last position seen. A partition-level tombstone feeds the `before_all_clustered_rows()`/`after_all_clustered_rows()` sentinels straight to the collector, as before.
3. Regression tests added: a partition-level tombstone combined with clustering rows in the same partition; static-row-only partitions, which feed no clustering positions into the collector and must leave the deferred max state disengaged; prefix-row min/max coverage (prefix row alone, prefix row + full-key row sharing the prefix, prefix row as max, range tombstone with prefix bounds in a compact-storage table).
4. `check_min_max_column_names`, a test helper duplicated across three test files, deduplicated into `test/boost/sstable_test.hh`.

Testing:
`test/boost/sstable_datafile_test` (all writable sstable versions, `--smp 1`), `test/boost/sstable_3_x_test`, and the `sstable_compaction_test` min/max cases.

Results: no change in pass/fail results versus unmodified master.

Backport: no, benign improvement
