### PR TITLE
cql3: don't apply client query limits when reparsing own CQL

### DIFF
--- a/cql3/dialect.hh
+++ b/cql3/dialect.hh
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include <limits>
+
 #include <fmt/core.h>
 
 namespace cql3 {
@@ -13,12 +15,17 @@ struct dialect {
     bool operator==(const dialect&) const = default;
 };
 
+// Dialect for CQL that the database generates for itself, e.g. from a
+// materialized view's stored WHERE clause. Guardrails meant for client
+// queries must not apply here: such a statement was already accepted when
+// the user submitted it, and rejecting it now would make the schema
+// unusable.
 inline
 dialect
 internal_dialect() {
     return dialect{
         .duplicate_bind_variable_names_refer_to_same_variable = true,
-        .max_relations_in_where_clause = 100,
+        .max_relations_in_where_clause = std::numeric_limits<unsigned>::max(),
     };
 }
 

--- a/cql3/statements/alter_table_statement.cc
+++ b/cql3/statements/alter_table_statement.cc
@@ -486,7 +486,7 @@ std::pair<schema_ptr, std::vector<view_ptr>> alter_table_statement::prepare_sche
                 auto new_where = util::rename_columns_in_where_clause(
                         view->view_info()->where_clause(),
                         view_renames,
-                        cql3::dialect{});
+                        cql3::internal_dialect());
                 builder.with_view_info(new_base_schema, view->view_info()->include_all_columns(), std::move(new_where));
                 view_updates.push_back(view_ptr(builder.build()));
             }

--- a/cql3/statements/select_statement.cc
+++ b/cql3/statements/select_statement.cc
@@ -2765,9 +2765,9 @@ std::unique_ptr<cql3::statements::raw::select_statement> build_select_statement(
     if (!where_clause.empty()) {
         out << " WHERE " << where_clause << " ALLOW FILTERING";
     }
-    // In general it's not a good idea to use the default dialect, but here the database is talking to
-    // itself, so we can hope the dialects are mutually compatible here.
-    return do_with_parser(out.str(), dialect{}, std::mem_fn(&cql3_parser::CqlParser::selectStatement));
+    // The database is talking to itself here, over a statement which was already validated when the
+    // user submitted it, so the client-facing dialect limits must not be applied again.
+    return do_with_parser(out.str(), internal_dialect(), std::mem_fn(&cql3_parser::CqlParser::selectStatement));
 }
 
 }

--- a/test/boost/schema_loader_test.cc
+++ b/test/boost/schema_loader_test.cc
@@ -232,6 +232,39 @@ SEASTAR_THREAD_TEST_CASE(test_materialized_view) {
             {view_type::view});
 };
 
+/// A view whose WHERE clause has more relations than the default
+/// max_relations_in_where_clause of 100 can only be created by a node with a
+/// raised limit. The tools cannot know that configuration, so they have to load
+/// such a schema regardless of the limit.
+/// Regression test for SCYLLADB-3583.
+SEASTAR_THREAD_TEST_CASE(test_materialized_view_above_default_relation_limit) {
+    db::config dbcfg;
+    dbcfg.rf_rack_valid_keyspaces(true);
+
+    constexpr unsigned relations = 110;
+    std::string column_definitions;
+    std::string key_columns;
+    std::string where;
+    for (unsigned i = 0; i < relations; ++i) {
+        const auto column = fmt::format("c{}", i);
+        column_definitions += fmt::format("{} int, ", column);
+        key_columns += i ? fmt::format(", {}", column) : column;
+        where += i ? fmt::format(" AND {} IS NOT NULL", column) : fmt::format("{} IS NOT NULL", column);
+    }
+
+    check_views(
+            tools::load_schemas(
+                    dbcfg,
+                    fmt::format(
+                            "CREATE TABLE ks.cf ({}v int, PRIMARY KEY ({})); "
+                            "CREATE MATERIALIZED VIEW ks.cf_by_c AS"
+                            "    SELECT * FROM ks.cf"
+                            "    WHERE {}"
+                            "    PRIMARY KEY ({});",
+                            column_definitions, key_columns, where, key_columns)).get(),
+            {view_type::view});
+}
+
 SEASTAR_THREAD_TEST_CASE(test_index) {
     db::config dbcfg;
     dbcfg.rf_rack_valid_keyspaces(true);

--- a/test/cluster/mv/test_mv_where_clause_relations.py
+++ b/test/cluster/mv/test_mv_where_clause_relations.py
@@ -1,0 +1,89 @@
+#
+# Copyright (C) 2026-present ScyllaDB
+#
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
+#
+import logging
+
+from test.cluster.util import new_materialized_view, new_test_keyspace, new_test_table
+from test.pylib.manager_client import ManagerClient
+from test.pylib.util import wait_for_view
+
+logger = logging.getLogger(__name__)
+
+# The number of relations in the view's WHERE clause, above the default
+# max_relations_in_where_clause of 100.
+RELATIONS = 110
+
+
+def table_and_view_definition():
+    """The key columns, the table schema and the view WHERE clause of a table
+    whose every key column takes one relation in the view's WHERE clause."""
+    clustering_columns = [f"c{i}" for i in range(RELATIONS - 1)]
+    key_columns = ["p"] + clustering_columns
+    schema = ", ".join([f"{c} int" for c in key_columns] + ["v int", f"PRIMARY KEY ({', '.join(key_columns)})"])
+    where = " AND ".join(f"{c} IS NOT NULL" for c in key_columns)
+    return key_columns, schema, where
+
+
+def prepare_insert(cql, table, key_columns):
+    return cql.prepare(f"INSERT INTO {table} ({', '.join(key_columns)}, v) VALUES ({', '.join(['?'] * (len(key_columns) + 1))})")
+
+
+# Regression test for SCYLLADB-3583.
+async def test_view_where_clause_above_default_relation_limit(manager: ManagerClient):
+    """A view whose WHERE clause has more relations than the default limit is
+    usable, no matter what the limit was when it was created. Scylla reparses
+    the stored WHERE clause internally, and that reparse must not be subject to
+    the client-facing limit."""
+    await manager.server_add(config={'max_relations_in_where_clause': RELATIONS * 2})
+    cql = manager.get_cql()
+
+    key_columns, schema, where = table_and_view_definition()
+
+    async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1}") as ks:
+        async with new_test_table(manager, ks, schema) as table:
+            insert = prepare_insert(cql, table, key_columns)
+            logger.info("writing a row before the view exists, to be picked up by the view builder")
+            await cql.run_async(insert, list(range(len(key_columns))) + [0])
+
+            async with new_materialized_view(manager, table, '*', ', '.join(key_columns), where) as mv:
+                logger.info("writing a row while the view exists, generating a view update")
+                await cql.run_async(insert, [1] + list(range(1, len(key_columns))) + [1])
+
+                await wait_for_view(cql, mv.split('.')[1], 1)
+                rows = await cql.run_async(f"SELECT v FROM {mv}")
+                assert sorted(row.v for row in rows) == [0, 1]
+
+
+# Regression test for SCYLLADB-3583.
+async def test_rename_base_column_of_view_above_default_relation_limit(manager: ManagerClient):
+    """Renaming a base column rewrites the stored WHERE clause of every view
+    referring to it, which means reparsing that clause. Just like the reparse
+    done for the view's select statement, it must not be subject to the
+    client-facing relation limit."""
+    await manager.server_add(config={'max_relations_in_where_clause': RELATIONS * 2})
+    cql = manager.get_cql()
+
+    key_columns, schema, where = table_and_view_definition()
+
+    async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1}") as ks:
+        async with new_test_table(manager, ks, schema) as table:
+            async with new_materialized_view(manager, table, '*', ', '.join(key_columns), where) as mv:
+                view_name = mv.split('.')[1]
+                await wait_for_view(cql, view_name, 1)
+
+                logger.info("renaming a base clustering column which the view's WHERE clause refers to")
+                await cql.run_async(f"ALTER TABLE {table} RENAME c1 TO c1_renamed")
+
+                rows = await cql.run_async(f"SELECT where_clause FROM system_schema.views WHERE keyspace_name = '{ks}' AND view_name = '{view_name}'")
+                new_where = rows[0].where_clause.lower()
+                assert "c1_renamed is not null" in new_where
+                assert "c1 is not null" not in new_where
+
+                renamed_columns = ["c1_renamed" if c == "c1" else c for c in key_columns]
+                logger.info("writing a row after the rename, generating a view update against the rewritten WHERE clause")
+                await cql.run_async(prepare_insert(cql, table, renamed_columns), list(range(len(key_columns))) + [0])
+
+                rows = await cql.run_async(f"SELECT v FROM {mv}")
+                assert [row.v for row in rows] == [0]

--- a/tools/schema_loader.cc
+++ b/tools/schema_loader.cc
@@ -291,7 +291,7 @@ std::vector<schema_ptr> do_load_schemas(const db::config& cfg, std::string_view 
 
     std::vector<std::unique_ptr<cql3::statements::raw::parsed_statement>> raw_statements;
     try {
-        raw_statements = cql3::query_processor::parse_statements(schema_str, cql3::dialect{});
+        raw_statements = cql3::query_processor::parse_statements(schema_str, cql3::internal_dialect());
     } catch (...) {
         throw std::runtime_error(format("tools:do_load_schemas(): failed to parse CQL statements: {}", std::current_exception()));
     }


### PR DESCRIPTION
A materialized view's WHERE clause is stored as text and reparsed
whenever the database needs the view's select statement, but that
reparse used the default dialect. A view accepted with more relations
than the default limit then broke every write to its base table and
its build, even though its schema was perfectly legal.

Such a statement was already validated when the user submitted it, and
the limit only exists to reject expensive client queries, so it must
not be applied again. The same asymmetry could also reject a view when
renaming a base column, or when offline tools load a schema dump.

Fixes: SCYLLADB-3583

Backport: no backport, just a minor bugfix.