### PR TITLE
docs: fix llms.txt generation in multiversion builds

### DIFF
--- a/docs/_ext/scylladb_llms_confdir.py
+++ b/docs/_ext/scylladb_llms_confdir.py
@@ -1,0 +1,60 @@
+#
+# Copyright (C) 2026-present ScyllaDB
+#
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
+#
+"""
+Fix llms.txt generation for every version of the multiversion documentation.
+
+sphinx-llm generates the Markdown files referenced by llms.txt by rerunning
+Sphinx for each version. By default, each run uses that version's conf.py and
+extensions. Custom extensions (/ext dir) can crash the Markdown builder,
+preventing llms.txt from being generated.
+
+Pass `-c` to each run so it uses the current checkout's conf.py, matching the
+configuration used by the rest of the build.
+"""
+
+
+import subprocess
+
+try:
+    from sphinx_llm import txt as sphinx_llm_txt
+except ImportError:
+    sphinx_llm_txt = None
+
+_real_popen = subprocess.Popen
+
+
+class _SubprocessWithConfdir:
+    def __init__(self, confdir):
+        self._confdir = str(confdir)
+
+    def Popen(self, cmd, *args, **kwargs):
+        if isinstance(cmd, (list, tuple)) and "-c" not in cmd:
+            cmd = list(cmd)
+            try:
+                i = cmd.index("-b")
+                if cmd[i + 1] == "markdown":
+                    cmd[i + 2 : i + 2] = ["-c", self._confdir]
+            except (ValueError, IndexError):
+                pass
+        return _real_popen(cmd, *args, **kwargs)
+
+    def __getattr__(self, name):
+        return getattr(subprocess, name)
+
+
+def forward_confdir(app, *_):
+    if sphinx_llm_txt is not None:
+        sphinx_llm_txt.subprocess = _SubprocessWithConfdir(app.confdir)
+
+
+def setup(app):
+    app.connect("config-inited", forward_confdir)
+
+    return {
+        "version": "0.1",
+        "parallel_read_safe": True,
+        "parallel_write_safe": True,
+    }

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -65,7 +65,8 @@ extensions = [
     "scylladb_include_flag",
     "scylladb_dynamic_substitutions",
     "scylladb_swagger",
-    "scylladb_metrics"
+    "scylladb_metrics",
+    "scylladb_llms_confdir",
 ]
 
 # The suffix(es) of source filenames.


### PR DESCRIPTION
## Problem

ScyllaDB Theme 1.9.3 added `llms.txt` generation, but `https://docs.scylladb.com/manual/stable/llms.txt` returns a 404.

`sphinx-llm` reruns Sphinx for each version without passing `-c`, so the sub-build loads that version's `conf.py` and extensions. In older versions, some custom extensions under `/_ext` access `app.builder.templates`, which the Markdown builder does not provide. The sub-build fails, so `llms.txt` is not generated.

## Solution

Add `docs/_ext/scylladb_llms_confdir.py` to pass the current checkout's configuration directory to the `sphinx-llm` Markdown sub-build.

## How to test

Run:

```bash
make multiversion
```

Confirm that each `_build/dirhtml/<version>/` directory contains `llms.txt` and per-page `.md` files.