### PR TITLE
s3: handle zero-length objects in the upload sinks and download sources

### DIFF
--- a/sstables/mx/writer.cc
+++ b/sstables/mx/writer.cc
@@ -1053,13 +1053,6 @@ void writer::close_partitions_writer() {
 
 void writer::close_rows_writer() {
     if (_rows_writer) {
-        // Append some garbage padding to the file just to ensure that it's never empty.
-        // (Otherwise it would be empty if the sstable contains only small partitions).
-        // This is a hack to work around some bad interactions between zero-sized files
-        // and object storage. (It seems that e.g. minio considers a zero-sized file
-        // upload to be a no-op, which breaks some assumptions).
-        uint32_t garbage = seastar::cpu_to_be(0x13371337);
-        _rows_writer->write(reinterpret_cast<const char*>(&garbage), sizeof(garbage));
         _sst.get_components_digests().map[component_type::Rows] = close_digest_writer(_rows_writer);
     }
 }

--- a/test/boost/s3_test.cc
+++ b/test/boost/s3_test.cc
@@ -288,6 +288,82 @@ SEASTAR_THREAD_TEST_CASE(test_client_multipart_copy_upload_proxy) {
     do_test_client_multipart_upload(make_proxy_client, true);
 }
 
+// A zero-byte component is not hypothetical. BTI's Rows.db is empty for an
+// sstable holding only small partitions, and sstables/mx/writer.cc papers over
+// that by appending four bytes of padding before closing the writer. The tests
+// below pin down what each upload path does when nothing at all is written.
+
+void do_test_client_put_empty_object(const client_maker_function& client_maker) {
+    s3_test_fixture guard(client_maker);
+    auto cln = guard.client();
+    const auto name = guard.object_path("testemptyobject");
+
+    testlog.info("PUT an empty object\n");
+    cln->put_object(name, temporary_buffer<char>()).get();
+
+    BOOST_REQUIRE(cln->object_exists(name).get());
+    BOOST_REQUIRE_EQUAL(cln->get_object_size(name).get(), 0);
+}
+
+void do_test_client_upload_empty_object(const client_maker_function& client_maker, bool with_copy_upload) {
+    s3_test_fixture guard(client_maker);
+    auto cln = guard.client();
+    const auto name = guard.object_path(fmt::format("testempty{}object", with_copy_upload ? "jumbo" : "large"));
+
+    testlog.info("Upload an empty object (with copy = {})\n", with_copy_upload);
+    auto out = output_stream<char>(
+        with_copy_upload ? cln->make_upload_jumbo_sink(name, 3) : cln->make_upload_sink(name)
+    );
+    auto close = seastar::deferred_close(out);
+
+    // Nothing is written to the stream.
+    testlog.info("Flush upload\n");
+    out.flush().get();
+
+    testlog.info("Closing\n");
+    close.close_now();
+
+    BOOST_REQUIRE(cln->object_exists(name).get());
+    BOOST_REQUIRE_EQUAL(cln->get_object_size(name).get(), 0);
+}
+
+// Reading a zero-length object needs the same care as writing one: no byte range
+// is satisfiable on an empty object, so a ranged GET is answered with 416.
+void do_test_download_empty_object(const client_maker_function& client_maker, bool is_chunked) {
+    s3_test_fixture guard(client_maker);
+    auto cln = guard.client();
+    const auto name = guard.object_path("testemptydownloadobject");
+
+    cln->put_object(name, temporary_buffer<char>()).get();
+
+    testlog.info("Download an empty object (chunked = {})\n", is_chunked);
+    auto in = is_chunked ? input_stream<char>(cln->make_chunked_download_source(name, s3::full_range))
+                         : input_stream<char>(cln->make_download_source(name, s3::full_range));
+    auto close = seastar::deferred_close(in);
+
+    BOOST_REQUIRE(in.read().get().empty());
+}
+
+SEASTAR_THREAD_TEST_CASE(test_client_put_empty_object_minio) {
+    do_test_client_put_empty_object(make_minio_client);
+}
+
+SEASTAR_THREAD_TEST_CASE(test_download_empty_object_minio) {
+    do_test_download_empty_object(make_minio_client, false);
+}
+
+SEASTAR_THREAD_TEST_CASE(test_chunked_download_empty_object_minio) {
+    do_test_download_empty_object(make_minio_client, true);
+}
+
+SEASTAR_THREAD_TEST_CASE(test_client_upload_empty_object_minio) {
+    do_test_client_upload_empty_object(make_minio_client, false);
+}
+
+SEASTAR_THREAD_TEST_CASE(test_client_copy_upload_empty_object_minio) {
+    do_test_client_upload_empty_object(make_minio_client, true);
+}
+
 using with_remainder_t = bool_class<class with_remainder_tag>;
 
 void test_client_upload_file(const client_maker_function& client_maker, size_t total_size) {

--- a/utils/s3/client.cc
+++ b/utils/s3/client.cc
@@ -11,7 +11,6 @@
 #include <initializer_list>
 #include <memory>
 #include <numeric>
-#include <regex>
 #include <stdexcept>
 #if __has_include(<rapidxml.h>)
 #include <rapidxml.h>

--- a/utils/s3/client.cc
+++ b/utils/s3/client.cc
@@ -859,6 +859,11 @@ protected:
     named_gate _bg_flushes;
     std::optional<tag> _tag;
     seastar::abort_source* _as;
+    // Set once this sink has produced its object, either with a plain PUT or with
+    // a completed multipart upload. finalize_upload() clears _upload_id and
+    // output_stream::close() flushes a second time, so upload_started() alone
+    // cannot tell "nothing was ever written" from "already uploaded".
+    bool _object_produced = false;
 
     future<> start_upload();
     future<> finalize_upload();
@@ -868,6 +873,15 @@ protected:
 
     bool upload_started() const noexcept {
         return !_upload_id.empty();
+    }
+
+    // Create the object even though nothing was written into the sink. A
+    // zero-length component is still a component, and object stores hold
+    // zero-length objects. Without this the object is silently missing.
+    future<> put_empty_object() {
+        s3l.trace("PUT empty object {}", _object_name);
+        _object_produced = true;
+        return _client->put_object(_object_name, temporary_buffer<char>());
     }
 
     multipart_upload(shared_ptr<client> cln, sstring object_name, std::optional<tag> tag, seastar::abort_source* as)
@@ -1155,6 +1169,10 @@ future<> client::multipart_upload::abort_upload() {
 }
 
 future<> client::multipart_upload::finalize_upload() {
+    // Set before the request rather than after it: on failure the caller aborts the
+    // upload, which clears _upload_id, and a later flush must not then mistake this
+    // sink for one that never wrote anything and PUT an empty object over it.
+    _object_produced = true;
     s3l.trace("wait for {} parts to complete (upload id {})", _part_etags.size(), _upload_id);
     co_await _bg_flushes.close();
 
@@ -1222,21 +1240,31 @@ public:
         : upload_sink_base(std::move(cln), std::move(object_name), std::move(tag), as)
     {}
 
+    // True while nothing has been written into the sink, so it has no object to
+    // copy-upload from. Used by upload_jumbo_sink to skip such a piece.
+    bool empty() const noexcept {
+        return _bufs.size() == 0 && !upload_started();
+    }
+
     virtual future<> put(std::span<temporary_buffer<char>> data) override {
         append_buffers(_bufs, std::move(data));
         return maybe_flush();
     }
 
     virtual future<> flush() override {
-        if (_bufs.size() != 0) {
+        if (!_object_produced) {
             // This is handy for small objects that are uploaded via the sink. It makes
-            // upload happen in one REST call, instead of three (create + PUT + wrap-up)
+            // upload happen in one REST call, instead of three (create + PUT + wrap-up).
+            // Empty _bufs get here too and make the zero-length object
             if (!upload_started()) {
                 s3l.trace("Sink fallback to plain PUT for {}", _object_name);
+                _object_produced = true;
                 co_return co_await _client->put_object(_object_name, std::move(_bufs));
             }
 
-            co_await upload_part(std::move(_bufs));
+            if (_bufs.size() != 0) {
+                co_await upload_part(std::move(_bufs));
+            }
         }
         if (upload_started()) {
             std::exception_ptr ex;
@@ -1331,7 +1359,15 @@ public:
 
     virtual future<> flush() override {
         if (_current) {
-            co_await upload_part(std::exchange(_current, nullptr));
+            auto piece = std::exchange(_current, nullptr);
+            if (piece->empty()) {
+                // Nothing was written into the piece, so upload_sink::flush()
+                // would not create its object and the copy-upload below would
+                // fail with NoSuchKey, leaving the ETag list short. Drop it.
+                co_await piece->close();
+            } else {
+                co_await upload_part(std::move(piece));
+            }
         }
         if (upload_started()) {
             std::exception_ptr ex;
@@ -1344,6 +1380,8 @@ public:
                 co_await abort_upload();
                 std::rethrow_exception(ex);
             }
+        } else if (!_object_produced) {
+            co_await put_empty_object();
         }
     }
 

--- a/utils/s3/client.cc
+++ b/utils/s3/client.cc
@@ -1403,11 +1403,6 @@ data_sink client::make_upload_jumbo_sink(sstring object_name, std::optional<unsi
 }
 
 class client::chunked_download_source final : public seastar::data_source_impl {
-    struct content_range {
-        uint64_t start;
-        uint64_t end;
-        uint64_t total;
-    };
     shared_ptr<client> _client;
     sstring _object_name;
     seastar::abort_source* _as;
@@ -1423,16 +1418,6 @@ class client::chunked_download_source final : public seastar::data_source_impl {
     condition_variable _bg_fiber_cv;
     condition_variable _get_cv;
     future<> _filling_fiber = make_ready_future<>();
-
-    static content_range parse_content_range(const std::string& header) {
-        static const std::regex pattern(R"(bytes (\d+)-(\d+)/(\d+))");
-        std::smatch match;
-
-        if (std::regex_match(header, match, pattern)) {
-            return {std::stoull(match[1].str()), std::stoull(match[2].str()), std::stoull(match[3].str())};
-        }
-        throw std::runtime_error("Invalid Content-Range header format");
-    }
 
     future<> make_filling_fiber() {
         seastar::http::no_retry_strategy no_retry;
@@ -1460,43 +1445,56 @@ class client::chunked_download_source final : public seastar::data_source_impl {
                     co_return;
                 }
 
+                // The object size is not known yet, so ask for the whole object and
+                // learn the size from Content-Length. Requesting a byte range instead
+                // would fail on an empty object: no byte range is satisfiable when the
+                // object is zero-length (RFC 7233), so the server answers 416. Only the
+                // first request per object is range-less, the rest are chunked below.
+                const bool discover_size = _range == s3::full_range;
                 range current_range{0};
-                if (_range == s3::full_range) {
-                    current_range = {0, _max_buffers_size};
-                    s3l.trace(
-                        "No download range for object '{}' was provided. Setting the download range to `_max_buffers_size` {}", _object_name, current_range);
-                } else if (_is_contiguous_mode) {
-                    current_range = _range;
-                    s3l.trace("Setting contiguous download mode for '{}', range: {}", _object_name, current_range);
-                } else {
-                    // In non-contiguous mode we download the object in chunks of _max_buffers_size
-                    current_range = {_range.offset(), std::min(_range.length(), _max_buffers_size - _buffers_size)};
-                    s3l.trace("Setting ranged download mode for '{}', range: {}", _object_name, current_range);
-                }
-                if (current_range.length() == 0) {
-                    s3l.trace("Fiber for object '{}' completed downloading, signals EOS and leaving fiber", _object_name);
-                    _buffers.emplace_back(temporary_buffer<char>());
-                    _get_cv.signal();
-                    _is_finished = true;
-                    co_return;
+                if (!discover_size) {
+                    if (_is_contiguous_mode) {
+                        current_range = _range;
+                        s3l.trace("Setting contiguous download mode for '{}', range: {}", _object_name, current_range);
+                    } else {
+                        // In non-contiguous mode we download the object in chunks of _max_buffers_size
+                        current_range = {_range.offset(), std::min(_range.length(), _max_buffers_size - _buffers_size)};
+                        s3l.trace("Setting ranged download mode for '{}', range: {}", _object_name, current_range);
+                    }
+                    if (current_range.length() == 0) {
+                        s3l.trace("Fiber for object '{}' completed downloading, signals EOS and leaving fiber", _object_name);
+                        _buffers.emplace_back(temporary_buffer<char>());
+                        _get_cv.signal();
+                        _is_finished = true;
+                        co_return;
+                    }
                 }
 
                 auto req = http::request::make("GET", _client->_host, _object_name);
-                req._headers["Range"] = current_range.to_header_string();
+                if (!discover_size) {
+                    req._headers["Range"] = current_range.to_header_string();
+                }
 
-                s3l.trace("Fiber for object '{}' will make HTTP request within range {}", _object_name, current_range);
+                if (discover_size) {
+                    s3l.trace("Fiber for object '{}' will request the whole object", _object_name);
+                } else {
+                    s3l.trace("Fiber for object '{}' will make HTTP request within range {}", _object_name, current_range);
+                }
                 co_await _client->make_request(
                     std::move(req),
-                    [this, &units, pf_length = current_range.length()](group_client& gc, const http::reply& reply, input_stream<char>&& in_) mutable -> future<> {
+                    [this, &units, discover_size, pf_length = discover_size ? 0 : current_range.length()](
+                        group_client& gc, const http::reply& reply, input_stream<char>&& in_) mutable -> future<> {
                         if (reply._status != http::reply::status_type::ok && reply._status != http::reply::status_type::partial_content) {
                             s3l.warn("Fiber for object '{}' failed: {}. Exiting", _object_name, reply._status);
                             throw httpd::unexpected_status_error(reply._status);
                         }
                         gc.prefetch_bytes += pf_length;
-                        if (_range == s3::full_range && !reply.get_header("Content-Range").empty()) {
-                            auto content_range_header = parse_content_range(reply.get_header("Content-Range"));
-                            _range = range{content_range_header.start, content_range_header.total};
-                            s3l.trace("No range for object '{}' was provided. Setting the range to {} from the Content-Range header", _object_name, _range);
+                        if (discover_size) {
+                            // A zero length here needs no special case: the read loop
+                            // below sees an empty buffer with nothing left to fetch and
+                            // signals EOS on its own.
+                            _range = range{0, reply.content_length};
+                            s3l.trace("No range for object '{}' was provided. Setting the range to {} from Content-Length", _object_name, _range);
                         }
                         auto in = std::move(in_);
                         while (_buffers_size < _max_buffers_size && !_is_finished) {
@@ -1642,7 +1640,12 @@ data_source client::make_download_source(sstring object_name, range download_ran
 auto client::download_source::request_body() -> future<external_body> {
     auto req = http::request::make("GET", _client->_host, _object_name);
     s3l.trace("GET {} download range {}", _object_name, _range);
-    req._headers["Range"] = _range.to_header_string();
+    if (_range != s3::full_range) {
+        // Asking for the whole object needs no Range header, and adding one would
+        // make an empty object unreadable: no byte range is satisfiable when the
+        // object is zero-length (RFC 7233), so the server answers 416.
+        req._headers["Range"] = _range.to_header_string();
+    }
 
     auto bp = std::make_unique<std::optional<promise<external_body>>>(std::in_place);
     auto& p = *bp;


### PR DESCRIPTION
A component written through an S3 upload sink is lost if nothing is written into it, and a zero-length component already in a bucket cannot be read back at all. `sstables/mx/writer.cc` has worked around this since BTI index population landed by writing four bytes of padding into `Rows.db` so that it is never empty.

### Problem

`upload_sink::flush()` is guarded by "have buffered data" and "multipart upload started". When nothing is written, neither holds, the call is a no-op, and no object is created. `upload_jumbo_sink` turns that into a visible failure: it hands the piece to `upload_part()`, which starts a multipart upload and issues `UploadPartCopy` from the piece object. That object does not exist, so the copy fails with `NoSuchKey`, the part ETag is never recorded, and `finalize_upload()` reports the short list as `Failed to parse ETag list`.

On the read side, both download paths ask for a byte range even when they want the whole object. RFC 7233 makes a range satisfiable only if some first-byte-pos is below the current length, so at length zero every range is unsatisfiable and servers answer 416. Measured against minio `RELEASE.2025-09-07`: `bytes=0-`, `bytes=0-0` and `bytes=0-5242879` all return 416 on an empty object, while a range-less GET returns 200 with `Content-Length: 0`.

`Rows.db` is legitimately empty for an sstable holding only small partitions, which is why the padding exists. It does not cover the whole problem: `close_rows_writer()` runs only from `consume_end_of_stream()`, so an interrupted compaction closes the component writers through `~writer()` and produces an empty `Rows.db` with no padding at all. That is the reported failure.

### Changes

An empty upload sink now creates the object with a plain PUT, and `upload_jumbo_sink` skips copy-uploading a piece that produced no object. An `_object_produced` flag distinguishes "nothing was ever written" from "already uploaded", which `upload_started()` cannot do because `finalize_upload()` clears `_upload_id` and `output_stream::close()` flushes a second time — without it the second flush overwrites a completed object with an empty one.

`chunked_download_source` sends no `Range` header for the first request of an object whose size it does not know, and takes the size from `Content-Length` rather than `Content-Range`. A size of zero then needs no special case: the existing read loop sees an empty buffer with nothing left to fetch and signals end of stream on its own. Later requests stay chunked. `download_source` omits the header for a whole-object GET for the same reason.

Five tests in `s3_test.cc` cover writing and reading a zero-length object through `put_object`, both sinks, and both download sources.

The `Rows.db` padding is then removed.

### Measurements

`test/cluster/object_store`, dev build, minio:

| | result |
|---|---|
| padding present, no fixes (baseline) | 131 passed, 1 skipped |
| padding removed, no fixes | 37 failed, 94 passed — including 33 aborts, because a failed memtable flush takes the node down |
| padding removed, with these fixes | 131 passed, 1 skipped |

`s3_test` goes from 41 to 45 passing.

Fixes: https://scylladb.atlassian.net/browse/SCYLLADB-3373

Backport: the defect reaches `2026.1`, `2026.2` and `2026.3`
