### PR TITLE
test.py: forward --exe-path/--exe-url to pytest

### DIFF
--- a/test.py
+++ b/test.py
@@ -208,7 +208,14 @@ def parse_cmd_line() -> argparse.Namespace:
     if args.skip_patterns and args.k:
         parser.error(palette.fail('arguments --skip and -k are mutually exclusive, please use only one of them'))
 
-    if not args.modes:
+    if args.exe_path or args.exe_url:
+        if args.modes:
+            parser.error(palette.fail('arguments --exe-path/--exe-url and --mode are mutually exclusive, please use only one of them'))
+        # The executable under test is given explicitly, so no configured
+        # build is required; the pytest runner derives the "custom_exe" mode
+        # from the executable options.
+        args.modes = []
+    elif not args.modes:
         try:
             args.modes = get_configured_modes()
         except Exception:
@@ -363,6 +370,10 @@ def run_pytest(options: argparse.Namespace) -> int:
         args.append(f'-k={options.k}')
     if options.extra_scylla_cmdline_options:
         args.append(f'--extra-scylla-cmdline-options={options.extra_scylla_cmdline_options}')
+    if options.exe_path:
+        args.append(f'--exe-path={options.exe_path}')
+    if options.exe_url:
+        args.append(f'--exe-url={options.exe_url}')
     if not options.save_log_on_success:
         args.append('--allure-no-capture')
     else:


### PR DESCRIPTION
test.py parses `--exe-path` and `--exe-url` but never adds them to the pytest invocation, so they are silently ignored and the tests always run the binary of the configured build mode. Forwarding them manually via `--pytest-arg` does not help either: test.py unconditionally passes `--mode` for every configured mode, which the pytest runner rejects in combination with `--exe-path` ("Can't use --mode with --exe-path or --exe-url.").

This change:
- forwards both options to pytest;
- rejects an explicit `--mode` combined with them up front with a clear argparse error, instead of the late runner failure (they are mutually exclusive by design — the runner derives the `custom_exe` mode from the executable options);
- skips the `ninja mode_list` lookup in that case, since testing an explicitly given executable requires no configured build.

Verified by running `./test.py --exe-path=<path-to-binary> test/cluster/test_read_repair.py` from a checkout with no build tree: the tests pass, run against the given executable under `testlog/custom_exe/`, and `./test.py --mode=dev --exe-path=...` now fails fast with a clear error.

Backport: no, test infrastructure improvement