### PR TITLE
test: rename the nightly marker to tier2 and add a no_parallel marker

### DIFF
--- a/test/boost/mutation_reader_test.cc
+++ b/test/boost/mutation_reader_test.cc
@@ -1242,7 +1242,7 @@ SEASTAR_TEST_CASE(test_combined_mutation_source_is_a_mutation_source) {
 }
 
 // Best run with SMP >= 2
-SEASTAR_THREAD_TEST_CASE(test_foreign_reader_as_mutation_source, *test_label::label("nightly")) {
+SEASTAR_THREAD_TEST_CASE(test_foreign_reader_as_mutation_source, *test_label::label("tier2")) {
     if (this_smp_shard_count() < 2) {
         std::cerr << "Cannot run test " << get_name() << " with this_smp_shard_count() < 2" << std::endl;
         return;

--- a/test/cluster/lwt/test_lwt_contention.py
+++ b/test/cluster/lwt/test_lwt_contention.py
@@ -210,7 +210,7 @@ class ContentionLWTTester(BaseLWTTester):
         )
 
 
-@pytest.mark.nightly
+@pytest.mark.tier2
 @pytest.mark.parametrize("tablets_enabled", [True, False], ids=["tablets", "vnodes"])
 async def test_lwt_contention_many_workers(manager: ManagerClient, scale_timeout, tablets_enabled):
     """
@@ -223,7 +223,7 @@ async def test_lwt_contention_many_workers(manager: ManagerClient, scale_timeout
     Runs for both tablets and vnodes to ensure contention handling
     is correct regardless of the storage backend.
 
-    This is a nightly-only test due to the high contention load.
+    This is a tier2-only test due to the high contention load.
     """
     num_workers = 300
     num_iterations = 1

--- a/test/cluster/lwt/test_lwt_during_tablets_resize.py
+++ b/test/cluster/lwt/test_lwt_during_tablets_resize.py
@@ -131,7 +131,7 @@ async def run_random_resizes(
     }
 
 
-@pytest.mark.tier2
+@pytest.mark.no_parallel
 async def test_multi_column_lwt_during_split_merge(manager: ManagerClient, scale_timeout):
     """
     Test scenario:

--- a/test/cluster/lwt/test_lwt_during_tablets_resize.py
+++ b/test/cluster/lwt/test_lwt_during_tablets_resize.py
@@ -131,7 +131,7 @@ async def run_random_resizes(
     }
 
 
-@pytest.mark.nightly
+@pytest.mark.tier2
 async def test_multi_column_lwt_during_split_merge(manager: ManagerClient, scale_timeout):
     """
     Test scenario:

--- a/test/cluster/lwt/test_lwt_with_counters_during_tablets_resize_and_migrations.py
+++ b/test/cluster/lwt/test_lwt_with_counters_during_tablets_resize_and_migrations.py
@@ -292,7 +292,7 @@ async def run_random_resizes(
         "seen_merge": merge_count,
     }
 
-@pytest.mark.tier2
+@pytest.mark.no_parallel
 async def test_multi_column_lwt_migrate_and_random_resizes(manager: ManagerClient, scale_timeout):
 
     cfg = {

--- a/test/cluster/lwt/test_lwt_with_counters_during_tablets_resize_and_migrations.py
+++ b/test/cluster/lwt/test_lwt_with_counters_during_tablets_resize_and_migrations.py
@@ -292,7 +292,7 @@ async def run_random_resizes(
         "seen_merge": merge_count,
     }
 
-@pytest.mark.nightly
+@pytest.mark.tier2
 async def test_multi_column_lwt_migrate_and_random_resizes(manager: ManagerClient, scale_timeout):
 
     cfg = {

--- a/test/cluster/mv/tablets/test_mv_tablets_replace.py
+++ b/test/cluster/mv/tablets/test_mv_tablets_replace.py
@@ -63,7 +63,7 @@ def select_non_coordinator_replica_pair(base_by_rack, view_by_rack, coord_serv):
         f"base_by_rack={base_by_rack}, view_by_rack={view_by_rack}")
 
 
-@pytest.mark.nightly
+@pytest.mark.tier2
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_tablet_mv_replica_pairing_during_replace(manager: ManagerClient, scale_timeout: Callable[[int | float], int | float]):
     """

--- a/test/cluster/test_alternator.py
+++ b/test/cluster/test_alternator.py
@@ -372,7 +372,7 @@ async def test_localnodes_down_normal_node(manager: ManagerClient):
     assert await wait_for(check_localnodes_one, time.time() + 60)
 
 
-@pytest.mark.nightly
+@pytest.mark.tier2
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_localnodes_joining_nodes(manager: ManagerClient):
     """Test that if a cluster is being enlarged and a node is coming up but

--- a/test/cluster/test_change_replication_factor_1_to_0.py
+++ b/test/cluster/test_change_replication_factor_1_to_0.py
@@ -23,7 +23,7 @@ logger = logging.getLogger(__name__)
     [
         pytest.param(False, id="vnodes"),
         pytest.param(True, id="tablets", marks=[pytest.mark.skip_bug(
-            link="https://github.com/scylladb/scylladb/issues/20282", reason="Coredump and error of: failed to log message: fmt='Requested location for node {} not in topology",),pytest.mark.nightly])
+            link="https://github.com/scylladb/scylladb/issues/20282", reason="Coredump and error of: failed to log message: fmt='Requested location for node {} not in topology",),pytest.mark.tier2])
     ]
 )
 async def test_change_replication_factor_1_to_0(request: pytest.FixtureRequest, manager: ManagerClient, use_tablets: bool) -> None:

--- a/test/cluster/test_node_isolation.py
+++ b/test/cluster/test_node_isolation.py
@@ -20,7 +20,7 @@ from test.cluster.util import create_new_test_keyspace
 logger = logging.getLogger(__name__)
 
 
-@pytest.mark.nightly
+@pytest.mark.tier2
 async def test_banned_node_notification(manager: ManagerClient, failure_detector_timeout) -> None:
     """Test that a node banned from the cluster get notification about been banned"""
     # Decrease the failure detector threshold so we don't have to wait for too long.

--- a/test/cluster/test_tablets.py
+++ b/test/cluster/test_tablets.py
@@ -1893,7 +1893,7 @@ async def test_remove_failure_then_replace(manager: ManagerClient, with_zero_tok
         replace_cfg = ReplaceConfig(replaced_id=node_to_remove.server_id, reuse_ip_addr = False, use_host_id=True, wait_dead=True)
         await manager.server_add(replace_cfg=replace_cfg, property_file=node_to_remove.property_file())
 
-@pytest.mark.nightly
+@pytest.mark.tier2
 @pytest.mark.parametrize("with_zero_token_node", [False, True])
 async def test_replace_with_no_normal_token_owners_in_dc(manager: ManagerClient, with_zero_token_node: bool):
     """

--- a/test/cqlpy/cassandra_tests/validation/entities/timestamp_test.py
+++ b/test/cqlpy/cassandra_tests/validation/entities/timestamp_test.py
@@ -129,7 +129,7 @@ def testTimestampsOnUnsetColumnsWide(cql, test_keyspace):
                    [2, 2, None, None],
                    [3, 3, 3, 1])
 
-@pytest.mark.nightly
+@pytest.mark.tier2
 def testTimestampAndTTLPrepared(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(k int, c int, i int, PRIMARY KEY (k, c))") as table:
         execute(cql, table, "INSERT INTO %s (k, c, i) VALUES (1, 1, 1) USING TIMESTAMP ? AND TTL ?;", 1, 5)
@@ -146,7 +146,7 @@ def testTimestampAndTTLPrepared(cql, test_keyspace):
         time.sleep(6)
         assert_empty(execute(cql, table, "SELECT k, c, i, writetime(i) FROM %s "))
 
-@pytest.mark.nightly
+@pytest.mark.tier2
 def testTimestampAndTTLUpdatePrepared(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(k int, c int, i int, PRIMARY KEY (k, c))") as table:
         execute(cql, table, "UPDATE %s USING TIMESTAMP ? AND TTL ? SET i=1 WHERE k=1 AND c = 1 ;", 1, 5)

--- a/test/cqlpy/cassandra_tests/validation/operations/batch_test.py
+++ b/test/cqlpy/cassandra_tests/validation/operations/batch_test.py
@@ -189,7 +189,7 @@ def testBatchWithInRestriction(cql, test_keyspace):
 # TTLs. These sleeps also make it dependent on timing - in the very unlikely
 # case that the test code is delayed by a large fraction of a second, we can
 # end up with the wrong TTL.
-@pytest.mark.nightly
+@pytest.mark.tier2
 def testBatchTTLConditionalInteraction(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(id int, clustering1 int, clustering2 int, clustering3 int, val int, PRIMARY KEY (id, clustering1, clustering2, clustering3))") as clustering:
         execute(cql, clustering, "DELETE FROM %s WHERE id=1")
@@ -338,7 +338,7 @@ def testBatchTTLConditionalInteraction(cql, test_keyspace):
 # TTLs. These sleeps also make it dependent on timing - in the very unlikely
 # case that the test code is delayed by a large fraction of a second, we can
 # end up with the wrong TTL.
-@pytest.mark.nightly
+@pytest.mark.tier2
 def testBatchStaticTTLConditionalInteraction(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(id int, clustering1 int, clustering2 int, clustering3 int, sval int static, val int, PRIMARY KEY (id, clustering1, clustering2, clustering3))") as clustering_static:
         execute(cql, clustering_static, f"DELETE FROM {clustering_static} WHERE id=1")

--- a/test/cqlpy/run.py
+++ b/test/cqlpy/run.py
@@ -519,17 +519,17 @@ def _has_marker_expression(pytest_args: list[str]) -> bool:
 def _prepare_pytest_args(pytest_args: list[str]) -> list[str]:
     """Prepare pytest arguments for runpy wrappers.
 
-    By default, runpy wrappers skip tests marked ``nightly`` to keep
+    By default, runpy wrappers skip tests marked ``tier2`` to keep
     local and per-PR runs focused and fast.
 
     Marker policy:
-    * if no marker expression is provided, add ``-m 'not nightly'``;
+    * if no marker expression is provided, add ``-m 'not tier2'``;
     * if marker expression is provided, keep it unchanged.
     """
     prepared_args = list(pytest_args)
     if _has_marker_expression(prepared_args):
         return prepared_args
-    return ["-m", "not nightly"] + prepared_args
+    return ["-m", "not tier2"] + prepared_args
 
 def run_pytest(pytest_dir, additional_parameters):
     global run_with_temporary_dir_pids

--- a/test/cqlpy/test_system_tables.py
+++ b/test/cqlpy/test_system_tables.py
@@ -75,7 +75,7 @@ def test_partitions_estimate_simple_small(cql, test_keyspace):
 # This is a relatively long test (takes around 2 seconds), and isn't
 # needed to reproduce #9083 (the previous shorter test does it too),
 # so we skip this test.
-@pytest.mark.nightly
+@pytest.mark.tier2
 def test_partitions_estimate_simple_large(cql, test_keyspace):
     N = 10000
     count = write_table_and_estimate_partitions(cql, test_keyspace, N)

--- a/test/cqlpy/test_wasm.py
+++ b/test/cqlpy/test_wasm.py
@@ -579,7 +579,7 @@ def test_UDA(cql, test_keyspace, table1, scylla_with_wasm_only, metrics):
 
 # The function grows the memory by n pages and returns n.
 @pytest.mark.skip_bug(link="https://scylladb.atlassian.net/browse/SCYLLADB-2800", reason="bug in WASM memory limit enforcement")
-@pytest.mark.nightly
+@pytest.mark.tier2
 def test_mem_grow(cql, test_keyspace, table1, scylla_with_wasm_only, metrics):
     table = table1
     mem_grow_name = "mem_grow_" + unique_name()

--- a/test/pylib/runner.py
+++ b/test/pylib/runner.py
@@ -760,8 +760,8 @@ def modify_pytest_item(item: pytest.Item, run_ids: defaultdict[tuple[str, str], 
             raise TypeError(f"Failed to process skip_mode mark, {mark} for test {item}, error {e}")
 
     if (any(mark.name == "xfail" for mark in item.iter_markers("xfail"))
-            and not any(mark.name == "nightly" for mark in item.iter_markers("nightly"))):
-        item.add_marker(pytest.mark.nightly)
+            and not any(mark.name == "tier2" for mark in item.iter_markers("tier2"))):
+        item.add_marker(pytest.mark.tier2)
 
     if (any(mark.name in ("perf", "manual", "unstable") for mark in item.iter_markers())
             and not any(mark.name == "non_gating" for mark in item.iter_markers("non_gating"))):

--- a/test/pylib/runner.py
+++ b/test/pylib/runner.py
@@ -763,7 +763,7 @@ def modify_pytest_item(item: pytest.Item, run_ids: defaultdict[tuple[str, str], 
             and not any(mark.name == "tier2" for mark in item.iter_markers("tier2"))):
         item.add_marker(pytest.mark.tier2)
 
-    if (any(mark.name in ("perf", "manual", "unstable") for mark in item.iter_markers())
+    if (any(mark.name in ("perf", "manual", "unstable", "no_parallel") for mark in item.iter_markers())
             and not any(mark.name == "non_gating" for mark in item.iter_markers("non_gating"))):
         item.add_marker(pytest.mark.non_gating)
 

--- a/test/pytest.ini
+++ b/test/pytest.ini
@@ -36,7 +36,7 @@ markers =
     manual: to mark manual test cases, these tests will automatically apply non_gating marker
     unstable: mark for unstable tests that may pass may fail, these tests will continue to run every night and generate up-to-date statistics with failures without failing the “Main” verification path(scylla-ci, Next), these tests will automatically apply non_gating marker
     non_gating: tests that are not run in CI/Next/Nightly verification, but can be run manually or on special job when needed
-    nightly: for tests that are quite old, stable, and test functionality that rather not be changed or affected by other features, are partially covered in other tests, verify non-critical functionality, have not found any issues or regressions, too long to run on every PR,  and can be popped out from the CI run, but will continue run in Next/Nightly verification
+    tier2: for tests that are quite old, stable, and test functionality that rather not be changed or affected by other features, are partially covered in other tests, verify non-critical functionality, have not found any issues or regressions, too long to run on every PR,  and can be popped out from the CI run, but will continue run in Next/Nightly verification
     skip_mode(mode, reason, platform_key=None): Skip test in a specific build mode (e.g. dev, debug, release).
     skip_bug(link=..., reason=...): Skip due to a known bug (link = issue URL, reason = human-readable explanation).
     skip_env(reason): Skip due to a missing environment requirement.

--- a/test/pytest.ini
+++ b/test/pytest.ini
@@ -35,6 +35,7 @@ markers =
     perf: mark for performance tests, these tests will automatically apply non_gating marker
     manual: to mark manual test cases, these tests will automatically apply non_gating marker
     unstable: mark for unstable tests that may pass may fail, these tests will continue to run every night and generate up-to-date statistics with failures without failing the “Main” verification path(scylla-ci, Next), these tests will automatically apply non_gating marker
+    no_parallel: for genuinely heavy tests that must not run in parallel with other tests, they run in a separate step of the Nightly pipeline with parallelization 1, these tests will automatically apply non_gating marker
     non_gating: tests that are not run in CI/Next/Nightly verification, but can be run manually or on special job when needed
     tier2: for tests that are quite old, stable, and test functionality that rather not be changed or affected by other features, are partially covered in other tests, verify non-critical functionality, have not found any issues or regressions, too long to run on every PR,  and can be popped out from the CI run, but will continue run in Next/Nightly verification
     skip_mode(mode, reason, platform_key=None): Skip test in a specific build mode (e.g. dev, debug, release).


### PR DESCRIPTION
### `nightly` → `tier2`

The marker named *when* a test runs rather than *why* it was set aside. Its
description is about the test itself — old, stable, non-critical, too long
for every PR — so name it after that tier. Description unchanged.

Renamed where the marker is defined, applied and selected: `pytest.ini`, the
`xfail` promotion in `runner.py`, the `-m 'not tier2'` default in
`cqlpy/run.py`, and 13 test decorations. `mutation_reader_test.cc` is
included because a boost label becomes a pytest marker in
`pylib/cpp/base.py`, and `--strict-markers` would reject the leftover one.

The remaining "Next/Nightly" mentions name the CI path, not the marker.

### New `no_parallel` marker

For tests heavy enough that sharing a machine distorts them or the tests
around them. Added to the tuple in `runner.py` that auto-applies
`non_gating`, next to `perf`/`manual`/`unstable`, so a marked test stays out
of CI/Next without a second decoration.

`test_multi_column_lwt_migrate_and_random_resizes` is the first user — it
drives LWT writes while tablets split, merge and migrate underneath. It was
`tier2`, which only moved its flapping to Nightly rather than removing it.

Fixes: SCYLLADB-3412

### CI change required

The marker only classifies. Nightly needs a step running
`pytest -m no_parallel -n 1`, and its parallel step needs
`-m 'not no_parallel'` — without both, that test runs nowhere. Any job
passing `-m 'not nightly'` also needs the rename, or it matches nothing.

### Testing

Verified in the toolchain: both markers register, a `no_parallel` test comes
out carrying `non_gating`, and `-m no_parallel` selects it while
`-m 'not non_gating'` deselects it.

The Fixes: rationale is my inference from what you told me about the marker — I haven't read SCYLLADB-3412, so check the flapping description matches.