### PR TITLE
test: drop redundant server stop in test_tablet_incremental_repair_merge_higher_repaired_at_number

### DIFF
--- a/test/cluster/test_incremental_repair.py
+++ b/test/cluster/test_incremental_repair.py
@@ -621,9 +621,6 @@ async def test_tablet_incremental_repair_merge_higher_repaired_at_number(manager
     max_repaired_at = 2
     await verify_max_repaired_at(manager, scylla_path, servers, ks, 2)
 
-    for server in servers:
-        await manager.server_stop_gracefully(server.server_id)
-
     await verify_repaired_and_unrepaired_keys(manager, scylla_path, servers, ks, repaired_keys, unrepaired_keys)
 
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')


### PR DESCRIPTION
The per-sstable scylla-sstable subprocess overhead that dominated this test's runtime was already addressed by commit cdfaad955c0 ("test/cluster/test_incremental_repair.py: batch scylla-sstable dump calls"), which batches the dump-data/dump-statistics calls into a single invocation per component type. This PR was rebased on top of it and the duplicated batching helpers were dropped.

What remains is a duplicate server_stop_gracefully loop: the servers are already stopped before verify_max_repaired_at(), so stopping them again before verify_repaired_and_unrepaired_keys() is a no-op that only wastes time. Drop it.

Fixes: SCYLLADB-2275

Improvement. No backports.