### PR TITLE
test: don't abort failed-test log collection on a missing log file

### DIFF
--- a/test/cluster/conftest.py
+++ b/test/cluster/conftest.py
@@ -222,9 +222,8 @@ async def manager(request: pytest.FixtureRequest,
     Per test fixture to notify Manager client object when tests begin so it can perform checks for cluster state.
     """
     test_case_name = request.node.name
-    test_log = suite_log_dir / f"{Path(testpy_uname).stem}.{test_case_name}.log"
     # this should be consistent with scylla_cluster.py handler name in _before_test method
-    test_py_log_test = suite_log_dir / f"{test_log.stem}_cluster.log"
+    test_py_log_test = suite_log_dir / f"{Path(testpy_uname).stem}.{test_case_name}_cluster.log"
 
     manager_client = manager_internal()  # set up client object in fixture with scope function
     logger.debug("before_test for %s", test_case_name)
@@ -242,9 +241,12 @@ async def manager(request: pytest.FixtureRequest,
 
     # Publish what pytest_runtest_makereport needs to attach this test's logs on
     # failure (single source of truth), so it doesn't re-derive these paths.
+    # The pytest session log is not listed here: it is written per xdist worker
+    # (see PYTEST_LOG_FILE in test/pylib/runner.py) and is already linked from the
+    # failed test's properties by record_failed_test_artifacts().
     request.node.stash[MANAGER_LOGS_KEY] = {
         "client": manager_client,
-        "logs": {"pytest.log": test_log, "test_py.log": test_py_log_test},
+        "logs": {"test_py.log": test_py_log_test},
     }
     yield manager_client
     # `request.node.stash` contains reports stored per phase in `pytest_runtest_makereport`

--- a/test/pylib/manager_client.py
+++ b/test/pylib/manager_client.py
@@ -239,7 +239,13 @@ class ManagerClient:
             shutil.copyfile(log_file.file, failed_test_path_dir / f"{pathlib.Path(log_file.file).name}")
             allure.attach(log_file.file.read_bytes(), name=log_file.file.name, attachment_type=allure.attachment_type.TEXT)
         for name, log in logs.items():
-            allure.attach(log.read_bytes(), name=name, attachment_type=allure.attachment_type.TEXT) if name != "pytest.log" else None
+            # A log is missing when the handler that writes it was never installed, e.g. the
+            # test failed before before-test ran. Skip it: the caller collects the rest of the
+            # artifacts after this returns, so raising here would lose them all.
+            if not log.is_file():
+                logger.warning("Log %s (%s) does not exist, not attaching it", name, log)
+                continue
+            allure.attach(log.read_bytes(), name=name, attachment_type=allure.attachment_type.TEXT)
             shutil.copyfile(log, failed_test_path_dir / name)
 
     async def is_manager_up(self) -> bool:


### PR DESCRIPTION
pytest_runtest_makereport() collects artifacts for a failed test in one try block: server logs and the per-test logs via gather_related_logs(), then the traceback and artifact links via record_failed_test_artifacts(). Any exception in the middle is swallowed by the except at the end, so everything after the throwing statement is silently lost.

gather_related_logs() copies every entry of the `logs` dict without checking that the file is there:

    for name, log in logs.items():
        allure.attach(...) if name != "pytest.log" else None
        shutil.copyfile(log, failed_test_path_dir / name)

and the manager fixture passes an entry that nothing ever writes:

    test_log = suite_log_dir / f"{Path(testpy_uname).stem}.{test_case_name}.log"
    ...
    "logs": {"pytest.log": test_log, "test_py.log": test_py_log_test},

Only the second path exists. ScyllaManager._before_test() installs a handler for "<parent>.<test_case>_cluster.log"; the pytest session log goes to a per-xdist-worker file under pytest_logs/ (PYTEST_LOG_FILE), which record_failed_test_artifacts() already publishes as the PYTEST_LOG property. `test_log` is only used to derive the _cluster.log name.

So the copy of "pytest.log" raises FileNotFoundError for every failed test that uses the manager fixture, and test_py.log, stacktrace.txt and the TEST_LOGS/PYTEST_LOG links are never produced. Verified with a deliberately failing cluster test - before this patch failed_test/ holds only the server log, after it also holds test_py.log and stacktrace.txt.

Drop the entry that was never written, and skip - with a warning - a log that is not there rather than losing the remaining artifacts. This can happen legitimately, e.g. when a test fails before before-test installed the handler.

Broken since 291081c1b7 (test: collect and link failed-test server logs).

Fixes SCYLLADB-3621
