### PR TITLE
storage_proxy: count read repairs that actually found differences

### DIFF
--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -3101,6 +3101,10 @@ void storage_proxy_stats::stats::register_stats() {
                        sm::description("number of background read repairs"),
                        {storage_proxy_stats::current_scheduling_group_label()}).set_skip_when_empty(),
 
+        sm::make_total_operations("read_repairs_diff_found_total", read_repair_diff_found,
+                       sm::description("number of read repairs in which the full-data reconciliation found actual differences between replicas and repair mutations were sent"),
+                       {storage_proxy_stats::current_scheduling_group_label()}).set_skip_when_empty(),
+
         sm::make_total_operations("read_timeouts", [this]{return read_timeouts.count(); },
                        sm::description("number of read request failed due to a timeout"),
                        {storage_proxy_stats::current_scheduling_group_label(), basic_level}).set_skip_when_empty(),
@@ -4878,6 +4882,7 @@ future<result<>> storage_proxy::schedule_repair(locator::effective_replication_m
     if (diffs.empty()) {
         return make_ready_future<result<>>(bo::success());
     }
+    get_stats().read_repair_diff_found++;
     return mutate_internal(
             diffs |
                     std::views::values |

--- a/service/storage_proxy_stats.hh
+++ b/service/storage_proxy_stats.hh
@@ -142,6 +142,7 @@ struct stats : public write_stats {
     uint64_t read_repair_attempts = 0;
     uint64_t read_repair_repaired_blocking = 0;
     uint64_t read_repair_repaired_background = 0;
+    uint64_t read_repair_diff_found = 0;
     uint64_t global_read_repairs_canceled_due_to_concurrent_write = 0;
 
     // number of mutations received as a coordinator

--- a/test/cluster/test_read_repair.py
+++ b/test/cluster/test_read_repair.py
@@ -266,6 +266,18 @@ async def test_incremental_read_repair(data_class: DataClass, manager: ManagerCl
         check_rows(cql, host1, node1_rows)
         check_rows(cql, host2, node2_rows)
 
+        async def read_repair_metrics() -> tuple[int, int]:
+            digest_mismatches = 0
+            diff_found = 0
+            for node in nodes:
+                metrics = await manager.metrics.query(node.ip_addr)
+                digest_mismatches += metrics.get("scylla_storage_proxy_coordinator_foreground_read_repairs") or 0
+                digest_mismatches += metrics.get("scylla_storage_proxy_coordinator_background_read_repairs") or 0
+                diff_found += metrics.get("scylla_storage_proxy_coordinator_read_repairs_diff_found_total") or 0
+            return int(digest_mismatches), int(diff_found)
+
+        digest_mismatches_before, diff_found_before = await read_repair_metrics()
+
         logger.info("Run read-repair")
         res = cql.execute(SimpleStatement(data_class.get_select_query(ks), consistency_level=ConsistencyLevel.ALL), trace=True)
         res_rows = []
@@ -297,6 +309,15 @@ async def test_incremental_read_repair(data_class: DataClass, manager: ManagerCl
             assert row_id in all_rows
             data_class.check_result_row(row_id, res_row)
         assert actual_row_ids == all_rows
+
+        # The replicas diverged, so the CL=ALL read must have hit a digest
+        # mismatch, and the reconciliation must have found actual differences.
+        digest_mismatches_after, diff_found_after = await read_repair_metrics()
+        assert digest_mismatches_after > digest_mismatches_before
+        assert diff_found_after > diff_found_before
+        # Reconciliations are triggered by digest mismatches, so no more
+        # diff-found events than digest mismatches.
+        assert diff_found_after - diff_found_before <= digest_mismatches_after - digest_mismatches_before
 
         for node in (node1, node2):
             await manager.api.keyspace_flush(node.ip_addr, ks)


### PR DESCRIPTION
Operators currently have no Prometheus-level visibility into whether read repair actually finds inconsistencies, as opposed to merely running: `foreground/background_read_repairs` count digest mismatches that trigger a full-data read, but a mismatch may be benign (e.g. a write racing with the read). Nothing reports whether the reconciliation found real differences between the replicas.

This adds `scylla_storage_proxy_coordinator_read_repairs_diff_found_total`, incremented once per completed read-repair reconciliation that found differences and sent repair mutations, at the same granularity as the existing counters, so comparing it with foreground+background read repairs separates real divergence from benign digest mismatches.

The new counter follows the Prometheus `_total` naming convention for counters.

## How it was tested

`test_incremental_read_repair` now also asserts the read-repair counters move correctly around the CL=ALL read over diverged replicas.

Per-test wall time in dev mode (the added metric assertions cost only a few metrics-endpoint scrapes):

| Test | Duration |
|---|---|
| `test_incremental_read_repair[row-tombstone]` (pre-existing + metric asserts) | 8.9s |
| `test_incremental_read_repair[partition-tombstone]` (pre-existing + metric asserts) | 9.7s |

Backport: no, improvement

Split out of #30987 (part 1/2).
