### PR TITLE
s3: take the credentials semaphore when resetting on EXPIRED_TOKEN

### DIFF
--- a/utils/s3/client.cc
+++ b/utils/s3/client.cc
@@ -453,7 +453,10 @@ http::client::reply_handler client::wrap_handler(http::request& request,
             }
             if (possible_error->get_error_type() == aws::aws_error_type::EXPIRED_TOKEN) {
                 s3l.warn("Request failed with EXPIRED_TOKEN. Resetting credentials");
-                _credentials = {};
+                {
+                    auto units = co_await get_units(_creds_sem, 1);
+                    _credentials = {};
+                }
                 should_retry = utils::http::retryable::yes;
                 co_await authorize(request);
             }


### PR DESCRIPTION
### Problem

An S3 request can be signed with an empty access key id, which the server rejects with `InvalidAccessKeyId`. That error is not retryable, so the operation fails instead of retrying. It showed up as a `test_client_multipart_copy_upload_proxy` failure in CI.

Every place that resets `_credentials` holds `_creds_sem` while doing so, except the `EXPIRED_TOKEN` handler in `wrap_handler()`.

`authorize()` holds the semaphore across its only suspension point, and once it releases the semaphore it signs the request without yielding again. A reset that takes the semaphore therefore can never be observed mid-signing. The unsynchronized one can: it lands between the credentials refresh and the signature computation, leaving `_credentials` empty for the signing that follows.

### Changes

The `EXPIRED_TOKEN` handler takes `_creds_sem` before clearing `_credentials`, matching the four other reset sites. The semaphore is released before `authorize()`, which takes the same single-unit semaphore.

### Testing

Forcing the test proxy to inject only `ExpiredTokenException` reproduces the failure in debug mode at roughly 1 run in 360, with the same error the CI run reported:

```
storage_io_error: S3 request failed. Code: 23.
Reason: The Access Key Id you provided does not exist in our records.
```

360 runs pass with this change. No committed regression test — the race is timing-only and reproducing it needs an injection point at the resume inside `authorize()`.

Fixes: https://scylladb.atlassian.net/browse/SCYLLADB-3549

Backport to 2026.1, 2026.2 and 2026.3: the affected code is identical on all of them, and the failure mode is a non-retryable error on a request that should have succeeded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
