### PR TITLE
repair: expose repair round outcomes as metrics

### DIFF
--- a/repair/row_level.cc
+++ b/repair/row_level.cc
@@ -196,6 +196,9 @@ struct row_level_repair_metrics {
     uint64_t inc_sst_skipped_bytes{0};
     uint64_t inc_sst_read_bytes{0};
     uint64_t tablet_time_ms{0};
+    uint64_t rounds_total{0};
+    uint64_t rounds_in_sync_total{0};
+    uint64_t rounds_out_of_sync_total{0};
     row_level_repair_metrics() {
         namespace sm = seastar::metrics;
         _metrics.add_group("repair", {
@@ -221,6 +224,16 @@ struct row_level_repair_metrics {
                             sm::description("Total number of bytes read from sstables for incremental repair on this shard.")),
             sm::make_counter("tablet_time_ms", tablet_time_ms,
                             sm::description("Time spent on tablet repair on this shard in milliseconds.")),
+            sm::make_counter("rounds_total", rounds_total,
+                            sm::description("Total number of repair rounds executed on this shard as repair master, "
+                                            "for repair jobs only, excluding repair-based node operations.")),
+            sm::make_counter("rounds_in_sync_total", rounds_in_sync_total,
+                            sm::description("Total number of repair rounds in which all replicas were found already in sync on this shard, "
+                                            "for repair jobs only, excluding repair-based node operations.")),
+            sm::make_counter("rounds_out_of_sync_total", rounds_out_of_sync_total,
+                            sm::description("Total number of repair rounds in which differences between replicas were found "
+                                            "and rows were exchanged on this shard, "
+                                            "for repair jobs only, excluding repair-based node operations.")).set_skip_when_empty(),
         });
     }
 };
@@ -3176,12 +3189,20 @@ private:
                 _skipped_sync_boundary = _common_sync_boundary;
                 rlogger.debug("Skip set skipped_sync_boundary={}", _skipped_sync_boundary);
                 master.stats().round_nr_fast_path_already_synced++;
+                if (count_round_metrics()) {
+                    _metrics.rounds_total++;
+                    _metrics.rounds_in_sync_total++;
+                }
                 return op_status::next_round;
             } else {
                 _skipped_sync_boundary = std::nullopt;
             }
         } else {
             master.stats().round_nr_fast_path_already_synced++;
+            if (count_round_metrics()) {
+                _metrics.rounds_total++;
+                _metrics.rounds_in_sync_total++;
+            }
             // We are done with this range because all the nodes have no more data.
             return op_status::all_done;
         }
@@ -3236,6 +3257,10 @@ private:
             // `_working_row_buf` on all the nodes are the same
             // This is the second fast path.
             master.stats().round_nr_fast_path_same_combined_hashes++;
+            if (count_round_metrics()) {
+                _metrics.rounds_total++;
+                _metrics.rounds_in_sync_total++;
+            }
             return op_status::next_round;
         }
 
@@ -3376,9 +3401,20 @@ private:
             }
         })).get();
         master.stats().round_nr_slow_path++;
+        if (count_round_metrics()) {
+            _metrics.rounds_total++;
+            _metrics.rounds_out_of_sync_total++;
+        }
     }
 
 private:
+    // The row-level repair code also serves repair-based node operations
+    // (rebuild, replace, decommission, ...), where divergence between the
+    // syncing nodes is expected. The round-outcome metrics track repair jobs only.
+    bool count_round_metrics() const {
+        return _shard_task.reason() == streaming::stream_reason::repair;
+    }
+
     locator::effective_replication_map_ptr get_erm() {
         return _shard_task.get_erm();
     }

--- a/test/cluster/test_repair_metrics.py
+++ b/test/cluster/test_repair_metrics.py
@@ -1,0 +1,69 @@
+#
+# Copyright (C) 2026-present ScyllaDB
+#
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
+#
+
+import asyncio
+import logging
+import time
+
+from cassandra.query import ConsistencyLevel
+
+from test.pylib.internal_types import ServerInfo
+from test.pylib.manager_client import ManagerClient
+from test.pylib.repair import create_table_insert_data_for_repair
+from test.pylib.util import wait_for_cql_and_get_hosts
+
+logger = logging.getLogger(__name__)
+
+
+async def repair_rounds_metrics(manager: ManagerClient, servers: list[ServerInfo]) -> tuple[int, int, int]:
+    """Sum the repair round counters over all nodes and shards."""
+    rounds = in_sync = out_of_sync = 0
+    for server in servers:
+        metrics = await manager.metrics.query(server.ip_addr)
+        rounds += metrics.get("scylla_repair_rounds_total") or 0
+        in_sync += metrics.get("scylla_repair_rounds_in_sync_total") or 0
+        out_of_sync += metrics.get("scylla_repair_rounds_out_of_sync_total") or 0
+    return int(rounds), int(in_sync), int(out_of_sync)
+
+
+async def test_repair_rounds_metrics(manager: ManagerClient):
+    """Test that repair reports whether it actually found inconsistencies.
+
+    A repair over diverged replicas must increase rounds_out_of_sync_total, while
+    a second repair over the now-synced replicas must only increase
+    rounds_in_sync_total.
+    """
+    nr_keys = 128
+    servers, cql, _, ks, _ = await create_table_insert_data_for_repair(
+        manager, nr_keys=nr_keys, cmdline=["--hinted-handoff-enabled", "0"])
+
+    # Make the replicas diverge: write new rows while one node is down.
+    await manager.server_stop_gracefully(servers[2].server_id)
+    insert_stmt = cql.prepare(f"INSERT INTO {ks}.test (pk, c) VALUES (?, ?)")
+    insert_stmt.consistency_level = ConsistencyLevel.ONE
+    await asyncio.gather(*[cql.run_async(insert_stmt, (k, k)) for k in range(nr_keys, 2 * nr_keys)])
+    await manager.server_start(servers[2].server_id, wait_others=2)
+    await wait_for_cql_and_get_hosts(cql, servers, time.time() + 60)
+
+    rounds_before, in_sync_before, out_of_sync_before = await repair_rounds_metrics(manager, servers)
+
+    await manager.api.tablet_repair(servers[0].ip_addr, ks, "test", "all")
+
+    rounds_after, in_sync_after, out_of_sync_after = await repair_rounds_metrics(manager, servers)
+    logger.info(f"First repair round deltas: rounds={rounds_after - rounds_before} "
+                f"in_sync={in_sync_after - in_sync_before} out_of_sync={out_of_sync_after - out_of_sync_before}")
+    assert rounds_after > rounds_before
+    assert out_of_sync_after > out_of_sync_before
+
+    # The replicas are in sync now, so a second repair must not find anything to fix.
+    await manager.api.tablet_repair(servers[0].ip_addr, ks, "test", "all")
+
+    rounds_final, in_sync_final, out_of_sync_final = await repair_rounds_metrics(manager, servers)
+    logger.info(f"Second repair round deltas: rounds={rounds_final - rounds_after} "
+                f"in_sync={in_sync_final - in_sync_after} out_of_sync={out_of_sync_final - out_of_sync_after}")
+    assert rounds_final > rounds_after
+    assert in_sync_final > in_sync_after
+    assert out_of_sync_final == out_of_sync_after


### PR DESCRIPTION
Operators currently have no Prometheus-level visibility into whether repair actually finds inconsistencies, as opposed to merely running: row-level repair tracks the per-repair round outcomes internally (already-in-sync fast paths vs. the slow path that exchanges rows), but they are only printed to the log when the repair ends.

This adds `scylla_repair_rounds_total`, `scylla_repair_rounds_in_sync_total`, `scylla_repair_rounds_out_of_sync_total` — repair-master round outcome counters, updated for repair jobs only (repair-based node operations such as rebuild/replace are excluded, since divergence between the syncing nodes is expected there). `rounds_total` is incremented alongside whichever outcome counter applies, so a round that aborts with an error is excluded from all three counters and `rounds_total` always equals `rounds_in_sync_total + rounds_out_of_sync_total`.

The new counters follow the Prometheus `_total` naming convention for counters.

## How it was tested

The new `test/cluster/test_repair_metrics.py` verifies that repairing diverged replicas bumps `rounds_out_of_sync_total` while re-repairing the now-synced replicas bumps only `rounds_in_sync_total`.

Per-test wall time in dev mode:

| Test | Duration |
|---|---|
| `test_repair_rounds_metrics` (new) | 7.9s |

Backport: no, improvement

Split out of #30987 (part 2/2).

