### PR TITLE
test: isolate Azure KMS mock tests from developer credentials

### DIFF
--- a/test/lib/azure_kms_fixture.cc
+++ b/test/lib/azure_kms_fixture.cc
@@ -9,6 +9,7 @@
 #include <string>
 #include <memory>
 #include <regex>
+#include <vector>
 
 #include <seastar/core/with_timeout.hh>
 #include <seastar/core/reactor.hh>
@@ -16,6 +17,7 @@
 #include <seastar/net/inet_address.hh>
 
 #include "azure_kms_fixture.hh"
+#include "scoped_env_var.hh"
 #include "tmpdir.hh"
 #include "proc_utils.hh"
 #include "test_utils.hh"
@@ -110,6 +112,9 @@ public:
     azure_mode mode;
     std::optional<tp::process_fixture> local_azure;
     tmpdir tmp;
+    // Environment overrides applied to isolate mock tests from a developer's
+    // real Azure credentials. Restored on teardown.
+    std::vector<scoped_env_var> env_overrides;
 
     impl(azure_mode);
 
@@ -134,6 +139,30 @@ azure_kms_fixture::impl::impl(azure_mode m)
 
 seastar::future<> azure_kms_fixture::impl::setup() {
     if ((key_name.empty() || mode == azure_mode::local) && mode != azure_mode::real) {
+        // Isolate the default-credentials chain from the developer's real Azure
+        // credentials, so tests that expect the chain to find *no* credentials
+        // (e.g. test_azure_provider_with_incomplete_creds) don't spuriously
+        // succeed.
+        //
+        // The Env source reads service-principal credentials directly from the
+        // environment, so scrub those variables.
+        for (const char* var : {
+                "AZURE_TENANT_ID",
+                "AZURE_CLIENT_ID",
+                "AZURE_CLIENT_SECRET",
+                "AZURE_CLIENT_CERTIFICATE_PATH",
+                "AZURE_AUTHORITY_HOST"}) {
+            scoped_env_var v;
+            v.unset(var);
+            env_overrides.push_back(std::move(v));
+        }
+        // The Azure CLI source spawns `az`, which reads the logged-in account
+        // from AZURE_CONFIG_DIR (defaulting to ~/.azure). Point it at an empty
+        // directory so `az` finds no account.
+        auto empty_azure_dir = tmp.path() / "empty-azure-config";
+        fs::create_directories(empty_azure_dir);
+        env_overrides.emplace_back("AZURE_CONFIG_DIR", empty_azure_dir.string());
+
         auto host = getenv_or_default("MOCK_AZURE_VAULT_SERVER_HOST", "127.0.0.1");
         auto [proc, port] = co_await start_fake_azure_server(tmp, host);
         local_azure.emplace(std::move(proc));
@@ -170,6 +199,8 @@ seastar::future<> azure_kms_fixture::impl::teardown() {
         local_azure->terminate();
         co_await local_azure->wait();
     }
+    // Restore any environment variables we overrode during setup.
+    env_overrides.clear();
 }
 
 static thread_local azure_kms_fixture* active_azure_kms_fixture = nullptr;

--- a/test/lib/scoped_env_var.hh
+++ b/test/lib/scoped_env_var.hh
@@ -1,0 +1,85 @@
+/*
+ * Copyright (C) 2026-present ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
+ */
+
+#pragma once
+
+#include <cstdlib>
+#include <optional>
+#include <string>
+
+// RAII helper that overrides a single environment variable and restores its
+// previous state on destruction (or on release()). If the variable was not set
+// before, it is unset again; otherwise the previous value is restored.
+class scoped_env_var {
+    std::string _name;
+    std::optional<std::string> _saved;
+    bool _active = false;
+
+    void save(std::string name) {
+        release();
+        _name = std::move(name);
+        if (const char* prev = ::getenv(_name.c_str())) {
+            _saved = prev;
+        } else {
+            _saved.reset();
+        }
+        _active = true;
+    }
+
+public:
+    scoped_env_var() = default;
+
+    // Override `name` with `value`.
+    scoped_env_var(const std::string& name, const std::string& value) {
+        set(name, value);
+    }
+
+    scoped_env_var(scoped_env_var&& o) noexcept
+            : _name(std::move(o._name)), _saved(std::move(o._saved)), _active(o._active) {
+        o._active = false;
+    }
+    scoped_env_var& operator=(scoped_env_var&& o) noexcept {
+        if (this != &o) {
+            release();
+            _name = std::move(o._name);
+            _saved = std::move(o._saved);
+            _active = o._active;
+            o._active = false;
+        }
+        return *this;
+    }
+    scoped_env_var(const scoped_env_var&) = delete;
+    scoped_env_var& operator=(const scoped_env_var&) = delete;
+
+    ~scoped_env_var() { release(); }
+
+    // Save the current value of `name` and set it to `value`.
+    void set(const std::string& name, const std::string& value) {
+        save(name);
+        ::setenv(_name.c_str(), value.c_str(), 1);
+    }
+
+    // Save the current value of `name` and remove it from the environment.
+    void unset(const std::string& name) {
+        save(name);
+        ::unsetenv(_name.c_str());
+    }
+
+    // Restore the variable to the state saved when it was last set/unset.
+    void release() noexcept {
+        if (!_active) {
+            return;
+        }
+        if (_saved) {
+            ::setenv(_name.c_str(), _saved->c_str(), 1);
+        } else {
+            ::unsetenv(_name.c_str());
+        }
+        _active = false;
+    }
+};


### PR DESCRIPTION
The Azure default-credentials chain (Env -> Azure CLI -> IMDS) picks up credentials from the developer's environment: the Env source reads AZURE_TENANT_ID / AZURE_CLIENT_ID / AZURE_CLIENT_SECRET / AZURE_CLIENT_CERTIFICATE_PATH, and the Azure CLI source spawns `az`, which reads the logged-in account from AZURE_CONFIG_DIR (defaulting to ~/.azure).

When a developer has a valid Azure login (e.g. in ~/.azure), tests that expect the chain to find no credentials at all -- notably test_azure_provider_with_incomplete_creds, which asserts "No credentials found in any source." -- would spuriously succeed and fail the assertion.

Make the mock fixture hermetic: scrub the service-principal environment variables and point AZURE_CONFIG_DIR at an empty directory during setup, restoring the previous state on teardown. Add a small scoped_env_var RAII helper to save/restore individual environment variables.

Easy to work around for the rare developer that is logged in to Azure, so not backporting.