### PR TITLE
[Backport 2025.1] sstables_loader: Fix stream_progress assertion failure due to float r…

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1523,6 +1523,7 @@ deps['test/boost/combined_tests'] += [
     'test/boost/sstable_compaction_test.cc',
     'test/boost/sstable_directory_test.cc',
     'test/boost/sstable_set_test.cc',
+    'test/boost/sstable_tablet_streaming_test.cc',
     'test/boost/statement_restrictions_test.cc',
     'test/boost/storage_proxy_test.cc',
     'test/boost/tablets_test.cc',

--- a/sstables_loader.hh
+++ b/sstables_loader.hh
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include <algorithm>
 #include <vector>
 #include <seastar/core/sharded.hh>
 #include "schema/schema_fwd.hh"
@@ -53,7 +54,10 @@ struct stream_progress {
         // we should not move backward
         assert(amount >= 0);
         completed += amount;
-        assert(completed <= total);
+        // Clamp to total to absorb floating point rounding errors from
+        // fractional progress contributions (e.g. per-tablet progress
+        // computed as num_streamed / num_mapped).
+        completed = std::min(completed, total);
     }
 };
 

--- a/test/boost/CMakeLists.txt
+++ b/test/boost/CMakeLists.txt
@@ -336,6 +336,7 @@ add_scylla_test(combined_tests
     sstable_compaction_test.cc
     sstable_directory_test.cc
     sstable_set_test.cc
+    sstable_tablet_streaming_test.cc
     statement_restrictions_test.cc
     storage_proxy_test.cc
     tablets_test.cc

--- a/test/boost/sstable_tablet_streaming_test.cc
+++ b/test/boost/sstable_tablet_streaming_test.cc
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2025-present ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
+ */
+
+#undef SEASTAR_TESTING_MAIN
+#include <seastar/testing/test_case.hh>
+#include "dht/token.hh"
+#include "sstable_test.hh"
+#include "sstables_loader.hh"
+#include "test/lib/sstable_test_env.hh"
+
+BOOST_AUTO_TEST_SUITE(sstable_tablet_streaming_test)
+
+// Reproduces the assertion failure in stream_progress::advance() caused by
+// floating-point rounding when per-tablet fractional contributions accumulate
+// to slightly more than 1.0 per tablet.
+SEASTAR_TEST_CASE(test_stream_progress_float_rounding) {
+    // Simulate tablet_sstable_streamer::stream() with tablets whose sstable
+    // counts cause inexact float divisions when batched (16 + 16 + 16 + 3 = 51
+    // sstables per tablet; each batch contributes batch/51 which rounds up in
+    // float32, so per-tablet total > 1.0).
+    const size_t tablet_count = 32;
+    const size_t sstables_per_tablet = 51;
+    const size_t batch_size = 16;
+
+    auto progress = make_shared<stream_progress>();
+    progress->start(tablet_count);
+
+    for (size_t tablet = 0; tablet < tablet_count; ++tablet) {
+        // Mimics per_tablet_stream_progress with _num_sstables_mapped = sstables_per_tablet
+        size_t remaining = sstables_per_tablet;
+        while (remaining > 0) {
+            size_t batch = std::min(batch_size, remaining);
+            remaining -= batch;
+            // This is what per_tablet_stream_progress::advance() does:
+            float contribution = static_cast<float>(batch) / static_cast<float>(sstables_per_tablet);
+            progress->advance(contribution);
+        }
+    }
+
+    // Without the fix (clamping), the above triggers:
+    //   assert(completed <= total) in stream_progress::advance()
+    // because float32 rounding makes each tablet's contributions sum to
+    // slightly more than 1.0 (≈1.0000001), and over 32 tablets the
+    // accumulated error pushes completed past total.
+    BOOST_REQUIRE_LE(progress->completed, progress->total);
+    return make_ready_future<>();
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
…ounding

The stream_progress::advance() assertion 'completed <= total' can fire during tablet-aware restore because per_tablet_stream_progress reports fractional contributions (batch_size / num_sstables_mapped) that accumulate floating-point rounding errors. For example, with 51 sstables per tablet batched as 16+16+16+3, each batch/51 float32 division rounds up slightly (~1e-7), and over many tablets the error pushes 'completed' past 'total'.

Fix by clamping 'completed' to 'total' instead of asserting, which absorbs the inevitable IEEE 754 imprecision while still preventing backward progress (amount >= 0 assertion remains).

Add a reproducer test that exercises the exact float32 arithmetic triggering the issue.

Fixes SCYLLADB-2201

Signed-off-by: Pavel Emelyanov <xemul@scylladb.com>

Closes scylladb/scylladb#30273

(cherry picked from commit f24f560af4a64ca9c33cd49a94128dc87b416aa0)

**Please replace this line with justification for the backport/\* labels added to this PR**