### PR TITLE
storage_proxy: repair: expose metrics on inconsistencies actually found [ DO NOT MERGE - will split to 2 separate PRs]

### DIFF
--- a/repair/row_level.cc
+++ b/repair/row_level.cc
@@ -196,6 +196,9 @@ struct row_level_repair_metrics {
     uint64_t inc_sst_skipped_bytes{0};
     uint64_t inc_sst_read_bytes{0};
     uint64_t tablet_time_ms{0};
+    uint64_t rounds_total{0};
+    uint64_t rounds_in_sync_total{0};
+    uint64_t rounds_out_of_sync_total{0};
     row_level_repair_metrics() {
         namespace sm = seastar::metrics;
         _metrics.add_group("repair", {
@@ -221,6 +224,12 @@ struct row_level_repair_metrics {
                             sm::description("Total number of bytes read from sstables for incremental repair on this shard.")),
             sm::make_counter("tablet_time_ms", tablet_time_ms,
                             sm::description("Time spent on tablet repair on this shard in milliseconds.")),
+            sm::make_counter("rounds_total", rounds_total,
+                            sm::description("Total number of repair rounds executed on this shard as repair master, for repair jobs only, excluding repair-based node operations.")),
+            sm::make_counter("rounds_in_sync_total", rounds_in_sync_total,
+                            sm::description("Total number of repair rounds in which all replicas were found already in sync on this shard, for repair jobs only, excluding repair-based node operations.")),
+            sm::make_counter("rounds_out_of_sync_total", rounds_out_of_sync_total,
+                            sm::description("Total number of repair rounds in which differences between replicas were found and rows were exchanged on this shard, for repair jobs only, excluding repair-based node operations.")),
         });
     }
 };
@@ -3131,6 +3140,9 @@ private:
         rlogger.debug("ROUND {}, _last_sync_boundary={}, _current_sync_boundary={}, _skipped_sync_boundary={}",
                 master.stats().round_nr, master.last_sync_boundary(), master.current_sync_boundary(), _skipped_sync_boundary);
         master.stats().round_nr++;
+        if (count_round_metrics()) {
+            _metrics.rounds_total++;
+        }
         parallel_for_each(master.all_nodes(), coroutine::lambda([&] (repair_node_state& ns) -> future<> {
             const auto& node = ns.node;
             auto dst_cpu_id = ns.shard;
@@ -3176,12 +3188,18 @@ private:
                 _skipped_sync_boundary = _common_sync_boundary;
                 rlogger.debug("Skip set skipped_sync_boundary={}", _skipped_sync_boundary);
                 master.stats().round_nr_fast_path_already_synced++;
+                if (count_round_metrics()) {
+                    _metrics.rounds_in_sync_total++;
+                }
                 return op_status::next_round;
             } else {
                 _skipped_sync_boundary = std::nullopt;
             }
         } else {
             master.stats().round_nr_fast_path_already_synced++;
+            if (count_round_metrics()) {
+                _metrics.rounds_in_sync_total++;
+            }
             // We are done with this range because all the nodes have no more data.
             return op_status::all_done;
         }
@@ -3236,6 +3254,9 @@ private:
             // `_working_row_buf` on all the nodes are the same
             // This is the second fast path.
             master.stats().round_nr_fast_path_same_combined_hashes++;
+            if (count_round_metrics()) {
+                _metrics.rounds_in_sync_total++;
+            }
             return op_status::next_round;
         }
 
@@ -3376,9 +3397,19 @@ private:
             }
         })).get();
         master.stats().round_nr_slow_path++;
+        if (count_round_metrics()) {
+            _metrics.rounds_out_of_sync_total++;
+        }
     }
 
 private:
+    // The row-level repair code also serves repair-based node operations
+    // (rebuild, replace, decommission, ...), where divergence between the
+    // syncing nodes is expected. The round-outcome metrics track repair jobs only.
+    bool count_round_metrics() const {
+        return _shard_task.reason() == streaming::stream_reason::repair;
+    }
+
     locator::effective_replication_map_ptr get_erm() {
         return _shard_task.get_erm();
     }

--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -3101,6 +3101,10 @@ void storage_proxy_stats::stats::register_stats() {
                        sm::description("number of background read repairs"),
                        {storage_proxy_stats::current_scheduling_group_label()}).set_skip_when_empty(),
 
+        sm::make_total_operations("read_repairs_diff_found_total", read_repair_diff_found,
+                       sm::description("number of read repairs in which the full-data reconciliation found actual differences between replicas and repair mutations were sent"),
+                       {storage_proxy_stats::current_scheduling_group_label()}).set_skip_when_empty(),
+
         sm::make_total_operations("read_timeouts", [this]{return read_timeouts.count(); },
                        sm::description("number of read request failed due to a timeout"),
                        {storage_proxy_stats::current_scheduling_group_label(), basic_level}).set_skip_when_empty(),
@@ -4878,6 +4882,7 @@ future<result<>> storage_proxy::schedule_repair(locator::effective_replication_m
     if (diffs.empty()) {
         return make_ready_future<result<>>(bo::success());
     }
+    get_stats().read_repair_diff_found++;
     return mutate_internal(
             diffs |
                     std::views::values |

--- a/service/storage_proxy_stats.hh
+++ b/service/storage_proxy_stats.hh
@@ -142,6 +142,7 @@ struct stats : public write_stats {
     uint64_t read_repair_attempts = 0;
     uint64_t read_repair_repaired_blocking = 0;
     uint64_t read_repair_repaired_background = 0;
+    uint64_t read_repair_diff_found = 0;
     uint64_t global_read_repairs_canceled_due_to_concurrent_write = 0;
 
     // number of mutations received as a coordinator

--- a/test/cluster/test_read_repair.py
+++ b/test/cluster/test_read_repair.py
@@ -266,6 +266,18 @@ async def test_incremental_read_repair(data_class: DataClass, manager: ManagerCl
         check_rows(cql, host1, node1_rows)
         check_rows(cql, host2, node2_rows)
 
+        async def read_repair_metrics() -> tuple[int, int]:
+            digest_mismatches = 0
+            diff_found = 0
+            for node in nodes:
+                metrics = await manager.metrics.query(node.ip_addr)
+                digest_mismatches += metrics.get("scylla_storage_proxy_coordinator_foreground_read_repairs") or 0
+                digest_mismatches += metrics.get("scylla_storage_proxy_coordinator_background_read_repairs") or 0
+                diff_found += metrics.get("scylla_storage_proxy_coordinator_read_repairs_diff_found_total") or 0
+            return int(digest_mismatches), int(diff_found)
+
+        digest_mismatches_before, diff_found_before = await read_repair_metrics()
+
         logger.info("Run read-repair")
         res = cql.execute(SimpleStatement(data_class.get_select_query(ks), consistency_level=ConsistencyLevel.ALL), trace=True)
         res_rows = []
@@ -297,6 +309,15 @@ async def test_incremental_read_repair(data_class: DataClass, manager: ManagerCl
             assert row_id in all_rows
             data_class.check_result_row(row_id, res_row)
         assert actual_row_ids == all_rows
+
+        # The replicas diverged, so the CL=ALL read must have hit a digest
+        # mismatch, and the reconciliation must have found actual differences.
+        digest_mismatches_after, diff_found_after = await read_repair_metrics()
+        assert digest_mismatches_after > digest_mismatches_before
+        assert diff_found_after > diff_found_before
+        # Reconciliations are triggered by digest mismatches, so no more
+        # diff-found events than digest mismatches.
+        assert diff_found_after - diff_found_before <= digest_mismatches_after - digest_mismatches_before
 
         for node in (node1, node2):
             await manager.api.keyspace_flush(node.ip_addr, ks)

--- a/test/cluster/test_repair_metrics.py
+++ b/test/cluster/test_repair_metrics.py
@@ -1,0 +1,68 @@
+#
+# Copyright (C) 2026-present ScyllaDB
+#
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
+#
+
+import asyncio
+import logging
+import time
+
+from cassandra.query import ConsistencyLevel
+
+from test.pylib.manager_client import ManagerClient
+from test.pylib.repair import create_table_insert_data_for_repair
+from test.pylib.util import wait_for_cql_and_get_hosts
+
+logger = logging.getLogger(__name__)
+
+
+async def repair_rounds_metrics(manager: ManagerClient, servers) -> tuple[int, int, int]:
+    """Sum the repair round counters over all nodes and shards."""
+    rounds = in_sync = out_of_sync = 0
+    for server in servers:
+        metrics = await manager.metrics.query(server.ip_addr)
+        rounds += metrics.get("scylla_repair_rounds_total") or 0
+        in_sync += metrics.get("scylla_repair_rounds_in_sync_total") or 0
+        out_of_sync += metrics.get("scylla_repair_rounds_out_of_sync_total") or 0
+    return int(rounds), int(in_sync), int(out_of_sync)
+
+
+async def test_repair_rounds_metrics(manager: ManagerClient):
+    """Test that repair reports whether it actually found inconsistencies.
+
+    A repair over diverged replicas must increase rounds_out_of_sync_total, while
+    a second repair over the now-synced replicas must only increase
+    rounds_in_sync_total.
+    """
+    nr_keys = 128
+    servers, cql, hosts, ks, table_id = await create_table_insert_data_for_repair(
+        manager, nr_keys=nr_keys, cmdline=["--hinted-handoff-enabled", "0"])
+
+    # Make the replicas diverge: write new rows while one node is down.
+    await manager.server_stop_gracefully(servers[2].server_id)
+    insert_stmt = cql.prepare(f"INSERT INTO {ks}.test (pk, c) VALUES (?, ?)")
+    insert_stmt.consistency_level = ConsistencyLevel.ONE
+    await asyncio.gather(*[cql.run_async(insert_stmt, (k, k)) for k in range(nr_keys, 2 * nr_keys)])
+    await manager.server_start(servers[2].server_id, wait_others=2)
+    await wait_for_cql_and_get_hosts(cql, servers, time.time() + 60)
+
+    rounds_before, in_sync_before, out_of_sync_before = await repair_rounds_metrics(manager, servers)
+
+    await manager.api.tablet_repair(servers[0].ip_addr, ks, "test", "all")
+
+    rounds_after, in_sync_after, out_of_sync_after = await repair_rounds_metrics(manager, servers)
+    logger.info(f"First repair round deltas: rounds={rounds_after - rounds_before} "
+                f"in_sync={in_sync_after - in_sync_before} out_of_sync={out_of_sync_after - out_of_sync_before}")
+    assert rounds_after > rounds_before
+    assert out_of_sync_after > out_of_sync_before
+
+    # The replicas are in sync now, so a second repair must not find anything to fix.
+    await manager.api.tablet_repair(servers[0].ip_addr, ks, "test", "all")
+
+    rounds_final, in_sync_final, out_of_sync_final = await repair_rounds_metrics(manager, servers)
+    logger.info(f"Second repair round deltas: rounds={rounds_final - rounds_after} "
+                f"in_sync={in_sync_final - in_sync_after} out_of_sync={out_of_sync_final - out_of_sync_after}")
+    assert rounds_final > rounds_after
+    assert in_sync_final > in_sync_after
+    assert out_of_sync_final == out_of_sync_after


### PR DESCRIPTION
Operators currently have no Prometheus-level visibility into whether the anti-entropy mechanisms actually find inconsistencies, as opposed to merely running:

- Read repair: `foreground/background_read_repairs` count digest mismatches that trigger a full-data read, but a mismatch may be benign (e.g. a write racing with the read). Nothing reports whether the reconciliation found real differences between the replicas.
- Repair: row-level repair tracks the per-repair round outcomes internally (already-in-sync fast paths vs. the slow path that exchanges rows), but they are only printed to the log when the repair ends.

This series adds:
- `scylla_storage_proxy_coordinator_read_repairs_diff_found_total` — incremented once per completed read-repair reconciliation that found differences and sent repair mutations, at the same granularity as the existing counters, so comparing it with foreground+background read repairs separates real divergence from benign digest mismatches.
- `scylla_repair_rounds_total`, `scylla_repair_rounds_in_sync_total`, `scylla_repair_rounds_out_of_sync_total` — repair-master round outcome counters, updated for repair jobs only (repair-based node operations such as rebuild/replace are excluded, since divergence between the syncing nodes is expected there).

The new counters follow the Prometheus `_total` naming convention for counters.

## How it was tested

`test_incremental_read_repair` now also asserts the read-repair counters move correctly around the CL=ALL read over diverged replicas, and the new `test/cluster/test_repair_metrics.py` verifies that repairing diverged replicas bumps `rounds_out_of_sync_total` while re-repairing the now-synced replicas bumps only `rounds_in_sync_total`.

Per-test wall time in dev mode (the added metric assertions cost only a few metrics-endpoint scrapes; the only new runtime is the ~8s repair test):

| Test | Duration |
|---|---|
| `test_incremental_read_repair[row-tombstone]` (pre-existing + metric asserts) | 8.9s |
| `test_incremental_read_repair[partition-tombstone]` (pre-existing + metric asserts) | 9.7s |
| `test_repair_rounds_metrics` (new) | 7.9s |

Backport: no, improvement

🤖 Generated with [Claude Code](https://claude.com/claude-code)