### PR TITLE
test: shut down driver Clusters that fail to connect

### DIFF
--- a/test/cluster/dtest/dtest_setup.py
+++ b/test/cluster/dtest/dtest_setup.py
@@ -303,10 +303,18 @@ class DTestSetup:
             # longer than a test timeout.
             reconnection_policy=ExponentialReconnectionPolicy(1.0, 4.0),
         )
-        session = cluster.connect(wait_for_all_pools=True)
+        try:
+            session = cluster.connect(wait_for_all_pools=True)
 
-        if keyspace is not None:
-            session.set_keyspace(keyspace)
+            if keyspace is not None:
+                session.set_keyspace(keyspace)
+        except BaseException:
+            # The Cluster constructor already started the driver's "Task Scheduler" thread,
+            # and Cluster has no __del__, so a half-built Cluster would keep that thread
+            # running forever and eventually crash the pytest worker with
+            # "cannot schedule new futures after shutdown".
+            safe_driver_shutdown(cluster)
+            raise
 
         if keep_session:
             self.connections.append(session)

--- a/test/pylib/driver_utils.py
+++ b/test/pylib/driver_utils.py
@@ -7,6 +7,8 @@
 """Utilities for working with the scylla-driver (cassandra-driver)."""
 
 import logging
+from collections.abc import Iterator
+from contextlib import contextmanager
 
 from cassandra.cluster import Cluster  # type: ignore # pylint: disable=no-name-in-module
 
@@ -43,3 +45,18 @@ def safe_driver_shutdown(cluster: Cluster) -> None:
         scheduler.join(timeout=_SCHEDULER_JOIN_TIMEOUT)
         if scheduler.is_alive():
             logger.warning("Driver Task Scheduler thread did not terminate within %.1fs", _SCHEDULER_JOIN_TIMEOUT)
+
+
+@contextmanager
+def safe_shutting_down(cluster: Cluster) -> Iterator[Cluster]:
+    """Scope a Cluster so it is always torn down with safe_driver_shutdown().
+
+    Cluster starts its "Task Scheduler" thread in the constructor and has no
+    __del__, so a Cluster that is dropped without shutdown() leaks that thread.
+    Cluster's own context manager calls a plain shutdown(), which lacks the
+    Task Scheduler race workaround; use this instead.
+    """
+    try:
+        yield cluster
+    finally:
+        safe_driver_shutdown(cluster)

--- a/test/pylib/driver_utils.py
+++ b/test/pylib/driver_utils.py
@@ -21,6 +21,10 @@ def safe_driver_shutdown(cluster: Cluster) -> None:
 
     Works around a race where the "Task Scheduler" thread raises RuntimeError
     after Cluster.shutdown() returns, or during the call itself.
+
+    Safe to call on a Cluster whose connect() failed: shutting down a partially
+    initialized Cluster may raise, but that must never mask the original error,
+    so any other exception is logged instead of propagated.
     """
     # Capture scheduler thread before shutdown to join it later
     scheduler = getattr(cluster, 'scheduler', None)
@@ -29,8 +33,11 @@ def safe_driver_shutdown(cluster: Cluster) -> None:
         cluster.shutdown()
     except RuntimeError as exc:
         if 'cannot schedule new futures after shutdown' not in str(exc):
-            raise
-        logger.debug("Suppressed expected RuntimeError during driver shutdown: %s", exc)
+            logger.warning("Error shutting down driver Cluster: %s", exc)
+        else:
+            logger.debug("Suppressed expected RuntimeError during driver shutdown: %s", exc)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("Error shutting down driver Cluster: %s", exc)
 
     if scheduler:
         scheduler.join(timeout=_SCHEDULER_JOIN_TIMEOUT)

--- a/test/pylib/scylla_cluster.py
+++ b/test/pylib/scylla_cluster.py
@@ -32,7 +32,7 @@ from test.pylib.host_registry import Host, HostRegistry
 from test.pylib.pool import Pool
 from test.pylib.rest_client import ScyllaRESTAPIClient, HTTPError
 from test.pylib.util import LogPrefixAdapter, read_last_line, gather_safely, get_xdist_worker_id, scale_timeout_by_mode
-from test.pylib.driver_utils import safe_driver_shutdown
+from test.pylib.driver_utils import safe_driver_shutdown, safe_shutting_down
 from test.pylib.internal_types import ServerNum, IPAddress, HostID, ServerInfo, ServerUpState
 from test.pylib.version_fetch_utils import fetch_and_install_scylla_version
 from functools import partial
@@ -724,7 +724,7 @@ class ScyllaServer:
             # here is directed to a node different from the initial contact
             # point, so make sure we execute the checks strictly via
             # this connection
-            with Cluster(**cluster_kwargs) as cluster:
+            with safe_shutting_down(Cluster(**cluster_kwargs)) as cluster:
                 with cluster.connect() as session:
                     connected = True
                     # See the comment above about `auth::standard_role_manager`. We execute
@@ -733,8 +733,17 @@ class ScyllaServer:
                     # Only create the persistent control connection once; re-creating it on
                     # every successful CQL check would leak driver connections.
                     if self.control_connection is None:
-                        self.control_cluster = Cluster(**cluster_kwargs)
-                        self.control_connection = self.control_cluster.connect()
+                        # Connect before publishing the cluster, so a failed connect()
+                        # doesn't leave a leaked Cluster behind for the next check to
+                        # silently overwrite.
+                        control_cluster = Cluster(**cluster_kwargs)
+                        try:
+                            control_connection = control_cluster.connect()
+                        except BaseException:
+                            safe_driver_shutdown(control_cluster)
+                            raise
+                        self.control_cluster = control_cluster
+                        self.control_connection = control_connection
                     cql_queried = True
         except (NoHostAvailable, InvalidRequest, OperationTimedOut) as exc:
             self.logger.debug("Exception when checking if CQL is up: %s", exc)
@@ -969,14 +978,14 @@ class ScyllaServer:
         auth = PlainTextAuthProvider(username='cassandra', password='cassandra')
         profile = ExecutionProfile(load_balancing_policy=WhiteListRoundRobinPolicy(self.seeds),
                                    request_timeout=self.TOPOLOGY_TIMEOUT)
-        with Cluster(execution_profiles={EXEC_PROFILE_DEFAULT: profile},
-                     contact_points=self.seeds,
-                     auth_provider=auth,
-                     # This is the latest version Scylla supports
-                     protocol_version=4,
-                     control_connection_timeout=self.TOPOLOGY_TIMEOUT,
-                     reconnection_policy=_DRIVER_RECONNECTION_POLICY,
-                     ) as cluster:
+        with safe_shutting_down(Cluster(execution_profiles={EXEC_PROFILE_DEFAULT: profile},
+                                        contact_points=self.seeds,
+                                        auth_provider=auth,
+                                        # This is the latest version Scylla supports
+                                        protocol_version=4,
+                                        control_connection_timeout=self.TOPOLOGY_TIMEOUT,
+                                        reconnection_policy=_DRIVER_RECONNECTION_POLICY,
+                                        )) as cluster:
             with cluster.connect() as session:
                 session.execute("CREATE KEYSPACE IF NOT EXISTS k WITH REPLICATION = {" +
                                 "'class' : 'NetworkTopologyStrategy', 'replication_factor' : 1 }")


### PR DESCRIPTION
## Summary

A pytest-xdist worker running the dtest auth tests occasionally dies with
`RuntimeError: cannot schedule new futures after shutdown`, raised from the
driver's "Task Scheduler" thread. No assertion fails - the worker process itself
goes away.

`Cluster.__init__` starts that thread in the constructor, before `connect()` is
called, and `Cluster` has no `__del__` (only `Session` does). A `Cluster` dropped
without `shutdown()` is therefore never reclaimed, and if `connect()` did not get
as far as `_register_cluster_shutdown()` the driver's `atexit` sweep misses it
too. `DTestSetup._create_session()` registered the session in `self.connections` -
the list the dtest teardown shuts down - only *after* `connect()` and
`set_keyspace()`, so any exception from those leaked the `Cluster` and its thread.

Only the control-connection failure inside `connect()` self-heals. Failures after
that point (`_new_session()`, `wait_futures()` on the initial connect futures,
`set_keyspace()`) leak outright, once per retry - every dtest connection helper
goes through `_create_session()`, and the `patient_*` variants retry.

SCYLLADB-1662 and SCYLLADB-1434 added `safe_driver_shutdown()` and routed teardown
through it; that only covers connections the framework tracks. This one is never
tracked at all.

## What changed

- **`test/cluster/dtest/dtest_setup.py`** - `_create_session()` shuts the `Cluster`
  down before re-raising. One guard covers every connection helper.
- **`test/pylib/driver_utils.py`** - `safe_driver_shutdown()` logs rather than
  re-raises, since it now runs on half-built clusters where cleanup must not mask
  the original error. Adds `safe_shutting_down()`, a context manager that always
  tears down through it (`Cluster.__exit__` calls a plain `shutdown()`, without
  the scheduler join).
- **`test/pylib/scylla_cluster.py`** - same defect in the CQL-up poll loop:
  `self.control_cluster` was assigned before being connected, so a swallowed
  `NoHostAvailable` let the next poll overwrite and leak it. Now published only on
  success. Both `with Cluster(...)` sites use `safe_shutting_down()`.

## Testing

The crash is flaky, so the leak was reproduced directly: simulating a failure after
the control connection is up leaves **five orphaned Task Scheduler threads before
the change and none after**. That synthetic case is the real evidence - dev-mode
suite runs only ever hit the control-connection path the driver already self-heals,
so they demonstrate no regression rather than the fix. The reported failure was in
`debug` mode.

Dev mode, in `./tools/toolchain/dbuild`: `auth_test.py` + `auth_roles_test.py` +
`schema_management_test.py` - 76 passed; plus `test_boot_nodes.py` - 61 passed on
the final tree. `test_auth_certificate_or_password.py` fails two tests identically
with and without these commits (pre-existing).

Fixed SCYLLADB-3443