### PR TITLE
Fix vnodes-to-tablets migration finalization with zero-token and RF=0 nodes

### DIFF
--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -4505,15 +4505,50 @@ future<storage_service::keyspace_migration_status> storage_service::get_tablets_
         }
     }
 
+    // Determine which nodes take part in the sample table's tablet replication.
+    // Nodes with no replicas (e.g., zero-token nodes in arbiter DCs, or token-owning
+    // nodes in a DC with RF=0) have nothing to migrate, so their effective current mode
+    // matches their intended mode.
+    auto tmptr = _db.local().get_token_metadata_ptr();
+    const auto& tablet_metadata = tmptr->tablets();
+    std::unordered_set<locator::host_id> nodes_with_replicas;
+    if (tablet_metadata.has_tablet_map(sample_table_id)) {
+        const auto& tmap = tablet_metadata.get_tablet_map(sample_table_id);
+        co_await tmap.for_each_tablet([&] (locator::tablet_id, const locator::tablet_info& tinfo) -> future<> {
+            for (const auto& replica : tinfo.replicas) {
+                nodes_with_replicas.insert(replica.host);
+            }
+            return make_ready_future<>();
+        });
+        // Also count replicas a tablet is transitioning to. A pending replica is not in
+        // tablet_info::replicas yet, but it does receive the tablet, so reporting it as
+        // having nothing to migrate would be wrong. The tablet load balancer skips tables
+        // under migration (see is_migrating_table() in tablet_allocator.cc), so there
+        // should be no transitions here, but don't rely on that.
+        for (const auto& [tid, trinfo] : tmap.transitions()) {
+            for (const auto& replica : trinfo.next) {
+                nodes_with_replicas.insert(replica.host);
+            }
+            co_await coroutine::maybe_yield();
+        }
+    }
+
     const auto& topo = _topology_state_machine._topology;
     for (const auto& [server_id, rs] : topo.normal_nodes) {
         auto host_id = locator::host_id{server_id.uuid()};
-        bool reports_tablets = nodes_reporting_tablets.contains(host_id);
-
-        auto current_mode = reports_tablets
-            ? intended_storage_mode::tablets
-            : intended_storage_mode::vnodes;
         auto intended_mode = rs.storage_mode.value_or(intended_storage_mode::vnodes);
+
+        intended_storage_mode current_mode;
+        if (!nodes_with_replicas.contains(host_id)) {
+            // Node has no replicas for this keyspace (e.g., zero-token node in arbiter DC,
+            // or token-owning node in a DC with RF=0). It has nothing to migrate, so its
+            // effective current mode matches its intended mode.
+            current_mode = intended_mode;
+        } else {
+            current_mode = nodes_reporting_tablets.contains(host_id)
+                ? intended_storage_mode::tablets
+                : intended_storage_mode::vnodes;
+        }
 
         result.nodes.push_back(node_migration_status{
             .host_id = host_id,

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -4505,15 +4505,39 @@ future<storage_service::keyspace_migration_status> storage_service::get_tablets_
         }
     }
 
+    // Determine which nodes are actual tablet replicas for the sample table.
+    // Nodes with no replicas (e.g., zero-token nodes in arbiter DCs, or token-owning
+    // nodes in a DC with RF=0) have nothing to migrate, so their effective current mode
+    // matches their intended mode.
+    auto tmptr = _db.local().get_token_metadata_ptr();
+    const auto& tablet_metadata = tmptr->tablets();
+    std::unordered_set<locator::host_id> nodes_with_replicas;
+    if (tablet_metadata.has_tablet_map(sample_table_id)) {
+        const auto& tmap = tablet_metadata.get_tablet_map(sample_table_id);
+        co_await tmap.for_each_tablet([&] (locator::tablet_id, const locator::tablet_info& tinfo) -> future<> {
+            for (const auto& replica : tinfo.replicas) {
+                nodes_with_replicas.insert(replica.host);
+            }
+            return make_ready_future<>();
+        });
+    }
+
     const auto& topo = _topology_state_machine._topology;
     for (const auto& [server_id, rs] : topo.normal_nodes) {
         auto host_id = locator::host_id{server_id.uuid()};
-        bool reports_tablets = nodes_reporting_tablets.contains(host_id);
-
-        auto current_mode = reports_tablets
-            ? intended_storage_mode::tablets
-            : intended_storage_mode::vnodes;
         auto intended_mode = rs.storage_mode.value_or(intended_storage_mode::vnodes);
+
+        intended_storage_mode current_mode;
+        if (!nodes_with_replicas.contains(host_id)) {
+            // Node has no replicas for this keyspace (e.g., zero-token node in arbiter DC,
+            // or token-owning node in a DC with RF=0). It has nothing to migrate, so its
+            // effective current mode matches its intended mode.
+            current_mode = intended_mode;
+        } else {
+            current_mode = nodes_reporting_tablets.contains(host_id)
+                ? intended_storage_mode::tablets
+                : intended_storage_mode::vnodes;
+        }
 
         result.nodes.push_back(node_migration_status{
             .host_id = host_id,

--- a/service/topology_coordinator.cc
+++ b/service/topology_coordinator.cc
@@ -4697,12 +4697,26 @@ future<topology_coordinator::tablet_load_stats_collect_result> topology_coordina
     std::unordered_map<table_id, size_t> total_replicas;
     bool table_load_stats_invalid = false;
 
-    for (auto& [dc, nodes] : tm->get_datacenter_token_owners_nodes()) {
+    for (auto& [dc, nodes] : tm->get_topology().get_datacenter_nodes()) {
         locator::load_stats dc_stats;
-        rtlogger.debug("raft topology: Refreshing table load stats for DC {} that has {} token owners", dc, nodes.size());
+        // Nodes owning no tokens (e.g. in an arbiter DC) are polled too, so that the
+        // vnodes-to-tablets migration can tell whether they switched to tablets. They hold
+        // no tablet replicas though, so they must stay out of the DC-level aggregation
+        // below: split readiness is a minimum over replicas, so a non-replica would pin it
+        // at its initial minimum and stall resize convergence.
+        bool dc_has_token_owners = std::ranges::any_of(nodes, [&] (const auto& node) {
+            return tm->is_normal_token_owner(node.get().host_id());
+        });
+        rtlogger.debug("raft topology: Refreshing table load stats for DC {} that has {} node(s)", dc, nodes.size());
         co_await coroutine::parallel_for_each(nodes, [&] (const auto& node) -> future<> {
             auto dst = node.get().host_id();
             auto dst_server = raft::server_id(dst.uuid());
+
+            // get_datacenter_nodes() also contains nodes in transient states; only normal
+            // ones take part in the migration and can be expected to report load stats.
+            if (!_topo_sm._topology.normal_nodes.contains(dst_server)) {
+                co_return;
+            }
 
             _as.check();
 
@@ -4743,8 +4757,17 @@ future<topology_coordinator::tablet_load_stats_collect_result> topology_coordina
             }
 
             _load_stats_per_node[dst] = node_stats;
-            dc_stats += node_stats;
+            if (tm->is_normal_token_owner(dst)) {
+                dc_stats += node_stats;
+            }
         });
+
+        // A DC without token owners has no replicas of any table. Merging its (empty)
+        // dc_stats would invalidate split readiness for every table already aggregated,
+        // because load_stats::operator+= keys that off the destination, not the source.
+        if (!dc_has_token_owners) {
+            continue;
+        }
 
         for (auto& [table_id, table_stats] : dc_stats.tables) {
             co_await coroutine::maybe_yield();

--- a/service/topology_coordinator.cc
+++ b/service/topology_coordinator.cc
@@ -4697,53 +4697,60 @@ future<topology_coordinator::tablet_load_stats_collect_result> topology_coordina
     std::unordered_map<table_id, size_t> total_replicas;
     bool table_load_stats_invalid = false;
 
+    // Helper lambda to query load stats from a single node.
+    // Updates _load_stats_per_node and optionally accumulates into dc_stats.
+    auto query_node_load_stats = [&] (locator::host_id dst, locator::load_stats* dc_stats) -> future<> {
+        auto dst_server = raft::server_id(dst.uuid());
+
+        _as.check();
+
+        // FIXME: if a node is down, completion status cannot be relied upon, but the average tablet size
+        //  could still be inferred from the replicas available.
+
+        auto timeout = netw::messaging_service::clock_type::now() + wait_for_live_nodes_timeout;
+
+        abort_source as;
+        auto request_abort = [&as] () mutable noexcept {
+            as.request_abort();
+        };
+        auto t = timer<lowres_clock>(request_abort);
+        t.arm(timeout);
+        auto sub = _as.subscribe(request_abort);
+
+        locator::load_stats node_stats;
+        if (!_gossiper.is_alive(dst)) {
+            if (require == require_live_nodes::no && _load_stats_per_node.contains(dst) &&
+                    !utils::get_local_injector().enter("force_down_node_load_stats_invalid")) {
+                node_stats = _load_stats_per_node[dst];
+            } else {
+                rtlogger.debug("raft topology: Unable to refresh table load on {} because it's down.", dst);
+                table_load_stats_invalid = true;
+                co_return;
+            }
+        } else if (_feature_service.tablet_load_stats_v2) {
+            node_stats = co_await ser::storage_service_rpc_verbs::send_table_load_stats(&_messaging,
+                                                                                        dst,
+                                                                                        as,
+                                                                                        dst_server);
+        } else {
+            node_stats = locator::load_stats::from_v1(
+                co_await ser::storage_service_rpc_verbs::send_table_load_stats_v1(&_messaging,
+                                                                                  dst,
+                                                                                  as,
+                                                                                  dst_server));
+        }
+
+        _load_stats_per_node[dst] = node_stats;
+        if (dc_stats) {
+            *dc_stats += node_stats;
+        }
+    };
+
     for (auto& [dc, nodes] : tm->get_datacenter_token_owners_nodes()) {
         locator::load_stats dc_stats;
         rtlogger.debug("raft topology: Refreshing table load stats for DC {} that has {} token owners", dc, nodes.size());
         co_await coroutine::parallel_for_each(nodes, [&] (const auto& node) -> future<> {
-            auto dst = node.get().host_id();
-            auto dst_server = raft::server_id(dst.uuid());
-
-            _as.check();
-
-            // FIXME: if a node is down, completion status cannot be relied upon, but the average tablet size
-            //  could still be inferred from the replicas available.
-
-            auto timeout = netw::messaging_service::clock_type::now() + wait_for_live_nodes_timeout;
-
-            abort_source as;
-            auto request_abort = [&as] () mutable noexcept {
-                as.request_abort();
-            };
-            auto t = timer<lowres_clock>(request_abort);
-            t.arm(timeout);
-            auto sub = _as.subscribe(request_abort);
-
-            locator::load_stats node_stats;
-            if (!_gossiper.is_alive(dst)) {
-                if (require == require_live_nodes::no && _load_stats_per_node.contains(dst) &&
-                        !utils::get_local_injector().enter("force_down_node_load_stats_invalid")) {
-                    node_stats = _load_stats_per_node[dst];
-                } else {
-                    rtlogger.debug("raft topology: Unable to refresh table load on {} because it's down.", dst);
-                    table_load_stats_invalid = true;
-                    co_return;
-                }
-            } else if (_feature_service.tablet_load_stats_v2) {
-                node_stats = co_await ser::storage_service_rpc_verbs::send_table_load_stats(&_messaging,
-                                                                                            dst,
-                                                                                            as,
-                                                                                            dst_server);
-            } else {
-                node_stats = locator::load_stats::from_v1(
-                    co_await ser::storage_service_rpc_verbs::send_table_load_stats_v1(&_messaging,
-                                                                                      dst,
-                                                                                      as,
-                                                                                      dst_server));
-            }
-
-            _load_stats_per_node[dst] = node_stats;
-            dc_stats += node_stats;
+            co_await query_node_load_stats(node.get().host_id(), &dc_stats);
         });
 
         for (auto& [table_id, table_stats] : dc_stats.tables) {
@@ -4773,6 +4780,19 @@ future<topology_coordinator::tablet_load_stats_collect_result> topology_coordina
 
         stats += dc_stats;
     }
+
+    // Also query zero-token nodes (e.g., in arbiter DCs) to populate _load_stats_per_node.
+    // These nodes have no token-ring presence and are excluded from the DC-based loop above.
+    // They must still report load stats for finalization to verify they have migrated to tablets.
+    // Their stats are not included in the DC-level aggregation (their DCs have RF=0).
+    co_await coroutine::parallel_for_each(_topo_sm._topology.normal_nodes, [&] (const auto& entry) -> future<> {
+        auto host_id = to_host_id(entry.first);
+        if (tm->is_normal_token_owner(host_id)) {
+            co_return; // Already queried in the DC-based loop above.
+        }
+        rtlogger.debug("raft topology: Refreshing table load stats for zero-token node {}", host_id);
+        co_await query_node_load_stats(host_id, nullptr);
+    });
 
     for (auto& [table_id, table_load_stats] : stats.tables) {
         if (!total_replicas.contains(table_id)) {

--- a/test/cluster/test_vnodes_to_tablets_migration.py
+++ b/test/cluster/test_vnodes_to_tablets_migration.py
@@ -1203,3 +1203,111 @@ async def test_pow2_convergence_virtual_task(manager: ManagerClient):
         convergence_tasks = [t for t in tasks if t.type == "pow2_convergence"]
         assert len(convergence_tasks) == 0, \
             f"Expected no convergence tasks after completion, got {len(convergence_tasks)}"
+
+
+async def test_migration_with_zero_token_node(manager: ManagerClient):
+    """Verify vnodes-to-tablets migration succeeds in the presence of zero-token nodes (arbiter DCs).
+
+    Reproduces SCYLLADB-3268: finalization used to fail with "No load stats available" for
+    zero-token nodes because collect_tablet_load_stats only queried token-owning nodes, but
+    the finalization check iterated all normal nodes.
+
+    Steps:
+    1. Start a 2-node cluster: one token-owning node in dc1 and one zero-token node in dc2 (arbiter DC).
+    2. Create a vnode keyspace with RF={'dc1': 1, 'dc2': 0}.
+    3. Start the migration.
+    4. Mark both nodes for upgrade and restart them.
+    5. Verify the status API reports correct current_mode for the zero-token node.
+    6. Finalize the migration — this should succeed (previously it would fail).
+    7. Verify data integrity.
+    """
+    num_keys = 100
+    tokens_per_node = 16
+
+    logger.info("Starting a token-owning node in dc1")
+    cfg = {'tablet_load_stats_refresh_interval_in_seconds': 1, 'num_tokens': tokens_per_node}
+    server_dc1 = await manager.server_add(cmdline=['--smp', '2'], config=cfg, property_file={"dc": "dc1", "rack": "rack1"})
+
+    logger.info("Starting a zero-token node in dc2 (arbiter DC)")
+    zero_token_cfg = cfg | {'join_ring': False}
+    server_dc2 = await manager.server_add(cmdline=['--smp', '2'], config=zero_token_cfg, property_file={"dc": "dc2", "rack": "rack1"})
+
+    # Only pass token-owning servers to get_ready_cql: the CQL driver cannot
+    # discover zero-token nodes (they have no tokens in the ring metadata).
+    token_owning_servers = [server_dc1]
+    cql, _ = await manager.get_ready_cql(token_owning_servers)
+
+    host_id_dc1 = await manager.get_host_id(server_dc1.server_id)
+    host_id_dc2 = await manager.get_host_id(server_dc2.server_id)
+
+    logger.info("Creating keyspace with RF={'dc1': 1, 'dc2': 0}")
+    async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'dc1': 1, 'dc2': 0} AND tablets = {'enabled': false}") as ks:
+        await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int)")
+
+        logger.info(f"Populating table with {num_keys} rows")
+        stmt = cql.prepare(f"INSERT INTO {ks}.test (pk, c) VALUES (?, ?)")
+        await asyncio.gather(*(cql.run_async(stmt, [k, k]) for k in range(num_keys)))
+
+        logger.info("Starting vnodes-to-tablets migration")
+        await manager.api.create_vnode_tablet_migration(server_dc1.ip_addr, ks)
+
+        logger.info("Verifying migration status: both nodes should appear")
+        # The zero-token node has no replicas, so its current_mode matches its
+        # intended_mode (nothing to migrate). Initially both intended modes are 'vnodes'.
+        await verify_migration_status(manager, server_dc1, ks,
+            expected_status='migrating_to_tablets',
+            expected_node_statuses={
+                host_id_dc1: ('vnodes', 'vnodes'),
+                host_id_dc2: ('vnodes', 'vnodes'),
+            })
+
+        logger.info("Marking both nodes for tablets migration")
+        await manager.api.upgrade_node_to_tablets(server_dc1.ip_addr)
+        await manager.api.upgrade_node_to_tablets(server_dc2.ip_addr)
+
+        logger.info("Verifying status API after marking for upgrade")
+        # dc1 (token-owning, has replicas): still uses vnodes (hasn't restarted)
+        # dc2 (zero-token, no replicas): current_mode='tablets' immediately because
+        #   it has nothing to migrate — current_mode tracks intended_mode for such nodes.
+        await verify_migration_status(manager, server_dc1, ks,
+            expected_status='migrating_to_tablets',
+            expected_node_statuses={
+                host_id_dc1: ('vnodes', 'tablets'),
+                host_id_dc2: ('tablets', 'tablets'),
+            })
+
+        logger.info("Restarting token-owning node to trigger resharding")
+        await manager.server_restart(server_dc1.server_id)
+        await reconnect_driver(manager)
+        cql, _ = await manager.get_ready_cql(token_owning_servers)
+
+        logger.info("Restarting zero-token node to trigger its migration")
+        await manager.server_restart(server_dc2.server_id)
+        await reconnect_driver(manager)
+        cql, _ = await manager.get_ready_cql(token_owning_servers)
+
+        logger.info("Verifying status API: dc1 node should use tablets, dc2 zero-token node should also report tablets")
+        # The zero-token node has no replicas, so the status API should report
+        # current_mode matching intended_mode (since it has nothing to migrate).
+        await verify_migration_status(manager, server_dc1, ks,
+            expected_status='migrating_to_tablets',
+            expected_node_statuses={
+                host_id_dc1: ('tablets', 'tablets'),
+                host_id_dc2: ('tablets', 'tablets'),
+            },
+            retries=5, retry_interval=1)
+
+        logger.info("Finalizing tablets migration (should succeed with zero-token node present)")
+        await manager.api.finalize_vnode_tablet_migration(server_dc1.ip_addr, ks)
+
+        logger.info("Verifying that the keyspace schema has tablets enabled")
+        res = await cql.run_async(f"SELECT * FROM system_schema.scylla_keyspaces WHERE keyspace_name = '{ks}'")
+        assert len(res) == 1 and res[0].initial_tablets is not None, \
+            "Keyspace is still using vnodes after migration finalization"
+
+        logger.info("Verifying migration status after finalization")
+        await verify_migration_status(manager, server_dc1, ks, expected_status='tablets', expected_node_statuses={})
+
+        logger.info("Verifying data integrity after finalization")
+        await verify_data_integrity(cql, ks, "test", num_keys)
+

--- a/test/cluster/test_vnodes_to_tablets_migration.py
+++ b/test/cluster/test_vnodes_to_tablets_migration.py
@@ -1203,3 +1203,119 @@ async def test_pow2_convergence_virtual_task(manager: ManagerClient):
         convergence_tasks = [t for t in tasks if t.type == "pow2_convergence"]
         assert len(convergence_tasks) == 0, \
             f"Expected no convergence tasks after completion, got {len(convergence_tasks)}"
+
+
+async def test_migration_with_zero_token_node(manager: ManagerClient):
+    """Verify vnodes-to-tablets migration succeeds in the presence of zero-token nodes (arbiter DCs).
+
+    Reproduces SCYLLADB-3268: finalization used to fail with "No load stats available" for
+    zero-token nodes because collect_tablet_load_stats only queried token-owning nodes, but
+    the finalization check iterated all normal nodes.
+
+    Steps:
+    1. Start a 2-node cluster: one token-owning node in dc1 and one zero-token node in dc2 (arbiter DC).
+    2. Create a vnode keyspace with RF={'dc1': 1, 'dc2': 0}.
+    3. Start the migration.
+    4. Mark both nodes for upgrade and restart them.
+    5. Verify the status API reports correct current_mode for the zero-token node.
+    6. Finalize the migration — this should succeed (previously it would fail).
+    7. Verify data integrity.
+    """
+    num_keys = 100
+    tokens_per_node = 16
+
+    logger.info("Starting a token-owning node in dc1")
+    cfg = {'tablet_load_stats_refresh_interval_in_seconds': 1, 'num_tokens': tokens_per_node}
+    server_dc1 = await manager.server_add(cmdline=['--smp', '2'], config=cfg, property_file={"dc": "dc1", "rack": "rack1"})
+
+    logger.info("Starting a zero-token node in dc2 (arbiter DC)")
+    zero_token_cfg = cfg | {'join_ring': False}
+    server_dc2 = await manager.server_add(cmdline=['--smp', '2'], config=zero_token_cfg, property_file={"dc": "dc2", "rack": "rack1"})
+
+    # Only wait for the token-owning node to be CQL-ready: the zero-token node has no
+    # tokens in the ring metadata, so the driver does not treat it as a replica for any
+    # query. It does serve CQL though, and the driver may still route a query to it, so
+    # reads that must observe a specific group0 state are pinned to a host explicitly.
+    token_owning_servers = [server_dc1]
+    cql, _ = await manager.get_ready_cql(token_owning_servers)
+
+    host_id_dc1 = await manager.get_host_id(server_dc1.server_id)
+    host_id_dc2 = await manager.get_host_id(server_dc2.server_id)
+
+    logger.info("Creating keyspace with RF={'dc1': 1, 'dc2': 0}")
+    async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'dc1': 1, 'dc2': 0} AND tablets = {'enabled': false}") as ks:
+        await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int)")
+
+        logger.info(f"Populating table with {num_keys} rows")
+        stmt = cql.prepare(f"INSERT INTO {ks}.test (pk, c) VALUES (?, ?)")
+        await asyncio.gather(*(cql.run_async(stmt, [k, k]) for k in range(num_keys)))
+
+        logger.info("Starting vnodes-to-tablets migration")
+        await manager.api.create_vnode_tablet_migration(server_dc1.ip_addr, ks)
+
+        logger.info("Verifying migration status: both nodes should appear")
+        # The zero-token node has no replicas, so its current_mode matches its
+        # intended_mode (nothing to migrate). Initially both intended modes are 'vnodes'.
+        await verify_migration_status(manager, server_dc1, ks,
+            expected_status='migrating_to_tablets',
+            expected_node_statuses={
+                host_id_dc1: ('vnodes', 'vnodes'),
+                host_id_dc2: ('vnodes', 'vnodes'),
+            })
+
+        logger.info("Marking both nodes for tablets migration")
+        await manager.api.upgrade_node_to_tablets(server_dc1.ip_addr)
+        await manager.api.upgrade_node_to_tablets(server_dc2.ip_addr)
+
+        logger.info("Verifying status API after marking for upgrade")
+        # dc1 (token-owning, has replicas): still uses vnodes (hasn't restarted)
+        # dc2 (zero-token, no replicas): current_mode='tablets' immediately because
+        #   it has nothing to migrate — current_mode tracks intended_mode for such nodes.
+        await verify_migration_status(manager, server_dc1, ks,
+            expected_status='migrating_to_tablets',
+            expected_node_statuses={
+                host_id_dc1: ('vnodes', 'tablets'),
+                host_id_dc2: ('tablets', 'tablets'),
+            })
+
+        logger.info("Restarting token-owning node to trigger resharding")
+        await manager.server_restart(server_dc1.server_id)
+        await reconnect_driver(manager)
+        cql, _ = await manager.get_ready_cql(token_owning_servers)
+
+        logger.info("Restarting zero-token node to trigger its migration")
+        await manager.server_restart(server_dc2.server_id)
+        await reconnect_driver(manager)
+        cql, _ = await manager.get_ready_cql(token_owning_servers)
+
+        logger.info("Verifying status API: dc1 node should use tablets, dc2 zero-token node should also report tablets")
+        # The zero-token node has no replicas, so the status API should report
+        # current_mode matching intended_mode (since it has nothing to migrate).
+        await verify_migration_status(manager, server_dc1, ks,
+            expected_status='migrating_to_tablets',
+            expected_node_statuses={
+                host_id_dc1: ('tablets', 'tablets'),
+                host_id_dc2: ('tablets', 'tablets'),
+            },
+            retries=5, retry_interval=1)
+
+        logger.info("Finalizing tablets migration (should succeed with zero-token node present)")
+        await manager.api.finalize_vnode_tablet_migration(server_dc1.ip_addr, ks)
+
+        # finalize_vnode_tablet_migration returns once the group0 command is applied on the
+        # topology coordinator; other nodes apply it asynchronously. Barrier before reading
+        # the schema so we observe the latest group0 state.
+        await read_barrier(manager.api, server_dc1.ip_addr)
+        host_dc1 = cql.cluster.metadata.get_host(server_dc1.ip_addr)
+
+        logger.info("Verifying that the keyspace schema has tablets enabled")
+        res = await cql.run_async(f"SELECT * FROM system_schema.scylla_keyspaces WHERE keyspace_name = '{ks}'", host=host_dc1)
+        assert len(res) == 1 and res[0].initial_tablets is not None, \
+            "Keyspace is still using vnodes after migration finalization"
+
+        logger.info("Verifying migration status after finalization")
+        await verify_migration_status(manager, server_dc1, ks, expected_status='tablets', expected_node_statuses={})
+
+        logger.info("Verifying data integrity after finalization")
+        await verify_data_integrity(cql, ks, "test", num_keys)
+

--- a/test/cluster/test_vnodes_to_tablets_migration.py
+++ b/test/cluster/test_vnodes_to_tablets_migration.py
@@ -1319,3 +1319,84 @@ async def test_migration_with_zero_token_node(manager: ManagerClient):
         logger.info("Verifying data integrity after finalization")
         await verify_data_integrity(cql, ks, "test", num_keys)
 
+
+async def test_migration_status_api_with_rf_zero_dc(manager: ManagerClient):
+    """Verify the status API correctly reports current_mode for token-owning nodes in a DC with RF=0.
+
+    Reproduces SCYLLADB-3268 (status API part): nodes with no replicas for the migrating
+    keyspace were always reported as current_mode='vnodes' because they never appeared in
+    system.tablet_sizes.
+
+    Steps:
+    1. Start a 2-node cluster with one node in dc1 (RF=1) and one in dc2 (RF=0).
+    2. Create a vnode keyspace with RF={'dc1': 1, 'dc2': 0}.
+    3. Start migration, mark both nodes for upgrade, restart both.
+    4. Verify status API reports current_mode='tablets' for the dc2 node (which has no replicas
+       but has completed its local migration).
+    """
+    num_keys = 50
+    tokens_per_node = 16
+
+    logger.info("Starting a token-owning node in dc1")
+    cfg = {'tablet_load_stats_refresh_interval_in_seconds': 1, 'num_tokens': tokens_per_node}
+    server_dc1 = await manager.server_add(cmdline=['--smp', '2'], config=cfg, property_file={"dc": "dc1", "rack": "rack1"})
+
+    logger.info("Starting a token-owning node in dc2")
+    server_dc2 = await manager.server_add(cmdline=['--smp', '2'], config=cfg, property_file={"dc": "dc2", "rack": "rack1"})
+
+    servers = [server_dc1, server_dc2]
+    cql, _ = await manager.get_ready_cql(servers)
+
+    host_id_dc1 = await manager.get_host_id(server_dc1.server_id)
+    host_id_dc2 = await manager.get_host_id(server_dc2.server_id)
+
+    logger.info("Creating keyspace with RF={'dc1': 1, 'dc2': 0}")
+    async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'dc1': 1, 'dc2': 0} AND tablets = {'enabled': false}") as ks:
+        await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int)")
+
+        logger.info(f"Populating table with {num_keys} rows")
+        stmt = cql.prepare(f"INSERT INTO {ks}.test (pk, c) VALUES (?, ?)")
+        await asyncio.gather(*(cql.run_async(stmt, [k, k]) for k in range(num_keys)))
+
+        logger.info("Starting vnodes-to-tablets migration")
+        await manager.api.create_vnode_tablet_migration(server_dc1.ip_addr, ks)
+
+        logger.info("Marking both nodes for tablets migration")
+        await manager.api.upgrade_node_to_tablets(server_dc1.ip_addr)
+        await manager.api.upgrade_node_to_tablets(server_dc2.ip_addr)
+
+        logger.info("Restarting both nodes")
+        await manager.server_restart(server_dc1.server_id)
+        await reconnect_driver(manager)
+        cql, _ = await manager.get_ready_cql(servers)
+        await manager.server_restart(server_dc2.server_id)
+        await reconnect_driver(manager)
+        cql, _ = await manager.get_ready_cql(servers)
+
+        logger.info("Verifying status API: both nodes should report current_mode='tablets'")
+        # dc2 node has no replicas for this keyspace, but since it set intended_mode=tablets
+        # and restarted, the status API should correctly report current_mode='tablets'.
+        await verify_migration_status(manager, server_dc1, ks,
+            expected_status='migrating_to_tablets',
+            expected_node_statuses={
+                host_id_dc1: ('tablets', 'tablets'),
+                host_id_dc2: ('tablets', 'tablets'),
+            },
+            retries=5, retry_interval=1)
+
+        logger.info("Finalizing tablets migration")
+        await manager.api.finalize_vnode_tablet_migration(server_dc1.ip_addr, ks)
+
+        # finalize_vnode_tablet_migration returns once the group0 command is applied on the
+        # topology coordinator; other nodes apply it asynchronously. Both nodes are token
+        # owners here, so the driver may route the read to the one that is still behind.
+        await read_barrier(manager.api, server_dc1.ip_addr)
+        host_dc1 = cql.cluster.metadata.get_host(server_dc1.ip_addr)
+
+        logger.info("Verifying that the keyspace schema has tablets enabled")
+        res = await cql.run_async(f"SELECT * FROM system_schema.scylla_keyspaces WHERE keyspace_name = '{ks}'", host=host_dc1)
+        assert len(res) == 1 and res[0].initial_tablets is not None, \
+            "Keyspace is still using vnodes after migration finalization"
+
+        logger.info("Final data integrity check")
+        await verify_data_integrity(cql, ks, "test", num_keys)

--- a/test/cluster/test_vnodes_to_tablets_migration.py
+++ b/test/cluster/test_vnodes_to_tablets_migration.py
@@ -1311,3 +1311,78 @@ async def test_migration_with_zero_token_node(manager: ManagerClient):
         logger.info("Verifying data integrity after finalization")
         await verify_data_integrity(cql, ks, "test", num_keys)
 
+
+async def test_migration_status_api_with_rf_zero_dc(manager: ManagerClient):
+    """Verify the status API correctly reports current_mode for token-owning nodes in a DC with RF=0.
+
+    Reproduces SCYLLADB-3268 (status API part): nodes with no replicas for the migrating
+    keyspace were always reported as current_mode='vnodes' because they never appeared in
+    system.tablet_sizes.
+
+    Steps:
+    1. Start a 2-node cluster with one node in dc1 (RF=1) and one in dc2 (RF=0).
+    2. Create a vnode keyspace with RF={'dc1': 1, 'dc2': 0}.
+    3. Start migration, mark both nodes for upgrade, restart both.
+    4. Verify status API reports current_mode='tablets' for the dc2 node (which has no replicas
+       but has completed its local migration).
+    """
+    num_keys = 50
+    tokens_per_node = 16
+
+    logger.info("Starting a token-owning node in dc1")
+    cfg = {'tablet_load_stats_refresh_interval_in_seconds': 1, 'num_tokens': tokens_per_node}
+    server_dc1 = await manager.server_add(cmdline=['--smp', '2'], config=cfg, property_file={"dc": "dc1", "rack": "rack1"})
+
+    logger.info("Starting a token-owning node in dc2")
+    server_dc2 = await manager.server_add(cmdline=['--smp', '2'], config=cfg, property_file={"dc": "dc2", "rack": "rack1"})
+
+    servers = [server_dc1, server_dc2]
+    cql, _ = await manager.get_ready_cql(servers)
+
+    host_id_dc1 = await manager.get_host_id(server_dc1.server_id)
+    host_id_dc2 = await manager.get_host_id(server_dc2.server_id)
+
+    logger.info("Creating keyspace with RF={'dc1': 1, 'dc2': 0}")
+    async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'dc1': 1, 'dc2': 0} AND tablets = {'enabled': false}") as ks:
+        await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int)")
+
+        logger.info(f"Populating table with {num_keys} rows")
+        stmt = cql.prepare(f"INSERT INTO {ks}.test (pk, c) VALUES (?, ?)")
+        await asyncio.gather(*(cql.run_async(stmt, [k, k]) for k in range(num_keys)))
+
+        logger.info("Starting vnodes-to-tablets migration")
+        await manager.api.create_vnode_tablet_migration(server_dc1.ip_addr, ks)
+
+        logger.info("Marking both nodes for tablets migration")
+        await manager.api.upgrade_node_to_tablets(server_dc1.ip_addr)
+        await manager.api.upgrade_node_to_tablets(server_dc2.ip_addr)
+
+        logger.info("Restarting both nodes")
+        await manager.server_restart(server_dc1.server_id)
+        await reconnect_driver(manager)
+        cql, _ = await manager.get_ready_cql(servers)
+        await manager.server_restart(server_dc2.server_id)
+        await reconnect_driver(manager)
+        cql, _ = await manager.get_ready_cql(servers)
+
+        logger.info("Verifying status API: both nodes should report current_mode='tablets'")
+        # dc2 node has no replicas for this keyspace, but since it set intended_mode=tablets
+        # and restarted, the status API should correctly report current_mode='tablets'.
+        await verify_migration_status(manager, server_dc1, ks,
+            expected_status='migrating_to_tablets',
+            expected_node_statuses={
+                host_id_dc1: ('tablets', 'tablets'),
+                host_id_dc2: ('tablets', 'tablets'),
+            },
+            retries=5, retry_interval=1)
+
+        logger.info("Finalizing tablets migration")
+        await manager.api.finalize_vnode_tablet_migration(server_dc1.ip_addr, ks)
+
+        logger.info("Verifying that the keyspace schema has tablets enabled")
+        res = await cql.run_async(f"SELECT * FROM system_schema.scylla_keyspaces WHERE keyspace_name = '{ks}'")
+        assert len(res) == 1 and res[0].initial_tablets is not None, \
+            "Keyspace is still using vnodes after migration finalization"
+
+        logger.info("Final data integrity check")
+        await verify_data_integrity(cql, ks, "test", num_keys)


### PR DESCRIPTION
Vnodes-to-tablets migration finalization fails when the cluster contains nodes that have no tablet replicas for the migrating keyspace. This happens with zero-token nodes (arbiter DCs) and affects the status API for token-owning nodes in a DC with RF=0.

### Problem

**Finalization failure (zero-token nodes):**
The finalization check in the topology coordinator iterates all `normal_nodes` and requires each to have an entry in `_load_stats_per_node` containing the migrating table. However, `collect_tablet_load_stats` only queries token-owning nodes (via `get_datacenter_token_owners_nodes`), so zero-token nodes never get an entry. Finalization fails with "No load stats available for node X".

**Status API (nodes with no replicas):**
`get_tablets_migration_status_with_node_details` determines `current_mode` by checking if a node appears in `system.tablet_sizes` replicas. Nodes with no replicas for the keyspace (zero-token nodes, or token-owning nodes in DC with RF=0) never appear there, so they always report `current_mode='vnodes'` regardless of their actual state. This breaks progress tracking in the task manager and nodetool output.

### Fix

**`collect_tablet_load_stats`:** Add a second loop after the existing DC-based loop that queries all normal nodes which are not token owners. Their stats are stored in `_load_stats_per_node` (so finalization can verify them) but are NOT included in the DC-level aggregation (their DCs have RF=0, so they must not affect size normalization for the load balancer). The migration workflow for zero-token nodes is: `set_node_intended_storage_mode(tablets)` → restart → node builds tablet ERM → reports table in load stats → finalization passes.

**`get_tablets_migration_status_with_node_details`:** After collecting nodes from `system.tablet_sizes`, also determine which nodes are actual replicas by iterating the tablet map. For nodes NOT in the replica set, report `current_mode = intended_mode` — they have nothing to migrate, so their effective state matches their intent.

Fixes https://scylladb.atlassian.net/browse/SCYLLADB-3268

Backport is not required, this is more a limitation and it was stated in the documentation that multi-dc is not supported