### PR TITLE
Make cluster backup a topology operation

### DIFF
--- a/db/snapshot-ctl.cc
+++ b/db/snapshot-ctl.cc
@@ -30,6 +30,7 @@
 #include "sstables/sstables_manager.hh"
 #include "sstables/object_storage_client.hh"
 #include "service/storage_proxy.hh"
+#include "service/topology_guard.hh"
 #include "idl/snapshot_backup.dist.hh"
 
 using namespace std::chrono_literals;
@@ -65,11 +66,13 @@ snapshot_ctl::snapshot_ctl(sharded<replica::database>& db, sharded<service::stor
         _delete_expired_snapshots = delete_expired_snapshots();
     }
     ser::snapshot_backup_rpc_verbs::register_backup_snapshot_sstables(&_ms
-        , [this](table_id table_id, std::string tag, std::string endpoint, std::string bucket, std::string prefix, dht::token first_token, dht::token last_token, utils::chunked_vector<sstables::sstable_id> sstable_ids, bool use_move) -> future<> {
+        , [this](table_id table_id, std::string tag, std::string endpoint, std::string bucket, std::string prefix, dht::token first_token, dht::token last_token, utils::chunked_vector<sstables::sstable_id> sstable_ids, bool use_move, service::frozen_topology_guard frozen_guard) -> future<> {
             co_await with_gate(_ops, [&]() -> future<> {
-                // Removed shard 0 restriction. backup_sstables does not care...
+                //this can run on any shard. 
+                service::topology_guard guard(frozen_guard);
+                auto& as = guard.abort_source();
                 co_await coroutine::switch_to(_config.backup_sched_group);
-                co_await snapshot::backup_sstables(_qp.local(), table_id, std::move(tag), std::move(endpoint), std::move(bucket), std::move(prefix), first_token, last_token, std::move(sstable_ids), use_move);
+                co_await snapshot::backup_sstables(_qp.local(), table_id, std::move(tag), std::move(endpoint), std::move(bucket), std::move(prefix), first_token, last_token, std::move(sstable_ids), use_move, &as);
             });
         }
     );

--- a/db/snapshot-ctl.cc
+++ b/db/snapshot-ctl.cc
@@ -64,7 +64,15 @@ snapshot_ctl::snapshot_ctl(sharded<replica::database>& db, sharded<service::stor
     if (this_shard_id() == 0) {
         _delete_expired_snapshots = delete_expired_snapshots();
     }
-    ser::snapshot_backup_rpc_verbs::register_backup_snapshot_sstables(&_ms, std::bind_front(&snapshot_ctl::backup_sstables, this));
+    ser::snapshot_backup_rpc_verbs::register_backup_snapshot_sstables(&_ms
+        , [this](table_id table_id, std::string tag, std::string endpoint, std::string bucket, std::string prefix, dht::token first_token, dht::token last_token, utils::chunked_vector<sstables::sstable_id> sstable_ids, bool use_move) -> future<> {
+            co_await with_gate(_ops, [&]() -> future<> {
+                // Removed shard 0 restriction. backup_sstables does not care...
+                co_await coroutine::switch_to(_config.backup_sched_group);
+                co_await snapshot::backup_sstables(*this, table_id, std::move(tag), std::move(endpoint), std::move(bucket), std::move(prefix), first_token, last_token, std::move(sstable_ids), use_move);
+            });
+        }
+    );
 }
 
 future<> snapshot_ctl::stop() {
@@ -374,19 +382,6 @@ future<tasks::task_id> snapshot_ctl::start_global_backup(std::unordered_map<sstr
     snap_log.info("Backup sstables from {}(cluster snapshot {}) to {}", ks_tables, tag, locations);
 
     co_return co_await snapshot::start_global_backup(*this, static_pointer_cast<tasks::task_manager::module>(_task_manager_module), tag, std::move(ks_tables), std::move(locations), move_files);
-}
-
-future<>
-snapshot_ctl::backup_sstables(table_id table_id, std::string tag, std::string endpoint, std::string bucket, std::string prefix, dht::token first_token, dht::token last_token, utils::chunked_vector<sstables::sstable_id> sstable_ids, bool use_move) {
-    // backup_task_impl assumes we create and run it on shard 0
-    if (this_shard_id() != 0) {
-        co_return co_await container().invoke_on(0, [&](auto& local) {
-            return local.backup_sstables(table_id, tag, endpoint, bucket, prefix, first_token, last_token, sstable_ids, use_move);
-        });
-    }
-
-    co_await coroutine::switch_to(_config.backup_sched_group);
-    co_await snapshot::backup_sstables(*this, table_id, std::move(tag), std::move(endpoint), std::move(bucket), std::move(prefix), first_token, last_token, std::move(sstable_ids), use_move);
 }
 
 future<int64_t> snapshot_ctl::true_snapshots_size(sstring ks, sstring cf) {

--- a/db/snapshot-ctl.cc
+++ b/db/snapshot-ctl.cc
@@ -69,7 +69,7 @@ snapshot_ctl::snapshot_ctl(sharded<replica::database>& db, sharded<service::stor
             co_await with_gate(_ops, [&]() -> future<> {
                 // Removed shard 0 restriction. backup_sstables does not care...
                 co_await coroutine::switch_to(_config.backup_sched_group);
-                co_await snapshot::backup_sstables(*this, table_id, std::move(tag), std::move(endpoint), std::move(bucket), std::move(prefix), first_token, last_token, std::move(sstable_ids), use_move);
+                co_await snapshot::backup_sstables(_qp.local(), table_id, std::move(tag), std::move(endpoint), std::move(bucket), std::move(prefix), first_token, last_token, std::move(sstable_ids), use_move);
             });
         }
     );

--- a/db/snapshot-ctl.hh
+++ b/db/snapshot-ctl.hh
@@ -198,7 +198,6 @@ private:
     future<> do_take_cluster_column_family_snapshot(std::vector<sstring> ks_names, std::vector<sstring> tables, sstring tag, snapshot_options opts = {});
 
     future<> delete_expired_snapshots();
-    future<> backup_sstables(table_id, std::string, std::string, std::string, std::string, dht::token, dht::token, utils::chunked_vector<sstables::sstable_id>, bool);
 };
 
 }

--- a/db/snapshot/cluster_backup.cc
+++ b/db/snapshot/cluster_backup.cc
@@ -30,6 +30,7 @@
 #include "utils/upload_progress.hh"
 #include "utils/memory_data_sink.hh"
 #include "idl/snapshot_backup.dist.hh"
+#include "cql3/query_processor.hh"
 
 extern logging::logger snap_log;
 
@@ -40,7 +41,7 @@ struct std::hash<db::snapshot_dc_location> {
     }
 };
 
-class cluster_backup_task : public tasks::task_manager::task::impl {
+class cluster_backup_task : public tasks::task_manager::task::impl, private tasks::progress_sink {
     db::snapshot_ctl& _snap_ctl;
     std::string _snapshot;
     std::unordered_multimap<sstring, sstring> _ks_tables;
@@ -73,6 +74,14 @@ public:
     }
     tasks::is_user_task is_user_task() const noexcept override {
         return tasks::is_user_task::yes;
+    }
+
+    void set_total(double v) override {
+        _total_progress.total = v;
+    }
+    void add_progress(double v) override {
+        _total_progress.completed += v;
+        _as.check(); // maybe abort
     }
 };
 
@@ -131,16 +140,41 @@ future<> cluster_backup_task::do_backup() {
         }
     }
 
-    auto locations = co_await sth.get_snapshot_remote_locations(_snapshot);
+    /**
+     * This is a bit overzealous, but we've removed the snapshot-ctl from the run_global_backup call (prep for topo op)
+     * so in this legacy call, just hold the snapshot gate across the whole backup run. The motivation being that we should 
+     * either fail or finish if competing with shutdown/drain. This is somewhat dubious here, since we will do a bunch of 
+     * RPC:s to nodes that might be just as dead/dying as us, but...
+     */
+    co_await _snap_ctl.run_snapshot_modify_operation([&]() -> future<> {
+        co_await run_global_backup(_snap_ctl.qp().local(), _snapshot, _ks_tables, _locations, _remove_on_uploaded
+            , [&](locator::host_id host, table_id tid, sstring tag, sstring endpoint, sstring bucket, sstring prefix, dht::token first_token, dht::token last_token, utils::chunked_vector<sstables::sstable_id> sstable_ids, bool use_move) -> future<> {
+                co_await ser::snapshot_backup_rpc_verbs::send_backup_snapshot_sstables(&_snap_ctl.ms(), host, tid, tag, endpoint, bucket, prefix, first_token, last_token, std::move(sstable_ids), use_move);
+            }
+            , *this
+        );
+    });
+}
+
+future<> 
+db::snapshot::run_global_backup(cql3::query_processor& qp, std::string snapshot_name, std::unordered_multimap<sstring, sstring> ks_tables, std::unordered_map<sstring, db::snapshot_dc_location> dc_locations, bool move_files, send_backup_rpc_func send_rpc, tasks::progress_sink& progress) {
+    db::snapshot_table_helper sth(qp);
+
+    auto snapshot = co_await sth.get_snapshot(snapshot_name);
+    if (!snapshot) {
+        throw std::invalid_argument("No such snapshot: " + snapshot_name);
+    }
+
+    auto locations = co_await sth.get_snapshot_remote_locations(snapshot_name);
     std::unordered_map<std::string, db::snapshot_state> state_filter;
 
-    for (auto& dc : _locations | std::views::keys) {
+    for (auto& dc : dc_locations | std::views::keys) {
         state_filter[dc] = db::snapshot_state::remote_and_local;
     }
 
     for (auto& loc : locations) {
-        auto i = _locations.find(loc.datacenter);
-        if (i == _locations.end()) {
+        auto i = dc_locations.find(loc.datacenter);
+        if (i == dc_locations.end()) {
             continue;
         }
 
@@ -152,16 +186,21 @@ future<> cluster_backup_task::do_backup() {
             filter = db::snapshot_state::remote;
         }
         if (loc.state >= db::snapshot_state::remote_and_local) {
-            snap_log.warn("Snapshot {} for {} is already backed up: {}:{}", _snapshot, loc.datacenter, loc.bucket, loc.prefix);
-            _locations.erase(loc.datacenter);
+            snap_log.warn("Snapshot {} for {} is already backed up: {}:{}", snapshot_name, loc.datacenter, loc.bucket, loc.prefix);
+            dc_locations.erase(loc.datacenter);
         }
 
         state_filter[loc.datacenter] = filter;
     }
 
-    auto new_locations = _locations | std::views::transform([&](auto& p) {
+    if (dc_locations.empty()) {
+        snap_log.info("All locations for snapshot {} are already backed up.", snapshot_name);
+        co_return;
+    }
+
+    auto new_locations = dc_locations | std::views::transform([&](auto& p) {
         return db::snapshot_remote_location_entry {
-            .snapshot_name = _snapshot,
+            .snapshot_name = snapshot_name,
             .datacenter = p.first,
             .endpoint = p.second.endpoint,
             .bucket = p.second.bucket,
@@ -170,21 +209,17 @@ future<> cluster_backup_task::do_backup() {
         };
     }) | std::ranges::to<std::vector<db::snapshot_remote_location_entry>>();
 
-    // We are already on shard 0. Can use all objects fine. Just need to acquire snap locks.
-    // Mainly for semantic consistency. Maybe all this should be a raft op.
-    co_await _snap_ctl.run_snapshot_modify_operation([&]() -> future<> {
-        co_await sth.insert_snapshot_remote_locations(new_locations); // update status
-    });
+    co_await sth.insert_snapshot_remote_locations(new_locations); // update status
 
-    auto nodes = co_await sth.get_snapshot_nodes(_snapshot);
-    auto nodes_for_location = nodes | std::views::filter([&](auto& n) { return _locations.count(n.datacenter); });
-    auto& db = _snap_ctl.db().local();
+    auto nodes = co_await sth.get_snapshot_nodes(snapshot_name);
+    auto nodes_for_location = nodes | std::views::filter([&](auto& n) { return dc_locations.count(n.datacenter); });
+    auto& db = qp.db().real_database();
 
-    _total_progress.total = (std::distance(nodes_for_location.begin(), nodes_for_location.end()) + _locations.size() /* manifests */) * _ks_tables.size();
+    progress.set_total((std::distance(nodes_for_location.begin(), nodes_for_location.end()) + dc_locations.size() /* manifests */) * ks_tables.size());
 
-    co_await coroutine::parallel_for_each(_ks_tables, [&](const std::pair<sstring, sstring>& pair) -> future<>{
+    co_await coroutine::parallel_for_each(ks_tables, [&](const std::pair<sstring, sstring>& pair) -> future<>{
         auto [keyspace, table] = pair;
-        snap_log.info("Processing {}, {}:{}", _snapshot, keyspace, table);
+        snap_log.info("Processing {}, {}:{}", snapshot_name, keyspace, table);
 
         auto& t = db.find_column_family(keyspace, table);
         auto schema = t.schema();
@@ -198,25 +233,21 @@ future<> cluster_backup_task::do_backup() {
         std::unordered_map<db::snapshot_dc_location, dst_data> dst_mapping;
         // redundant since we don't support per-dc tablets, but why not complicate things
         std::unordered_map<std::string, utils::chunked_vector<db::snapshot_tablet_entry>> dc_tablets;
-        for (auto& dc : _locations | std::views::keys) {
-            dc_tablets.emplace(dc, co_await sth.get_snapshot_tablets(_snapshot, keyspace, table, dc));
+        for (auto& dc : dc_locations | std::views::keys) {
+            dc_tablets.emplace(dc, co_await sth.get_snapshot_tablets(snapshot_name, keyspace, table, dc));
         }
         std::unordered_map<db::snapshot_dc_location, std::unordered_map<dht::token, locator::host_id>> repair_masters;
         std::unordered_map<locator::host_id, std::pair<size_t, size_t>> node_sstables;
 
         for (const db::snapshot_node_entry& node : nodes_for_location) {
-            if (auto e = _as.abort_requested_exception_ptr(); e) {
-                snap_log.warn("Abort {} requested when processing {}, {}:{}", _snapshot, node.node, keyspace, table);
-                std::rethrow_exception(e);
-            }
-            snap_log.info("Calculating sstable set for {} node {}, {}:{}", _snapshot, node.node, keyspace, table);
+            snap_log.info("Calculating sstable set for {} node {}, {}:{}", snapshot_name, node.node, keyspace, table);
 
             assert(state_filter.count(node.datacenter));
-            assert(_locations.count(node.datacenter));
+            assert(dc_locations.count(node.datacenter));
 
-            auto& dst = _locations.at(node.datacenter);
+            auto& dst = dc_locations.at(node.datacenter);
             auto& repair_master = repair_masters[dst];
-            auto sstables = co_await sth.get_snapshot_sstables(_snapshot, keyspace, table, node.datacenter, node.rack);
+            auto sstables = co_await sth.get_snapshot_sstables(snapshot_name, keyspace, table, node.datacenter, node.rack);
             auto& tablets = dc_tablets.at(node.datacenter);
             auto ti = tablets.begin();
             auto te = tablets.end();
@@ -251,20 +282,14 @@ future<> cluster_backup_task::do_backup() {
         }
 
         co_await coroutine::parallel_for_each(nodes_for_location, [&](const db::snapshot_node_entry& node) -> future<>{
-            if (auto e = _as.abort_requested_exception_ptr(); e) {
-                // note the point at which we aborted
-                snap_log.warn("Abort {} requested when processing {}, {}:{}", _snapshot, node.node, keyspace, table);
-                std::rethrow_exception(e);
-            }
-
-            snap_log.info("Processing {} node {}, {}:{}", _snapshot, node.node, keyspace, table);
+            snap_log.info("Processing {} node {}, {}:{}", snapshot_name, node.node, keyspace, table);
 
             assert(state_filter.count(node.datacenter));
-            assert(_locations.count(node.datacenter));
+            assert(dc_locations.count(node.datacenter));
 
             auto [off, n]= node_sstables.at(node.node);
             auto filter = state_filter.at(node.datacenter);
-            auto& dst = _locations.at(node.datacenter);
+            auto& dst = dc_locations.at(node.datacenter);
             auto& dst_info = dst_mapping[dst];
 
             // filter out sstables already backed up
@@ -273,8 +298,8 @@ future<> cluster_backup_task::do_backup() {
             }) | std::ranges::to<utils::chunked_vector<db::snapshot_sstable_entry>>();
 
             if (sstables.empty()) {
-                snap_log.info("All sstables for {} node {}, {}:{} already backed up", _snapshot, node.node, keyspace, table);
-                _total_progress.completed += 1;
+                snap_log.info("All sstables for {} node {}, {}:{} already backed up", snapshot_name, node.node, keyspace, table);
+                progress.add_progress(1);
                 co_return;
             }
             if (filter > db::snapshot_state::remote_and_local) {
@@ -282,7 +307,7 @@ future<> cluster_backup_task::do_backup() {
                 for (auto& sst : sstables) {
                     sst.state = db::snapshot_state::local;
                 }
-                co_await sth.insert_snapshot_sstables(_snapshot, keyspace, table, node.datacenter, node.rack, sstables);
+                co_await sth.insert_snapshot_sstables(snapshot_name, keyspace, table, node.datacenter, node.rack, sstables);
             }
 
             // we don't really need/use this atm, but...
@@ -298,22 +323,23 @@ future<> cluster_backup_task::do_backup() {
             snap_log.info("Requesting backup of {}: {}", node.node, sstable_ids);
 
             try {
-                auto prefix = db::snapshot::sstables_location(dst.prefix, t, _snapshot);
-                co_await ser::snapshot_backup_rpc_verbs::send_backup_snapshot_sstables(&_snap_ctl.ms(), node.node, tid, _snapshot, dst.endpoint, dst.bucket, prefix, first_token, last_token, std::move(sstable_ids), _remove_on_uploaded);
-                _total_progress.completed += 1;
+                auto prefix = db::snapshot::sstables_location(dst.prefix, t, snapshot_name);
+                co_await send_rpc(node.node, tid, snapshot_name, dst.endpoint, dst.bucket, prefix, first_token, last_token, std::move(sstable_ids), move_files);
+
+                progress.add_progress(1);
             } catch (...) {
-                snap_log.error("Exception requesting backup of {}:{} from {}", _snapshot, sstable_ids, node.node);
+                snap_log.error("Exception requesting backup of {}:{} from {}", snapshot_name, sstable_ids, node.node);
                 throw; // fail the whole process already
             }
         });
 
-        snap_log.info("Generate manifests for {} {}:{}", _snapshot, keyspace, table);
+        snap_log.info("Generate manifests for {} {}:{}", snapshot_name, keyspace, table);
 
         // Note: atm, tablet mapping is same across all dcs. If this changes, we need to get this per dc,
         // each of which can shared dest with others. Thus we also need to change manifest grammar to allow
         // tablet info per dc.
-        auto tablets = co_await sth.get_snapshot_tablets(_snapshot, keyspace, table, _locations.begin()->first);
-        auto tables = co_await sth.get_snapshot_tables(_snapshot, keyspace, table);
+        auto tablets = co_await sth.get_snapshot_tablets(snapshot_name, keyspace, table, dc_locations.begin()->first);
+        auto tables = co_await sth.get_snapshot_tables(snapshot_name, keyspace, table);
 
         auto& manager = db.get_sstables_manager(*schema);
 
@@ -321,7 +347,7 @@ future<> cluster_backup_task::do_backup() {
         co_await coroutine::parallel_for_each(dst_mapping, [&](const auto& pair) -> future<> {
             auto& [dst, info] = pair;
 
-            snap_log.info("Generate manifest for {} {}:{} ({}:{}/{})", _snapshot, keyspace, table, dst.endpoint, dst.bucket, dst.prefix);
+            snap_log.info("Generate manifest for {} {}:{} ({}:{}/{})", snapshot_name, keyspace, table, dst.endpoint, dst.bucket, dst.prefix);
 
             manifest_json manifest;
 
@@ -331,7 +357,7 @@ future<> cluster_backup_task::do_backup() {
             manifest.manifest = std::move(minfo);
 
             manifest_json::snapshot_info snapshot_info;
-            snapshot_info.name = _snapshot;
+            snapshot_info.name = snapshot_name;
             snapshot_info.created_at = decltype(snapshot->created_at)::clock::to_time_t(snapshot->created_at);
             snapshot_info.expires_at = decltype(snapshot->expires_at)::clock::to_time_t(snapshot->expires_at);
             manifest.snapshot = std::move(snapshot_info);
@@ -355,23 +381,21 @@ future<> cluster_backup_task::do_backup() {
             }
 
             auto client = manager.get_endpoint_client(dst.endpoint);
-            auto prefix = db::snapshot::snapshot_meta_location(dst.prefix, t, _snapshot);
-            output_stream<char> out(client->make_upload_sink(sstables::object_name(dst.bucket, prefix, "manifest.json"), &_as));
+            auto prefix = db::snapshot::snapshot_meta_location(dst.prefix, t, snapshot_name);
+            output_stream<char> out(client->make_upload_sink(sstables::object_name(dst.bucket, prefix, "manifest.json")));
             auto streamer = json::stream_object(std::move(manifest));
             co_await streamer(std::move(out));
-            _total_progress.completed += 1;
-        });
 
+            progress.add_progress(1);
+        });
     });
 
     for (auto& loc : new_locations) {
-        loc.state = _remove_on_uploaded ? db::snapshot_state::remote : db::snapshot_state::remote_and_local;
+        loc.state = move_files ? db::snapshot_state::remote : db::snapshot_state::remote_and_local;
     }
 
     // See above.
-    co_await _snap_ctl.run_snapshot_modify_operation([&]() -> future<> {
-        co_await sth.insert_snapshot_remote_locations(new_locations); // update status
-    });
+    co_await sth.insert_snapshot_remote_locations(new_locations); // update status
 }
 
 future<tasks::task_id> 
@@ -384,18 +408,19 @@ db::snapshot::start_global_backup(db::snapshot_ctl& ctl, tasks::task_manager::mo
 }
 
 future<>
-db::snapshot::backup_sstables(db::snapshot_ctl& snap, table_id table_id, std::string tag, std::string endpoint, std::string bucket, std::string prefix, dht::token first_token, dht::token last_token, utils::chunked_vector<sstables::sstable_id> sstable_ids, bool use_move) {
+db::snapshot::backup_sstables(cql3::query_processor& qp, table_id table_id, std::string tag, std::string endpoint, std::string bucket, std::string prefix, dht::token first_token, dht::token last_token, utils::chunked_vector<sstables::sstable_id> sstable_ids, bool use_move, seastar::abort_source* as) {
     snap_log.info("Got backup request for snapshot {}, table {}, sstables {} ({}:{}) -> {}:{}:{}", tag, table_id, sstable_ids, first_token, last_token, endpoint, bucket, prefix);
 
-    auto& db = snap.db().local();
+    auto& db = qp.db().real_database();
+    auto& sp = qp.proxy();
     // This is not super efficient. We need to match files on disk, but we do want to use 
     // "proper" ids like sstable_id for designating tables to backup. We could open files
     // on scan to match ID:s, but it might be easier/faster to just re-use the meta table
     auto& cf = db.find_column_family(table_id);
-    auto local = snap.sp().local().shared_token_metadata().get()->get_topology().get_location();
+    auto local = sp.shared_token_metadata().get()->get_topology().get_location();
     auto ksname = cf.schema()->ks_name();
     auto cfname = cf.schema()->cf_name();
-    db::snapshot_table_helper sth(snap.qp().local());
+    db::snapshot_table_helper sth(qp);
     auto sstables = co_await sth.get_snapshot_sstables(tag, ksname, cfname 
         , local.dc
         , local.rack
@@ -422,7 +447,7 @@ db::snapshot::backup_sstables(db::snapshot_ctl& snap, table_id table_id, std::st
 
     snap_log.debug("Found {} sstables not yet backed up", sstables.size());
 
-    auto global_table = co_await get_table_on_all_shards(snap.db(), ksname, cfname);
+    auto global_table = co_await get_table_on_all_shards(db.container(), ksname, cfname);
     auto& storage_options = global_table->get_storage_options();
     if (!storage_options.is_local_type()) {
         throw std::invalid_argument("not able to backup a non-local table");
@@ -475,95 +500,142 @@ db::snapshot::backup_sstables(db::snapshot_ctl& snap, table_id table_id, std::st
             | std::views::chunk(size_t(std::ceil(double(base_names.size())/this_smp_shard_count())))
             | std::ranges::to<std::vector>()
             ;
-    co_await snap.db().invoke_on_all([&](auto& db) -> future<> {
-        if (this_shard_id() >= chunks.size()) {
-            co_return;
-        }
-        std::exception_ptr p;
 
-        auto chunk = chunks[this_shard_id()];
-        auto client = snap.sstm().container().local().get_endpoint_client(endpoint);
-        auto& t = db.find_column_family(table_id);
-        auto& manager = db.get_sstables_manager(*t.schema());
+    struct shard_ctxt {
+        seastar::gate gate;
+        seastar::abort_source as;
+    };
 
-        co_await coroutine::parallel_for_each(chunk | std::views::values, [&](const gen_info& info) -> future<>{
-            auto& id = info.sstable.sstable_id;
-            auto table_prefix = fmt::format("{}/{}", prefix, id);
+    seastar::sharded<shard_ctxt> per_shard;
+    std::exception_ptr ex;
 
-            auto gen_info = sstables::parse_path(std::filesystem::path(info.sstable.toc_name), ksname, cfname);
-            if (!gen_info) {
-                throw std::runtime_error(fmt::format("Could not parse sstable generation for {}", id));
+    co_await per_shard.start();
+
+    seastar::optimized_optional<seastar::abort_source::subscription> abort_sub;
+
+    if (as) {
+        // If we abort, we need to signal all shards.
+        // Note that abort callback is non-waiting, so
+        // we cannot wait for our abort dispatch.
+        // The per-context gate ensures we finish any aborts before
+        // destroying any coroutine frame vars.
+        abort_sub = as->subscribe([&] () noexcept {
+            std::ignore = per_shard.invoke_on_all([] (auto& ps) {
+                ps.as.request_abort();
+            });
+        });
+    }
+
+    try {
+        co_await per_shard.invoke_on_all([&](auto& ps) -> future<> {
+            if (this_shard_id() >= chunks.size()) {
+                co_return;
             }
 
-            auto gen = (*gen_info).generation;
-            auto ref_name = sstables::object_name(bucket, table_prefix, fmt::format("refs/snapshot-{}/{}", tag, gen));
-            co_await client->put_object(ref_name, memory_data_sink_buffers{}); // any exception here can just propagate
+            std::exception_ptr p;
 
-            bool any_failed = false;
-            co_await coroutine::parallel_for_each(info.filenames, [&](std::string_view name) -> future<> {
-                auto units = co_await manager.dir_semaphore().get_units(1);
+            auto h = ps.gate.hold();
+            auto& as = ps.as;
+            auto& ldb = db.container().local();
+            auto chunk = chunks[this_shard_id()];
+            auto& t = ldb.find_column_family(table_id);
+            auto& manager = ldb.get_sstables_manager(*t.schema());
+            auto client = manager.get_endpoint_client(endpoint);
 
-                // Pre-upload break point. For testing abort in actual s3 client usage.
-                co_await utils::get_local_injector().inject("backup_task_pre_upload", utils::wait_for_message(std::chrono::minutes(2)));
+            co_await coroutine::parallel_for_each(chunk | std::views::values, [&](const gen_info& info) -> future<> {
+                auto& id = info.sstable.sstable_id;
+                auto table_prefix = fmt::format("{}/{}", prefix, id);
 
-                auto component_name = dir / name;
-                auto destination = sstables::object_name(bucket, table_prefix, name);
+                auto gen_info = sstables::parse_path(std::filesystem::path(info.sstable.toc_name), ksname, cfname);
+                if (!gen_info) {
+                    throw std::runtime_error(fmt::format("Could not parse sstable generation for {}", id));
+                }
 
-                snap_log.trace("Upload {} to {}", component_name.native(), destination);
+                auto gen = (*gen_info).generation;
+                auto ref_name = sstables::object_name(bucket, table_prefix, fmt::format("refs/snapshot-{}/{}", tag, gen));
+                co_await client->put_object(ref_name, memory_data_sink_buffers{}); // any exception here can just propagate
 
-                bool error = false;
+                bool any_failed = false;
+                co_await coroutine::parallel_for_each(info.filenames, [&](std::string_view name) -> future<> {
+                    auto units = co_await manager.dir_semaphore().get_units(1, as);
+
+                    // Pre-upload break point. For testing abort in actual s3 client usage.
+                    co_await utils::get_local_injector().inject("backup_task_pre_upload", utils::wait_for_message(std::chrono::minutes(2)));
+
+                    auto component_name = dir / name;
+                    auto destination = sstables::object_name(bucket, table_prefix, name);
+
+                    snap_log.trace("Upload {} to {}", component_name.native(), destination);
+
+                    bool error = false;
+
+                    try {
+                        auto exists = co_await client->object_exists(destination, &as);
+
+                        if (exists) {
+                            snap_log.trace("Object {} already exists. Skipping...", destination);
+                        } else {
+                            utils::upload_progress dummy;
+                            as.check();
+                            co_await client->upload_file(component_name, std::move(destination), dummy, &as);
+                        }
+                    } catch (...) {
+                        error = true; // we might have written parts
+                        snap_log.error("Error uploading {}: {}", component_name.native(), std::current_exception());
+                        if (!p) {
+                            p = std::current_exception();
+                        }
+                    }
+                    if (error) {
+                        any_failed = true;
+                        co_return;
+                    }
+                    if (use_move) {
+                        try {
+                            co_await remove_file(component_name.native());
+                        } catch (...) {
+                            snap_log.warn("Failed to remove {}: {}", component_name, std::current_exception());
+                        }
+                    }
+                    co_await utils::get_local_injector().inject("backup_task_pause", utils::wait_for_message(std::chrono::minutes(2)));
+                });
+
+                if (any_failed) {
+                    try {
+                        co_await client->delete_object(ref_name);
+                    } catch (...) {
+                        // nothing to do here...
+                    }
+                    co_return; // don't update status.
+                }
 
                 try {
-                    auto exists = co_await client->object_exists(destination);
-
-                    if (exists) {
-                        snap_log.trace("Object {} already exists. Skipping...", destination);
-                    } else {
-                        utils::upload_progress dummy;
-                        co_await client->upload_file(component_name, std::move(destination), dummy);
-                    }
+                    snap_log.info("Marking {} as uploaded", id);
+                    as.check();
+                    db::snapshot_table_helper sth(qp.container().local());
+                    info.sstable.state = use_move ? db::snapshot_state::remote : db::snapshot_state::remote_and_local;
+                    co_await sth.insert_snapshot_sstables(tag, ksname, cfname, local.dc, local.rack, { info.sstable });
                 } catch (...) {
-                    error = true; // we might have written parts
-                    snap_log.error("Error uploading {}: {}", component_name.native(), std::current_exception());
-                    if (!p) {
-                        p = std::current_exception();
-                    }
+                    snap_log.error("Error marking {} as uploaded: {}", id, std::current_exception());
                 }
-                if (error) {
-                    any_failed = true;
-                    co_return;
-                }
-                if (use_move) {
-                    try {
-                        co_await remove_file(component_name.native());
-                    } catch (...) {
-                        snap_log.warn("Failed to remove {}: {}", component_name, std::current_exception());
-                    }
-                }
-                co_await utils::get_local_injector().inject("backup_task_pause", utils::wait_for_message(std::chrono::minutes(2)));
             });
 
-            if (any_failed) {
-                try {
-                    co_await client->delete_object(ref_name);
-                } catch (...) {
-                    // nothing to do here...
-                }
-                co_return; // don't update status.
-            }
-
-            try {
-                snap_log.info("Marking {} as uploaded", id);
-                db::snapshot_table_helper sth(snap.qp().local());
-                info.sstable.state = use_move ? db::snapshot_state::remote : db::snapshot_state::remote_and_local;
-                co_await sth.insert_snapshot_sstables(tag, ksname, cfname, local.dc, local.rack, { info.sstable });
-            } catch (...) {
-                snap_log.error("Error marking {} as uploaded: {}", id, std::current_exception());
+            if (p) {
+                co_await coroutine::return_exception_ptr(std::move(p));
             }
         });
+    } catch (...) {
+        ex = std::current_exception();
+    }
 
-        if (p) {
-            co_await coroutine::return_exception_ptr(std::move(p));
-        }
+    abort_sub = {};
+    co_await per_shard.invoke_on_all([&](auto& ps) {
+        return ps.gate.close();
     });
+
+    co_await per_shard.stop();
+
+    if (ex) {
+        std::rethrow_exception(ex);
+    }
 }

--- a/db/snapshot/cluster_backup.cc
+++ b/db/snapshot/cluster_backup.cc
@@ -149,7 +149,6 @@ future<> cluster_backup_task::do_backup() {
             _locations, _ks_tables, _snapshot, _remove_on_uploaded
         );
 
-        // TODO: progress and abort
         auto sub = _as.subscribe([&]() noexcept {
             // would be great to wait here
             snap_log.info("Aborting snapshot {}", _snapshot);
@@ -161,7 +160,11 @@ future<> cluster_backup_task::do_backup() {
             co_return;
         }
 
-        co_await ctl.wait();
+        _total_progress.total = 100;
+
+        co_await ctl.wait([this](uint32_t v) {
+            _total_progress.completed = v;
+        });
         co_return;
     }
 
@@ -348,10 +351,16 @@ db::snapshot::run_global_backup(cql3::query_processor& qp, std::string snapshot_
             snap_log.info("Requesting backup of {}: {}", node.node, sstable_ids);
 
             try {
+                // Pre-rpc call break point. 
+                co_await utils::get_local_injector().inject("cluster_backup_pre_node_rpc", utils::wait_for_message(std::chrono::minutes(2)));
+
                 auto prefix = db::snapshot::sstables_location(dst.prefix, t, snapshot_name);
                 co_await send_rpc(node.node, tid, snapshot_name, dst.endpoint, dst.bucket, prefix, first_token, last_token, std::move(sstable_ids), move_files);
 
                 progress.add_progress(1);
+
+                // Post-rpc call break point. 
+                co_await utils::get_local_injector().inject("cluster_backup_post_node_rpc", utils::wait_for_message(std::chrono::minutes(2)));
             } catch (...) {
                 snap_log.error("Exception requesting backup of {}:{} from {}", snapshot_name, sstable_ids, node.node);
                 throw; // fail the whole process already

--- a/db/snapshot/cluster_backup.cc
+++ b/db/snapshot/cluster_backup.cc
@@ -140,6 +140,31 @@ future<> cluster_backup_task::do_backup() {
         }
     }
 
+    if (_snap_ctl.db().local().features().backup_as_topology_operation) {
+        // No real point in holding any snap gate here. We only send the
+        // op to topology coordinator. If it is us, topo gate(s) will
+        // handle shutdown attempt, otherwise things will either die
+        // or run, regardless. We do no state changes in this code here.
+        auto ctl = co_await _snap_ctl.sp().local().start_backup_snapshot(
+            _locations, _ks_tables, _snapshot, _remove_on_uploaded
+        );
+
+        // TODO: progress and abort
+        auto sub = _as.subscribe([&]() noexcept {
+            // would be great to wait here
+            snap_log.info("Aborting snapshot {}", _snapshot);
+            std::ignore = ctl.abort();
+        });
+
+        if (_as.abort_requested()) {
+            co_await ctl.abort();
+            co_return;
+        }
+
+        co_await ctl.wait();
+        co_return;
+    }
+
     /**
      * This is a bit overzealous, but we've removed the snapshot-ctl from the run_global_backup call (prep for topo op)
      * so in this legacy call, just hold the snapshot gate across the whole backup run. The motivation being that we should 
@@ -149,7 +174,7 @@ future<> cluster_backup_task::do_backup() {
     co_await _snap_ctl.run_snapshot_modify_operation([&]() -> future<> {
         co_await run_global_backup(_snap_ctl.qp().local(), _snapshot, _ks_tables, _locations, _remove_on_uploaded
             , [&](locator::host_id host, table_id tid, sstring tag, sstring endpoint, sstring bucket, sstring prefix, dht::token first_token, dht::token last_token, utils::chunked_vector<sstables::sstable_id> sstable_ids, bool use_move) -> future<> {
-                co_await ser::snapshot_backup_rpc_verbs::send_backup_snapshot_sstables(&_snap_ctl.ms(), host, tid, tag, endpoint, bucket, prefix, first_token, last_token, std::move(sstable_ids), use_move);
+                co_await ser::snapshot_backup_rpc_verbs::send_backup_snapshot_sstables(&_snap_ctl.ms(), host, tid, tag, endpoint, bucket, prefix, first_token, last_token, std::move(sstable_ids), use_move, service::frozen_topology_guard{});
             }
             , *this
         );
@@ -523,6 +548,7 @@ db::snapshot::backup_sstables(cql3::query_processor& qp, table_id table_id, std:
             std::ignore = per_shard.invoke_on_all([] (auto& ps) {
                 ps.as.request_abort();
             });
+            utils::get_local_injector().inject("backup_task_abort_dispatch", []{});
         });
     }
 

--- a/db/snapshot/cluster_backup.cc
+++ b/db/snapshot/cluster_backup.cc
@@ -232,7 +232,7 @@ future<> cluster_backup_task::do_backup() {
                 if (ti == te) {
                     throw std::runtime_error("Could not find tablet range");
                 }
-                if (e.repaired_at < ti->repaired_at) {
+                if (e.repaired_at < ti->repaired_at || e.repaired_at == 0) {
                     return true; // must include
                 }
                 auto i = repair_master.find(ti->first_token);

--- a/db/snapshot/cluster_backup.hh
+++ b/db/snapshot/cluster_backup.hh
@@ -15,6 +15,7 @@
 #include "tasks/task_manager.hh"
 #include "db/snapshot_types.hh"
 #include "schema/schema_fwd.hh"
+#include "locator/host_id.hh"
 
 namespace db {
 class snapshot_ctl;
@@ -25,7 +26,16 @@ class storage_proxy;
 }
 
 namespace replica {
+    class database;
     class table;
+}
+
+namespace message {
+    class messaging_service;
+}
+
+namespace cql3 {
+    class query_processor;
 }
 
 namespace db::snapshot {
@@ -36,7 +46,14 @@ std::string snapshot_meta_location(std::string_view prefix, const replica::table
 future<tasks::task_id> 
 start_global_backup(db::snapshot_ctl&, tasks::task_manager::module_ptr, std::string snapshot_name, std::unordered_multimap<sstring, sstring> ks_tables, std::unordered_map<sstring, snapshot_dc_location> locations, bool move_files);
 
+using send_backup_rpc_func = std::function<future<>(
+    locator::host_id id, table_id, sstring, sstring, sstring, sstring, dht::token, dht::token, utils::chunked_vector<sstables::sstable_id>, bool
+)>;
+
+future<> 
+run_global_backup(cql3::query_processor&, std::string snapshot_name, std::unordered_multimap<sstring, sstring> ks_tables, std::unordered_map<sstring, db::snapshot_dc_location> locations, bool move_files, send_backup_rpc_func f, tasks::progress_sink&);
+
 future<>
-backup_sstables(db::snapshot_ctl&, table_id table_id, std::string tag, std::string endpoint, std::string bucket, std::string prefix, dht::token first_token, dht::token last_token, utils::chunked_vector<sstables::sstable_id> sstable_ids, bool use_move);
+backup_sstables(cql3::query_processor&, table_id table_id, std::string tag, std::string endpoint, std::string bucket, std::string prefix, dht::token first_token, dht::token last_token, utils::chunked_vector<sstables::sstable_id> sstable_ids, bool use_move, seastar::abort_source* as = nullptr);
 
 }

--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -59,6 +59,7 @@
 #include "db/compaction_history_entry.hh"
 #include "mutation/async_utils.hh"
 #include "utils/chunked_string.hh"
+#include "db/snapshot_types.hh"
 
 #include <unordered_map>
 
@@ -332,6 +333,8 @@ schema_ptr system_keyspace::topology_requests() {
             .with_column("finalize_migration_ks_name", utf8_type)
             .with_column("restore_table_id", uuid_type)
             .with_column("restore_snapshot_name", utf8_type)
+            .with_column("backup_locations", map_type_impl::get_instance(utf8_type, tuple_type_impl::get_instance({utf8_type, utf8_type, utf8_type}), false))
+            .with_column("backup_use_move", boolean_type)
             .set_comment("Topology request tracking")
             .with_hash_version()
             .build();
@@ -3621,6 +3624,21 @@ system_keyspace::topology_requests_entry system_keyspace::topology_request_row_t
     if (row.has("restore_table_id")) {
         entry.restore_table_id = table_id(row.get_as<utils::UUID>("restore_table_id"));
         entry.restore_snapshot_name = row.get_as<sstring>("restore_snapshot_name");
+    }
+    if (row.has("backup_locations")) {
+        entry.backup_locations = row.get_map<sstring, std::vector<data_value>>("backup_locations"
+            , data_type_for<sstring>()
+            , tuple_type_impl::get_instance({utf8_type, utf8_type, utf8_type}))
+            |  std::views::transform([](auto& p) { 
+                return std::make_pair(p.first, db::snapshot_dc_location {
+                    .endpoint = value_cast<sstring>(p.second[0]),
+                    .bucket = value_cast<sstring>(p.second[1]),
+                    .prefix = value_cast<sstring>(p.second[2]),
+                });
+            }) 
+            | std::ranges::to<std::unordered_map<sstring, db::snapshot_dc_location>>()
+            ;
+        entry.backup_use_move = row.get_as<bool>("backup_use_move");
     }
 
     return entry;

--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -335,6 +335,7 @@ schema_ptr system_keyspace::topology_requests() {
             .with_column("restore_snapshot_name", utf8_type)
             .with_column("backup_locations", map_type_impl::get_instance(utf8_type, tuple_type_impl::get_instance({utf8_type, utf8_type, utf8_type}), false))
             .with_column("backup_use_move", boolean_type)
+            .with_column("percent_complete", int32_type)
             .set_comment("Topology request tracking")
             .with_hash_version()
             .build();
@@ -3550,23 +3551,27 @@ future<> system_keyspace::sstables_registry_list(table_id tid, locator::host_id 
 
 future<service::topology_request_state> system_keyspace::get_topology_request_state(utils::UUID id, bool require_entry) {
     auto rs = co_await execute_cql(
-        format("SELECT done, error FROM system.{} WHERE id = {}", TOPOLOGY_REQUESTS, id));
+        format("SELECT done, error, percent_complete FROM system.{} WHERE id = {}", TOPOLOGY_REQUESTS, id));
     if (!rs || rs->empty()) {
         if (require_entry) {
             on_internal_error(slogger, format("no entry for request id {}", id));
         } else {
-            co_return service::topology_request_state{false, ""};
+            co_return service::topology_request_state{false, "", 0};
         }
     }
 
     auto& row = rs->one();
     sstring error;
+    int32_t pc = 0;
 
     if (row.has("error")) {
         error = row.get_as<sstring>("error");
     }
+    if (row.has("percent_complete")) {
+        pc = row.get_as<int32_t>("percent_complete");
+    }
 
-    co_return service::topology_request_state{row.get_as<bool>("done"), std::move(error)};
+    co_return service::topology_request_state{row.get_as<bool>("done"), std::move(error), pc};
 }
 
 system_keyspace::topology_requests_entry system_keyspace::topology_request_row_to_entry(utils::UUID id, const cql3::untyped_result_set_row& row) {
@@ -3625,6 +3630,7 @@ system_keyspace::topology_requests_entry system_keyspace::topology_request_row_t
         entry.restore_table_id = table_id(row.get_as<utils::UUID>("restore_table_id"));
         entry.restore_snapshot_name = row.get_as<sstring>("restore_snapshot_name");
     }
+    entry.backup_use_move = false;
     if (row.has("backup_locations")) {
         entry.backup_locations = row.get_map<sstring, std::vector<data_value>>("backup_locations"
             , data_type_for<sstring>()

--- a/db/system_keyspace.hh
+++ b/db/system_keyspace.hh
@@ -115,6 +115,8 @@ class system_keyspace_view_build_progress;
 struct replay_position;
 typedef std::vector<db::replay_position> replay_positions;
 
+struct snapshot_dc_location;
+
 struct compaction_history_entry;
 
 class system_keyspace : public seastar::peering_sharded_service<system_keyspace>, public seastar::async_sharded_service<system_keyspace> {
@@ -430,6 +432,9 @@ public:
         std::optional<sstring> finalize_migration_ks_name;
         std::optional<table_id> restore_table_id;
         std::optional<sstring> restore_snapshot_name;
+
+        std::optional<std::unordered_map<sstring, db::snapshot_dc_location>> backup_locations;
+        bool backup_use_move;
     };
     using topology_requests_entries = std::unordered_map<utils::UUID, system_keyspace::topology_requests_entry>;
 

--- a/gms/feature_service.hh
+++ b/gms/feature_service.hh
@@ -112,6 +112,7 @@ public:
     gms::feature range_tombstone_and_dead_rows_detection { *this, "RANGE_TOMBSTONE_AND_DEAD_ROWS_DETECTION"sv };
     gms::feature truncate_as_topology_operation { *this, "TRUNCATE_AS_TOPOLOGY_OPERATION"sv };
     gms::feature snapshot_as_topology_operation { *this, "SNAPSHOT_AS_TOPOLOGY_OPERATION"sv };
+    gms::feature backup_as_topology_operation { *this, "BACKUP_AS_TOPOLOGY_OPERATION"sv };
     gms::feature secondary_indexes_on_static_columns { *this, "SECONDARY_INDEXES_ON_STATIC_COLUMNS"sv };
     gms::feature tablets { *this, "TABLETS"sv };
     gms::feature table_digest_insensitive_to_expiry { *this, "TABLE_DIGEST_INSENSITIVE_TO_EXPIRY"sv };

--- a/idl/snapshot_backup.idl.hh
+++ b/idl/snapshot_backup.idl.hh
@@ -11,11 +11,12 @@
 #include "utils/chunked_vector.hh"
 #include "idl/uuid.idl.hh"
 #include "idl/sstables.idl.hh"
+#include "service/topology_guard.hh"
 
 // RPC verb for cluster level backup. Sent by coordinator to sstable owning nodes.
 // "endpoint" is an object storage endpoint reference. Needs to be equivalent across
 // all participating nodes.
 // first_token and last_token represent the range covered by the sstables requested
 // for backing up.   
-verb [[]] backup_snapshot_sstables(table_id table_id, sstring tag, sstring endpoint, sstring bucket, sstring prefix, dht::token first_token, dht::token last_token, utils::chunked_vector<sstables::sstable_id> sstable_ids, bool use_move);
+verb [[]] backup_snapshot_sstables(table_id table_id, sstring tag, sstring endpoint, sstring bucket, sstring prefix, dht::token first_token, dht::token last_token, utils::chunked_vector<sstables::sstable_id> sstable_ids, bool use_move, service::frozen_topology_guard frozen_guard);
 

--- a/node_ops/task_manager_module.cc
+++ b/node_ops/task_manager_module.cc
@@ -7,6 +7,7 @@
  */
 
 #include "db/system_keyspace.hh"
+#include "db/snapshot_types.hh"
 #include "node_ops/task_manager_module.hh"
 #include "service/storage_service.hh"
 #include "service/topology_coordinator.hh"

--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -57,6 +57,7 @@
 #include <seastar/core/metrics.hh>
 #include <seastar/core/execution_stage.hh>
 #include "db/timeout_clock.hh"
+#include "db/snapshot/cluster_backup.hh"
 #include "replica/multishard_query.hh"
 #include "replica/database.hh"
 #include "db/consistency_level_validations.hh"
@@ -489,6 +490,13 @@ public:
     future<> snapshot_with_tablets(const std::vector<std::pair<sstring, sstring>>& ks_cf_names, sstring tag, const db::snapshot_options& opts) {
         co_await seastar::with_gate(_snapshot_gate, [&] () -> future<> {
             co_await request_snapshot_with_tablets(ks_cf_names, tag, opts);
+        });
+    }
+
+    future<utils::UUID> start_backup_snapshot(const std::unordered_map<sstring, db::snapshot_dc_location>& locations, const std::vector<std::pair<sstring, sstring>>& ks_cf_names, sstring tag, bool move_files) {
+        co_return co_await seastar::with_gate(_snapshot_gate, [&]() -> future<utils::UUID> {
+            auto id = co_await request_start_backup_snapshot(locations, ks_cf_names, tag, move_files);
+            co_return id;
         });
     }
 
@@ -1316,6 +1324,35 @@ private:
         );
     }
 
+    future<utils::UUID> request_start_backup_snapshot(const std::unordered_map<sstring, db::snapshot_dc_location>& locations, const std::vector<std::pair<sstring, sstring>>& ks_cf_names, sstring tag, bool move_files) {
+        std::unordered_set<table_id> ids;
+        co_return co_await start_topology_request("Backup snapshot"
+            , [&] {
+                ids = ks_names_to_ids(_sp.local_db(), ks_cf_names);
+                return fmt::format("BACKUP SNAPSHOT tables {}", ks_cf_names);
+            }
+            , [&](const db::system_keyspace::topology_requests_entry& entry, const service::global_topology_request& global_request) {
+                if (global_request == global_topology_request::backup_snapshot) {
+                    const std::optional<topology::transition_state>& tstate = _topology_state_machine._topology.tstate;
+                    if (!tstate || *tstate != topology::transition_state::backup_snapshot) {
+                        return entry.snapshot_table_ids == ids && entry.snapshot_tag == tag
+                            && entry.backup_locations ==  locations
+                            && entry.backup_use_move == move_files
+                            ;
+                    }
+                }
+                return false;
+            }
+            , [&](topology_request_tracking_mutation_builder& trbuilder) {
+                trbuilder.set_backup_snapshot_data(ids, locations, tag, move_files)
+                         .set("done", false)
+                         .set("start_time", db_clock::now());
+                slogger.info("Creating BACKUP SNAPSHOT global topology request for snapshot {}, tables {}", tag, ks_cf_names);
+                return global_topology_request::backup_snapshot;
+            }
+            , "request_backup_tablet_snapshot"
+        );
+    }
 };
 
 using namespace exceptions;
@@ -7319,7 +7356,7 @@ future<> storage_proxy::truncate_blocking(sstring keyspace, sstring cfname, std:
 
 future<> storage_proxy::snapshot_keyspace(std::unordered_multimap<sstring, sstring> ks_tables, sstring tag, const db::snapshot_options& opts) {
     if (!features().snapshot_as_topology_operation) {
-        throw std::runtime_error("Cannot do cluster wide snapshot. Feature 'snapshot_as_topology_operation' is not available in cluster");
+        throw gms::unsupported_feature_exception("Cannot do cluster wide snapshot. Feature 'snapshot_as_topology_operation' is not available in cluster");
     }
 
     for (auto& [ksname, _] : ks_tables) {
@@ -7338,6 +7375,20 @@ future<> storage_proxy::snapshot_keyspace(std::unordered_multimap<sstring, sstri
         | std::ranges::to<std::vector>()
         ;
     co_await remote().snapshot_with_tablets(table_pairs, tag, opts);
+}
+
+future<abortable_topology_task> storage_proxy::start_backup_snapshot(std::unordered_map<sstring, db::snapshot_dc_location> locations, std::unordered_multimap<sstring, sstring> ks_tables, sstring tag, bool move_files) {
+    if (!features().backup_as_topology_operation) {
+        throw gms::unsupported_feature_exception("Cannot do cluster wide topology coordinated backup. Feature 'backup_as_topology_operation' is not available in cluster");
+    }
+
+    slogger.debug("Starting a blocking backup operation on keyspaces {}", ks_tables);
+
+    auto table_pairs = ks_tables | std::views::transform([](auto& p) { return std::pair<sstring, sstring>(p.first, p.second); }) 
+        | std::ranges::to<std::vector>()
+        ;
+    auto id = co_await remote().start_backup_snapshot(locations, table_pairs, tag, move_files);
+    co_return abortable_topology_task(*this, id);
 }
 
 db::system_keyspace& storage_proxy::system_keyspace() {

--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -1272,20 +1272,25 @@ private:
         );
     }
 
+    static std::unordered_set<table_id> ks_names_to_ids(replica::database& db, const std::vector<std::pair<sstring, sstring>>& ks_cf_names) {
+        std::unordered_set<table_id> ids;
+        for (auto& [ks_name, cf_name] : ks_cf_names) {
+            if (cf_name.empty()) {
+                auto& ks = db.find_keyspace(ks_name);
+                auto id_range = ks.metadata()->cf_meta_data() | std::views::values | std::views::transform(std::mem_fn(&schema::id));
+                ids.insert(id_range.begin(), id_range.end());
+            } else {
+                ids.insert(db.find_uuid(ks_name, cf_name));
+            }
+        }
+        return ids;
+    }
+
     future<> request_snapshot_with_tablets(const std::vector<std::pair<sstring, sstring>> ks_cf_names, sstring tag, const db::snapshot_options& opts) {
         std::unordered_set<table_id> ids;
         co_await do_topology_request("Snapshot table"
             , [&] {
-                auto& db = _sp.local_db();
-                for (auto& [ks_name, cf_name] : ks_cf_names) {
-                    if (cf_name.empty()) {
-                        auto& ks = db.find_keyspace(ks_name);
-                        auto id_range = ks.metadata()->cf_meta_data() | std::views::values | std::views::transform(std::mem_fn(&schema::id));
-                        ids.insert(id_range.begin(), id_range.end());
-                    } else {
-                        ids.insert(db.find_uuid(ks_name, cf_name));
-                    }
-                }
+                ids = ks_names_to_ids(_sp.local_db(), ks_cf_names);
                 return fmt::format("SNAPSHOT tables {}", ks_cf_names);
             }
             , [&](const db::system_keyspace::topology_requests_entry& entry, const service::global_topology_request& global_request) {

--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -7731,13 +7731,25 @@ abortable_topology_task::abortable_topology_task(storage_proxy& sp, utils::UUID 
 abortable_topology_task::abortable_topology_task(abortable_topology_task&& t) noexcept = default;
 abortable_topology_task& abortable_topology_task::operator=(abortable_topology_task&& t) noexcept = default;
 
-future<> abortable_topology_task::wait() {
+future<> abortable_topology_task::wait(topology_state_machine::completion_callback cc) {
     // group0 is only set on shard 0
     auto me = this_shard_id();
     std::string result;
     co_await _sp->container().invoke_on(0, [&](storage_proxy& sp) -> future<> {
         auto& r = sp.remote();
-        auto error = co_await r.topology_state_machine().wait_for_request_completion(r.system_keyspace(), _request_id, true);
+        // progress needs to be handled non-waiting. use a gate to ensure we've reported all
+        // before returning (handle exceptions...)
+        gate g;
+        auto error = co_await r.topology_state_machine().wait_for_request_completion(r.system_keyspace(), _request_id, true, [&](int32_t pc) {
+            if (cc) {
+                auto h = g.hold();
+                std::ignore = smp::submit_to(me, [pc, &cc] {
+                    cc(pc);
+                }).finally([h = std::move(h)] {});
+            }
+        }).finally([&] {
+            return g.close();
+        });
         if (!error.empty()) {
             co_await smp::submit_to(me, [&error, &result] {
                 result = error; // copy!

--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -43,6 +43,7 @@
 #include "db/hints/manager.hh"
 #include "db/system_keyspace.hh"
 #include "db/system_distributed_keyspace.hh"
+#include "cql3/query_processor.hh"
 #include "exceptions/exceptions.hh"
 #include <boost/intrusive/list.hpp>
 #include <boost/outcome/result.hpp>
@@ -311,6 +312,10 @@ public:
 
     paxos::paxos_store& paxos_store() {
         return _paxos_store.local();
+    }
+
+    topology_state_machine& topology_state_machine() {
+        return _topology_state_machine;
     }
 
     const db::view::view_building_state_machine& view_building_state_machine() {
@@ -7661,4 +7666,40 @@ future<> storage_proxy::cancel_nonlocal_write_response_handlers() {
     }
     co_await g.close();
 }
+
+abortable_topology_task::abortable_topology_task(storage_proxy& sp, utils::UUID id) noexcept 
+    : _sp(&sp)
+    , _request_id(id)
+{}
+
+abortable_topology_task::abortable_topology_task(abortable_topology_task&& t) noexcept = default;
+abortable_topology_task& abortable_topology_task::operator=(abortable_topology_task&& t) noexcept = default;
+
+future<> abortable_topology_task::wait() {
+    // group0 is only set on shard 0
+    auto me = this_shard_id();
+    std::string result;
+    co_await _sp->container().invoke_on(0, [&](storage_proxy& sp) -> future<> {
+        auto& r = sp.remote();
+        auto error = co_await r.topology_state_machine().wait_for_request_completion(r.system_keyspace(), _request_id, true);
+        if (!error.empty()) {
+            co_await smp::submit_to(me, [&error, &result] {
+                result = error; // copy!
+            });
+        }
+    });
+
+    if (!result.empty()) {
+        throw std::runtime_error(fmt::format("Abortable task wait failed: {}", result));
+    }
+}
+
+future<> abortable_topology_task::abort() {
+    co_await _sp->container().invoke_on(0, [&](storage_proxy& sp) -> future<> {
+        auto& r = sp.remote();
+        co_await r.system_keyspace().query_processor().storage_service().abort_topology_request(_request_id);
+    });
+}
+
+
 }

--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -1156,11 +1156,11 @@ private:
     using can_replace_op_with_ongoing_func = std::function<bool(const db::system_keyspace::topology_requests_entry&, const service::global_topology_request&)>;
     using create_op_mutations_func = std::function<global_topology_request(topology_request_tracking_mutation_builder&)>;
 
-    future<> do_topology_request(std::string_view reason, begin_op_func begin, can_replace_op_with_ongoing_func can_replace_op, create_op_mutations_func create_mutations, std::string_view origin) {
+    future<utils::UUID> start_topology_request(std::string_view reason, begin_op_func begin, can_replace_op_with_ongoing_func can_replace_op, create_op_mutations_func create_mutations, std::string_view origin) {
         if (this_shard_id() != 0) {
             // group0 is only set on shard 0
             co_return co_await _sp.container().invoke_on(0, [&] (storage_proxy& sp) {
-                return sp.remote().do_topology_request(reason, begin, can_replace_op, create_mutations, origin);
+                return sp.remote().start_topology_request(reason, begin, can_replace_op, create_mutations, origin);
             });
         }
 
@@ -1219,6 +1219,19 @@ private:
             }
         }
 
+        co_return global_request_id;
+    }
+
+    future<> do_topology_request(std::string_view reason, begin_op_func begin, can_replace_op_with_ongoing_func can_replace_op, create_op_mutations_func create_mutations, std::string_view origin) {
+        if (this_shard_id() != 0) {
+            // group0 is only set on shard 0
+            co_return co_await _sp.container().invoke_on(0, [&] (storage_proxy& sp) {
+                return sp.remote().do_topology_request(reason, begin, can_replace_op, create_mutations, origin);
+            });
+        }
+
+        auto global_request_id = co_await start_topology_request(reason, begin, can_replace_op, create_mutations, origin);
+ 
         // Wait for the topology request to complete
         sstring error = co_await _topology_state_machine.wait_for_request_completion(_sys_ks.local(), global_request_id, true);
         if (!error.empty()) {

--- a/service/storage_proxy.hh
+++ b/service/storage_proxy.hh
@@ -75,6 +75,7 @@ class feature_service;
 namespace db {
 class system_keyspace;
 struct snapshot_options;
+struct snapshot_dc_location;
 enum class large_data_violation_type : uint8_t;
 
 namespace view {
@@ -827,6 +828,8 @@ public:
      * Performs snapshot on keyspace/tables. To snapshot all tables in a keyspace, put "ks: ''" in map
      */
     future<> snapshot_keyspace(std::unordered_multimap<sstring, sstring> ks_tables, sstring tag, const db::snapshot_options& opts);
+
+    future<abortable_topology_task> start_backup_snapshot(std::unordered_map<sstring, db::snapshot_dc_location> locations, std::unordered_multimap<sstring, sstring> ks_tables, sstring tag, bool move_files);
 
     /*
      * Executes data query on the whole cluster.

--- a/service/storage_proxy.hh
+++ b/service/storage_proxy.hh
@@ -132,7 +132,7 @@ public:
     abortable_topology_task(abortable_topology_task&&) noexcept;
     abortable_topology_task& operator=(abortable_topology_task&&) noexcept;
 
-    future<> wait();
+    future<> wait(topology_state_machine::completion_callback = {});
     future<> abort();
 };
 

--- a/service/storage_proxy.hh
+++ b/service/storage_proxy.hh
@@ -123,6 +123,18 @@ using is_cancellable = bool_class<struct cancellable_tag>;
 
 using storage_proxy_clock_type = lowres_clock;
 
+class abortable_topology_task {
+    storage_proxy* _sp;
+    utils::UUID _request_id;
+public:
+    abortable_topology_task(storage_proxy&, utils::UUID request_id) noexcept;
+    abortable_topology_task(abortable_topology_task&&) noexcept;
+    abortable_topology_task& operator=(abortable_topology_task&&) noexcept;
+
+    future<> wait();
+    future<> abort();
+};
+
 class storage_proxy_coordinator_query_options {
     storage_proxy_clock_type::time_point _timeout;
 
@@ -230,6 +242,7 @@ private:
     using unique_response_handler_vector = utils::small_vector<unique_response_handler, 1>;
     using response_handlers_map = std::unordered_map<response_id_type, ::shared_ptr<abstract_write_response_handler>>;
 
+    friend class abortable_topology_task;
 public:
     static const sstring COORDINATOR_STATS_CATEGORY;
     static const sstring REPLICA_STATS_CATEGORY;

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -724,6 +724,8 @@ future<> storage_service::topology_state_load(state_change_hint hint) {
                     [[fallthrough]];
                 case topology::transition_state::snapshot_tables:
                     [[fallthrough]];
+                case topology::transition_state::backup_snapshot:
+                    [[fallthrough]];
                 case topology::transition_state::rollback_to_normal:
                     return read_new_t::no;
                 case topology::transition_state::write_both_read_new:

--- a/service/tablet_allocator.cc
+++ b/service/tablet_allocator.cc
@@ -24,6 +24,7 @@
 #include "utils/div_ceil.hh"
 #include "db/config.hh"
 #include "db/tablet_options.hh"
+#include "db/snapshot_types.hh"
 #include "locator/load_sketch.hh"
 #include "replica/database.hh"
 #include "gms/feature_service.hh"

--- a/service/task_manager_module.cc
+++ b/service/task_manager_module.cc
@@ -16,6 +16,7 @@
 #include "tasks/task_handler.hh"
 #include "tasks/virtual_task_hint.hh"
 #include "utils/UUID_gen.hh"
+#include "db/snapshot_types.hh"
 #include <cmath>
 #include <seastar/coroutine/maybe_yield.hh>
 

--- a/service/topology_coordinator.cc
+++ b/service/topology_coordinator.cc
@@ -2867,12 +2867,13 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
         co_await global_tablet_token_metadata_barrier(std::move(guard));
     }
 
+    using do_topo_op_func = std::function<future<std::optional<sstring>>(const db::system_keyspace::topology_requests_entry&, group0_guard&)>;
     using get_table_ids_func = std::function<std::unordered_set<table_id>(const db::system_keyspace::topology_requests_entry&)>;
     using send_rpc_func = std::function<future<>(locator::host_id, const service::frozen_topology_guard&)>;
     using desc_func = std::function<std::string()>;
     using before_finalize_func = std::function<future<>()>;
 
-    future<> handle_topology_ordered_op(group0_guard guard, get_table_ids_func get_table_ids, send_rpc_func send_rpc, desc_func desc, std::string_view what, before_finalize_func bf = {}) {
+    future<> handle_topology_ordered_op0(group0_guard guard, do_topo_op_func do_topo_op, std::string_view what, before_finalize_func bf = {}) {
         // Execute a barrier to make sure the nodes we are performing truncate on see the session
         // and are able to create a topology_guard using the frozen_guard we are sending over RPC
         // TODO: Exclude nodes which don't contain replicas of the table we are truncating
@@ -2884,45 +2885,7 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
         // handler performed the truncate and cleared the session, but crashed before finalizing the request
         if (_topo_sm._topology.session) {
             const auto topology_requests_entry = co_await _sys_ks.get_topology_request_entry(global_request_id);
-            std::unordered_set<table_id> tables;
-            try {
-                tables = get_table_ids(topology_requests_entry);
-            } catch (std::exception& e) {
-                error = e.what();
-            }
-            if (!tables.empty()) {
-                // Collect the IDs of the hosts with replicas, but ignore excluded nodes
-                std::unordered_set<locator::host_id> replica_hosts;
-                for (auto table_id : tables) {
-                    const locator::tablet_map& tmap = get_token_metadata_ptr()->tablets().get_tablet_map(table_id);
-                    co_await tmap.for_each_tablet([&] (locator::tablet_id tid, const locator::tablet_info& tinfo) {
-                        for (const locator::tablet_replica& replica: tinfo.replicas) {
-                            if (!_topo_sm._topology.excluded_tablet_nodes.contains(raft::server_id(replica.host.uuid()))) {
-                                replica_hosts.insert(replica.host);
-                            }
-                        }
-                        return make_ready_future<>();
-                    });
-                }
-
-                // Release the guard to avoid blocking group0 for long periods of time while invoking RPCs
-                release_guard(std::move(guard));
-
-                co_await utils::get_local_injector().inject(fmt::format("{}_table_wait", what), utils::wait_for_message(std::chrono::minutes(2)));
-
-                // Check if all the nodes with replicas are alive
-                for (const locator::host_id& replica_host: replica_hosts) {
-                    if (!_gossiper.is_alive(replica_host)) {
-                        throw std::runtime_error(::format("Cannot perform {} because host {} is down", desc(), replica_host));
-                    }
-                }
-
-                // Send the RPC to all replicas
-                const service::frozen_topology_guard frozen_guard { _topo_sm._topology.session };
-                co_await coroutine::parallel_for_each(replica_hosts, [&] (const locator::host_id& host_id) -> future<> {
-                    co_await send_rpc(host_id, frozen_guard);
-                });
-            }
+            error = co_await do_topo_op(topology_requests_entry, guard);
 
             // Clear the session and save the error message
             while (true) {
@@ -2984,6 +2947,55 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
             } catch (group0_concurrent_modification&) {
             }
         }
+    }
+
+    future<> handle_topology_ordered_op(group0_guard guard, get_table_ids_func get_table_ids, send_rpc_func send_rpc, desc_func desc, std::string_view what, before_finalize_func bf = {}) {
+        co_await handle_topology_ordered_op0(std::move(guard), [&](const db::system_keyspace::topology_requests_entry& topology_requests_entry, group0_guard& guard) -> future<std::optional<sstring>> {
+            std::unordered_set<table_id> tables;
+            std::optional<sstring> error;
+
+            try {
+                tables = get_table_ids(topology_requests_entry);
+            } catch (std::exception& e) {
+                error = e.what();
+            }
+
+            if (!tables.empty()) {
+                // Collect the IDs of the hosts with replicas, but ignore excluded nodes
+                std::unordered_set<locator::host_id> replica_hosts;
+                for (auto table_id : tables) {
+                    const locator::tablet_map& tmap = get_token_metadata_ptr()->tablets().get_tablet_map(table_id);
+                    co_await tmap.for_each_tablet([&] (locator::tablet_id tid, const locator::tablet_info& tinfo) {
+                        for (const locator::tablet_replica& replica: tinfo.replicas) {
+                            if (!_topo_sm._topology.excluded_tablet_nodes.contains(raft::server_id(replica.host.uuid()))) {
+                                replica_hosts.insert(replica.host);
+                            }
+                        }
+                        return make_ready_future<>();
+                    });
+                }
+
+                // Release the guard to avoid blocking group0 for long periods of time while invoking RPCs
+                release_guard(std::move(guard));
+                assert(!guard);
+                co_await utils::get_local_injector().inject(fmt::format("{}_table_wait", what), utils::wait_for_message(std::chrono::minutes(2)));
+
+                // Check if all the nodes with replicas are alive
+                for (const locator::host_id& replica_host: replica_hosts) {
+                    if (!_gossiper.is_alive(replica_host)) {
+                        throw std::runtime_error(::format("Cannot perform {} because host {} is down", desc(), replica_host));
+                    }
+                }
+
+                // Send the RPC to all replicas
+                const service::frozen_topology_guard frozen_guard { _topo_sm._topology.session };
+                co_await coroutine::parallel_for_each(replica_hosts, [&] (const locator::host_id& host_id) -> future<> {
+                    co_await send_rpc(host_id, frozen_guard);
+                });
+            }
+
+            co_return error;
+        }, what, std::move(bf));
     }
 
     future<> handle_truncate_table(group0_guard guard) {

--- a/service/topology_coordinator.cc
+++ b/service/topology_coordinator.cc
@@ -2955,7 +2955,7 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
                                 .build());
 
             try {
-                co_await update_topology_state(std::move(guard), std::move(updates), fmt::format("{}{} has completed", ::toupper(what[0]), what.substr(1)));
+                co_await update_topology_state(std::move(guard), std::move(updates), fmt::format("{}{} has completed", char(::toupper(what[0])), what.substr(1)));
                 break;
             } catch (group0_concurrent_modification&) {
             }

--- a/service/topology_coordinator.cc
+++ b/service/topology_coordinator.cc
@@ -30,6 +30,7 @@
 #include "cql3/statements/ks_prop_defs.hh"
 #include "db/system_distributed_keyspace.hh"
 #include "db/system_keyspace.hh"
+#include "db/snapshot/cluster_backup.hh"
 #include "dht/boot_strapper.hh"
 #include "gms/gossiper.hh"
 #include "gms/feature_service.hh"
@@ -67,6 +68,7 @@
 
 #include "idl/join_node.dist.hh"
 #include "idl/storage_service.dist.hh"
+#include "idl/snapshot_backup.dist.hh"
 #include "replica/exceptions.hh"
 #include "service/paxos/prepare_response.hh"
 #include "idl/storage_proxy.dist.hh"
@@ -1308,6 +1310,17 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
                    .drop_first_global_topology_request_id(_topo_sm._topology.global_requests_queue, req_id)
                    .set_session(session_id(req_id));
             co_await update_topology_state(std::move(guard), {builder.build()}, "SNAPSHOT TABLES requested");
+        }
+        break;
+        case global_topology_request::backup_snapshot: {
+            rtlogger.info("BACKUP SNAPSHOT requested");
+            topology_mutation_builder builder(guard.write_timestamp());
+            builder.set_transition_state(topology::transition_state::backup_snapshot)
+                   .set_global_topology_request(req)
+                   .set_global_topology_request_id(req_id)
+                   .drop_first_global_topology_request_id(_topo_sm._topology.global_requests_queue, req_id)
+                   .set_session(session_id(req_id));
+            co_await update_topology_state(std::move(guard), {builder.build()}, "BACKUP SNAPSHOT requested");
         }
         break;
         case global_topology_request::finalize_migration: {
@@ -3071,6 +3084,44 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
         );
     }
 
+    future<> handle_backup_snapshot(group0_guard guard) {
+        co_await handle_topology_ordered_op0(std::move(guard), [&](const db::system_keyspace::topology_requests_entry& topology_requests_entry, group0_guard& guard) -> future<std::optional<sstring>> {
+            std::optional<sstring> error;
+
+            try {
+                auto tag = *topology_requests_entry.snapshot_tag;
+                auto move_files = topology_requests_entry.backup_use_move;
+                auto locations = *topology_requests_entry.backup_locations;
+                std::unordered_multimap<sstring, sstring> ks_tables;
+
+                for (auto& id : *topology_requests_entry.snapshot_table_ids) {
+                    lw_shared_ptr<replica::table> table = _db.get_tables_metadata().get_table_if_exists(id);
+                    if (!table) {
+                        throw std::invalid_argument(fmt::format("Cannot BACKUP SNAPSHOT of table with UUID {} because it does not exist.", id));
+                    }
+                    ks_tables.emplace(table->schema()->ks_name(), table->schema()->cf_name());
+                }
+
+                // Release the guard to avoid blocking group0 for long periods of time while invoking RPCs
+                release_guard(std::move(guard));
+
+                const service::frozen_topology_guard frozen_guard { _topo_sm._topology.session };
+                tasks::progress_sink ps{}; // TODO: progress
+                co_await db::snapshot::run_global_backup(_sys_ks.query_processor()
+                    , std::move(tag), std::move(ks_tables), std::move(locations), move_files
+                    , [&](locator::host_id host, table_id tid, sstring tag, sstring endpoint, sstring bucket, sstring prefix, dht::token first_token, dht::token last_token, utils::chunked_vector<sstables::sstable_id> sstable_ids, bool use_move) -> future<> {
+                        co_await ser::snapshot_backup_rpc_verbs::send_backup_snapshot_sstables(&_messaging, host, tid, tag, endpoint, bucket, prefix, first_token, last_token, std::move(sstable_ids), use_move, frozen_guard);
+                    }
+                    , ps
+                );
+            } catch (std::exception& e) {
+                error = e.what();
+            }
+
+            co_return error;
+        }, "backup");
+    }
+
     // This function must not release and reacquire the guard, callers rely
     // on the fact that the block which calls this is atomic.
     // FIXME: Don't take the ownership of the guard to make the above guarantee explicit.
@@ -3978,6 +4029,9 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
                 break;
             case topology::transition_state::snapshot_tables:
                 co_await handle_snapshot_tables(std::move(guard));
+                break;
+            case topology::transition_state::backup_snapshot:
+                co_await handle_backup_snapshot(std::move(guard));
                 break;
         }
         co_return true;

--- a/service/topology_coordinator.cc
+++ b/service/topology_coordinator.cc
@@ -3883,7 +3883,7 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
                 // Denotes the case when this path is already executed before and first topology state update was successful.
                 // So we can skip all steps and perform the second topology state update operation (which modifies node state to left)
                 // and remove node conditionally from group0.
-                if (auto [done, error] = co_await _sys_ks.get_topology_request_state(node.rs->request_id, false); done) {
+                if (auto [done, error, _] = co_await _sys_ks.get_topology_request_state(node.rs->request_id, false); done) {
                     co_await finish_left_token_ring_transition(node);
                     break;
                 }

--- a/service/topology_coordinator.cc
+++ b/service/topology_coordinator.cc
@@ -78,6 +78,7 @@
 #include "idl/sstables_loader.dist.hh"
 
 #include "service/topology_coordinator.hh"
+#include "tasks/task_manager.hh"
 
 #include <boost/range/join.hpp>
 #include <seastar/core/metrics_registration.hh>
@@ -2950,9 +2951,13 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
                                 .del_global_topology_request()
                                 .del_global_topology_request_id()
                                 .build());
-            updates.push_back(topology_request_tracking_mutation_builder(global_request_id)
-                                .done()
-                                .build());
+
+            auto b = topology_request_tracking_mutation_builder(global_request_id);
+            b.done();
+            if (!error) {
+                b.percent_complete(100); // if anyone cares.
+            }
+            updates.push_back(b.build());
 
             try {
                 co_await update_topology_state(std::move(guard), std::move(updates), fmt::format("{}{} has completed", char(::toupper(what[0])), what.substr(1)));
@@ -3084,9 +3089,77 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
         );
     }
 
+    class topo_request_progress_sink : public tasks::progress_sink {
+        double _total = 0;
+        double _done = 0;
+        double _pub = 0;
+        topology_coordinator& _tc;
+        group0_guard& _guard;
+        utils::UUID _request_id;
+        std::string _what;
+        future<> _background = make_ready_future<>();
+    public:
+        topo_request_progress_sink(topology_coordinator& tc, group0_guard& g, utils::UUID id, std::string_view what)
+            : _tc(tc)
+            , _guard(g)
+            , _request_id(id)
+            , _what(what)
+        {}
+
+        // must call this before destroy, since we might have pending
+        // progress sends in background
+        future<> finalize() {
+            return std::exchange(_background, make_ready_future<>());
+        }
+
+        void set_total(double v) override {
+            _total = v;
+        };
+        void add_progress(double v) override {
+            if (_total == 0) {
+                return;
+            }
+            _done += v;
+            auto npcd = uint32_t(100 * _done / _total);
+
+            // avoid doing this too often or while we are still
+            // trying to write a previous update
+            if ((npcd - _pub) < 5 || !_background.available()) {
+                return;
+            }
+
+            // don't (can't) wait for the update until all 
+            // work is done.
+            _background = [this, npcd]() -> future<> {
+                auto n = npcd;
+                auto* me = this;
+                while (true) {
+                    if (!_guard) {
+                        _guard = co_await _tc.start_operation();
+                    }
+                    utils::chunked_vector<canonical_mutation> updates;
+                    updates.push_back(topology_request_tracking_mutation_builder(_request_id)
+                                        .percent_complete(n)
+                                        .build());
+
+                    try {
+                        co_await _tc.update_topology_state(std::move(_guard), std::move(updates), fmt::format("{}{} {} percent complete", char(::toupper(_what[0])), _what.substr(1), n));
+                        me->_pub = n;
+                        break;
+                    } catch (group0_concurrent_modification&) {
+                    } catch (...) {
+                        break; // ignore any other exception.
+                    }
+                }
+            }();
+        }
+    };
+
     future<> handle_backup_snapshot(group0_guard guard) {
         co_await handle_topology_ordered_op0(std::move(guard), [&](const db::system_keyspace::topology_requests_entry& topology_requests_entry, group0_guard& guard) -> future<std::optional<sstring>> {
             std::optional<sstring> error;
+
+            topo_request_progress_sink ps(*this, guard, topology_requests_entry.id, "backup");
 
             try {
                 auto tag = *topology_requests_entry.snapshot_tag;
@@ -3106,7 +3179,7 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
                 release_guard(std::move(guard));
 
                 const service::frozen_topology_guard frozen_guard { _topo_sm._topology.session };
-                tasks::progress_sink ps{}; // TODO: progress
+
                 co_await db::snapshot::run_global_backup(_sys_ks.query_processor()
                     , std::move(tag), std::move(ks_tables), std::move(locations), move_files
                     , [&](locator::host_id host, table_id tid, sstring tag, sstring endpoint, sstring bucket, sstring prefix, dht::token first_token, dht::token last_token, utils::chunked_vector<sstables::sstable_id> sstable_ids, bool use_move) -> future<> {
@@ -3118,6 +3191,14 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
                 error = e.what();
             }
 
+            // make sure any progress updates are done before we
+            // signal done.
+            try {
+                co_await ps.finalize();
+            } catch (...) {
+                // should not happen. if it ever would, not worth propagating.
+                on_internal_error_noexcept(rtlogger, fmt::format("Unexpected exception in progress update: {}", std::current_exception()));
+            }
             co_return error;
         }, "backup");
     }

--- a/service/topology_mutation.cc
+++ b/service/topology_mutation.cc
@@ -8,6 +8,7 @@
 
 #include "utils/assert.hh"
 #include "db/system_keyspace.hh"
+#include "db/snapshot_types.hh"
 #include "topology_mutation.hh"
 #include "types/tuple.hh"
 #include "types/types.hh"
@@ -399,6 +400,23 @@ topology_request_tracking_mutation_builder& topology_request_tracking_mutation_b
                                 set_type_impl::native_type(uuids.begin(), uuids.end())));
     apply_atomic("snapshot_tag", tag);
     apply_atomic("snapshot_skip_flush", skip_flush);
+    return *this;
+}
+
+topology_request_tracking_mutation_builder& topology_request_tracking_mutation_builder::set_backup_snapshot_data(const std::unordered_set<table_id>& table_ids, const std::unordered_map<sstring, db::snapshot_dc_location>& locations, const sstring& tag, bool use_move) {
+    set_snapshot_tables_data(table_ids, tag, false);
+
+    auto locs = locations | std::views::transform([](const std::pair<sstring, db::snapshot_dc_location>& p) {
+        auto& [dc, l] = p;
+        return std::pair<data_value, data_value>(dc, tuple_type_impl::get_instance({utf8_type, utf8_type, utf8_type})->make_value(std::vector<data_value>({
+           l.endpoint, l.bucket, l.prefix
+        })));
+    });
+    apply_atomic("backup_locations",
+                 make_map_value(schema().get_column_definition("backup_locations")->type,
+                                map_type_impl::native_type(locs.begin(), locs.end())));
+    apply_atomic("backup_use_move", use_move);
+
     return *this;
 }
 

--- a/service/topology_mutation.cc
+++ b/service/topology_mutation.cc
@@ -388,6 +388,10 @@ topology_request_tracking_mutation_builder& topology_request_tracking_mutation_b
     return set("done", true);
 }
 
+topology_request_tracking_mutation_builder& topology_request_tracking_mutation_builder::percent_complete(uint32_t pc) {
+    return set("percent_complete", pc);
+}
+
 topology_request_tracking_mutation_builder& topology_request_tracking_mutation_builder::set_truncate_table_data(const table_id& table_id) {
     apply_atomic("truncate_table_id", table_id.uuid());
     return *this;

--- a/service/topology_mutation.hh
+++ b/service/topology_mutation.hh
@@ -166,6 +166,7 @@ public:
     topology_request_tracking_mutation_builder& set(const char* cell, global_topology_request value);
     topology_request_tracking_mutation_builder& abort(sstring error);
     topology_request_tracking_mutation_builder& done(std::optional<sstring> error = std::nullopt);
+    topology_request_tracking_mutation_builder& percent_complete(uint32_t);
     topology_request_tracking_mutation_builder& set_truncate_table_data(const table_id& table_id);
     topology_request_tracking_mutation_builder& set_new_keyspace_rf_change_data(const sstring& ks_name, const std::map<sstring, sstring>& rf_per_dc);
     topology_request_tracking_mutation_builder& set_snapshot_tables_data(const std::unordered_set<table_id>&, const sstring& tag, bool);

--- a/service/topology_mutation.hh
+++ b/service/topology_mutation.hh
@@ -23,6 +23,10 @@
 #include "mutation/timestamp.hh"
 #include "utils/UUID.hh"
 
+namespace db {
+struct snapshot_dc_location;
+}
+
 namespace service {
 
 template<typename Builder>
@@ -165,6 +169,7 @@ public:
     topology_request_tracking_mutation_builder& set_truncate_table_data(const table_id& table_id);
     topology_request_tracking_mutation_builder& set_new_keyspace_rf_change_data(const sstring& ks_name, const std::map<sstring, sstring>& rf_per_dc);
     topology_request_tracking_mutation_builder& set_snapshot_tables_data(const std::unordered_set<table_id>&, const sstring& tag, bool);
+    topology_request_tracking_mutation_builder& set_backup_snapshot_data(const std::unordered_set<table_id>&, const std::unordered_map<sstring, db::snapshot_dc_location>&, const sstring& tag, bool);
     topology_request_tracking_mutation_builder& set_finalize_migration_data(const sstring& ks_name);
     topology_request_tracking_mutation_builder& set_restore_tablets_data(const table_id& tid, const sstring& snapshot_name);
 

--- a/service/topology_state_machine.cc
+++ b/service/topology_state_machine.cc
@@ -380,6 +380,10 @@ future<> topology_state_machine::abort_request(service::raft_group0& group0,
             break;
         }
 
+        if (muts.empty() && request_id == _topology.session.uuid()) {
+            muts.push_back(topology_mutation_builder(guard.write_timestamp()).del_session().build());
+        }
+
         if (muts.empty()) {
             // FIXME: Handle global requests.
             throw std::runtime_error(format("Don't know how to abort {}", request_id));

--- a/service/topology_state_machine.cc
+++ b/service/topology_state_machine.cc
@@ -146,6 +146,7 @@ static std::unordered_map<topology::transition_state, sstring> transition_state_
     {topology::transition_state::rollback_to_normal, "rollback to normal"},
     {topology::transition_state::truncate_table, "truncate table"},
     {topology::transition_state::snapshot_tables, "snapshot tables"},
+    {topology::transition_state::backup_snapshot, "backup_snapshot"},
     {topology::transition_state::lock, "lock"},
 };
 
@@ -213,6 +214,7 @@ static std::unordered_map<global_topology_request, sstring> global_topology_requ
     {global_topology_request::finalize_migration, "finalize_migration"},
     {global_topology_request::quiesce, "quiesce"},
     {global_topology_request::restore_tablets, "restore_tablets"},
+    {global_topology_request::backup_snapshot, "backup_snapshot"},
 };
 
 global_topology_request global_topology_request_from_string(const sstring& s) {

--- a/service/topology_state_machine.cc
+++ b/service/topology_state_machine.cc
@@ -277,11 +277,15 @@ validate_removing_node(replica::database& db, locator::host_id host_id) {
     return node_validation_success {};
 }
 
-future<sstring> topology_state_machine::wait_for_request_completion(db::system_keyspace& sys_ks, utils::UUID id, bool require_entry) {
+future<sstring> topology_state_machine::wait_for_request_completion(db::system_keyspace& sys_ks, utils::UUID id, bool require_entry, completion_callback cc) {
     tsmlogger.debug("Start waiting for topology request completion (request id {})", id);
     while (true) {
         auto c = reload_count;
-        auto [done, error] = co_await sys_ks.get_topology_request_state(id, require_entry);
+        auto [done, error, pc] = co_await sys_ks.get_topology_request_state(id, require_entry);
+        if (cc) {
+            tsmlogger.debug("Request with id {} is {} percent complete", id, pc);
+            cc(pc); // maybe report progress
+        }
         if (done) {
             tsmlogger.debug("Request with id {} is completed with status: {}", id, error.empty() ? sstring("success") : error);
             co_return error;

--- a/service/topology_state_machine.hh
+++ b/service/topology_state_machine.hh
@@ -295,7 +295,9 @@ struct topology_state_machine {
     std::function<void()> on_tablet_split_ready;
 
     future<> await_not_busy();
-    future<sstring> wait_for_request_completion(db::system_keyspace& sys_ks, utils::UUID id, bool require_entry);
+
+    using completion_callback = std::function<void(int32_t)>;
+    future<sstring> wait_for_request_completion(db::system_keyspace& sys_ks, utils::UUID id, bool require_entry, completion_callback = {});
 
     // Generates mutations that cancel a topology request which is active on the given node.
     // If no request is found, or it cannot be canceled at this stage, no mutations are generated.
@@ -353,6 +355,7 @@ struct fencing_token {
 struct topology_request_state {
     bool done;
     sstring error;
+    int32_t percent_complete;
 };
 
 struct node_validation_success {};

--- a/service/topology_state_machine.hh
+++ b/service/topology_state_machine.hh
@@ -92,6 +92,7 @@ enum class global_topology_request: uint16_t {
     finalize_migration,
     quiesce,
     restore_tablets,
+    backup_snapshot,
 };
 
 struct ring_slice {
@@ -150,6 +151,7 @@ struct topology {
         truncate_table,
         lock,
         snapshot_tables,
+        backup_snapshot,
     };
 
     std::optional<transition_state> tstate;

--- a/tasks/task_manager.hh
+++ b/tasks/task_manager.hh
@@ -51,6 +51,13 @@ enum class task_kind {
     node,
 };
 
+class progress_sink {
+public:
+    virtual ~progress_sink() = default;
+    virtual void set_total(double) {}; // default - nothing
+    virtual void add_progress(double) {}; // default - nothing
+};
+
 struct task_identity;
 struct task_status;
 struct task_stats;

--- a/test/cluster/object_store/test_backup.py
+++ b/test/cluster/object_store/test_backup.py
@@ -1717,6 +1717,7 @@ async def run_cluster_backup(object_storage, prefix: str, manager: ManagerClient
     manifest = json.load(manifest_obj['Body'])
 
     manifest_sstables = [sst['toc_name'] for sst in manifest['sstables']]
+    manifest_tablets = manifest['tablets']
 
     for ss in servers:
         locations = list(cql.execute(f"SELECT * FROM system_distributed.snapshot_remote_locations WHERE snapshot_name = '{snapshot_name}' AND datacenter = '{s.datacenter}'"))
@@ -1739,6 +1740,14 @@ async def run_cluster_backup(object_storage, prefix: str, manager: ManagerClient
         for sstable in sstables:
             assert sstable.state < 3 or sstable.toc_name in objects
             assert sstable.state < 3 or sstable.toc_name in manifest_sstables
+            if sstable.state < 3:
+                assert sstable.repaired_at > 0
+                # tablets are in token order in manifest
+                for t in manifest_tablets:
+                    if t['last_token'] > sstable.first_token:
+                        assert t['first_token'] <= sstable.first_token
+                        assert t['repaired_at'] > 0
+                        break
 
     return manifest
 

--- a/test/cluster/object_store/test_backup.py
+++ b/test/cluster/object_store/test_backup.py
@@ -1800,3 +1800,56 @@ async def test_cluster_snapshot_repair_set_unique(manager: ManagerClient, object
     Tests a cluster snapshot reduces the snapshot sstable set by the current repair set for each tablet
     """
     await do_test_snapshot_on_all_nodes(manager, partial(run_cluster_backup_and_check_redundancy, object_storage), object_storage, True, True)
+
+async def do_aborted_cluster_backup(object_storage, manager: ManagerClient, snapshot_name: str, ks: str, cf:str, servers: list[ServerInfo]):
+    """
+    Helper
+    """
+    s = servers[0]
+    breakpoint_name = "backup_task_pre_upload"
+    abort_breakpoint_name = "backup_task_abort_dispatch"
+    prefix = "gargamel"
+    await manager.api.enable_injection(s.ip_addr, breakpoint_name, one_shot=True)
+    await manager.api.enable_injection(s.ip_addr, abort_breakpoint_name, one_shot=False)
+
+    backup_tid = await manager.api.backup_cluster_snapshot(s.ip_addr, ks, snapshot_name, s.datacenter, 
+                                                           object_storage.address, object_storage.bucket_name,
+                                                           prefix, tables = [cf])
+
+    await manager.api.wait_for_injection_enter(s.ip_addr, breakpoint_name)
+    await manager.api.abort_task(s.ip_addr, backup_tid)
+    await manager.api.wait_for_injection_enter(s.ip_addr, abort_breakpoint_name)
+
+    await manager.api.message_injection(s.ip_addr, breakpoint_name)
+    status = await manager.api.wait_task(s.ip_addr, backup_tid)
+
+    assert (status is not None) and (status['state'] == 'failed')
+    assert "abort requested" in status['error'] or "aborted" in status['error']
+
+    cql = manager.get_cql()
+    num_sstables = 0;
+
+    for ss in servers:
+        sstables = list(cql.execute(f"""
+                    SELECT COUNT(*) FROM system_distributed.snapshot_sstables WHERE 
+                    snapshot_name = '{snapshot_name}' AND \"keyspace\" = '{ks}' AND
+                    \"table\" = '{cf}' AND datacenter = '{ss.datacenter}' AND
+                    rack = '{ss.rack}'
+                    """))
+        num_sstables += sstables[0].count
+
+    objects = set(os.path.basename(o.key) for o in
+                  object_storage.get_resource().Bucket(object_storage.bucket_name).
+                  objects.filter(Prefix=f"{prefix}/sstables"))
+
+    objects = list(filter(lambda o: o.endswith("TOC.txt"), objects))
+
+    assert len(objects) < num_sstables, "should not manage to upload all files"
+
+@pytest.mark.asyncio
+@pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
+async def test_cluster_snapshot_backup_abortable(manager: ManagerClient, object_storage):
+    """
+    Tests a cluster snapshot backup can be aborted
+    """
+    await do_test_snapshot_on_all_nodes(manager, partial(do_aborted_cluster_backup, object_storage), object_storage, True)

--- a/test/cluster/object_store/test_backup.py
+++ b/test/cluster/object_store/test_backup.py
@@ -1690,16 +1690,12 @@ async def do_test_snapshot_on_all_nodes(manager: ManagerClient,
                 #todo: clear snapshot
                 pass
 
-async def run_cluster_backup(object_storage, prefix: str, manager: ManagerClient, snapshot_name: str, ks: str, cf:str, servers: list[ServerInfo]):
+async def check_cluster_backup(object_storage, prefix: str, manager: ManagerClient, snapshot_name: str, ks: str, cf:str, servers: list[ServerInfo], backup_tid):
     """
-    Helper to run a cluster backup
+    Helper to check a cluster backup
     """
     cql = manager.get_cql()
     s = servers[0]
-
-    backup_tid = await manager.api.backup_cluster_snapshot(s.ip_addr, ks, snapshot_name, s.datacenter, 
-                                                           object_storage.address, object_storage.bucket_name,
-                                                           prefix, tables = [cf])
 
     backup_status = await manager.api.wait_task(s.ip_addr, backup_tid)
     assert backup_status is not None and backup_status.get('state') == 'done', "Cluster backup failed"
@@ -1750,6 +1746,18 @@ async def run_cluster_backup(object_storage, prefix: str, manager: ManagerClient
                         break
 
     return manifest
+
+async def run_cluster_backup(object_storage, prefix: str, manager: ManagerClient, snapshot_name: str, ks: str, cf:str, servers: list[ServerInfo]):
+    """
+    Helper to run a cluster backup
+    """
+    s = servers[0]
+
+    backup_tid = await manager.api.backup_cluster_snapshot(s.ip_addr, ks, snapshot_name, s.datacenter, 
+                                                           object_storage.address, object_storage.bucket_name,
+                                                           prefix, tables = [cf])
+
+    return await check_cluster_backup(object_storage, prefix, manager, snapshot_name, ks, cf, servers, backup_tid)
 
 @pytest.mark.asyncio
 async def test_cluster_snapshot_backup(manager: ManagerClient, object_storage):
@@ -1853,3 +1861,41 @@ async def test_cluster_snapshot_backup_abortable(manager: ManagerClient, object_
     Tests a cluster snapshot backup can be aborted
     """
     await do_test_snapshot_on_all_nodes(manager, partial(do_aborted_cluster_backup, object_storage), object_storage, True)
+
+async def do_progress_checked_cluster_backup(object_storage, manager: ManagerClient, snapshot_name: str, ks: str, cf:str, servers: list[ServerInfo]):
+    """
+    Helper
+    """
+
+    s = servers[0]
+    breakpoint_name = "cluster_backup_post_node_rpc"
+    prefix = "smurfette"
+    await manager.api.enable_injection(s.ip_addr, breakpoint_name, one_shot=False)
+
+    backup_tid = await manager.api.backup_cluster_snapshot(s.ip_addr, ks, snapshot_name, s.datacenter, 
+                                                           object_storage.address, object_storage.bucket_name,
+                                                           prefix, tables = [cf])
+
+    await manager.api.wait_for_injection_enter(s.ip_addr, breakpoint_name)
+
+    deadline = time.time() + 60.0
+
+    async def _check():
+        status = await manager.api.get_task_status(s.ip_addr, backup_tid)
+        assert (status is not None) and (status['state'] != 'done')
+        if status["progress_completed"] != 0.0 and status["progress_completed"] < status["progress_total"]:
+            return True
+        return None
+
+    await wait_for(_check, deadline, label="progress_reported")
+    await manager.api.message_injection(s.ip_addr, breakpoint_name)
+    await manager.api.disable_injection(s.ip_addr, breakpoint_name)
+    await check_cluster_backup(object_storage, prefix, manager, snapshot_name, ks, cf, servers, backup_tid)
+
+@pytest.mark.asyncio
+@pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
+async def test_cluster_snapshot_backup_incremental_progress(manager: ManagerClient, object_storage):
+    """
+    Tests a cluster snapshot backup has incremental progress
+    """
+    await do_test_snapshot_on_all_nodes(manager, partial(do_progress_checked_cluster_backup, object_storage), object_storage, True)


### PR DESCRIPTION
Fixes SCYLLADB-3428

This change set will, if supported by cluster, run the cluster backup dispatched as a topology operation, to ensure both serial execution, but also to allow abort-dispatch across RPC calls to participating nodes.

As such, it adds some more columns to carry the required info from requestor to topo coordinator, on which 
the backup coordination will run.

To implement completion reporting to the API task running the backup, a new column, "percent_complete" is added to topology request. An operation can write to this (similar to actual completion), and the waiting requestor can, optionally, subscribe to it changing. Through this we implement coordinator -> requestor API task progress report. 

Note: The progress mechanism _could_ have been implemented via either an extra column somewhere in sys_dist snapshot tables, or an extra table or whatnot. The choice to utilize the topo request column is based on a.) Already have notification on changes in place + fits into the report/wait mechanism (reasonably), and b.) This way, the mechanism can be possibly re-used by other topo ops (existing or coming). 