### PR TITLE
sstables: stop resolving unused per-cell value type on complex-column read

### DIFF
--- a/sstables/kl/reader.cc
+++ b/sstables/kl/reader.cc
@@ -578,9 +578,9 @@ public:
                 return;
             }
             if (is_multi_cell) {
-                auto& value_type = visit(*col.cdef->type, make_visitor(
-                    [] (const collection_type_impl& ctype) -> const abstract_type& { return *ctype.value_comparator(); },
-                    [&] (const user_type_impl& utype) -> const abstract_type& {
+                visit(*col.cdef->type, make_visitor(
+                    [] (const collection_type_impl&) { },
+                    [&] (const user_type_impl& utype) {
                         if (col.collection_extra_data.size() != sizeof(int16_t)) {
                             throw_malformed_sstable_exception(format("wrong size of field index while reading UDT column: expected {}, got {}",
                                         sizeof(int16_t), col.collection_extra_data.size()));
@@ -591,14 +591,12 @@ public:
                             throw_malformed_sstable_exception(format("field index too big while reading UDT column: type has {} fields, got {}",
                                         utype.size(), field_idx));
                         }
-
-                        return *utype.type(field_idx);
                     },
-                    [] (const abstract_type& o) -> const abstract_type& {
+                    [] (const abstract_type& o) {
                         throw_malformed_sstable_exception(format("attempted to read multi-cell column, but expected type was {}", o.name()));
                     }
                 ));
-                auto ac = make_atomic_cell(value_type,
+                auto ac = make_atomic_cell(*col.cdef->type,
                                            api::timestamp_type(timestamp),
                                            value,
                                            gc_clock::duration(ttl),

--- a/sstables/mx/reader.cc
+++ b/sstables/mx/reader.cc
@@ -395,9 +395,9 @@ public:
         }
         check_schema_mismatch(column_info, column_def);
         if (column_def.is_multi_cell()) {
-            auto& value_type = visit(*column_def.type, make_visitor(
-                [] (const collection_type_impl& ctype) -> const abstract_type& { return *ctype.value_comparator(); },
-                [&] (const user_type_impl& utype) -> const abstract_type& {
+            visit(*column_def.type, make_visitor(
+                [] (const collection_type_impl&) { },
+                [&] (const user_type_impl& utype) {
                     if (cell_path.size() != sizeof(int16_t)) {
                         throw_malformed_sstable_exception(format("wrong size of field index while reading UDT column: expected {}, got {}",
                                     sizeof(int16_t), cell_path.size()));
@@ -408,15 +408,13 @@ public:
                         throw_malformed_sstable_exception(format("field index too big while reading UDT column: type has {} fields, got {}",
                                     utype.size(), field_idx));
                     }
-
-                    return *utype.type(field_idx);
                 },
-                [] (const abstract_type& o) -> const abstract_type& {
+                [] (const abstract_type& o) {
                     throw_malformed_sstable_exception(format("attempted to read multi-cell column, but expected type was {}", o.name()));
                 }
             ));
             auto ac = is_deleted ? atomic_cell::make_dead(timestamp, local_deletion_time)
-                                 : make_atomic_cell(value_type,
+                                 : make_atomic_cell(*column_def.type,
                                                     timestamp,
                                                     value,
                                                     ttl,

--- a/test/boost/sstable_3_x_test.cc
+++ b/test/boost/sstable_3_x_test.cc
@@ -5836,6 +5836,69 @@ SEASTAR_TEST_CASE(test_legacy_udt_in_collection_table) {
   });
 }
 
+namespace {
+
+struct malformed_read_consumer {
+    stop_iteration consume(static_row sr) { return stop_iteration::no; }
+    stop_iteration consume(clustering_row cr) { return stop_iteration::no; }
+    stop_iteration consume(range_tombstone_change rt) { return stop_iteration::no; }
+    stop_iteration consume(tombstone tomb) { return stop_iteration::no; }
+    void consume_end_of_stream() {}
+    void consume_new_partition(const dht::decorated_key& dk) {}
+    stop_iteration consume_end_of_partition() { return stop_iteration::no; }
+};
+
+} // namespace
+
+// A non-frozen UDT is stored as a multi-cell (complex) column; each cell's
+// path is the 2-byte, big-endian field index. The sstable writer stores the
+// cell path as-is, so a malformed path can be crafted at the mutation level
+// and is only caught by the reader's validation in consume_column() (the
+// visit() reworked by this series). Cover both malformed cases: a cell path
+// that is not 2 bytes long, and a field index out of range for the UDT.
+SEASTAR_TEST_CASE(test_malformed_udt_field_index_mx) {
+  return test_env::do_with_async([] (test_env& env) {
+    sstables::scoped_no_abort_on_malformed_sstable_error no_abort;
+    auto ut = user_type_impl::get_instance("ks", to_bytes("ut"),
+            {to_bytes("a"), to_bytes("b")},
+            {int32_type, int32_type}, true);
+    auto s = schema_builder(this_smp_shard_count(), "ks", "t")
+        .with_column("pk", int32_type, column_kind::partition_key)
+        .with_column("u", ut)
+        .set_compressor_params(compression_parameters::no_compression())
+        .build();
+    auto u_cdef = s->get_column_definition(to_bytes("u"));
+    BOOST_REQUIRE(u_cdef);
+
+    auto write_and_read_malformed = [&] (bytes cell_path, const sstring& expected_msg) {
+        mutation mut{s, partition_key::from_deeply_exploded(*s, {0})};
+        auto ckey = clustering_key::make_empty();
+        {
+            collection_mutation_writer w({});
+            w.push_back(bytes_view(cell_path),
+                atomic_cell::make_live(*int32_type, write_timestamp, int32_type->decompose(0), atomic_cell::collection_member::yes));
+            mut.set_clustered_cell(ckey, *u_cdef, std::move(w).finish());
+        }
+        auto sst = make_sstable_containing(env.make_sstable(s, sstable_version_types::mc), {std::move(mut)}, validate::no).get();
+        auto r = sst->make_reader(s, env.make_reader_permit(), query::full_partition_range, s->full_slice());
+        auto close_r = deferred_close(r);
+        try {
+            r.consume(malformed_read_consumer{}).get();
+            BOOST_FAIL("expecting malformed_sstable_exception");
+        } catch (const malformed_sstable_exception& e) {
+            BOOST_REQUIRE(sstring(e.what()).find(expected_msg) != sstring::npos);
+        }
+    };
+
+    // Cell path is not a 2-byte field index.
+    write_and_read_malformed(bytes(4, '\0'), "wrong size of field index");
+    // Field index (big-endian 2-byte) out of range: ut has only fields 0 and 1.
+    auto oob_path = bytes(2, '\0');
+    oob_path[1] = 5;
+    write_and_read_malformed(std::move(oob_path), "field index too big");
+  });
+}
+
 SEASTAR_TEST_CASE(test_compression_premature_eof) {
     return test_env::do_with_async([] (test_env& env) {
         sstables::scoped_no_abort_on_malformed_sstable_error no_abort;


### PR DESCRIPTION
Motivation:
`consume_column`/`consume_cell` resolved a per-cell value type (collection value comparator, or UDT field type) via a `visit()` call, but the result is never used downstream - `atomic_cell::make_live()` doesn't reference its `type` parameter.

Change:
Rework the visitor to validate only and return `void`, dropping the dead computation. All validation (size/bounds checks, malformed-sstable fallback) is preserved verbatim.

Testing:
Verified compiling clean with `-Wall -Werror -Wextra`; existing collection/UDT round-trip tests (which default to the `mt` format) exercise this path.

Backport: no, benign improvement