### PR TITLE
raft: fix problems exposed by the reseeded task-queue shuffle

### DIFF
--- a/raft/log.cc
+++ b/raft/log.cc
@@ -71,12 +71,22 @@ void log::truncate_uncommitted(index_t idx) {
     _memory_usage -= released_memory;
     stable_to(std::min(_stable_idx, last_idx()));
     if (_last_conf_idx > last_idx()) {
-        // If _prev_conf_idx is 0, this log does not contain any
-        // other configuration changes, since no two uncommitted
-        // configuration changes can be in progress.
-        SCYLLA_ASSERT(_prev_conf_idx < _last_conf_idx);
-        _last_conf_idx = _prev_conf_idx;
-        _prev_conf_idx = index_t{0};
+        // The last configuration entry was truncated. In a legal raft
+        // history it is the only one that can be: a leader appends a new
+        // configuration entry only after the previous one is committed, and
+        // a committed entry can never conflict with any leader's log, so
+        // the entry at _prev_conf_idx must have survived the truncation.
+        // If this assert fires, some node went through a history raft does
+        // not allow, e.g. lost persisted state while keeping its identity.
+        SCYLLA_ASSERT(_prev_conf_idx <= last_idx());
+        // Re-derive the tracked configuration indices from the entries that
+        // remain in the log, as the constructor does. Rolling _last_conf_idx
+        // back to _prev_conf_idx and zeroing _prev_conf_idx would lose track
+        // of an older configuration entry that may still be in the log:
+        // get_prev_configuration() and last_conf_for() would then wrongly
+        // fall back to the snapshot configuration.
+        _last_conf_idx = _prev_conf_idx = index_t{0};
+        init_last_conf_idx();
     }
 }
 

--- a/test/raft/fsm_test.cc
+++ b/test/raft/fsm_test.cc
@@ -1124,6 +1124,63 @@ BOOST_AUTO_TEST_CASE(test_leader_stepdown) {
     /// End test
 }
 
+BOOST_AUTO_TEST_CASE(test_truncate_rederives_config_indices) {
+    // When a leader's AppendEntries overwrites a follower's last
+    // configuration entry, log::truncate_uncommitted() must re-derive the
+    // two tracked configuration indices from the entries that remain in the
+    // log. Rolling _last_conf_idx back to _prev_conf_idx and zeroing
+    // _prev_conf_idx is not enough: an older configuration entry may still
+    // be in the log, and with _prev_conf_idx zeroed both
+    // get_prev_configuration() and last_conf_for() skip it and wrongly fall
+    // back to the snapshot configuration. last_conf_for() supplies the
+    // configuration stored in snapshots, so a snapshot taken at an index
+    // between the two surviving configuration entries would be stamped with
+    // a stale configuration.
+    server_id A = id(), B = id(), C = id(), D = id();
+
+    // Original cluster {A,B,C,D} captured in the snapshot at idx 0.
+    raft::configuration snap_cfg = config_from_ids({A, B, C, D});
+
+    // Log contents:
+    //   idx 1 (term 1): committed config {A,B,C}
+    //   idx 2 (term 1): dummy entry
+    //   idx 3 (term 1): committed config {A,B}
+    //   idx 4 (term 2): uncommitted joint config curr={A} prev={A,B}
+    raft::log_entries entries;
+    entries.push_back(seastar::make_lw_shared<const raft::log_entry>(
+            raft::log_entry{term_t{1}, index_t{1}, config_from_ids({A, B, C})}));
+    entries.push_back(seastar::make_lw_shared<const raft::log_entry>(
+            raft::log_entry{term_t{1}, index_t{2}, raft::log_entry::dummy{}}));
+    entries.push_back(seastar::make_lw_shared<const raft::log_entry>(
+            raft::log_entry{term_t{1}, index_t{3}, config_from_ids({A, B})}));
+    entries.push_back(seastar::make_lw_shared<const raft::log_entry>(
+            raft::log_entry{term_t{2}, index_t{4},
+                    raft::configuration{config_set({A}), config_set({A, B})}}));
+
+    raft::log log(raft::snapshot_descriptor{.idx = index_t{0}, .config = snap_cfg},
+            std::move(entries));
+    BOOST_CHECK_EQUAL(log.last_conf_idx(), index_t{4});
+    BOOST_CHECK(log.get_configuration().is_joint());
+
+    // A new leader (term 3) overwrites the log from idx 4 with a
+    // non-configuration entry, conflicting on term. This truncates the
+    // uncommitted joint configuration entry.
+    raft::log_entry_ptr_list overwrite;
+    overwrite.push_back(seastar::make_lw_shared<const raft::log_entry>(
+            raft::log_entry{term_t{3}, index_t{4}, raft::log_entry::dummy{}}));
+    log.maybe_append(std::move(overwrite));
+
+    // The config at idx 3 is the effective one again, and the older config
+    // at idx 1 - not the snapshot config - is the previous one.
+    BOOST_CHECK_EQUAL(log.last_conf_idx(), index_t{3});
+    BOOST_CHECK(!log.get_configuration().is_joint());
+    BOOST_CHECK(log.get_configuration().current == config_from_ids({A, B}).current);
+    BOOST_REQUIRE(log.get_prev_configuration() != nullptr);
+    BOOST_CHECK(log.get_prev_configuration()->current == config_from_ids({A, B, C}).current);
+    BOOST_CHECK(log.last_conf_for(index_t{2}).current == config_from_ids({A, B, C}).current);
+    BOOST_CHECK(log.last_conf_for(index_t{1}).current == config_from_ids({A, B, C}).current);
+}
+
 BOOST_AUTO_TEST_CASE(test_empty_configuration) {
     // When a server is joining an existing cluster, its configuration is empty.
     // The leader sends its configuration over in AppendEntries or

--- a/test/raft/replication.hh
+++ b/test/raft/replication.hh
@@ -916,24 +916,38 @@ future<> raft_cluster<Clock>::reset_server(size_t id, initial_state state) {
 
 template <typename Clock>
 future<> raft_cluster<Clock>::start_all() {
-    // Start the leader (node 0) last. With fast bootstrap the smallest-id
-    // node becomes a candidate during start(), sending a vote_request to all
-    // peers. All peers must be started and published by that point, otherwise
-    // the request is dropped and node 0 loses its advantage: it is already a
-    // candidate so wait_until_candidate() won't tick it, and all nodes race
-    // equally once tickers start — the winner is non-deterministic.
+    // Start the leader (node 0) last, and publish its RPC endpoint before
+    // starting it. With fast bootstrap the smallest-id node becomes a
+    // candidate during start() and sends vote requests to all peers, and
+    // the peers reply at once. The test RPC net silently discards messages
+    // whose destination is not published, so every party of that exchange
+    // must be published before it begins: the followers to receive the
+    // requests, and node 0 to receive the replies, which may arrive while
+    // its start() is still running. Publishing node 0 before starting it is
+    // safe: no follower contacts it on its own before it sends the first
+    // vote request (follower tickers are not armed yet), and the RPC
+    // object is wired to the server at construction time.
     BOOST_REQUIRE(_leader == 0);
     co_await coroutine::parallel_for_each(std::views::iota(size_t{1}, _servers.size()), [this] (size_t i) -> future<> {
         co_await _servers[i].server->start();
         _servers[i].rpc->publish();
     });
-    co_await _servers[0].server->start();
     _servers[0].rpc->publish();
-    co_await init_raft_tickers();
+    co_await _servers[0].server->start();
+
     BOOST_TEST_MESSAGE("Electing first leader " << _leader);
+    // Elect node 0 with no tickers armed. Followers answer vote requests
+    // over RPC without ticking, so no node can reach its election timeout
+    // and compete with node 0, which therefore wins regardless of the
+    // order in which the reactor runs tasks (debug builds shuffle the
+    // task queue). No retry mechanism is needed: the test transport never
+    // drops vote RPCs (only append_entries and read_quorum sends honor
+    // rpc_config::drops), and every node is published before node 0
+    // starts, so the initial vote exchange cannot be lost.
     _servers[_leader].server->wait_until_candidate();
     co_await _servers[_leader].server->wait_election_done();
     BOOST_REQUIRE(_servers[_leader].server->is_leader());
+    co_await init_raft_tickers();
 }
 
 template <typename Clock>


### PR DESCRIPTION
Two fixes for the raft test flakiness that appeared after the Seastar update reseeded the debug task-queue shuffle from std::random_device (seastar 3a496d94c0). Supersedes #30925 and #30936.

### test/raft: make the initial leader election deterministic

`raft_cluster::start_all()` had two startup races. Node 0's RPC endpoint was published only after start() returned, but with fast bootstrap node 0 becomes a candidate already during start(); the test RPC net silently drops vote replies addressed to an unpublished node, leaving node 0 a candidate with nothing to retry the election. And every node's ticker was armed before the initial election completed, so other nodes could reach their election timeouts and compete, making the winner depend on task ordering.

Publish node 0's RPC before starting it, and arm only node 0's ticker for the initial election — it must run because the *_drops tests drop packets starting from the very first RPC, and only node 0's election timeout can retry a lost vote exchange. The remaining tickers are armed once it has won.

### raft: fix config index bookkeeping in log::truncate_uncommitted()

Based on the fix in #30936. When truncation removes the last configuration entry, the old rollback zeroed _prev_conf_idx, losing track of an older configuration entry still in the log: get_prev_configuration() and last_conf_for() then wrongly fell back to the snapshot configuration, so e.g. a snapshot taken between the two surviving config entries would be stamped with a stale configuration. Re-derive both indices from the remaining log entries, as the constructor does.

Unlike #30936, we treat truncating both tracked configuration entries as impossible in a legal raft history: a leader appends a configuration entry only after the previous one is committed, and a committed entry can never conflict with any leader's log. The old, trivially-true assert is replaced by one enforcing exactly this; if it ever fires, some node went through a history raft does not allow (e.g. lost persisted state while keeping its identity), and we will get a trace pointing at the truncation moment. The #30936 reproducer manufactured such a state directly and is replaced by a legal-history regression test for the _prev_conf_idx bug, which fails on the old code.

Tested: fsm_test passes in all modes; replication_test in debug with --repeat 50 no longer reproduces the original failure.

Note there is no real fix for the crash #30936 chased: after the first commit the failure no longer reproduces (--repeat 50 in debug, plus a few thousand directed runs of the config-change tests with elevated packet drops), so we could not confirm any mechanism by which both configuration entries get truncated — and per the argument above, no legal history produces one. Rather than merging code that repairs a state we cannot explain, the assert turns the next occurrence, if any, into a CI failure with a trace pointing at the truncation moment.

Fixes: https://scylladb.atlassian.net/browse/SCYLLADB-3471
Fixes: https://scylladb.atlassian.net/browse/SCYLLADB-3486

backport: not sure, but probably I would prefer to refrain from backporting this -- the main problem is in the tests, no in the code.

UPD: I considered arguments for backporting in [this comment](https://github.com/scylladb/scylladb/pull/30984#discussion_r3713765215), decided to backport the second commit.