### PR TITLE
message/stream_compressor: fix rare result corruption in lz4_dstream 

### DIFF
--- a/message/advanced_rpc_compressor.cc
+++ b/message/advanced_rpc_compressor.cc
@@ -377,7 +377,7 @@ rpc::snd_buf advanced_rpc_compressor::compress(size_t head_space, rpc::snd_buf d
         try {
             return compress_impl(head_space + 1 + checksum_size + protocol_header_size, std::move(data), get_compressor(algo), true, rpc::snd_buf::chunk_size);
         } catch (...) {
-            arc_logger.error("Error during decompression with algorithm {}: {}. ", algo.name(), std::current_exception());
+            arc_logger.error("Error during compression with algorithm {}: {}. ", algo.name(), std::current_exception());
             throw;
         }
     });
@@ -460,7 +460,7 @@ rpc::rcv_buf advanced_rpc_compressor::decompress(rpc::rcv_buf data) {
         try {
             return decompress_impl(data, get_decompressor(algo), true, rpc::snd_buf::chunk_size);
          } catch (...) {
-            arc_logger.error("Error during compression with algorithm {}: {}. ", algo.name(), std::current_exception());
+            arc_logger.error("Error during decompression with algorithm {}: {}. ", algo.name(), std::current_exception());
             throw;
         }
     });

--- a/message/advanced_rpc_compressor.cc
+++ b/message/advanced_rpc_compressor.cc
@@ -10,6 +10,7 @@
 #include <seastar/util/defer.hh>
 #include <numeric>
 #include "utils/log.hh"
+#include "bytes.hh"
 #include "advanced_rpc_compressor.hh"
 #include "advanced_rpc_compressor_protocol.hh"
 #include "stream_compressor.hh"
@@ -433,6 +434,34 @@ T read_from_rcv_buf(rpc::rcv_buf& data) {
     return out[0];
 }
 
+static std::string format_dict_id(const shared_dict::dict_id& id) {
+    return fmt::format("{{timestamp={}, origin_node={}, content_sha256={}}}", id.timestamp, id.origin_node, fmt_hex(id.content_sha256));
+}
+
+static std::string format_dict_ptr(const dict_ptr& d) {
+    if (!d) {
+        return "null";
+    }
+    const auto& id = (**d).id;
+    return format_dict_id(id);
+}
+
+static std::string format_control_protocol(const control_protocol& cp) {
+    return fmt::format(
+        "{{sender_protocol_epoch={}, receiver_protocol_epoch={}"
+        ", sender_has_update={}, sender_has_commit={}"
+        ", receiver_has_update={}, receiver_has_commit={}"
+        ", sender_recent_dict={}, sender_committed_dict={}, sender_current_dict={}"
+        ", receiver_recent_dict={}, receiver_committed_dict={}, receiver_current_dict={}"
+        ", sender_current_algo={}, sender_committed_algo={}, algos={:#04x}}}",
+        cp._sender_protocol_epoch, cp._receiver_protocol_epoch,
+        cp._sender_has_update, cp._sender_has_commit,
+        cp._receiver_has_update, cp._receiver_has_commit,
+        format_dict_ptr(cp._sender_recent_dict), format_dict_ptr(cp._sender_committed_dict), format_dict_ptr(cp._sender_current_dict),
+        format_dict_ptr(cp._receiver_recent_dict), format_dict_ptr(cp._receiver_committed_dict), format_dict_ptr(cp._receiver_current_dict),
+        cp._sender_current_algo.name(), cp._sender_committed_algo.name(), cp._algos.value());
+}
+
 rpc::rcv_buf advanced_rpc_compressor::decompress(rpc::rcv_buf data) {
     const uint8_t header_byte = read_from_rcv_buf<uint8_t>(data);
     const bool has_checksum = header_byte & 0x40;
@@ -466,7 +495,17 @@ rpc::rcv_buf advanced_rpc_compressor::decompress(rpc::rcv_buf data) {
     });
     if (has_checksum) {
         const uint32_t actual_crc = crc_impl(decompressed);
-        if (expected_crc != actual_crc) {
+        if (expected_crc != actual_crc) [[unlikely]] {
+            arc_logger.error(
+                "RPC compression checksum error details:"
+                " expected_crc={:#010x}, actual_crc={:#010x}"
+                ", header_byte={:#04x}"
+                ", control_protocol={}"
+                ", compressed_size={}, decompressed_size={}",
+                expected_crc, actual_crc,
+                header_byte,
+                format_control_protocol(_control),
+                compressed_size, decompressed.size);
             seastar::on_internal_error(arc_logger, fmt::format("RPC compression checksum error (expected: {:x}, got: {:x}). This indicates a bug. Set `internode_compression: none` and restart the nodes to regain stability, then report the bug.", expected_crc, actual_crc));
         }
     }

--- a/message/stream_compressor.cc
+++ b/message/stream_compressor.cc
@@ -249,11 +249,11 @@ size_t lz4_cstream::compress(ZSTD_outBuffer* out, ZSTD_inBuffer* in, ZSTD_EndDir
         size_t n = std::min(_buf.size() - _buf_pos, in->size - in->pos);
         // The compressed block mustn't fill the entire ring buffer.
         // It must be at least 1 byte shorter. It's a dumb quirk of lz4. Perhaps it should be called a bug.
-        n = std::min(max_lz4_window_size - 1, n);
+        n = std::min(_buf.size() - 1, n);
         std::memcpy(_buf.data() + _buf_pos, static_cast<const char*>(in->src) + in->pos, n);
         in->pos += n;
         // The first header_size bytes contain the length of the compressed block, so we compress to _lz4_scratch.data() + sizeof(uint64_t).
-        int x = LZ4_compress_fast_continue(&_ctx, _buf.data() + _buf_pos, _lz4_scratch.data() + sizeof(uint64_t), n, _lz4_scratch.size(), 1);
+        int x = LZ4_compress_fast_continue(&_ctx, _buf.data() + _buf_pos, _lz4_scratch.data() + sizeof(uint64_t), n, _lz4_scratch.size() - sizeof(uint64_t), 1);
         if (x < 0) {
             throw std::runtime_error(fmt::format(
                 "LZ4_compress_fast_continue failed with negative return value {}. "
@@ -298,7 +298,9 @@ void lz4_cstream::set_dict(const LZ4_stream_t* dict) {
 
 lz4_dstream::lz4_dstream(size_t window_size)
     : _buf(window_size)
-{}
+{
+    reset();
+}
 
 void lz4_dstream::reset() noexcept {
     _scratch_pos = _buf_end = _buf_beg = 0;

--- a/message/stream_compressor.cc
+++ b/message/stream_compressor.cc
@@ -297,7 +297,10 @@ void lz4_cstream::set_dict(const LZ4_stream_t* dict) {
 }
 
 lz4_dstream::lz4_dstream(size_t window_size)
-    : _buf(window_size)
+    // The ring buffer has to be bigger than the compressor's by at least the maximum
+    // block size. See the comment on `_buf`.
+    : _buf(window_size + window_size)
+    , _max_block_size(window_size)
 {
     reset();
 }
@@ -312,8 +315,14 @@ void lz4_dstream::decompress(ZSTD_outBuffer* out, ZSTD_inBuffer* in, bool end_of
         // If we have no decompressed data that wasn't yet output,
         // we will decompress a new block.
 
-        if (_buf_end == _buf.size()) {
-            // The ring buffer wraps around here.
+        if (_buf.size() - _buf_end < _max_block_size) {
+            // There might not be enough contiguous space for the next block,
+            // so the ring buffer wraps around here.
+            //
+            // This is the update rule mandated by LZ4 (see the comment of
+            // LZ4_decoderRingBufferSize() in lz4.h), and the third scheme in the comment of
+            // LZ4_decompress_safe_continue() assumes it. In particular, we mustn't wrap
+            // any later than this, even though there might still be some space left.
             _buf_end = _buf_beg = 0;
         }
         // First, we have to ingest the first few bytes of input data, which contain

--- a/message/stream_compressor.hh
+++ b/message/stream_compressor.hh
@@ -97,6 +97,7 @@ uint32_t crc_impl(const seastar::rpc::rcv_buf& data) noexcept;
 
 // Size of the history buffer maintained by both sides of the compressed connection.
 // Governs the memory usage and effectiveness of streaming LZ4 compression.
+// (Note that the decompressor's history buffer is twice this size. See lz4_dstream::_buf).
 //
 // There is no value in making it greater than 64 kiB, because LZ4 doesn't support
 // greater history sizes, at least in the official releases of LZ4.
@@ -125,12 +126,11 @@ class lz4_cstream final : public stream_compressor {
     // of most recent views passed to LZ4_compress_fast_continue for that same block.
     // 
     // Thus there are some rules/schemes which have to be obeyed when maintaining the history buffer.
-    // 
-    // We use a scheme which LZ4 calls "synchronized".
-    // The two history ringbuffers on both sides of the stream are in "lockstep",
-    // meaning that every compression call with compressor's _buf as source,
-    // has a matching decompression call with decompressor's _buf as target,
-    // with the same length and offset in _buf.
+    //
+    // The legal schemes are listed in the comment of LZ4_decompress_safe_continue() in lz4.h.
+    // We use the third one: the decompressor's ring buffer is bigger than this one by at least
+    // the maximum block size, which frees the two sides from having to be synchronized.
+    // (See the comment on lz4_dstream::_buf for why we don't use the "synchronized" scheme).
     std::vector<char> _buf;
     // The current position in the ringbuffer _buf. New input will be appended at this position.
     size_t _buf_pos = 0;
@@ -159,10 +159,34 @@ public:
 
 // Implements a streaming compression interface similar to ZSTD_DStream.
 class lz4_dstream final : public stream_decompressor {
-    // See the _buf comment in lz4_cstream.
+    // The decompression-side counterpart of lz4_cstream::_buf. See its comment for the basics.
+    //
+    // Note that this is *not* a mirror image of the compressor's ring buffer:
+    // it's twice as big and block boundaries fall at different offsets within it.
+    //
+    // The alternative would LZ4's "synchronized" scheme, where the two ring buffers have
+    // exactly the same size and are updated in lockstep. But that scheme additionally requires
+    // that LZ4_decompress_safe_continue() is told the *exact* decompressed size of each block,
+    // and our protocol doesn't carry it. (It only carries compressed sizes).
+    //
+    // It was a painful lesson that an upper bound isn't good enough.
+    // If the bound isn't exact, LZ4 might internally overwrite some bytes which
+    // are backreferenced by the next sequence in the stream, which causes corrupt results.
+    //
+    // So we use the third scheme from the LZ4_decompress_safe_continue() comment instead:
+    // this buffer is at least `max block size` bytes bigger than the compressor's,
+    // which allows the two sides to be unsynchronized,
+    // and makes an upper bound on the block size good enough.
+    // The price is a doubled history buffer on the decompressor's side.
+    // (Which doesn't matter because we only have one decompressor per shard.
+    // It would matter if we e.g. had a decompressor per RPC connection, which we probably
+    // aren't going to do).
     std::vector<char> _buf;
+    // An upper bound on the decompressed size of a single block, which is what the third scheme
+    // above is parameterized by. The compressor never emits a block bigger than its own ring
+    // buffer, so its window size is a valid bound.
+    size_t _max_block_size;
     // The write position in `_buf`. New input will be decompressed to this offset.
-    // It's updated in lockstep with `_buf_pos` of the compressor.
     size_t _buf_end = 0;
     // The read position in `_buf`. The chunk between `_buf_beg` and `_buf_end` is the data
     // that was decompressed, but hasn't been copied to caller's `out` yet.

--- a/test/boost/stream_compressor_test.cc
+++ b/test/boost/stream_compressor_test.cc
@@ -6,12 +6,27 @@
  * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
  */
 
-#define BOOST_TEST_MODULE core
 #include <seastar/util/alloc_failure_injector.hh>
 #include "message/stream_compressor.hh"
+#include "test/lib/log.hh"
 #include "test/lib/random_utils.hh"
+#include "test/lib/scylla_test_case.hh"
+#include "utils/small_vector.hh"
+#include <seastar/core/reactor.hh>
+#include <seastar/core/thread.hh>
+#include <seastar/testing/thread_test_case.hh>
+#include <seastar/util/defer.hh>
 #include <boost/test/unit_test.hpp>
-#include "bytes.hh"
+
+#include <algorithm>
+#include <bit>
+#include <chrono>
+#include <cstdlib>
+#include <memory>
+#include <random>
+#include <span>
+#include <string_view>
+#include <fmt/format.h>
 
 template<class T>
 concept RpcBuf = std::same_as<T, rpc::rcv_buf> || std::same_as<T, rpc::snd_buf>;
@@ -122,6 +137,253 @@ BOOST_AUTO_TEST_CASE(test_correctness) {
     }
 }
 
+// A randomized round-trip test for the streaming compressors.
+//
+// It knows nothing about the compressors' internals. It only generates random inputs
+// and parameters, pushes a message through compress_impl()/decompress_impl(), and checks
+// that what comes out is what went in. All of its bug-finding power comes from the number
+// and the variety of the cases it covers, so it is meant to be run in a loop,
+// for as long as one can afford, rather than once.
+//
+// The whole run is derived from the test framework's random seed, which the test runner
+// prints as `random-seed=<N>`, so a failed run can be replayed with `--random-seed=<N>`.
+// Every individual case is in turn described by a single 64-bit seed, which is reported
+// when the case fails.
+
+// Draws a random integer from [lo, hi], with a distribution meant to hit boundary
+// conditions much more often than a uniform draw would:
+//
+// - Every order of magnitude (i.e. every bit width) gets a similar share of the probability
+//   space, so that "small" values aren't drowned out by the exponentially more numerous
+//   "big" ones. (With a uniform draw over [0, 512 kiB], we would practically never see
+//   a message shorter than a few kiB).
+// - Powers of two, their immediate neighbours, and the ends of the range get an extra
+//   boost, since that's where off-by-one bugs tend to hide.
+static uint64_t draw_interesting(std::mt19937_64& rng, uint64_t lo, uint64_t hi) {
+    BOOST_REQUIRE_LE(lo, hi);
+    auto uniform = [&rng] (uint64_t a, uint64_t b) {
+        return std::uniform_int_distribution<uint64_t>(a, b)(rng);
+    };
+    // One in three draws lands on a "special" value.
+    if (uniform(0, 2) == 0) {
+        utils::small_vector<uint64_t, 64> candidates;
+        auto add = [&] (int64_t v) {
+            if (v >= int64_t(lo) && v <= int64_t(hi)) {
+                candidates.push_back(uint64_t(v));
+            }
+        };
+        add(int64_t(lo));
+        add(int64_t(lo) + 1);
+        add(int64_t(hi) - 1);
+        add(int64_t(hi));
+        for (int k = 0; k < 63 && (uint64_t(1) << k) <= hi + 2; ++k) {
+            for (int64_t delta = -2; delta <= 2; ++delta) {
+                add(int64_t(uint64_t(1) << k) + delta);
+            }
+        }
+        if (!candidates.empty()) {
+            return candidates[uniform(0, candidates.size() - 1)];
+        }
+    }
+    // Otherwise: draw a bit width uniformly, then draw uniformly within that bit width.
+    const int width = int(uniform(std::bit_width(lo), std::bit_width(hi)));
+    const uint64_t band_lo = width ? (uint64_t(1) << (width - 1)) : 0;
+    const uint64_t band_hi = width ? ((uint64_t(1) << width) - 1) : 0;
+    return uniform(std::max(lo, band_lo), std::min(hi, band_hi));
+}
+
+// A string of `size` bytes, each drawn from the first `alphabet_size` byte values.
+// The alphabet size is a cheap knob for the compressibility of the data:
+// a 1-letter alphabet compresses to nothing, a 256-letter alphabet is incompressible.
+//
+// Generating the payload is a meaningful part of this test's runtime, so instead of running
+// a std::uniform_int_distribution per byte (which burns a whole 64-bit draw on 8 bits of
+// output), we spend one draw per 8 bytes and map each byte into the alphabet by a
+// multiply-shift. That's about 4x faster, and the resulting negligible bias
+// (for alphabet sizes which aren't a power of two) doesn't matter for test data.
+static bytes draw_message(std::mt19937_64& rng, size_t size, unsigned alphabet_size) {
+    auto b = bytes(bytes::initialized_later{}, size);
+    for (size_t i = 0; i < size; i += 8) {
+        uint64_t r = rng();
+        for (size_t k = i, end = std::min(i + 8, size); k < end; ++k) {
+            b[k] = static_cast<bytes::value_type>((alphabet_size * (r & 0xff)) >> 8);
+            r >>= 8;
+        }
+    }
+    return b;
+}
+
+// The compression algorithms exercised by the randomized round-trip test.
+enum class codec_algorithm {
+    lz4,
+    zstd,
+};
+
+static std::string_view codec_algorithm_name(codec_algorithm algo) {
+    switch (algo) {
+    case codec_algorithm::lz4: return "lz4";
+    case codec_algorithm::zstd: return "zstd";
+    }
+    std::abort();
+}
+
+// A matching compressor/decompressor pair, plus whatever dictionary objects they refer to.
+//
+// The streams take their dictionaries by reference, so the dictionary objects have to outlive
+// them; keeping both in one owner is the easiest way to guarantee that.
+struct codec_pair {
+    virtual netw::stream_compressor& compressor() = 0;
+    virtual netw::stream_decompressor& decompressor() = 0;
+    virtual ~codec_pair() {}
+};
+
+// `dict` must outlive the returned pair. (Both codecs refer to the dictionary bytes
+// rather than copying them).
+static std::unique_ptr<codec_pair> make_codec_pair(codec_algorithm algo, size_t lz4_window_size, bytes_view dict) {
+    struct lz4_pair final : codec_pair {
+        // Note that this holds the *dictionary*, not the compression context;
+        // that's just how LZ4 represents a preloaded dictionary.
+        std::unique_ptr<LZ4_stream_t, decltype(&LZ4_freeStream)> cdict{LZ4_createStream(), LZ4_freeStream};
+        netw::lz4_cstream cstream;
+        netw::lz4_dstream dstream;
+        lz4_pair(size_t window_size, bytes_view dict)
+            : cstream(window_size)
+            , dstream(window_size)
+        {
+            BOOST_REQUIRE(cdict);
+            if (dict.size()) {
+                LZ4_loadDict(cdict.get(), reinterpret_cast<const char*>(dict.data()), dict.size());
+                cstream.set_dict(cdict.get());
+                dstream.set_dict(std::as_bytes(std::span(dict.data(), dict.size())));
+            }
+        }
+        netw::stream_compressor& compressor() override { return cstream; }
+        netw::stream_decompressor& decompressor() override { return dstream; }
+    };
+    struct zstd_pair final : codec_pair {
+        std::unique_ptr<ZSTD_CDict, decltype(&ZSTD_freeCDict)> cdict{nullptr, ZSTD_freeCDict};
+        std::unique_ptr<ZSTD_DDict, decltype(&ZSTD_freeDDict)> ddict{nullptr, ZSTD_freeDDict};
+        netw::zstd_cstream cstream;
+        netw::zstd_dstream dstream;
+        explicit zstd_pair(bytes_view dict) {
+            if (dict.size()) {
+                // Level 1 is what zstd_cstream itself uses. (Only the compression dict cares).
+                cdict.reset(ZSTD_createCDict_byReference(dict.data(), dict.size(), 1));
+                ddict.reset(ZSTD_createDDict_byReference(dict.data(), dict.size()));
+                BOOST_REQUIRE(cdict);
+                BOOST_REQUIRE(ddict);
+                cstream.set_dict(cdict.get());
+                dstream.set_dict(ddict.get());
+            }
+        }
+        netw::stream_compressor& compressor() override { return cstream; }
+        netw::stream_decompressor& decompressor() override { return dstream; }
+    };
+    switch (algo) {
+    case codec_algorithm::lz4:
+        return std::make_unique<lz4_pair>(lz4_window_size, dict);
+    case codec_algorithm::zstd:
+        // zstd's window size is hardcoded in stream_compressor.cc, so there's nothing to pass.
+        return std::make_unique<zstd_pair>(dict);
+    }
+    std::abort();
+}
+
+// Pushes `message` through a compress_impl()/decompress_impl() round trip
+// with the given codec pair, and returns what came out.
+static bytes round_trip(codec_pair& codec, bytes_view message) {
+    const auto input = rpc::snd_buf(temporary_buffer<char>(reinterpret_cast<const char*>(message.data()), message.size()));
+    auto compressed = netw::compress_impl(0, input, codec.compressor(), true, rpc::snd_buf::chunk_size);
+    auto rcv_buf = convert_rpc_buf<rpc::rcv_buf>(std::move(compressed));
+    return rpc_buf_to_bytes(netw::decompress_impl(rcv_buf, codec.decompressor(), true, rpc::snd_buf::chunk_size));
+}
+
+// Checks that `message` survives a round trip. On failure, points at the first difference
+// and dumps the message to a file (named after `case_name`) for inspection.
+static void check_round_trip(codec_algorithm algo, bytes_view message, bytes_view dict, size_t lz4_window_size,
+        std::string_view case_name, std::string_view description) {
+    bytes decompressed;
+    try {
+        auto codec = make_codec_pair(algo, lz4_window_size, dict);
+        decompressed = round_trip(*codec, message);
+    } catch (...) {
+        // Without this, the case parameters would be lost, and the failure unreproducible.
+        BOOST_FAIL(fmt::format("{} round trip threw: {} exception={}",
+                codec_algorithm_name(algo), description, std::current_exception()));
+    }
+    if (decompressed != message) {
+        // The buffers can be huge, so instead of dumping them to the log we only point at the
+        // first difference, and write the buffers themselves out to files for inspection.
+        size_t i = 0;
+        while (i < std::min(message.size(), decompressed.size()) && message[i] == decompressed[i]) {
+            ++i;
+        }
+        BOOST_FAIL(fmt::format("{} round trip mismatch: {} decompressed_size={} first_difference_at={}",
+                codec_algorithm_name(algo), description, decompressed.size(), i));
+    }
+}
+
+static void run_roundtrip_case(codec_algorithm algo, uint64_t case_seed) {
+    constexpr size_t max_message_size = 512 * 1024;
+    constexpr size_t max_dict_size = 128 * 1024;
+
+    std::mt19937_64 rng(case_seed);
+    // Note: the window size must be at least 2. The compressor can't make progress with 1.
+    // It's ignored by codecs other than LZ4, which have no configurable window.
+    const size_t window_size = draw_interesting(rng, 2, netw::max_lz4_window_size);
+    const size_t message_size = draw_interesting(rng, 0, max_message_size);
+    const size_t dict_size = draw_interesting(rng, 0, max_dict_size);
+    const unsigned alphabet_size = draw_interesting(rng, 1, 256);
+
+    const auto description = fmt::format(
+            "case_seed={} window_size={} message_size={} dict_size={} alphabet_size={}",
+            case_seed, window_size, message_size, dict_size, alphabet_size);
+
+    const auto dict = draw_message(rng, dict_size, alphabet_size);
+    const auto message = draw_message(rng, message_size, alphabet_size);
+
+    check_round_trip(algo, message, dict, window_size,
+            fmt::format("{}.{}", codec_algorithm_name(algo), case_seed), description);
+}
+
+// Runs randomized round-trip cases for `algo` until the time budget runs out.
+static void run_randomized_roundtrip(codec_algorithm algo) {
+    // How long a single run of this test case is allowed to take.
+    //
+    // It's deliberately short: a single run only covers a handful of cases, which is
+    // all that's warranted as a part of a regular test suite run. The bug-finding power
+    // of this test comes from running it many times over (in parallel, and/or in a loop)
+    // in a dedicated session, so if you are hunting for something, raise this and/or
+    // run many copies of the test at once.
+    constexpr auto time_budget = std::chrono::milliseconds(200);
+
+    // A single case is up to ~640 kiB of uninterruptible compression work, which takes
+    // long enough to trip the stall detector. That's inherent to what this test does,
+    // so we mute the reports instead of drowning the log in them.
+    const auto prev_notify_ms = seastar::engine().get_blocked_reactor_notify_ms();
+    seastar::engine().update_blocked_reactor_notify_ms(std::chrono::hours(1));
+    const auto restore_notify_ms = seastar::defer([prev_notify_ms] () noexcept {
+        seastar::engine().update_blocked_reactor_notify_ms(prev_notify_ms);
+    });
+
+    // The whole case sequence hangs off the framework's seed, so `--random-seed=<N>`
+    // replays the run. (The test runner prints the seed it used at startup).
+    std::mt19937_64 master(tests::random::get_int<uint64_t>());
+
+    const auto deadline = std::chrono::steady_clock::now() + time_budget;
+    uint64_t cases = 0;
+    do {
+        run_roundtrip_case(algo, master());
+        ++cases;
+        seastar::thread::maybe_yield();
+    } while (std::chrono::steady_clock::now() < deadline);
+    testlog.info("{}_roundtrip_randomized: cases_tested={}", codec_algorithm_name(algo), cases);
+}
+
+SEASTAR_THREAD_TEST_CASE(test_lz4_roundtrip_randomized) {
+    run_randomized_roundtrip(codec_algorithm::lz4);
+}
+
 void test_recovery_after_oom_one(netw::stream_decompressor& dstream, netw::stream_compressor& cstream) {
     // Check that compressors and decompressors handle OOM properly and can be reused afterwards.
     for (int repeat = 0; repeat < 3; ++repeat) {
@@ -164,3 +426,4 @@ BOOST_AUTO_TEST_CASE(test_recovery_after_oom) {
         test_recovery_after_oom_one(dstream, cstream);
     }
 }
+

--- a/test/boost/test_config.yaml
+++ b/test/boost/test_config.yaml
@@ -51,6 +51,9 @@ custom_args:
         - '-c2 -m2G --logger-log-level s3=trace --logger-log-level http=trace --logger-log-level default_http_retry_strategy=trace'
     batchlog_manager_test:
         - '-c2 -m2G --logger-log-level batchlog_manager=trace:debug_error_injection=trace:testlog=trace'
+    # Purely CPU-bound, single-threaded, and it allocates nothing but its own buffers.
+    stream_compressor_test:
+        - '-c1 -m512M'
 run_in_debug:
     - logalloc_standard_allocator_segment_pool_backend_test
 # Tests skipped in debug/sanitize modes because they use many iterations


### PR DESCRIPTION
message/stream_compressor: fix rare result corruption in lz4_dstream
lz4_dstream is decompressing into a ring buffer, using what lz4 docs
call the "synchronized mode", where the encoding and decoding buffer
are used in lockstep, i.e. blocks are decompressed in order,
always into the same offet in the buffer as the source block's.

But there's an extra rule in this mode, which isn't quite documented
correctly, that every decompression call needs to receive the exact
decompressed size of the block, otherwise the results might be corrupted.
(Because, if the bound is inexact, it might internally overwrite some
bytes which are referenced by the next sequence in the stream).

lz4_dstream doesn't obey this rule, which resulted in some extremely
RPC compression checksum failures in production clusters.

We fix this by switching to a different "mode" described in lz4 docs,
in which the decompression ring is big enough compared to the encoding
buffer that decompression of a block doesn't overwrite any bytes which
could have been used as history, even with no synchronization.

We also add a more powerful randomized test, one which can catch this bug.
Before the patch, it fails on average once in 5M runs. (Which takes ~20 minutes of CPU time on my PC).
After the patch, it didn't fail in over 100M runs.

Fixes: SCYLLADB-3532

Bugfix, needs backport to all supported releases.