### PR TITLE
test/object_store: Use racks=2 in test_drop_keyspace_during_tablet_re…

### DIFF
--- a/test/cluster/object_store/test_backup.py
+++ b/test/cluster/object_store/test_backup.py
@@ -1485,7 +1485,7 @@ async def test_drop_keyspace_during_tablet_restore(manager: ManagerClient, objec
     The fix acquires a stream_in_progress() phaser guard before downloading,
     which makes table::stop() block until the download completes.
     """
-    topology = topo(rf=2, nodes=2, racks=1, dcs=1)
+    topology = topo(rf=2, nodes=2, racks=2, dcs=1)
     servers, host_ids = await create_cluster(topology, manager, logger, object_storage)
     await manager.disable_tablet_balancing()
     cql = manager.get_cql()


### PR DESCRIPTION
…store

The test used racks=1 (both RF=2 replicas sharing the same rack), which is not the topology tablet-aware restore is designed for (rf == racks). With a shared rack, both replicas' system_distributed.snapshot_sstables rows live in the same (dc, rack) partition, and the 'downloaded' column is not scoped per node — so whichever replica finishes its download and snapshot_sstables update first can cause the other, slower replica to see its own still-needed rows as already downloaded and skip downloading them, occasionally causing pause_download_sstable to never be reached and the test to time out flakily.

Switching to racks=2 gives each replica its own rack, hence its own partition, sidestepping the race for this test.

Fixes SCYLLADB-3370

Fixing flaky test. Worth backporting to where it was introduced