### PR TITLE
test/cqlpy: new tests for valid characters in table names

### DIFF
--- a/test/cqlpy/test_name.py
+++ b/test/cqlpy/test_name.py
@@ -3,12 +3,13 @@
 # SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
 
 #############################################################################
-# Tests for limits on the *names* of keyspaces, tables, indexes, views, function and columns.
+# Tests for limitations on the *names* of keyspaces, tables, indexes, views,
+# functions and columns.
 #############################################################################
 
 import pytest
 from contextlib import contextmanager
-from cassandra.protocol import InvalidRequest
+from cassandra.protocol import InvalidRequest, SyntaxException, ConfigurationException, Unauthorized
 from .util import unique_name, new_test_table, new_secondary_index, new_function, is_scylla
 
 # This context manager is similar to new_test_table() - creating a table and
@@ -173,8 +174,6 @@ def test_column_name_500(cql, test_keyspace):
     with new_test_table(cql, test_keyspace, "p int primary key, " + padded_name(500) + " int"):
         pass
 
-# TODO: add tests for the allowed characters in a table name
-
 # Test that column names containing hyphens work when double-quoted.
 # Hyphens are not valid in unquoted identifiers (the '-' is parsed as
 # subtraction), but double-quoted identifiers can contain any character.
@@ -191,3 +190,106 @@ def test_column_name_unquoted_hyphen_rejected(cql, test_keyspace):
     from cassandra.protocol import SyntaxException
     with pytest.raises(SyntaxException):
         cql.execute(f'CREATE TABLE {test_keyspace}.{unique_name()} (p int PRIMARY KEY, my-col text)')
+
+# Our documentation claims that table names must match the regular expression
+# [a-zA-Z_0-9]{1, 192}. Above, we already tested the length limits, and here
+# we want to test the allowed characters in table names given to CREATE TABLE.
+#
+# In particular, the documentation implies that while quoting a table name
+# allows uppercase letters to be preserved, quoting does NOT allow you to use
+# forbidden characters, like spaces or punctuation - the exact same rules apply
+# also to quoted names. We want to confirm that in a test.
+# We also demonstrate one exception - a difference between quoted and unquoted
+# name rules: A table name may begin with an underscore, but in that case must
+# be quoted.
+# See also test_utf8.py::test_unicode_in_table_names that verifies that only
+# ASCII letters are allowed in table names, not Unicode letters in general.
+def test_create_table_forbidden_chars(cql, test_keyspace):
+    # Spaces and various non-alphanumeric characters are not allowed in table
+    # names given to CREATE TABLE. Among other things, the "." and "-" which
+    # are allowed by Alternator are not allowed by CQL's CREATE TABLE. Neither
+    # are spaces, or the "$" character which we use in internal tables like
+    # "tablename$paxos".
+    base = unique_name()
+    for name in ['hello world', 'hello$world', 'hello-world', 'hello.world']:
+        # These names are not allowed, neither quoted nor unquoted. But the
+        # specific error message is different - invalid characters in an
+        # unquoted name result in a SyntaxException, while invalid characters
+        # inside quotes are detected later in the request's execution, and
+        # generate an InvalidRequest in ScyllaDB or ConfigurationException
+        # in Cassandra (we'll allow both).
+        with pytest.raises(SyntaxException):
+            with new_table(cql, test_keyspace, f'{base}{name}'):
+                pass
+        with pytest.raises((InvalidRequest, ConfigurationException)):
+            with new_table(cql, test_keyspace, f'"{base}{name}"'):
+                pass
+    # An underscore in the name of a table *is* allowed, in either quoted
+    # or unquoted table name:
+    with new_table(cql, test_keyspace, f'{base}hello_world'):
+        pass
+    with new_table(cql, test_keyspace, f'"{base}hello_world"'):
+        pass
+    # Despite what some older documentation says, an underscore as the first
+    # character of the table name *is* allowed. However, it turns out that it
+    # is just not allowed in an unquoted name - where it is considered a
+    # syntax error. It is allowed just fine in a quoted name.
+    with pytest.raises(SyntaxException):
+        with new_table(cql, test_keyspace, f'_{base}'):
+            pass
+    with new_table(cql, test_keyspace, f'"_{base}"'):
+        pass
+
+# Although as tested above CREATE TABLE has rules on which table names it can
+# create, if somehow a table with a name that doesn't follow these rules got
+# created, it can still be accessed by other operations like ALTER TABLE or
+# SELECT. In other words, only CREATE TABLE checks the validity of the table's
+# name - other operations just check if a table with the given name exists.
+#
+# A forbidden-name table can be created by Alternator (which allows the
+# characters '.' and '-' in table names) or by LWT (which creates
+# an internal table tablename$paxos). In this test we'll check the LWT table -
+# that it can be accessed despite having a name which CREATE TABLE would have
+# refused to create. This test is Scylla specific (we can't create tables with
+# invalid names in Cassandra) and needs tablets (the vnode implementation of
+# LWT did not create a table "tablename$paxos"). If the LWT implementation
+# changes we'll need to update this test.
+# See below for another test for the same thing without needing to create the
+# invalid-named table.
+def test_access_table_forbidden_chars_lwt(cql, scylla_only, test_keyspace_tablets):
+    if test_keyspace_tablets is None:
+        skip_env("skipping tablets specific test - tablets disabled")
+    with new_table(cql, test_keyspace_tablets) as table:
+        _, table_name = table.split('.')
+        # The extra "...$paxos" table only appears after a real LWT write is
+        # performed. So let's do an LWT operation that will cause it to be
+        # created.
+        cql.execute(f'INSERT INTO {table}(p,x) values (1,2) IF NOT EXISTS')
+        # Check that we can SELECT from the "$paxos" table even though this
+        # name is not a valid CQL table's name (we couldn't have created it
+        # with CREATE TABLE)
+        cql.execute(f'SELECT * FROM {test_keyspace_tablets}."{table_name}$paxos"')
+        # In the current implementation, the user is not "authorized" to
+        # ALTER the internal paxos table. But the important thing is that
+        # we don't get an error that the table's name is invalid or something.
+        try:
+            cql.execute(f'ALTER TABLE {test_keyspace_tablets}."{table_name}$paxos" WITH COMMENT=\'hi\'')
+        except Unauthorized:
+            pass # fine
+
+# This is a more general test for accessing (SELECT, ALTER) a table name with
+# invalid characters in its name. Here we don't need the invalid-named table
+# to actually exist, but just check when the operation fails, the error
+# reported is that the table doesn't exist - we don't get an error saying
+# that the table's name is considered invalid.
+def test_access_table_forbidden_chars(cql, test_keyspace):
+    bad_name = f'{unique_name()}$bad!'
+    # We expect to see an error that the table doesn't exist - not that it
+    # has a forbidden name. The does-not-exist error is slightly different
+    # between different versions of Cassandra and Scylla: Cassandra 3 says
+    # "does not exist", Cassandra 4 and 5 say "doesn't exist", and Scylla says
+    # "unconfigured table". We'll allow all of these in the test.
+    with pytest.raises(InvalidRequest, match='does not exist|doesn\'t exist|unconfigured table'):
+        cql.execute(f'SELECT * FROM {test_keyspace}."{bad_name}"')
+    with pytest.raises(InvalidRequest, match='does not exist|doesn\'t exist|unconfigured table'):
+        cql.execute(f'ALTER TABLE {test_keyspace}."{bad_name}" WITH COMMENT=\'hi\'')


### PR DESCRIPTION
Add tests requested by a TODO: We had tests for what length table names may have, here we add tests on which characters are allowed in the table name. In particular we verify that:

1. Only alphanumeric and underscore characters are allowed in CREATE TABLE. Quoting the name doesn't change that.

2. An underscore is the first character of the name is allowed (despite some old documentation suggesting otherwise), but requires quoting the name to avoid a syntax error.

3. Other operations, like ALTER TABLE or SELECT, do *not* do this name validation, they just check if the given table exists. So if for some reason there is a table with an "invalid" name (e.g., our internal LWT tables - tablename$paxos) we can SELECT on them or ALTER them.

   We add two tests for the last feature - one depends on the specifics of LWT (and works only on recent versions of Scylla), and the second works everywhere - by looking at the error message (which should mention that the table doesn't exist - not that its name is invalid).

The new tests pass on both Scylla and Cassandra - they do not show a bug but rather help cement our understanding of legal table names, and also prevent future regressions in this area.
