### PR TITLE
test::pylib::dockerized_service: Match success/failure lines case-ins…

### DIFF
--- a/test/pylib/dockerized_service.py
+++ b/test/pylib/dockerized_service.py
@@ -53,8 +53,8 @@ class DockerizedServer:
         self.logfilenamebase = logfilenamebase
         self.docker_args: Callable[[str, int], list[str]] = (lambda host,port : docker_args) if isinstance(docker_args, list) else docker_args
         self.image_args: Callable[[str, int], list[str]] = (lambda host,port : image_args) if isinstance(image_args, list) else image_args
-        self.is_success_line = lambda line, port : success_string in line if isinstance(success_string, str) else success_string
-        self.is_failure_line = lambda line, port : failure_string in line if isinstance(failure_string, str) else failure_string
+        self.is_success_line = lambda line, port : success_string.lower() in line.lower() if isinstance(success_string, str) else success_string
+        self.is_failure_line = lambda line, port : failure_string.lower() in line.lower() if isinstance(failure_string, str) else failure_string
         self.logfile = None
         self.port = None
         self.proc = None


### PR DESCRIPTION
…ensitively

The fake-gcs-server DockerizedServer is configured with failure_string="address already in use", but rootless podman's pasta network backend reports the same condition capitalized: "Listen failed for HOST TCP port */44655: Address already in use".

The case-sensitive substring check silently failed to match, so the port-bind race was never classified as a retryable failure: the container process just exited, leaving the startup future pending until the container's stderr pipe hit EOF, at which point it fell through to the generic "Log EOF" error path instead of the intended transient-failure retry.

Fixes SCYLLADB-3404 (several failures in a row without the fix, several successful runs with, see #30848)

Improving flaky test, not backporting