### PR TITLE
Fix replication factor calculation for tablets by computing it on the fly from the tablet replica set

### DIFF
--- a/alternator/ttl.cc
+++ b/alternator/ttl.cc
@@ -780,7 +780,7 @@ static future<bool> scan_table(
                     auto tablet_primary_replica = tablet_map.get_primary_replica(*tablet, erm->get_topology());
                     if (tablet_primary_replica.host == my_host_id && tablet_primary_replica.shard == this_shard_id()) {
                         range = dht::to_partition_range(std::move(tablet_token_range));
-                    } else if (erm->get_replication_factor() > 1) {
+                    } else if (erm->get_schema_replication_factor() > 1) {
                         // If each node only scans its own primary ranges, then when any node is
                         // down part of the token range will not get scanned. This can be viewed
                         // as acceptable (when it comes back online, it will resume its scan),

--- a/alternator/ttl.cc
+++ b/alternator/ttl.cc
@@ -780,7 +780,11 @@ static future<bool> scan_table(
                     auto tablet_primary_replica = tablet_map.get_primary_replica(*tablet, erm->get_topology());
                     if (tablet_primary_replica.host == my_host_id && tablet_primary_replica.shard == this_shard_id()) {
                         range = dht::to_partition_range(std::move(tablet_token_range));
-                    } else if (erm->get_schema_replication_factor() > 1) {
+                    } else if (tablet_map.get_tablet_info(*tablet).replicas.size() > 1) {
+                        // Note: checked against this tablet's actual replica set, not the schema
+                        // replication factor - during migrations caused by an RF change they may
+                        // disagree, and get_secondary_replica() throws if the tablet has no
+                        // secondary replica.
                         // If each node only scans its own primary ranges, then when any node is
                         // down part of the token range will not get scanned. This can be viewed
                         // as acceptable (when it comes back online, it will resume its scan),

--- a/db/consistency_level.cc
+++ b/db/consistency_level.cc
@@ -27,7 +27,7 @@ namespace db {
 logging::logger cl_logger("consistency");
 
 size_t quorum_for(const locator::effective_replication_map& erm) {
-    size_t replication_factor = erm.get_replication_factor();
+    size_t replication_factor = erm.get_schema_replication_factor();
     return replication_factor ? (replication_factor / 2) + 1 : 0;
 }
 
@@ -42,7 +42,7 @@ static size_t get_replication_factor_for_dc(const locator::effective_replication
         return nts->get_replication_factor(dc);
     }
 
-    return erm.get_replication_factor();
+    return erm.get_schema_replication_factor();
 }
 
 size_t local_quorum_for(const locator::effective_replication_map& erm, const sstring& dc) {
@@ -101,7 +101,7 @@ size_t block_for(const locator::effective_replication_map& erm, consistency_leve
     case consistency_level::SERIAL:
         return quorum_for(erm);
     case consistency_level::ALL:
-        return erm.get_replication_factor();
+        return erm.get_schema_replication_factor();
     case consistency_level::LOCAL_QUORUM:
         [[fallthrough]];
     case consistency_level::LOCAL_SERIAL:

--- a/db/consistency_level.cc
+++ b/db/consistency_level.cc
@@ -26,31 +26,17 @@ namespace db {
 
 logging::logger cl_logger("consistency");
 
-size_t quorum_for(const locator::effective_replication_map& erm) {
-    size_t replication_factor = erm.get_schema_replication_factor();
+size_t quorum_for(const locator::effective_replication_map& erm, dht::token token) {
+    size_t replication_factor = erm.get_replication_factor(token);
     return replication_factor ? (replication_factor / 2) + 1 : 0;
 }
 
-static size_t get_replication_factor_for_dc(const locator::effective_replication_map& erm, const sstring& dc) {
-    using namespace locator;
-
-    const auto& rs = erm.get_replication_strategy();
-
-    if (rs.get_type() == replication_strategy_type::network_topology) {
-        const network_topology_strategy* nts =
-            static_cast<const network_topology_strategy*>(&rs);
-        return nts->get_replication_factor(dc);
-    }
-
-    return erm.get_schema_replication_factor();
-}
-
-size_t local_quorum_for(const locator::effective_replication_map& erm, const sstring& dc) {
-    auto rf = get_replication_factor_for_dc(erm, dc);
+size_t local_quorum_for(const locator::effective_replication_map& erm, const sstring& dc, dht::token token) {
+    auto rf = erm.get_replication_factor(token, dc);
     return rf ? (rf / 2) + 1 : 0;
 }
 
-size_t block_for_local_serial(const locator::effective_replication_map& erm) {
+size_t block_for_local_serial(const locator::effective_replication_map& erm, dht::token token) {
     using namespace locator;
 
     //
@@ -61,10 +47,10 @@ size_t block_for_local_serial(const locator::effective_replication_map& erm) {
     //
 
     const auto& topo = erm.get_topology();
-    return local_quorum_for(erm, topo.get_datacenter());
+    return local_quorum_for(erm, topo.get_datacenter(), token);
 }
 
-size_t block_for_each_quorum(const locator::effective_replication_map& erm) {
+size_t block_for_each_quorum(const locator::effective_replication_map& erm, dht::token token) {
     using namespace locator;
 
     const auto& rs = erm.get_replication_strategy();
@@ -75,16 +61,16 @@ size_t block_for_each_quorum(const locator::effective_replication_map& erm) {
         size_t n = 0;
 
         for (auto& dc : nrs->get_datacenters()) {
-            n += local_quorum_for(erm, dc);
+            n += local_quorum_for(erm, dc, token);
         }
 
         return n;
     } else {
-        return quorum_for(erm);
+        return quorum_for(erm, token);
     }
 }
 
-size_t block_for(const locator::effective_replication_map& erm, consistency_level cl) {
+size_t block_for(const locator::effective_replication_map& erm, consistency_level cl, dht::token token) {
     switch (cl) {
     case consistency_level::ONE:
         [[fallthrough]];
@@ -99,15 +85,15 @@ size_t block_for(const locator::effective_replication_map& erm, consistency_leve
     case consistency_level::QUORUM:
         [[fallthrough]];
     case consistency_level::SERIAL:
-        return quorum_for(erm);
+        return quorum_for(erm, token);
     case consistency_level::ALL:
-        return erm.get_schema_replication_factor();
+        return erm.get_replication_factor(token);
     case consistency_level::LOCAL_QUORUM:
         [[fallthrough]];
     case consistency_level::LOCAL_SERIAL:
-        return block_for_local_serial(erm);
+        return block_for_local_serial(erm, token);
     case consistency_level::EACH_QUORUM:
-        return block_for_each_quorum(erm);
+        return block_for_each_quorum(erm, token);
     default:
         abort();
     }
@@ -155,6 +141,7 @@ bool assure_sufficient_live_nodes_each_quorum(
         consistency_level cl,
         const locator::effective_replication_map& erm,
         const host_id_vector_replica_set& live_endpoints,
+        dht::token token,
         const host_id_vector_topology_change& pending_endpoints) {
     using namespace locator;
 
@@ -162,7 +149,7 @@ bool assure_sufficient_live_nodes_each_quorum(
 
     if (rs.get_type() == replication_strategy_type::network_topology) {
         for (auto& entry : count_per_dc_endpoints(erm, live_endpoints, pending_endpoints)) {
-            auto dc_block_for = local_quorum_for(erm, entry.first);
+            auto dc_block_for = local_quorum_for(erm, entry.first, token);
             auto dc_live = entry.second.live;
             auto dc_pending = entry.second.pending;
 
@@ -181,8 +168,9 @@ void assure_sufficient_live_nodes(
         consistency_level cl,
         const locator::effective_replication_map& erm,
         const host_id_vector_replica_set& live_endpoints,
+        dht::token token,
         const host_id_vector_topology_change& pending_endpoints) {
-    size_t need = block_for(erm, cl);
+    size_t need = block_for(erm, cl, token);
 
     auto adjust_live_for_error = [] (size_t live, size_t pending) {
         // DowngradingConsistencyRetryPolicy uses alive replicas count from Unavailable
@@ -205,7 +193,7 @@ void assure_sufficient_live_nodes(
         // local hint is acceptable, and local node is always live
         break;
     case consistency_level::LOCAL_ONE:
-        if (size_t local_rf = get_replication_factor_for_dc(erm, local_dc); local_rf == 0) {
+        if (size_t local_rf = erm.get_replication_factor(token, local_dc); local_rf == 0) {
             throw exceptions::unavailable_exception(make_rf_zero_error_msg(local_dc), cl, 1, 0);
         }
         if (topo.count_local_endpoints(live_endpoints) < topo.count_local_endpoints(pending_endpoints) + 1) {
@@ -213,7 +201,7 @@ void assure_sufficient_live_nodes(
         }
         break;
     case consistency_level::LOCAL_QUORUM: {
-        if (size_t local_rf = get_replication_factor_for_dc(erm, local_dc); local_rf == 0) {
+        if (size_t local_rf = erm.get_replication_factor(token, local_dc); local_rf == 0) {
             throw exceptions::unavailable_exception(make_rf_zero_error_msg(local_dc), cl, need, 0);
         }
         size_t local_live = topo.count_local_endpoints(live_endpoints);
@@ -225,7 +213,7 @@ void assure_sufficient_live_nodes(
         break;
     }
     case consistency_level::EACH_QUORUM:
-        if (assure_sufficient_live_nodes_each_quorum(cl, erm, live_endpoints, pending_endpoints)) {
+        if (assure_sufficient_live_nodes_each_quorum(cl, erm, live_endpoints, token, pending_endpoints)) {
             break;
         }
     // Fallthrough on purpose for SimpleStrategy
@@ -249,7 +237,8 @@ filter_for_query(consistency_level cl,
                  read_repair_decision read_repair,
                  const gms::gossiper& g,
                  std::optional<locator::host_id>* extra,
-                 replica::column_family* cf) {
+                 replica::column_family* cf,
+                 dht::token token) {
     size_t local_count;
 
     if (read_repair == read_repair_decision::GLOBAL) { // take RRD.GLOBAL out of the way
@@ -265,7 +254,7 @@ filter_for_query(consistency_level cl,
         }
     }
 
-    size_t bf = block_for(erm, cl);
+    size_t bf = block_for(erm, cl, token);
 
     if (read_repair == read_repair_decision::DC_LOCAL) {
         bf = std::max(bf, local_count);
@@ -365,7 +354,8 @@ filter_for_query(consistency_level cl,
 bool
 is_sufficient_live_nodes(consistency_level cl,
                          const locator::effective_replication_map& erm,
-                         const host_id_vector_replica_set& live_endpoints) {
+                         const host_id_vector_replica_set& live_endpoints,
+                         dht::token token) {
     using namespace locator;
     const auto& topo = erm.get_topology();
 
@@ -376,14 +366,14 @@ is_sufficient_live_nodes(consistency_level cl,
     case consistency_level::LOCAL_ONE:
         return topo.count_local_endpoints(live_endpoints) >= 1;
     case consistency_level::LOCAL_QUORUM:
-        return topo.count_local_endpoints(live_endpoints) >= block_for(erm, cl);
+        return topo.count_local_endpoints(live_endpoints) >= block_for(erm, cl, token);
     case consistency_level::EACH_QUORUM:
     {
         auto& rs = erm.get_replication_strategy();
 
         if (rs.get_type() == replication_strategy_type::network_topology) {
             for (auto& entry : count_per_dc_endpoints(erm, live_endpoints)) {
-                if (entry.second.live < local_quorum_for(erm, entry.first)) {
+                if (entry.second.live < local_quorum_for(erm, entry.first, token)) {
                     return false;
                 }
             }
@@ -394,7 +384,7 @@ is_sufficient_live_nodes(consistency_level cl,
         [[fallthrough]];
         // Fallthrough on purpose for SimpleStrategy
     default:
-        return live_endpoints.size() >= block_for(erm, cl);
+        return live_endpoints.size() >= block_for(erm, cl, token);
     }
 }
 

--- a/db/consistency_level.hh
+++ b/db/consistency_level.hh
@@ -12,6 +12,7 @@
 
 #include "db/consistency_level_type.hh"
 #include "db/read_repair_decision.hh"
+#include "dht/token.hh"
 #include "inet_address_vectors.hh"
 #include "utils/log.hh"
 #include "replica/database_fwd.hh"
@@ -28,15 +29,15 @@ namespace db {
 
 extern logging::logger cl_logger;
 
-size_t quorum_for(const locator::effective_replication_map& erm);
+size_t quorum_for(const locator::effective_replication_map& erm, dht::token token);
 
-size_t local_quorum_for(const locator::effective_replication_map& erm, const sstring& dc);
+size_t local_quorum_for(const locator::effective_replication_map& erm, const sstring& dc, dht::token token);
 
-size_t block_for_local_serial(const locator::effective_replication_map& erm);
+size_t block_for_local_serial(const locator::effective_replication_map& erm, dht::token token);
 
-size_t block_for_each_quorum(const locator::effective_replication_map& erm);
+size_t block_for_each_quorum(const locator::effective_replication_map& erm, dht::token token);
 
-size_t block_for(const locator::effective_replication_map& erm, consistency_level cl);
+size_t block_for(const locator::effective_replication_map& erm, consistency_level cl, dht::token token);
 
 bool is_datacenter_local(consistency_level l);
 
@@ -48,7 +49,8 @@ filter_for_query(consistency_level cl,
                  read_repair_decision read_repair,
                  const gms::gossiper& g,
                  std::optional<locator::host_id>* extra,
-                 replica::column_family* cf);
+                 replica::column_family* cf,
+                 dht::token token);
 
 struct dc_node_count {
     size_t live = 0;
@@ -58,11 +60,13 @@ struct dc_node_count {
 bool
 is_sufficient_live_nodes(consistency_level cl,
                          const locator::effective_replication_map& erm,
-                         const host_id_vector_replica_set& live_endpoints);
+                         const host_id_vector_replica_set& live_endpoints,
+                         dht::token token);
 
 void assure_sufficient_live_nodes(
         consistency_level cl,
         const locator::effective_replication_map& erm,
         const host_id_vector_replica_set& live_endpoints,
+        dht::token token,
         const host_id_vector_topology_change& pending_endpoints = host_id_vector_topology_change());
 }

--- a/dht/range_streamer.cc
+++ b/dht/range_streamer.cc
@@ -63,7 +63,7 @@ range_streamer::get_range_fetch_map(const std::unordered_map<dht::token_range, s
         }
 
         if (!found_source) {
-            auto rf = erm->get_replication_factor();
+            auto rf = erm->get_schema_replication_factor();
             // When a replacing node replaces a dead node with keyspace of RF
             // 1, it is expected that replacing node could not find a peer node
             // that contains data to stream from.
@@ -152,7 +152,7 @@ range_streamer::get_all_ranges_with_strict_sources_for(const sstring& keyspace_n
                 std::unordered_set<locator::host_id> new_endpoints(it->second.begin(), it->second.end());
                 //Due to CASSANDRA-5953 we can have a higher RF then we have endpoints.
                 //So we need to be careful to only be strict when endpoints == RF
-                if (old_endpoints.size() == erm->get_replication_factor()) {
+                if (old_endpoints.size() == erm->get_schema_replication_factor()) {
                     std::erase_if(old_endpoints,
                         [&new_endpoints] (locator::host_id ep) { return new_endpoints.contains(ep); });
                     if (old_endpoints.size() != 1) {
@@ -184,7 +184,7 @@ range_streamer::get_all_ranges_with_strict_sources_for(const sstring& keyspace_n
 }
 
 bool range_streamer::use_strict_sources_for_ranges(const sstring& keyspace_name, const locator::effective_replication_map& erm) {
-    auto rf = erm.get_replication_factor();
+    auto rf = erm.get_schema_replication_factor();
     auto nr_nodes_in_ring = get_token_metadata().get_normal_token_owners().size();
     bool everywhere_topology = erm.get_replication_strategy().get_type() == locator::replication_strategy_type::everywhere_topology;
     // Use strict when number of nodes in the ring is equal or more than RF

--- a/locator/abstract_replication_strategy.cc
+++ b/locator/abstract_replication_strategy.cc
@@ -21,6 +21,7 @@
 #include <boost/icl/interval.hpp>
 #include <boost/icl/interval_map.hpp>
 #include <variant>
+#include "locator/network_topology_strategy.hh"
 
 namespace locator {
 
@@ -566,6 +567,15 @@ static_effective_replication_map::~static_effective_replication_map() {
     if (is_registered()) {
         _factory->erase_effective_replication_map(this);
     }
+}
+
+size_t static_effective_replication_map::get_replication_factor(token, const sstring& datacenter) const {
+    const auto& rs = get_replication_strategy();
+    if (rs.get_type() == replication_strategy_type::network_topology) {
+        const auto* nts = static_cast<const network_topology_strategy*>(&rs);
+        return nts->get_replication_factor(datacenter);
+    }
+    return get_schema_replication_factor();
 }
 
 vnode_effective_replication_map::~vnode_effective_replication_map() {

--- a/locator/abstract_replication_strategy.hh
+++ b/locator/abstract_replication_strategy.hh
@@ -274,6 +274,25 @@ public:
     // Use get_replication_factor(token) to get the actual replica count for a token.
     size_t get_schema_replication_factor() const noexcept { return _replication_factor; }
 
+    // Get the total replication factor for a token across all data centers.
+    // The vnode-based implementation ignores the token and returns the same value
+    // as get_schema_replication_factor().
+    // The tablets implementation returns the size of the read replica set of the
+    // token's tablet, which accounts for ongoing migrations. When no tablets are
+    // in transition and not undergoing a replication factor change, this returns
+    // the same value as get_schema_replication_factor().
+    virtual size_t get_replication_factor(token search_token) const = 0;
+
+    // Get the replication factor for a token in the given data center.
+    // The vnode-based implementation ignores the token and returns the replication
+    // factor configured for the data center by the replication strategy.
+    // The tablets implementation returns the number of replicas in the read replica
+    // set of the token's tablet which belong to the given data center, which accounts
+    // for ongoing migrations. All replicas are expected to be present in the topology
+    // associated with this instance (nodes which left the cluster are kept in
+    // topology while they appear in tablet replica sets).
+    virtual size_t get_replication_factor(token search_token, const sstring& datacenter) const = 0;
+
     void invalidate() const noexcept {
         _validity_abort_source->request_abort();
     }
@@ -433,6 +452,12 @@ public:
     virtual const local_effective_replication_map* maybe_as_local_effective_replication_map() const {
         return nullptr;
     }
+
+    virtual size_t get_replication_factor(token) const override {
+        return get_schema_replication_factor();
+    }
+
+    virtual size_t get_replication_factor(token, const sstring& datacenter) const override;
 
     virtual future<mutable_static_effective_replication_map_ptr> clone_gently(replication_strategy_ptr rs, token_metadata_ptr tmptr) const = 0;
 

--- a/locator/abstract_replication_strategy.hh
+++ b/locator/abstract_replication_strategy.hh
@@ -268,7 +268,11 @@ public:
     const token_metadata& get_token_metadata() const noexcept { return *_tmptr; }
     const token_metadata_ptr& get_token_metadata_ptr() const noexcept { return _tmptr; }
     const topology& get_topology() const noexcept { return _tmptr->get_topology(); }
-    size_t get_replication_factor() const noexcept { return _replication_factor; }
+    // Get the replication factor across all data centers as defined by the schema
+    // replication strategy options. During tablet migrations caused by a replication
+    // factor change, individual tablets may not have this many replicas yet (or still).
+    // Use get_replication_factor(token) to get the actual replica count for a token.
+    size_t get_schema_replication_factor() const noexcept { return _replication_factor; }
 
     void invalidate() const noexcept {
         _validity_abort_source->request_abort();

--- a/locator/abstract_replication_strategy.hh
+++ b/locator/abstract_replication_strategy.hh
@@ -155,8 +155,9 @@ protected:
 public:
     using ptr_type = seastar::shared_ptr<abstract_replication_strategy>;
 
-    // Check that the read replica set does not exceed what's allowed by the schema.
-    [[nodiscard]] virtual sstring sanity_check_read_replicas(const effective_replication_map& erm, const host_id_vector_replica_set& read_replicas) const = 0;
+    // Check that the read replica set does not exceed the replication factor
+    // effective for the given token.
+    [[nodiscard]] virtual sstring sanity_check_read_replicas(const effective_replication_map& erm, const host_id_vector_replica_set& read_replicas, dht::token token) const = 0;
 
     abstract_replication_strategy(
         replication_strategy_params params,

--- a/locator/everywhere_replication_strategy.cc
+++ b/locator/everywhere_replication_strategy.cc
@@ -41,7 +41,7 @@ void everywhere_replication_strategy::validate_options(const gms::feature_servic
 }
 
 sstring everywhere_replication_strategy::sanity_check_read_replicas(const effective_replication_map& erm, const host_id_vector_replica_set& read_replicas) const {
-    const auto replication_factor = erm.get_replication_factor();
+    const auto replication_factor = erm.get_schema_replication_factor();
     if (const auto& topo_info = erm.get_token_metadata().get_topology_change_info(); topo_info && topo_info->read_new) {
         if (read_replicas.size() > replication_factor + 1) {
             return seastar::format(

--- a/locator/everywhere_replication_strategy.cc
+++ b/locator/everywhere_replication_strategy.cc
@@ -40,7 +40,7 @@ void everywhere_replication_strategy::validate_options(const gms::feature_servic
     }
 }
 
-sstring everywhere_replication_strategy::sanity_check_read_replicas(const effective_replication_map& erm, const host_id_vector_replica_set& read_replicas) const {
+sstring everywhere_replication_strategy::sanity_check_read_replicas(const effective_replication_map& erm, const host_id_vector_replica_set& read_replicas, dht::token token) const {
     const auto replication_factor = erm.get_schema_replication_factor();
     if (const auto& topo_info = erm.get_token_metadata().get_topology_change_info(); topo_info && topo_info->read_new) {
         if (read_replicas.size() > replication_factor + 1) {

--- a/locator/everywhere_replication_strategy.hh
+++ b/locator/everywhere_replication_strategy.hh
@@ -28,6 +28,6 @@ public:
         return true;
     }
 
-    [[nodiscard]] sstring sanity_check_read_replicas(const effective_replication_map& erm, const host_id_vector_replica_set& read_replicas) const override;
+    [[nodiscard]] sstring sanity_check_read_replicas(const effective_replication_map& erm, const host_id_vector_replica_set& read_replicas, dht::token token) const override;
 };
 }

--- a/locator/local_strategy.cc
+++ b/locator/local_strategy.cc
@@ -34,7 +34,7 @@ size_t local_strategy::get_replication_factor(const token_metadata&) const {
     return 1;
 }
 
-sstring local_strategy::sanity_check_read_replicas(const effective_replication_map& erm, const host_id_vector_replica_set& read_replicas) const {
+sstring local_strategy::sanity_check_read_replicas(const effective_replication_map& erm, const host_id_vector_replica_set& read_replicas, dht::token token) const {
     if (read_replicas.size() > 1) {
         return seastar::format("local_strategy: the number of replicas for local_strategy is {}, cannot be higher than 1", read_replicas.size());
     }

--- a/locator/local_strategy.hh
+++ b/locator/local_strategy.hh
@@ -34,7 +34,7 @@ public:
         return false;
     }
 
-    [[nodiscard]] sstring sanity_check_read_replicas(const effective_replication_map& erm, const host_id_vector_replica_set& read_replicas) const override;
+    [[nodiscard]] sstring sanity_check_read_replicas(const effective_replication_map& erm, const host_id_vector_replica_set& read_replicas, dht::token token) const override;
 };
 
 }

--- a/locator/network_topology_strategy.cc
+++ b/locator/network_topology_strategy.cc
@@ -624,7 +624,8 @@ tablet_replica_set network_topology_strategy::drop_tablets_in_dc(schema_ptr s, c
 }
 
 sstring network_topology_strategy::sanity_check_read_replicas(const effective_replication_map& erm,
-                                                              const host_id_vector_replica_set& read_replicas) const {
+                                                              const host_id_vector_replica_set& read_replicas,
+                                                              dht::token token) const {
     const auto& topology = erm.get_topology();
 
     struct rf_node_count {
@@ -633,11 +634,13 @@ sstring network_topology_strategy::sanity_check_read_replicas(const effective_re
     };
 
     absl::flat_hash_map<sstring, rf_node_count> data_centers_replication_factor;
-    std::ranges::for_each(read_replicas, [&data_centers_replication_factor, &topology, this](const auto& node) {
+    std::ranges::for_each(read_replicas, [&data_centers_replication_factor, &topology, &erm, token](const auto& node) {
         auto res = data_centers_replication_factor.emplace(topology.get_datacenter(node), rf_node_count{0, 0});
         if (res.second) {
-            // For new item add replication factor.
-            res.first->second.replication_factor = get_replication_factor(res.first->first);
+            // For new item add the replication factor effective for the token.
+            // With tablets it may differ from the schema replication factor
+            // during migrations caused by a replication factor change.
+            res.first->second.replication_factor = erm.get_replication_factor(token, res.first->first);
         }
         ++res.first->second.node_count;
     });

--- a/locator/network_topology_strategy.hh
+++ b/locator/network_topology_strategy.hh
@@ -57,7 +57,7 @@ public:
         return true;
     }
 
-    [[nodiscard]] sstring sanity_check_read_replicas(const effective_replication_map& erm, const host_id_vector_replica_set& read_replicas) const override;
+    [[nodiscard]] sstring sanity_check_read_replicas(const effective_replication_map& erm, const host_id_vector_replica_set& read_replicas, dht::token token) const override;
 
 public: // tablet_aware_replication_strategy
     virtual effective_replication_map_ptr make_replication_map(table_id, token_metadata_ptr) const override;

--- a/locator/simple_strategy.cc
+++ b/locator/simple_strategy.cc
@@ -79,7 +79,7 @@ void simple_strategy::validate_options(const gms::feature_service&, const locato
     }
 }
 
-sstring simple_strategy::sanity_check_read_replicas(const effective_replication_map& erm, const host_id_vector_replica_set& read_replicas) const {
+sstring simple_strategy::sanity_check_read_replicas(const effective_replication_map& erm, const host_id_vector_replica_set& read_replicas, dht::token token) const {
     if (read_replicas.size() > _replication_factor) {
         return seastar::format("ERM inconsistency, the read replica set for simple strategy has higher count of"
                                " read replicas [{}] than its replication factor [{}]",

--- a/locator/simple_strategy.hh
+++ b/locator/simple_strategy.hh
@@ -26,7 +26,7 @@ public:
 
     virtual future<host_id_set> calculate_natural_endpoints(const token& search_token, const token_metadata& tm) const override;
 
-    [[nodiscard]] sstring sanity_check_read_replicas(const effective_replication_map& erm, const host_id_vector_replica_set& read_replicas) const override;
+    [[nodiscard]] sstring sanity_check_read_replicas(const effective_replication_map& erm, const host_id_vector_replica_set& read_replicas, dht::token token) const override;
 private:
     size_t _replication_factor = 1;
 };

--- a/locator/tablets.cc
+++ b/locator/tablets.cc
@@ -926,6 +926,52 @@ const tablet_transition_info* tablet_map::get_tablet_transition_info(tablet_id i
     return &i->second;
 }
 
+const tablet_replica_set& tablet_map::get_replicas_for_reading(tablet_id tablet) const {
+    auto* info = get_tablet_transition_info(tablet);
+    if (!info) {
+        return get_tablet_info(tablet).replicas;
+    }
+    switch (info->reads) {
+        case read_replica_set_selector::previous:
+            return get_tablet_info(tablet).replicas;
+        case read_replica_set_selector::next:
+            return info->next;
+    }
+    on_internal_error(tablet_logger, format("Invalid read replica selector: {}", static_cast<int>(info->reads)));
+}
+
+const tablet_replica_set& tablet_map::get_replicas_for_writing(tablet_id tablet) const {
+    auto* info = get_tablet_transition_info(tablet);
+    if (!info) {
+        return get_tablet_info(tablet).replicas;
+    }
+    switch (info->writes) {
+        case write_replica_set_selector::previous:
+            [[fallthrough]];
+        case write_replica_set_selector::both:
+            return get_tablet_info(tablet).replicas;
+        case write_replica_set_selector::next:
+            return info->next;
+    }
+    on_internal_error(tablet_logger, format("Invalid write replica selector: {}", static_cast<int>(info->writes)));
+}
+
+const tablet_replica* tablet_map::get_pending_replica(tablet_id tablet) const {
+    auto* info = get_tablet_transition_info(tablet);
+    if (!info || info->transition == tablet_transition_kind::intranode_migration) {
+        return nullptr;
+    }
+    switch (info->writes) {
+        case write_replica_set_selector::previous:
+            return nullptr;
+        case write_replica_set_selector::both:
+            return info->pending_replica ? &*info->pending_replica : nullptr;
+        case write_replica_set_selector::next:
+            return nullptr;
+    }
+    on_internal_error(tablet_logger, format("Invalid write replica selector: {}", static_cast<int>(info->writes)));
+}
+
 const tablet_raft_info& tablet_map::get_tablet_raft_info(tablet_id id) const {
     check_tablet_id(id);
     if (_raft_info.empty()) {
@@ -1513,22 +1559,7 @@ private:
     const tablet_replica_set& get_replicas_for_write(dht::token search_token) const {
         auto&& tablets = get_tablet_map();
         auto tablet = tablets.get_tablet_id(search_token);
-        auto* info = tablets.get_tablet_transition_info(tablet);
-        auto&& replicas = std::invoke([&] () -> const tablet_replica_set& {
-            if (!info) {
-                return tablets.get_tablet_info(tablet).replicas;
-            }
-            switch (info->writes) {
-                case write_replica_set_selector::previous:
-                    [[fallthrough]];
-                case write_replica_set_selector::both:
-                    return tablets.get_tablet_info(tablet).replicas;
-                case write_replica_set_selector::next: {
-                    return info->next;
-                }
-            }
-            on_internal_error(tablet_logger, format("Invalid write replica selector: {}", static_cast<int>(info->writes)));
-        });
+        auto&& replicas = tablets.get_replicas_for_writing(tablet);
         tablet_logger.trace("get_replicas_for_write({}): table={}, tablet={}, replicas={}", search_token, _table, tablet, replicas);
         return replicas;
     }
@@ -1536,44 +1567,18 @@ private:
     host_id_vector_topology_change get_pending_helper(const token& search_token) const {
         auto&& tablets = get_tablet_map();
         auto tablet = tablets.get_tablet_id(search_token);
-        auto&& info = tablets.get_tablet_transition_info(tablet);
-        if (!info || info->transition == tablet_transition_kind::intranode_migration) {
+        const auto* replica = tablets.get_pending_replica(tablet);
+        if (!replica) {
             return {};
         }
-        switch (info->writes) {
-            case write_replica_set_selector::previous:
-                return {};
-            case write_replica_set_selector::both: {
-                if (!info->pending_replica) {
-                    return {};
-                }
-                tablet_logger.trace("get_pending_endpoints({}): table={}, tablet={}, replica={}",
-                                    search_token, _table, tablet, *info->pending_replica);
-                return {info->pending_replica->host};
-            }
-            case write_replica_set_selector::next:
-                return {};
-        }
-        on_internal_error(tablet_logger, format("Invalid write replica selector: {}", static_cast<int>(info->writes)));
+        tablet_logger.trace("get_pending_endpoints({}): table={}, tablet={}, replica={}", search_token, _table, tablet, *replica);
+        return {replica->host};
     }
 
     host_id_vector_replica_set get_for_reading_helper(const token& search_token) const {
         auto&& tablets = get_tablet_map();
         auto tablet = tablets.get_tablet_id(search_token);
-        auto&& info = tablets.get_tablet_transition_info(tablet);
-        auto&& replicas = std::invoke([&] () -> const tablet_replica_set& {
-            if (!info) {
-                return tablets.get_tablet_info(tablet).replicas;
-            }
-            switch (info->reads) {
-                case read_replica_set_selector::previous:
-                    return tablets.get_tablet_info(tablet).replicas;
-                case read_replica_set_selector::next: {
-                    return info->next;
-                }
-            }
-            on_internal_error(tablet_logger, format("Invalid read replica selector: {}", static_cast<int>(info->reads)));
-        });
+        auto&& replicas = tablets.get_replicas_for_reading(tablet);
         tablet_logger.trace("get_endpoints_for_reading({}): table={}, tablet={}, replicas={}", search_token, _table, tablet, replicas);
         return to_host_set(replicas);
     }

--- a/locator/tablets.cc
+++ b/locator/tablets.cc
@@ -1629,6 +1629,29 @@ public:
         return get_for_reading_helper(search_token);
     }
 
+    // The replication factor is calculated on the fly from the current read replica
+    // set of the token's tablet rather than taken from the schema, because during
+    // migrations caused by a replication factor change the schema and the per-tablet
+    // replica sets may temporarily disagree.
+    virtual size_t get_replication_factor(token search_token) const override {
+        auto&& tablets = get_tablet_map();
+        auto tablet = tablets.get_tablet_id(search_token);
+        auto rf = tablets.get_replicas_for_reading(tablet).size();
+        tablet_logger.trace("get_replication_factor({}): table={}, tablet={}, rf={}", search_token, _table, tablet, rf);
+        return rf;
+    }
+
+    virtual size_t get_replication_factor(token search_token, const sstring& datacenter) const override {
+        auto&& tablets = get_tablet_map();
+        auto tablet = tablets.get_tablet_id(search_token);
+        const auto& topo = get_topology();
+        size_t rf = std::ranges::count_if(tablets.get_replicas_for_reading(tablet), [&] (const tablet_replica& r) {
+            return topo.get_datacenter(r.host) == datacenter;
+        });
+        tablet_logger.trace("get_replication_factor({}, {}): table={}, tablet={}, rf={}", search_token, datacenter, _table, tablet, rf);
+        return rf;
+    }
+
     std::optional<tablet_routing_info> check_locality(const token& search_token, unsigned original_shard) const override {
         auto&& tablets = get_tablet_map();
         auto tid = tablets.get_tablet_id(search_token);

--- a/locator/tablets.hh
+++ b/locator/tablets.hh
@@ -832,6 +832,19 @@ public:
     /// \throws std::logic_error If the given id does not belong to this instance.
     const tablet_transition_info* get_tablet_transition_info(tablet_id) const;
 
+    /// Returns the set of replicas which should serve reads for a given tablet,
+    /// taking the transition state (if any) into account.
+    const tablet_replica_set& get_replicas_for_reading(tablet_id) const;
+
+    /// Returns the set of replicas which should serve writes for a given tablet,
+    /// taking the transition state (if any) into account.
+    const tablet_replica_set& get_replicas_for_writing(tablet_id) const;
+
+    /// Returns the pending replica of a given tablet, or nullptr if there is none.
+    /// The pending replica is a replica which should receive writes but is not yet
+    /// part of the replica set returned by get_replicas_for_writing().
+    const tablet_replica* get_pending_replica(tablet_id) const;
+
     /// Returns true for strongly-consistent tablets.
     /// Use get_tablet_raft_info() to retrieve Raft info for a specific tablet_id.
     bool has_raft_info() const {

--- a/repair/repair.cc
+++ b/repair/repair.cc
@@ -1769,7 +1769,7 @@ future<> repair_service::bootstrap_with_repair(locator::token_metadata_ptr tmptr
             desired_ranges = strat.get_pending_address_ranges(tmptr, tokens, myid, myloc).get();
             bool find_node_in_local_dc_only = strat.get_type() == locator::replication_strategy_type::network_topology;
             bool everywhere_topology = strat.get_type() == locator::replication_strategy_type::everywhere_topology;
-            auto replication_factor = erm->get_replication_factor();
+            auto replication_factor = erm->get_schema_replication_factor();
 
             //Active ranges
             auto metadata_clone = tmptr->clone_only_token_map().get();

--- a/repair/task_manager_module.hh
+++ b/repair/task_manager_module.hh
@@ -236,7 +236,7 @@ public:
     locator::effective_replication_map_ptr get_erm();
 
     size_t get_total_rf() {
-        return get_erm()->get_replication_factor();
+        return get_erm()->get_schema_replication_factor();
     }
 
     future<> repair_range(const dht::token_range& range, table_info table);

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -4014,7 +4014,7 @@ void table::update_effective_replication_map(locator::effective_replication_map_
 
 void table::update_tombstone_gc_rf_one() {
     auto& st = _compaction_manager.get_shared_tombstone_gc_state();
-    if (_erm && _erm->get_replication_factor() == 1) {
+    if (_erm && _erm->get_schema_replication_factor() == 1) {
         st.set_table_rf_one(_schema->id());
     } else {
         st.set_table_rf_n(_schema->id());

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -3900,7 +3900,7 @@ void table::update_effective_replication_map(locator::effective_replication_map_
 
 void table::update_tombstone_gc_rf_one() {
     auto& st = _compaction_manager.get_shared_tombstone_gc_state();
-    if (_erm && _erm->get_replication_factor() == 1) {
+    if (_erm && _erm->get_schema_replication_factor() == 1) {
         st.set_table_rf_one(_schema->id());
     } else {
         st.set_table_rf_n(_schema->id());

--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -128,8 +128,8 @@ utils::small_vector<locator::host_id, N> addr_vector_to_id(const gms::gossiper& 
 // Check the effective replication map consistency:
 // we have an inconsistent effective replication map in case we the number of
 // read replicas is higher than the replication factor.
-[[maybe_unused]] void validate_read_replicas(const locator::effective_replication_map& erm, const host_id_vector_replica_set& read_replicas) {
-    const sstring error = erm.get_replication_strategy().sanity_check_read_replicas(erm, read_replicas);
+[[maybe_unused]] void validate_read_replicas(const locator::effective_replication_map& erm, const host_id_vector_replica_set& read_replicas, dht::token token) {
+    const sstring error = erm.get_replication_strategy().sanity_check_read_replicas(erm, read_replicas, token);
     if (!error.empty()) {
         on_internal_error(slogger, error);
     }
@@ -1765,7 +1765,7 @@ public:
             locator::effective_replication_map_ptr erm,
             db::consistency_level cl, db::write_type type,
             std::unique_ptr<mutation_holder> mh, host_id_vector_replica_set targets, tracing::trace_state_ptr trace_state,
-            storage_proxy::write_stats& stats, service_permit permit, db::per_partition_rate_limit::info rate_limit_info, size_t pending_endpoints = 0,
+            storage_proxy::write_stats& stats, service_permit permit, db::per_partition_rate_limit::info rate_limit_info, dht::token token, size_t pending_endpoints = 0,
             host_id_vector_topology_change dead_endpoints = {}, is_cancellable cancellable = is_cancellable::no)
             : _id(p->get_next_response_id()), _proxy(std::move(p))
             , _effective_replication_map_ptr(std::move(erm))
@@ -1775,7 +1775,7 @@ public:
         // original comment from cassandra:
         // during bootstrap, include pending endpoints in the count
         // or we may fail the consistency level guarantees (see #833, #8058)
-        _total_block_for = db::block_for(*_effective_replication_map_ptr, _cl) + pending_endpoints;
+        _total_block_for = db::block_for(*_effective_replication_map_ptr, _cl, token) + pending_endpoints;
         ++_stats.writes;
 
         if (cancellable) {
@@ -2066,9 +2066,9 @@ public:
             db::consistency_level cl, db::write_type type,
             std::unique_ptr<mutation_holder> mh, host_id_vector_replica_set targets,
             const host_id_vector_topology_change& pending_endpoints, host_id_vector_topology_change dead_endpoints, tracing::trace_state_ptr tr_state,
-            storage_proxy::write_stats& stats, service_permit permit, db::per_partition_rate_limit::info rate_limit_info) :
+            storage_proxy::write_stats& stats, service_permit permit, db::per_partition_rate_limit::info rate_limit_info, dht::token token) :
                 abstract_write_response_handler(p, ermp, cl, type, std::move(mh), // can't move ermp, it's used below
-                        std::move(targets), std::move(tr_state), stats, std::move(permit), rate_limit_info,
+                        std::move(targets), std::move(tr_state), stats, std::move(permit), rate_limit_info, token,
                         ermp->get_topology().count_local_endpoints(pending_endpoints), std::move(dead_endpoints)) {
         _total_endpoints = _effective_replication_map_ptr->get_topology().count_local_endpoints(_targets);
     }
@@ -2084,9 +2084,9 @@ public:
             db::consistency_level cl, db::write_type type,
             std::unique_ptr<mutation_holder> mh, host_id_vector_replica_set targets,
             const host_id_vector_topology_change& pending_endpoints, host_id_vector_topology_change dead_endpoints, tracing::trace_state_ptr tr_state,
-            storage_proxy::write_stats& stats, service_permit permit, db::per_partition_rate_limit::info rate_limit_info, is_cancellable cancellable) :
+            storage_proxy::write_stats& stats, service_permit permit, db::per_partition_rate_limit::info rate_limit_info, is_cancellable cancellable, dht::token token) :
                 abstract_write_response_handler(std::move(p), std::move(ermp), cl, type, std::move(mh),
-                        std::move(targets), std::move(tr_state), stats, std::move(permit), rate_limit_info, pending_endpoints.size(), std::move(dead_endpoints), cancellable) {
+                        std::move(targets), std::move(tr_state), stats, std::move(permit), rate_limit_info, token, pending_endpoints.size(), std::move(dead_endpoints), cancellable) {
         _total_endpoints = _targets.size();
     }
 };
@@ -2174,8 +2174,8 @@ public:
     datacenter_sync_write_response_handler(shared_ptr<storage_proxy> p, locator::effective_replication_map_ptr ermp, db::consistency_level cl, db::write_type type,
             std::unique_ptr<mutation_holder> mh, host_id_vector_replica_set targets, const host_id_vector_topology_change& pending_endpoints,
             host_id_vector_topology_change dead_endpoints, tracing::trace_state_ptr tr_state, storage_proxy::write_stats& stats, service_permit permit,
-            db::per_partition_rate_limit::info rate_limit_info) :
-        abstract_write_response_handler(std::move(p), std::move(ermp), cl, type, std::move(mh), targets, std::move(tr_state), stats, std::move(permit), rate_limit_info, 0, dead_endpoints) {
+            db::per_partition_rate_limit::info rate_limit_info, dht::token token) :
+        abstract_write_response_handler(std::move(p), std::move(ermp), cl, type, std::move(mh), targets, std::move(tr_state), stats, std::move(permit), rate_limit_info, token, 0, dead_endpoints) {
         auto* erm = _effective_replication_map_ptr.get();
         auto& topology = erm->get_topology();
 
@@ -2189,7 +2189,7 @@ public:
                 size_t total_endpoints_for_dc = std::ranges::count_if(targets, [&topology, &dc] (const locator::host_id& ep){
                     return topology.get_datacenter(ep) == dc;
                 });
-                _dc_responses.emplace(dc, dc_info{0, db::local_quorum_for(*erm, dc) + pending_for_dc, total_endpoints_for_dc, 0});
+                _dc_responses.emplace(dc, dc_info{0, db::local_quorum_for(*erm, dc, token) + pending_for_dc, total_endpoints_for_dc, 0});
                 _total_block_for += pending_for_dc;
             }
         }
@@ -2923,17 +2923,17 @@ future<result<>> storage_proxy::response_wait(storage_proxy::response_id_type id
 result<storage_proxy::response_id_type> storage_proxy::make_write_response_handler(locator::effective_replication_map_ptr ermp,
                              db::consistency_level cl, db::write_type type, std::unique_ptr<mutation_holder> m,
                              host_id_vector_replica_set targets, const host_id_vector_topology_change& pending_endpoints, host_id_vector_topology_change dead_endpoints, tracing::trace_state_ptr tr_state,
-                             storage_proxy::write_stats& stats, service_permit permit, db::per_partition_rate_limit::info rate_limit_info, is_cancellable cancellable, bool skip_large_data_guardrails, db::large_data_violation_type* violations_out)
+                             storage_proxy::write_stats& stats, service_permit permit, db::per_partition_rate_limit::info rate_limit_info, is_cancellable cancellable, dht::token token, bool skip_large_data_guardrails, db::large_data_violation_type* violations_out)
 {
     shared_ptr<abstract_write_response_handler> h;
     auto& rs = ermp->get_replication_strategy();
 
     if (db::is_datacenter_local(cl)) {
-        h = ::make_shared<datacenter_write_response_handler>(shared_from_this(), std::move(ermp), cl, type, std::move(m), std::move(targets), pending_endpoints, std::move(dead_endpoints), std::move(tr_state), stats, std::move(permit), rate_limit_info);
+        h = ::make_shared<datacenter_write_response_handler>(shared_from_this(), std::move(ermp), cl, type, std::move(m), std::move(targets), pending_endpoints, std::move(dead_endpoints), std::move(tr_state), stats, std::move(permit), rate_limit_info, token);
     } else if (cl == db::consistency_level::EACH_QUORUM && rs.get_type() == locator::replication_strategy_type::network_topology){
-        h = ::make_shared<datacenter_sync_write_response_handler>(shared_from_this(), std::move(ermp), cl, type, std::move(m), std::move(targets), pending_endpoints, std::move(dead_endpoints), std::move(tr_state), stats, std::move(permit), rate_limit_info);
+        h = ::make_shared<datacenter_sync_write_response_handler>(shared_from_this(), std::move(ermp), cl, type, std::move(m), std::move(targets), pending_endpoints, std::move(dead_endpoints), std::move(tr_state), stats, std::move(permit), rate_limit_info, token);
     } else {
-        h = ::make_shared<write_response_handler>(shared_from_this(), std::move(ermp), cl, type, std::move(m), std::move(targets), pending_endpoints, std::move(dead_endpoints), std::move(tr_state), stats, std::move(permit), rate_limit_info, cancellable);
+        h = ::make_shared<write_response_handler>(shared_from_this(), std::move(ermp), cl, type, std::move(m), std::move(targets), pending_endpoints, std::move(dead_endpoints), std::move(tr_state), stats, std::move(permit), rate_limit_info, cancellable, token);
     }
     h->set_skip_large_data_guardrails(skip_large_data_guardrails);
     h->set_violations_out(std::move(violations_out));
@@ -3869,10 +3869,10 @@ storage_proxy::create_write_response_handler_helper(schema_ptr s, const dht::tok
     slogger.trace("creating write handler with live: {} dead: {}", live_endpoints, dead_endpoints);
     tracing::trace(tr_state, "Creating write handler with live: {} dead: {}", live_endpoints, dead_endpoints);
 
-    db::assure_sufficient_live_nodes(cl, *erm, live_endpoints, pending_endpoints);
+    db::assure_sufficient_live_nodes(cl, *erm, live_endpoints, token, pending_endpoints);
 
     return make_write_response_handler(std::move(erm), cl, type, std::move(mh), std::move(live_endpoints), pending_endpoints,
-            std::move(dead_endpoints), std::move(tr_state), get_stats(), std::move(permit), rate_limit_info, cancellable, options.bypass_large_data_guardrails, std::move(options.violations_out));
+            std::move(dead_endpoints), std::move(tr_state), get_stats(), std::move(permit), rate_limit_info, cancellable, token, options.bypass_large_data_guardrails, std::move(options.violations_out));
 }
 
 /**
@@ -3914,7 +3914,8 @@ storage_proxy::create_write_response_handler(const read_repair_mutation& mut, db
     // No rate limiting for read repair
     // Read repair unconditionally skips large data guardrails — the data already
     // exists on a replica; rejecting would cause inconsistency.
-    return make_write_response_handler(std::move(mut.ermp), cl, type, std::move(mh), std::move(endpoints), host_id_vector_topology_change(), host_id_vector_topology_change(), std::move(tr_state), get_stats(), std::move(permit), std::monostate(), is_cancellable::no, /*skip_large_data_guardrails=*/ true);
+    const dht::token token = mh->token();
+    return make_write_response_handler(std::move(mut.ermp), cl, type, std::move(mh), std::move(endpoints), host_id_vector_topology_change(), host_id_vector_topology_change(), std::move(tr_state), get_stats(), std::move(permit), std::monostate(), is_cancellable::no, token, /*skip_large_data_guardrails=*/ true);
 }
 
 result<storage_proxy::response_id_type>
@@ -3944,7 +3945,7 @@ storage_proxy::create_write_response_handler(const std::tuple<lw_shared_ptr<paxo
 
     // No rate limiting for paxos (yet)
     return make_write_response_handler(std::move(ermp), cl, db::write_type::CAS, std::make_unique<cas_mutation>(std::move(commit), s, nullptr), std::move(endpoints),
-                    host_id_vector_topology_change(), host_id_vector_topology_change(), std::move(tr_state), get_stats(), std::move(permit), std::monostate(), is_cancellable::no);
+                    host_id_vector_topology_change(), host_id_vector_topology_change(), std::move(tr_state), get_stats(), std::move(permit), std::monostate(), is_cancellable::no, token);
 }
 
 // After sending the write to replicas(targets), the replicas might generate send view updates. If the number of view updates
@@ -4097,7 +4098,7 @@ locator::host_id storage_proxy::find_leader_for_counter_update(const mutation& m
     auto live_endpoints = get_live_endpoints(erm, m.token());
 
     if (live_endpoints.empty()) {
-        throw exceptions::unavailable_exception(cl, block_for(erm, cl), 0);
+        throw exceptions::unavailable_exception(cl, block_for(erm, cl, m.token()), 0);
     }
 
     const auto my_address = my_host_id(erm);
@@ -4153,6 +4154,7 @@ future<> storage_proxy::mutate_counters(Range&& mutations, db::consistency_level
     auto my_address = my_host_id(**erms.begin());
     co_await coroutine::parallel_for_each(leaders, [this, cl, timeout, tr_state = std::move(tr_state), permit = std::move(permit), my_address, fence] (auto& endpoint_and_mutations) -> future<> {
       auto first_schema = endpoint_and_mutations.second[0].s;
+      const auto first_token = endpoint_and_mutations.second[0].fm.token(*first_schema);
 
       try {
         auto endpoint = endpoint_and_mutations.first;
@@ -4192,14 +4194,14 @@ future<> storage_proxy::mutate_counters(Range&& mutations, db::consistency_level
                 std::rethrow_exception(std::move(exp));
             } catch (rpc::timeout_error&) {
                 get_stats().write_timeouts.mark();
-                throw mutation_write_timeout_exception(s->ks_name(), s->cf_name(), cl, 0, db::block_for(*erm, cl), db::write_type::COUNTER);
+                throw mutation_write_timeout_exception(s->ks_name(), s->cf_name(), cl, 0, db::block_for(*erm, cl, first_token), db::write_type::COUNTER);
             } catch (timed_out_error&) {
                 get_stats().write_timeouts.mark();
-                throw mutation_write_timeout_exception(s->ks_name(), s->cf_name(), cl, 0, db::block_for(*erm, cl), db::write_type::COUNTER);
+                throw mutation_write_timeout_exception(s->ks_name(), s->cf_name(), cl, 0, db::block_for(*erm, cl, first_token), db::write_type::COUNTER);
             } catch (rpc::closed_error&) {
-                throw mutation_write_failure_exception(s->ks_name(), s->cf_name(), cl, 0, 1, db::block_for(*erm, cl), db::write_type::COUNTER);
+                throw mutation_write_failure_exception(s->ks_name(), s->cf_name(), cl, 0, 1, db::block_for(*erm, cl, first_token), db::write_type::COUNTER);
             } catch (replica::stale_topology_exception& e) {
-                throw mutation_write_failure_exception(e.what(), cl, 0, 1, db::block_for(*erm, cl), db::write_type::COUNTER);
+                throw mutation_write_failure_exception(e.what(), cl, 0, 1, db::block_for(*erm, cl, first_token), db::write_type::COUNTER);
             }
         }
       }
@@ -4521,7 +4523,7 @@ storage_proxy::mutate_atomically_result(utils::chunked_vector<mutation> mutation
 
         future<result<>> send_batchlog_mutation(mutation m, db::consistency_level cl = db::consistency_level::ONE) {
             return _p.mutate_prepare<>(std::array<mutation, 1>{std::move(m)}, [this, cl, permit = _permit] (const mutation& m) {
-                return _p.make_write_response_handler(_ermp, cl, db::write_type::BATCH_LOG, std::make_unique<shared_mutation>(m), _batchlog_endpoints, {}, {}, _trace_state, _stats, permit, std::monostate(), is_cancellable::no);
+                return _p.make_write_response_handler(_ermp, cl, db::write_type::BATCH_LOG, std::make_unique<shared_mutation>(m), _batchlog_endpoints, {}, {}, _trace_state, _stats, permit, std::monostate(), is_cancellable::no, m.token());
             }).then(utils::result_wrap([this, cl] (unique_response_handler_vector ids) {
                 _p.register_cdc_operation_result_tracker(ids, _cdc_tracker);
                 return _p.mutate_begin(std::move(ids), cl, _trace_state, _timeout);
@@ -4608,7 +4610,8 @@ future<> storage_proxy::send_to_endpoint(
         tracing::trace_state_ptr tr_state,
         write_stats& stats,
         allow_hints allow_hints,
-        is_cancellable cancellable) {
+        is_cancellable cancellable,
+        dht::token token) {
     utils::latency_counter lc;
     lc.start();
 
@@ -4621,7 +4624,7 @@ future<> storage_proxy::send_to_endpoint(
     }
 
     return mutate_prepare(std::array{std::move(m)},
-            [this, tr_state, erm = std::move(ermp), target = std::array{target}, pending_endpoints, &stats, cancellable, cl, type, /* does view building should hold a real permit */ permit = empty_service_permit()] (std::unique_ptr<mutation_holder>& m) mutable {
+            [this, tr_state, erm = std::move(ermp), target = std::array{target}, pending_endpoints, &stats, cancellable, cl, type, token, /* does view building should hold a real permit */ permit = empty_service_permit()] (std::unique_ptr<mutation_holder>& m) mutable {
         host_id_vector_replica_set targets;
         targets.reserve(pending_endpoints.size() + 1);
         host_id_vector_topology_change dead_endpoints;
@@ -4631,7 +4634,7 @@ future<> storage_proxy::send_to_endpoint(
                 std::back_inserter(dead_endpoints),
                 std::bind_front(&storage_proxy::is_alive, this, std::cref(*erm)));
         slogger.trace("Creating write handler with live: {}; dead: {}", targets, dead_endpoints);
-        db::assure_sufficient_live_nodes(cl, *erm, targets, pending_endpoints);
+        db::assure_sufficient_live_nodes(cl, *erm, targets, token, pending_endpoints);
         return make_write_response_handler(
             std::move(erm),
             cl,
@@ -4644,7 +4647,8 @@ future<> storage_proxy::send_to_endpoint(
             stats,
             permit,
             std::monostate(), // TODO: Pass the correct enforcement type
-            cancellable);
+            cancellable,
+            token);
     }).then(utils::result_wrap([this, cl, tr_state = std::move(tr_state), timeout = std::move(timeout)] (unique_response_handler_vector ids) mutable {
         return mutate_begin(std::move(ids), cl, std::move(tr_state), std::move(timeout));
     })).then_wrapped([p = shared_from_this(), lc, &stats] (future<result<>> f) {
@@ -4661,6 +4665,7 @@ future<> storage_proxy::send_to_endpoint(
         tracing::trace_state_ptr tr_state,
         allow_hints allow_hints,
         is_cancellable cancellable) {
+    const auto token = fm_a_s.fm.token(*fm_a_s.s);
     return send_to_endpoint(
             std::make_unique<shared_mutation>(std::move(fm_a_s)),
             std::move(ermp),
@@ -4670,10 +4675,12 @@ future<> storage_proxy::send_to_endpoint(
             std::move(tr_state),
             get_stats(),
             allow_hints,
-            cancellable);
+            cancellable,
+            token);
 }
 
 future<> storage_proxy::send_hint_to_endpoint(frozen_mutation_and_schema fm_a_s, locator::effective_replication_map_ptr ermp, locator::host_id target, host_id_vector_topology_change pending_endpoints) {
+    const auto token = fm_a_s.fm.token(*fm_a_s.s);
     return send_to_endpoint(
             std::make_unique<hint_mutation>(std::move(fm_a_s)),
             std::move(ermp),
@@ -4683,7 +4690,8 @@ future<> storage_proxy::send_hint_to_endpoint(frozen_mutation_and_schema fm_a_s,
             tracing::trace_state_ptr(),
             get_stats(),
             allow_hints::no,
-            is_cancellable::yes);
+            is_cancellable::yes,
+            token);
 }
 
 future<> storage_proxy::send_hint_to_all_replicas(frozen_mutation_and_schema fm_a_s) {
@@ -6219,14 +6227,14 @@ result<::shared_ptr<abstract_read_executor>> storage_proxy::get_read_executor(lw
     auto cf = _db.local().find_column_family(schema).shared_from_this();
     host_id_vector_replica_set target_replicas = filter_replicas_for_read(cl, *erm, all_replicas, preferred_endpoints, repair_decision,
             retry_type == speculative_retry::type::NONE ? nullptr : &extra_replica,
-            _db.local().get_config().cache_hit_rate_read_balancing() ? &*cf : nullptr);
+            _db.local().get_config().cache_hit_rate_read_balancing() ? &*cf : nullptr, token);
 
     slogger.trace("creating read executor for token {} with all: {} targets: {} rp decision: {}", token, all_replicas, target_replicas, repair_decision);
     tracing::trace(trace_state, "Creating read executor for token {} with all: {} targets: {} repair decision: {}", token, all_replicas, target_replicas, repair_decision);
 
     // Throw UAE early if we don't have enough replicas.
     try {
-        db::assure_sufficient_live_nodes(cl, *erm, target_replicas, host_id_vector_topology_change{});
+        db::assure_sufficient_live_nodes(cl, *erm, target_replicas, token, host_id_vector_topology_change{});
     } catch (exceptions::unavailable_exception& ex) {
         slogger.debug("Read unavailable: cl={} required {} alive {}", ex.consistency, ex.required, ex.alive);
         get_stats().read_unavailables.mark();
@@ -6237,7 +6245,7 @@ result<::shared_ptr<abstract_read_executor>> storage_proxy::get_read_executor(lw
         get_stats().read_repair_attempts++;
     }
 
-    const size_t block_for = db::block_for(*erm, cl);
+    const size_t block_for = db::block_for(*erm, cl, token);
 
     db::per_partition_rate_limit::info rate_limit_info;
     if (cmd->allow_limit && _db.local().can_apply_per_partition_rate_limit(*schema, db::operation_type::read)) {
@@ -6531,7 +6539,7 @@ storage_proxy::query_partition_key_range_concurrent(storage_proxy::clock_type::t
             dht::partition_range& range = *i;
             host_id_vector_replica_set live_endpoints = get_endpoints_for_reading(*schema, *erm, end_token(range), node_local_only);
             host_id_vector_replica_set merged_preferred_replicas = preferred_replicas_for_range(*i);
-            host_id_vector_replica_set filtered_endpoints = filter_replicas_for_read(cl, *erm, live_endpoints, merged_preferred_replicas, pcf);
+            host_id_vector_replica_set filtered_endpoints = filter_replicas_for_read(cl, *erm, live_endpoints, merged_preferred_replicas, pcf, end_token(range));
             std::vector<dht::token_range> merged_ranges{to_token_range(range)};
             ++i;
 
@@ -6546,7 +6554,7 @@ storage_proxy::query_partition_key_range_concurrent(storage_proxy::clock_type::t
                     const auto current_range_preferred_replicas = preferred_replicas_for_range(*i);
                     dht::partition_range& next_range = *i;
                     host_id_vector_replica_set next_endpoints = get_endpoints_for_reading(*schema, *erm, end_token(next_range), node_local_only);
-                    host_id_vector_replica_set next_filtered_endpoints = filter_replicas_for_read(cl, *erm, next_endpoints, current_range_preferred_replicas, pcf);
+                    host_id_vector_replica_set next_filtered_endpoints = filter_replicas_for_read(cl, *erm, next_endpoints, current_range_preferred_replicas, pcf, end_token(next_range));
 
                     // Origin has this to say here:
                     // *  If the current range right is the min token, we should stop merging because CFS.getRangeSlice
@@ -6587,11 +6595,11 @@ storage_proxy::query_partition_key_range_concurrent(storage_proxy::clock_type::t
                     host_id_vector_replica_set current_merged_preferred_replicas = intersection(merged_preferred_replicas, current_range_preferred_replicas);
 
                     // Check if there is enough endpoint for the merge to be possible.
-                    if (!is_sufficient_live_nodes(cl, *erm, merged)) {
+                    if (!is_sufficient_live_nodes(cl, *erm, merged, end_token(next_range))) {
                         break;
                     }
 
-                    host_id_vector_replica_set filtered_merged = filter_replicas_for_read(cl, *erm, merged, current_merged_preferred_replicas, pcf);
+                    host_id_vector_replica_set filtered_merged = filter_replicas_for_read(cl, *erm, merged, current_merged_preferred_replicas, pcf, end_token(next_range));
 
                     // Estimate whether merging will be a win or not
                     if (filtered_merged.empty()
@@ -6645,7 +6653,7 @@ storage_proxy::query_partition_key_range_concurrent(storage_proxy::clock_type::t
             slogger.trace("creating range read executor for range {} in table {}.{} with targets {}",
                         range, schema->ks_name(), schema->cf_name(), filtered_endpoints);
             try {
-                db::assure_sufficient_live_nodes(cl, *erm, filtered_endpoints, host_id_vector_topology_change{});
+                db::assure_sufficient_live_nodes(cl, *erm, filtered_endpoints, end_token(range), host_id_vector_topology_change{});
             } catch(exceptions::unavailable_exception& ex) {
                 slogger.debug("Read unavailable: cl={} required {} alive {}", ex.consistency, ex.required, ex.alive);
                 get_stats().range_slice_unavailables.mark();
@@ -7222,7 +7230,7 @@ host_id_vector_replica_set storage_proxy::get_endpoints_for_reading(const schema
     // Skip for non-debug builds and maintenance mode.
     if constexpr (tools::build_info::is_debug_build()) {
         if (!_maintenance_mode) {
-            validate_read_replicas(erm, endpoints);
+            validate_read_replicas(erm, endpoints, token);
         }
     }
     auto it = std::ranges::remove_if(endpoints, std::not_fn(std::bind_front(&storage_proxy::is_alive, this, std::cref(erm)))).begin();
@@ -7240,7 +7248,8 @@ storage_proxy::filter_replicas_for_read(
         const host_id_vector_replica_set& preferred_endpoints,
         db::read_repair_decision repair_decision,
         std::optional<locator::host_id>* extra,
-        replica::column_family* cf) const {
+        replica::column_family* cf,
+        dht::token token) const {
     if (live_endpoints.empty() || only_me(erm, live_endpoints)) {
         // `db::filter_for_query` would return the same thing, but thanks to this branch we avoid having
         // to access `remote` - so we can perform local queries without the need of `remote`.
@@ -7249,7 +7258,7 @@ storage_proxy::filter_replicas_for_read(
 
     // There are nodes other than us in `live_endpoints`.
     auto& gossiper = remote().gossiper();
-    return db::filter_for_query(cl, erm, live_endpoints, preferred_endpoints, repair_decision, gossiper, extra, cf);
+    return db::filter_for_query(cl, erm, live_endpoints, preferred_endpoints, repair_decision, gossiper, extra, cf, token);
 }
 
 host_id_vector_replica_set
@@ -7258,8 +7267,9 @@ storage_proxy::filter_replicas_for_read(
         const locator::effective_replication_map& erm,
         const host_id_vector_replica_set& live_endpoints,
         const host_id_vector_replica_set& preferred_endpoints,
-        replica::column_family* cf) const {
-    return filter_replicas_for_read(cl, erm, live_endpoints, preferred_endpoints, db::read_repair_decision::NONE, nullptr, cf);
+        replica::column_family* cf,
+        dht::token token) const {
+    return filter_replicas_for_read(cl, erm, live_endpoints, preferred_endpoints, db::read_repair_decision::NONE, nullptr, cf, token);
 }
 
 bool storage_proxy::is_alive(const locator::effective_replication_map& erm, const locator::host_id& ep) const {

--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -128,8 +128,8 @@ utils::small_vector<locator::host_id, N> addr_vector_to_id(const gms::gossiper& 
 // Check the effective replication map consistency:
 // we have an inconsistent effective replication map in case we the number of
 // read replicas is higher than the replication factor.
-[[maybe_unused]] void validate_read_replicas(const locator::effective_replication_map& erm, const host_id_vector_replica_set& read_replicas) {
-    const sstring error = erm.get_replication_strategy().sanity_check_read_replicas(erm, read_replicas);
+[[maybe_unused]] void validate_read_replicas(const locator::effective_replication_map& erm, const host_id_vector_replica_set& read_replicas, dht::token token) {
+    const sstring error = erm.get_replication_strategy().sanity_check_read_replicas(erm, read_replicas, token);
     if (!error.empty()) {
         on_internal_error(slogger, error);
     }
@@ -1765,7 +1765,7 @@ public:
             locator::effective_replication_map_ptr erm,
             db::consistency_level cl, db::write_type type,
             std::unique_ptr<mutation_holder> mh, host_id_vector_replica_set targets, tracing::trace_state_ptr trace_state,
-            storage_proxy::write_stats& stats, service_permit permit, db::per_partition_rate_limit::info rate_limit_info, size_t pending_endpoints = 0,
+            storage_proxy::write_stats& stats, service_permit permit, db::per_partition_rate_limit::info rate_limit_info, dht::token token, size_t pending_endpoints = 0,
             host_id_vector_topology_change dead_endpoints = {}, is_cancellable cancellable = is_cancellable::no)
             : _id(p->get_next_response_id()), _proxy(std::move(p))
             , _effective_replication_map_ptr(std::move(erm))
@@ -1775,7 +1775,7 @@ public:
         // original comment from cassandra:
         // during bootstrap, include pending endpoints in the count
         // or we may fail the consistency level guarantees (see #833, #8058)
-        _total_block_for = db::block_for(*_effective_replication_map_ptr, _cl) + pending_endpoints;
+        _total_block_for = db::block_for(*_effective_replication_map_ptr, _cl, token) + pending_endpoints;
         ++_stats.writes;
 
         if (cancellable) {
@@ -2066,9 +2066,9 @@ public:
             db::consistency_level cl, db::write_type type,
             std::unique_ptr<mutation_holder> mh, host_id_vector_replica_set targets,
             const host_id_vector_topology_change& pending_endpoints, host_id_vector_topology_change dead_endpoints, tracing::trace_state_ptr tr_state,
-            storage_proxy::write_stats& stats, service_permit permit, db::per_partition_rate_limit::info rate_limit_info) :
+            storage_proxy::write_stats& stats, service_permit permit, db::per_partition_rate_limit::info rate_limit_info, dht::token token) :
                 abstract_write_response_handler(p, ermp, cl, type, std::move(mh), // can't move ermp, it's used below
-                        std::move(targets), std::move(tr_state), stats, std::move(permit), rate_limit_info,
+                        std::move(targets), std::move(tr_state), stats, std::move(permit), rate_limit_info, token,
                         ermp->get_topology().count_local_endpoints(pending_endpoints), std::move(dead_endpoints)) {
         _total_endpoints = _effective_replication_map_ptr->get_topology().count_local_endpoints(_targets);
     }
@@ -2084,9 +2084,9 @@ public:
             db::consistency_level cl, db::write_type type,
             std::unique_ptr<mutation_holder> mh, host_id_vector_replica_set targets,
             const host_id_vector_topology_change& pending_endpoints, host_id_vector_topology_change dead_endpoints, tracing::trace_state_ptr tr_state,
-            storage_proxy::write_stats& stats, service_permit permit, db::per_partition_rate_limit::info rate_limit_info, is_cancellable cancellable) :
+            storage_proxy::write_stats& stats, service_permit permit, db::per_partition_rate_limit::info rate_limit_info, is_cancellable cancellable, dht::token token) :
                 abstract_write_response_handler(std::move(p), std::move(ermp), cl, type, std::move(mh),
-                        std::move(targets), std::move(tr_state), stats, std::move(permit), rate_limit_info, pending_endpoints.size(), std::move(dead_endpoints), cancellable) {
+                        std::move(targets), std::move(tr_state), stats, std::move(permit), rate_limit_info, token, pending_endpoints.size(), std::move(dead_endpoints), cancellable) {
         _total_endpoints = _targets.size();
     }
 };
@@ -2174,8 +2174,8 @@ public:
     datacenter_sync_write_response_handler(shared_ptr<storage_proxy> p, locator::effective_replication_map_ptr ermp, db::consistency_level cl, db::write_type type,
             std::unique_ptr<mutation_holder> mh, host_id_vector_replica_set targets, const host_id_vector_topology_change& pending_endpoints,
             host_id_vector_topology_change dead_endpoints, tracing::trace_state_ptr tr_state, storage_proxy::write_stats& stats, service_permit permit,
-            db::per_partition_rate_limit::info rate_limit_info) :
-        abstract_write_response_handler(std::move(p), std::move(ermp), cl, type, std::move(mh), targets, std::move(tr_state), stats, std::move(permit), rate_limit_info, 0, dead_endpoints) {
+            db::per_partition_rate_limit::info rate_limit_info, dht::token token) :
+        abstract_write_response_handler(std::move(p), std::move(ermp), cl, type, std::move(mh), targets, std::move(tr_state), stats, std::move(permit), rate_limit_info, token, 0, dead_endpoints) {
         auto* erm = _effective_replication_map_ptr.get();
         auto& topology = erm->get_topology();
 
@@ -2189,7 +2189,7 @@ public:
                 size_t total_endpoints_for_dc = std::ranges::count_if(targets, [&topology, &dc] (const locator::host_id& ep){
                     return topology.get_datacenter(ep) == dc;
                 });
-                _dc_responses.emplace(dc, dc_info{0, db::local_quorum_for(*erm, dc) + pending_for_dc, total_endpoints_for_dc, 0});
+                _dc_responses.emplace(dc, dc_info{0, db::local_quorum_for(*erm, dc, token) + pending_for_dc, total_endpoints_for_dc, 0});
                 _total_block_for += pending_for_dc;
             }
         }
@@ -2923,17 +2923,17 @@ future<result<>> storage_proxy::response_wait(storage_proxy::response_id_type id
 result<storage_proxy::response_id_type> storage_proxy::make_write_response_handler(locator::effective_replication_map_ptr ermp,
                              db::consistency_level cl, db::write_type type, std::unique_ptr<mutation_holder> m,
                              host_id_vector_replica_set targets, const host_id_vector_topology_change& pending_endpoints, host_id_vector_topology_change dead_endpoints, tracing::trace_state_ptr tr_state,
-                             storage_proxy::write_stats& stats, service_permit permit, db::per_partition_rate_limit::info rate_limit_info, is_cancellable cancellable, bool skip_large_data_guardrails, db::large_data_violation_type* violations_out)
+                             storage_proxy::write_stats& stats, service_permit permit, db::per_partition_rate_limit::info rate_limit_info, is_cancellable cancellable, dht::token token, bool skip_large_data_guardrails, db::large_data_violation_type* violations_out)
 {
     shared_ptr<abstract_write_response_handler> h;
     auto& rs = ermp->get_replication_strategy();
 
     if (db::is_datacenter_local(cl)) {
-        h = ::make_shared<datacenter_write_response_handler>(shared_from_this(), std::move(ermp), cl, type, std::move(m), std::move(targets), pending_endpoints, std::move(dead_endpoints), std::move(tr_state), stats, std::move(permit), rate_limit_info);
+        h = ::make_shared<datacenter_write_response_handler>(shared_from_this(), std::move(ermp), cl, type, std::move(m), std::move(targets), pending_endpoints, std::move(dead_endpoints), std::move(tr_state), stats, std::move(permit), rate_limit_info, token);
     } else if (cl == db::consistency_level::EACH_QUORUM && rs.get_type() == locator::replication_strategy_type::network_topology){
-        h = ::make_shared<datacenter_sync_write_response_handler>(shared_from_this(), std::move(ermp), cl, type, std::move(m), std::move(targets), pending_endpoints, std::move(dead_endpoints), std::move(tr_state), stats, std::move(permit), rate_limit_info);
+        h = ::make_shared<datacenter_sync_write_response_handler>(shared_from_this(), std::move(ermp), cl, type, std::move(m), std::move(targets), pending_endpoints, std::move(dead_endpoints), std::move(tr_state), stats, std::move(permit), rate_limit_info, token);
     } else {
-        h = ::make_shared<write_response_handler>(shared_from_this(), std::move(ermp), cl, type, std::move(m), std::move(targets), pending_endpoints, std::move(dead_endpoints), std::move(tr_state), stats, std::move(permit), rate_limit_info, cancellable);
+        h = ::make_shared<write_response_handler>(shared_from_this(), std::move(ermp), cl, type, std::move(m), std::move(targets), pending_endpoints, std::move(dead_endpoints), std::move(tr_state), stats, std::move(permit), rate_limit_info, cancellable, token);
     }
     h->set_skip_large_data_guardrails(skip_large_data_guardrails);
     h->set_violations_out(std::move(violations_out));
@@ -3865,10 +3865,10 @@ storage_proxy::create_write_response_handler_helper(schema_ptr s, const dht::tok
     slogger.trace("creating write handler with live: {} dead: {}", live_endpoints, dead_endpoints);
     tracing::trace(tr_state, "Creating write handler with live: {} dead: {}", live_endpoints, dead_endpoints);
 
-    db::assure_sufficient_live_nodes(cl, *erm, live_endpoints, pending_endpoints);
+    db::assure_sufficient_live_nodes(cl, *erm, live_endpoints, token, pending_endpoints);
 
     return make_write_response_handler(std::move(erm), cl, type, std::move(mh), std::move(live_endpoints), pending_endpoints,
-            std::move(dead_endpoints), std::move(tr_state), get_stats(), std::move(permit), rate_limit_info, cancellable, options.bypass_large_data_guardrails, std::move(options.violations_out));
+            std::move(dead_endpoints), std::move(tr_state), get_stats(), std::move(permit), rate_limit_info, cancellable, token, options.bypass_large_data_guardrails, std::move(options.violations_out));
 }
 
 /**
@@ -3910,7 +3910,8 @@ storage_proxy::create_write_response_handler(const read_repair_mutation& mut, db
     // No rate limiting for read repair
     // Read repair unconditionally skips large data guardrails — the data already
     // exists on a replica; rejecting would cause inconsistency.
-    return make_write_response_handler(std::move(mut.ermp), cl, type, std::move(mh), std::move(endpoints), host_id_vector_topology_change(), host_id_vector_topology_change(), std::move(tr_state), get_stats(), std::move(permit), std::monostate(), is_cancellable::no, /*skip_large_data_guardrails=*/ true);
+    const dht::token token = mh->token();
+    return make_write_response_handler(std::move(mut.ermp), cl, type, std::move(mh), std::move(endpoints), host_id_vector_topology_change(), host_id_vector_topology_change(), std::move(tr_state), get_stats(), std::move(permit), std::monostate(), is_cancellable::no, token, /*skip_large_data_guardrails=*/ true);
 }
 
 result<storage_proxy::response_id_type>
@@ -3940,7 +3941,7 @@ storage_proxy::create_write_response_handler(const std::tuple<lw_shared_ptr<paxo
 
     // No rate limiting for paxos (yet)
     return make_write_response_handler(std::move(ermp), cl, db::write_type::CAS, std::make_unique<cas_mutation>(std::move(commit), s, nullptr), std::move(endpoints),
-                    host_id_vector_topology_change(), host_id_vector_topology_change(), std::move(tr_state), get_stats(), std::move(permit), std::monostate(), is_cancellable::no);
+                    host_id_vector_topology_change(), host_id_vector_topology_change(), std::move(tr_state), get_stats(), std::move(permit), std::monostate(), is_cancellable::no, token);
 }
 
 // After sending the write to replicas(targets), the replicas might generate send view updates. If the number of view updates
@@ -4093,7 +4094,7 @@ locator::host_id storage_proxy::find_leader_for_counter_update(const mutation& m
     auto live_endpoints = get_live_endpoints(erm, m.token());
 
     if (live_endpoints.empty()) {
-        throw exceptions::unavailable_exception(cl, block_for(erm, cl), 0);
+        throw exceptions::unavailable_exception(cl, block_for(erm, cl, m.token()), 0);
     }
 
     const auto my_address = my_host_id(erm);
@@ -4149,6 +4150,7 @@ future<> storage_proxy::mutate_counters(Range&& mutations, db::consistency_level
     auto my_address = my_host_id(**erms.begin());
     co_await coroutine::parallel_for_each(leaders, [this, cl, timeout, tr_state = std::move(tr_state), permit = std::move(permit), my_address, fence] (auto& endpoint_and_mutations) -> future<> {
       auto first_schema = endpoint_and_mutations.second[0].s;
+      const auto first_token = endpoint_and_mutations.second[0].fm.token(*first_schema);
 
       try {
         auto endpoint = endpoint_and_mutations.first;
@@ -4188,14 +4190,14 @@ future<> storage_proxy::mutate_counters(Range&& mutations, db::consistency_level
                 std::rethrow_exception(std::move(exp));
             } catch (rpc::timeout_error&) {
                 get_stats().write_timeouts.mark();
-                throw mutation_write_timeout_exception(s->ks_name(), s->cf_name(), cl, 0, db::block_for(*erm, cl), db::write_type::COUNTER);
+                throw mutation_write_timeout_exception(s->ks_name(), s->cf_name(), cl, 0, db::block_for(*erm, cl, first_token), db::write_type::COUNTER);
             } catch (timed_out_error&) {
                 get_stats().write_timeouts.mark();
-                throw mutation_write_timeout_exception(s->ks_name(), s->cf_name(), cl, 0, db::block_for(*erm, cl), db::write_type::COUNTER);
+                throw mutation_write_timeout_exception(s->ks_name(), s->cf_name(), cl, 0, db::block_for(*erm, cl, first_token), db::write_type::COUNTER);
             } catch (rpc::closed_error&) {
-                throw mutation_write_failure_exception(s->ks_name(), s->cf_name(), cl, 0, 1, db::block_for(*erm, cl), db::write_type::COUNTER);
+                throw mutation_write_failure_exception(s->ks_name(), s->cf_name(), cl, 0, 1, db::block_for(*erm, cl, first_token), db::write_type::COUNTER);
             } catch (replica::stale_topology_exception& e) {
-                throw mutation_write_failure_exception(e.what(), cl, 0, 1, db::block_for(*erm, cl), db::write_type::COUNTER);
+                throw mutation_write_failure_exception(e.what(), cl, 0, 1, db::block_for(*erm, cl, first_token), db::write_type::COUNTER);
             }
         }
       }
@@ -4517,7 +4519,7 @@ storage_proxy::mutate_atomically_result(utils::chunked_vector<mutation> mutation
 
         future<result<>> send_batchlog_mutation(mutation m, db::consistency_level cl = db::consistency_level::ONE) {
             return _p.mutate_prepare<>(std::array<mutation, 1>{std::move(m)}, [this, cl, permit = _permit] (const mutation& m) {
-                return _p.make_write_response_handler(_ermp, cl, db::write_type::BATCH_LOG, std::make_unique<shared_mutation>(m), _batchlog_endpoints, {}, {}, _trace_state, _stats, permit, std::monostate(), is_cancellable::no);
+                return _p.make_write_response_handler(_ermp, cl, db::write_type::BATCH_LOG, std::make_unique<shared_mutation>(m), _batchlog_endpoints, {}, {}, _trace_state, _stats, permit, std::monostate(), is_cancellable::no, m.token());
             }).then(utils::result_wrap([this, cl] (unique_response_handler_vector ids) {
                 _p.register_cdc_operation_result_tracker(ids, _cdc_tracker);
                 return _p.mutate_begin(std::move(ids), cl, _trace_state, _timeout);
@@ -4604,7 +4606,8 @@ future<> storage_proxy::send_to_endpoint(
         tracing::trace_state_ptr tr_state,
         write_stats& stats,
         allow_hints allow_hints,
-        is_cancellable cancellable) {
+        is_cancellable cancellable,
+        dht::token token) {
     utils::latency_counter lc;
     lc.start();
 
@@ -4617,7 +4620,7 @@ future<> storage_proxy::send_to_endpoint(
     }
 
     return mutate_prepare(std::array{std::move(m)},
-            [this, tr_state, erm = std::move(ermp), target = std::array{target}, pending_endpoints, &stats, cancellable, cl, type, /* does view building should hold a real permit */ permit = empty_service_permit()] (std::unique_ptr<mutation_holder>& m) mutable {
+            [this, tr_state, erm = std::move(ermp), target = std::array{target}, pending_endpoints, &stats, cancellable, cl, type, token, /* does view building should hold a real permit */ permit = empty_service_permit()] (std::unique_ptr<mutation_holder>& m) mutable {
         host_id_vector_replica_set targets;
         targets.reserve(pending_endpoints.size() + 1);
         host_id_vector_topology_change dead_endpoints;
@@ -4627,7 +4630,7 @@ future<> storage_proxy::send_to_endpoint(
                 std::back_inserter(dead_endpoints),
                 std::bind_front(&storage_proxy::is_alive, this, std::cref(*erm)));
         slogger.trace("Creating write handler with live: {}; dead: {}", targets, dead_endpoints);
-        db::assure_sufficient_live_nodes(cl, *erm, targets, pending_endpoints);
+        db::assure_sufficient_live_nodes(cl, *erm, targets, token, pending_endpoints);
         return make_write_response_handler(
             std::move(erm),
             cl,
@@ -4640,7 +4643,8 @@ future<> storage_proxy::send_to_endpoint(
             stats,
             permit,
             std::monostate(), // TODO: Pass the correct enforcement type
-            cancellable);
+            cancellable,
+            token);
     }).then(utils::result_wrap([this, cl, tr_state = std::move(tr_state), timeout = std::move(timeout)] (unique_response_handler_vector ids) mutable {
         return mutate_begin(std::move(ids), cl, std::move(tr_state), std::move(timeout));
     })).then_wrapped([p = shared_from_this(), lc, &stats] (future<result<>> f) {
@@ -4657,6 +4661,7 @@ future<> storage_proxy::send_to_endpoint(
         tracing::trace_state_ptr tr_state,
         allow_hints allow_hints,
         is_cancellable cancellable) {
+    const auto token = fm_a_s.fm.token(*fm_a_s.s);
     return send_to_endpoint(
             std::make_unique<shared_mutation>(std::move(fm_a_s)),
             std::move(ermp),
@@ -4666,10 +4671,12 @@ future<> storage_proxy::send_to_endpoint(
             std::move(tr_state),
             get_stats(),
             allow_hints,
-            cancellable);
+            cancellable,
+            token);
 }
 
 future<> storage_proxy::send_hint_to_endpoint(frozen_mutation_and_schema fm_a_s, locator::effective_replication_map_ptr ermp, locator::host_id target, host_id_vector_topology_change pending_endpoints) {
+    const auto token = fm_a_s.fm.token(*fm_a_s.s);
     return send_to_endpoint(
             std::make_unique<hint_mutation>(std::move(fm_a_s)),
             std::move(ermp),
@@ -4679,7 +4686,8 @@ future<> storage_proxy::send_hint_to_endpoint(frozen_mutation_and_schema fm_a_s,
             tracing::trace_state_ptr(),
             get_stats(),
             allow_hints::no,
-            is_cancellable::yes);
+            is_cancellable::yes,
+            token);
 }
 
 future<> storage_proxy::send_hint_to_all_replicas(frozen_mutation_and_schema fm_a_s) {
@@ -6212,14 +6220,14 @@ result<::shared_ptr<abstract_read_executor>> storage_proxy::get_read_executor(lw
     auto cf = _db.local().find_column_family(schema).shared_from_this();
     host_id_vector_replica_set target_replicas = filter_replicas_for_read(cl, *erm, all_replicas, preferred_endpoints, repair_decision,
             retry_type == speculative_retry::type::NONE ? nullptr : &extra_replica,
-            _db.local().get_config().cache_hit_rate_read_balancing() ? &*cf : nullptr);
+            _db.local().get_config().cache_hit_rate_read_balancing() ? &*cf : nullptr, token);
 
     slogger.trace("creating read executor for token {} with all: {} targets: {} rp decision: {}", token, all_replicas, target_replicas, repair_decision);
     tracing::trace(trace_state, "Creating read executor for token {} with all: {} targets: {} repair decision: {}", token, all_replicas, target_replicas, repair_decision);
 
     // Throw UAE early if we don't have enough replicas.
     try {
-        db::assure_sufficient_live_nodes(cl, *erm, target_replicas, host_id_vector_topology_change{});
+        db::assure_sufficient_live_nodes(cl, *erm, target_replicas, token, host_id_vector_topology_change{});
     } catch (exceptions::unavailable_exception& ex) {
         slogger.debug("Read unavailable: cl={} required {} alive {}", ex.consistency, ex.required, ex.alive);
         get_stats().read_unavailables.mark();
@@ -6230,7 +6238,7 @@ result<::shared_ptr<abstract_read_executor>> storage_proxy::get_read_executor(lw
         get_stats().read_repair_attempts++;
     }
 
-    const size_t block_for = db::block_for(*erm, cl);
+    const size_t block_for = db::block_for(*erm, cl, token);
 
     db::per_partition_rate_limit::info rate_limit_info;
     if (cmd->allow_limit && _db.local().can_apply_per_partition_rate_limit(*schema, db::operation_type::read)) {
@@ -6524,7 +6532,7 @@ storage_proxy::query_partition_key_range_concurrent(storage_proxy::clock_type::t
             dht::partition_range& range = *i;
             host_id_vector_replica_set live_endpoints = get_endpoints_for_reading(*schema, *erm, end_token(range), node_local_only);
             host_id_vector_replica_set merged_preferred_replicas = preferred_replicas_for_range(*i);
-            host_id_vector_replica_set filtered_endpoints = filter_replicas_for_read(cl, *erm, live_endpoints, merged_preferred_replicas, pcf);
+            host_id_vector_replica_set filtered_endpoints = filter_replicas_for_read(cl, *erm, live_endpoints, merged_preferred_replicas, pcf, end_token(range));
             std::vector<dht::token_range> merged_ranges{to_token_range(range)};
             ++i;
 
@@ -6539,7 +6547,7 @@ storage_proxy::query_partition_key_range_concurrent(storage_proxy::clock_type::t
                     const auto current_range_preferred_replicas = preferred_replicas_for_range(*i);
                     dht::partition_range& next_range = *i;
                     host_id_vector_replica_set next_endpoints = get_endpoints_for_reading(*schema, *erm, end_token(next_range), node_local_only);
-                    host_id_vector_replica_set next_filtered_endpoints = filter_replicas_for_read(cl, *erm, next_endpoints, current_range_preferred_replicas, pcf);
+                    host_id_vector_replica_set next_filtered_endpoints = filter_replicas_for_read(cl, *erm, next_endpoints, current_range_preferred_replicas, pcf, end_token(next_range));
 
                     // Origin has this to say here:
                     // *  If the current range right is the min token, we should stop merging because CFS.getRangeSlice
@@ -6580,11 +6588,11 @@ storage_proxy::query_partition_key_range_concurrent(storage_proxy::clock_type::t
                     host_id_vector_replica_set current_merged_preferred_replicas = intersection(merged_preferred_replicas, current_range_preferred_replicas);
 
                     // Check if there is enough endpoint for the merge to be possible.
-                    if (!is_sufficient_live_nodes(cl, *erm, merged)) {
+                    if (!is_sufficient_live_nodes(cl, *erm, merged, end_token(next_range))) {
                         break;
                     }
 
-                    host_id_vector_replica_set filtered_merged = filter_replicas_for_read(cl, *erm, merged, current_merged_preferred_replicas, pcf);
+                    host_id_vector_replica_set filtered_merged = filter_replicas_for_read(cl, *erm, merged, current_merged_preferred_replicas, pcf, end_token(next_range));
 
                     // Estimate whether merging will be a win or not
                     if (filtered_merged.empty()
@@ -6638,7 +6646,7 @@ storage_proxy::query_partition_key_range_concurrent(storage_proxy::clock_type::t
             slogger.trace("creating range read executor for range {} in table {}.{} with targets {}",
                         range, schema->ks_name(), schema->cf_name(), filtered_endpoints);
             try {
-                db::assure_sufficient_live_nodes(cl, *erm, filtered_endpoints, host_id_vector_topology_change{});
+                db::assure_sufficient_live_nodes(cl, *erm, filtered_endpoints, end_token(range), host_id_vector_topology_change{});
             } catch(exceptions::unavailable_exception& ex) {
                 slogger.debug("Read unavailable: cl={} required {} alive {}", ex.consistency, ex.required, ex.alive);
                 get_stats().range_slice_unavailables.mark();
@@ -7202,7 +7210,7 @@ host_id_vector_replica_set storage_proxy::get_endpoints_for_reading(const schema
     // Skip for non-debug builds and maintenance mode.
     if constexpr (tools::build_info::is_debug_build()) {
         if (!_maintenance_mode) {
-            validate_read_replicas(erm, endpoints);
+            validate_read_replicas(erm, endpoints, token);
         }
     }
     auto it = std::ranges::remove_if(endpoints, std::not_fn(std::bind_front(&storage_proxy::is_alive, this, std::cref(erm)))).begin();
@@ -7220,7 +7228,8 @@ storage_proxy::filter_replicas_for_read(
         const host_id_vector_replica_set& preferred_endpoints,
         db::read_repair_decision repair_decision,
         std::optional<locator::host_id>* extra,
-        replica::column_family* cf) const {
+        replica::column_family* cf,
+        dht::token token) const {
     if (live_endpoints.empty() || only_me(erm, live_endpoints)) {
         // `db::filter_for_query` would return the same thing, but thanks to this branch we avoid having
         // to access `remote` - so we can perform local queries without the need of `remote`.
@@ -7229,7 +7238,7 @@ storage_proxy::filter_replicas_for_read(
 
     // There are nodes other than us in `live_endpoints`.
     auto& gossiper = remote().gossiper();
-    return db::filter_for_query(cl, erm, live_endpoints, preferred_endpoints, repair_decision, gossiper, extra, cf);
+    return db::filter_for_query(cl, erm, live_endpoints, preferred_endpoints, repair_decision, gossiper, extra, cf, token);
 }
 
 host_id_vector_replica_set
@@ -7238,8 +7247,9 @@ storage_proxy::filter_replicas_for_read(
         const locator::effective_replication_map& erm,
         const host_id_vector_replica_set& live_endpoints,
         const host_id_vector_replica_set& preferred_endpoints,
-        replica::column_family* cf) const {
-    return filter_replicas_for_read(cl, erm, live_endpoints, preferred_endpoints, db::read_repair_decision::NONE, nullptr, cf);
+        replica::column_family* cf,
+        dht::token token) const {
+    return filter_replicas_for_read(cl, erm, live_endpoints, preferred_endpoints, db::read_repair_decision::NONE, nullptr, cf, token);
 }
 
 bool storage_proxy::is_alive(const locator::effective_replication_map& erm, const locator::host_id& ep) const {

--- a/service/storage_proxy.hh
+++ b/service/storage_proxy.hh
@@ -395,7 +395,7 @@ private:
             std::unique_ptr<mutation_holder> mh, db::consistency_level cl, db::write_type type, tracing::trace_state_ptr tr_state,
             service_permit permit, db::allow_per_partition_rate_limit allow_limit, is_cancellable, coordinator_mutate_options options);
     result<response_id_type> make_write_response_handler(locator::effective_replication_map_ptr ermp, db::consistency_level cl, db::write_type type, std::unique_ptr<mutation_holder> m, host_id_vector_replica_set targets,
-            const host_id_vector_topology_change& pending_endpoints, host_id_vector_topology_change, tracing::trace_state_ptr tr_state, storage_proxy::write_stats& stats, service_permit permit, db::per_partition_rate_limit::info rate_limit_info, is_cancellable, bool skip_large_data_guardrails = false, db::large_data_violation_type* violations_out = nullptr);
+            const host_id_vector_topology_change& pending_endpoints, host_id_vector_topology_change, tracing::trace_state_ptr tr_state, storage_proxy::write_stats& stats, service_permit permit, db::per_partition_rate_limit::info rate_limit_info, is_cancellable, dht::token token, bool skip_large_data_guardrails = false, db::large_data_violation_type* violations_out = nullptr);
     result<response_id_type> create_write_response_handler(const mutation&, db::consistency_level cl, db::write_type type, tracing::trace_state_ptr tr_state, service_permit permit, db::allow_per_partition_rate_limit allow_limit, coordinator_mutate_options options);
     result<response_id_type> create_write_response_handler(const hint_wrapper&, db::consistency_level cl, db::write_type type, tracing::trace_state_ptr tr_state, service_permit permit, db::allow_per_partition_rate_limit allow_limit, coordinator_mutate_options options);
     result<response_id_type> create_write_response_handler(const batchlog_replay_mutation&, db::consistency_level cl, db::write_type type, tracing::trace_state_ptr tr_state, service_permit permit, db::allow_per_partition_rate_limit allow_limit, coordinator_mutate_options options);
@@ -419,9 +419,9 @@ private:
     db::hints::manager& hints_manager_for(db::write_type type);
     void sort_endpoints_by_proximity(const locator::effective_replication_map& erm, host_id_vector_replica_set& eps) const;
     host_id_vector_replica_set get_endpoints_for_reading(const schema& s,  const locator::effective_replication_map& erm, const dht::token& token, node_local_only node_local_only) const;
-    host_id_vector_replica_set filter_replicas_for_read(db::consistency_level, const locator::effective_replication_map&, host_id_vector_replica_set live_endpoints, const host_id_vector_replica_set& preferred_endpoints, db::read_repair_decision, std::optional<locator::host_id>* extra, replica::column_family*) const;
+    host_id_vector_replica_set filter_replicas_for_read(db::consistency_level, const locator::effective_replication_map&, host_id_vector_replica_set live_endpoints, const host_id_vector_replica_set& preferred_endpoints, db::read_repair_decision, std::optional<locator::host_id>* extra, replica::column_family*, dht::token token) const;
     // As above with read_repair_decision=NONE, extra=nullptr.
-    host_id_vector_replica_set filter_replicas_for_read(db::consistency_level, const locator::effective_replication_map&, const host_id_vector_replica_set& live_endpoints, const host_id_vector_replica_set& preferred_endpoints, replica::column_family*) const;
+    host_id_vector_replica_set filter_replicas_for_read(db::consistency_level, const locator::effective_replication_map&, const host_id_vector_replica_set& live_endpoints, const host_id_vector_replica_set& preferred_endpoints, replica::column_family*, dht::token token) const;
     result<::shared_ptr<abstract_read_executor>> get_read_executor(lw_shared_ptr<query::read_command> cmd,
             locator::effective_replication_map_ptr ermp,
             schema_ptr schema,
@@ -519,7 +519,8 @@ private:
             tracing::trace_state_ptr tr_state,
             write_stats& stats,
             allow_hints,
-            is_cancellable);
+            is_cancellable,
+            dht::token token);
 
     void maybe_update_view_backlog_of(locator::host_id, std::optional<db::view::update_backlog>);
 

--- a/test/cluster/test_change_replication_factor_1_to_0.py
+++ b/test/cluster/test_change_replication_factor_1_to_0.py
@@ -22,8 +22,7 @@ logger = logging.getLogger(__name__)
     "use_tablets",
     [
         pytest.param(False, id="vnodes"),
-        pytest.param(True, id="tablets", marks=[pytest.mark.skip_bug(
-            link="https://github.com/scylladb/scylladb/issues/20282", reason="Coredump and error of: failed to log message: fmt='Requested location for node {} not in topology",),pytest.mark.tier2])
+        pytest.param(True, id="tablets"),
     ]
 )
 async def test_change_replication_factor_1_to_0(request: pytest.FixtureRequest, manager: ScyllaClusterManager, use_tablets: bool) -> None:

--- a/test/cluster/test_change_replication_factor_1_to_0.py
+++ b/test/cluster/test_change_replication_factor_1_to_0.py
@@ -22,8 +22,7 @@ logger = logging.getLogger(__name__)
     "use_tablets",
     [
         pytest.param(False, id="vnodes"),
-        pytest.param(True, id="tablets", marks=[pytest.mark.skip_bug(
-            link="https://github.com/scylladb/scylladb/issues/20282", reason="Coredump and error of: failed to log message: fmt='Requested location for node {} not in topology",),pytest.mark.nightly])
+        pytest.param(True, id="tablets"),
     ]
 )
 async def test_change_replication_factor_1_to_0(request: pytest.FixtureRequest, manager: ManagerClient, use_tablets: bool) -> None:


### PR DESCRIPTION
The current replication factor calculation takes the RF from the schema replication strategy options. With tablets, during migrations caused by a replication factor change (e.g. `ALTER KEYSPACE` changing a DC's RF), individual tablets are migrated one by one, so the schema RF and the actual per-tablet replica sets temporarily disagree. Using the schema value in consistency level calculations leads to:

- unavailability: requests blocked on more replicas than a tablet actually has (e.g. RF 1 -> 0, #20625, #20282);
- potential consistency loss: requests concurrent with an RF increase blocked on fewer replicas than the tablet's actual replica set requires.

This PR adds token-aware `effective_replication_map::get_replication_factor(token)` and `get_replication_factor(token, dc)` and uses them in the consistency level calculations (`block_for`, `quorum_for`, `local_quorum_for`, `is_sufficient_live_nodes`, `assure_sufficient_live_nodes`, `filter_for_query`) and in `sanity_check_read_replicas`. For vnode-based keyspaces the token is ignored and behavior is unchanged.

For tablets the replication factor is calculated **on the fly at query time** from the tablet's read replica set (counting replicas per DC via the topology). This is the key difference from the previous attempt in #21289, which precomputed a per-tablet DC->RF map at ERM construction time: ERM construction is not guaranteed to see mutually consistent tablet metadata and topology (#21856, pending #30517), which is what blocked that PR. Query-time calculation has no construction-time topology dependency, so this PR does not depend on #30517.

**Performance**

Measured with `perf-simple-query` (release, single shard, median of 5x8s runs), comparing this branch against its base commit:

- Instruction overhead is <= 0.7% per operation in the worst cell (tablets + LOCAL_QUORUM: 32,854 -> 33,042 insns/op for reads). Throughput deltas were within build-to-build noise (±2-3%, both directions, dominated by ThinLTO code-layout changes).
- The per-DC calculation cost scales linearly with the tablet's total replica count at ~8 ns/replica (microbenchmark: 25/77/120 ns per call at 1/3/5 DCs with RF 3 per DC). At ~3 calls per DC-local request this is ~0.25% of coordinator CPU for the common 1-DC case, ~1.3% in a 5-DC worst case.
- The total-RF variant (QUORUM/ALL/ONE) is `replicas.size()` — no measurable cost.

Once #30517 makes ERM construction topology-consistent, the calculation can be moved back to a precomputed map as an optimization — tracked in https://scylladb.atlassian.net/browse/SCYLLADB-3632.

Supersedes #21289.

Tests:
- No new test cases are added; the previously skipped `test_change_replication_factor_1_to_0[tablets]` variant (skipped due to #20282) is enabled.
- All 4 variants of `test/cluster/test_change_replication_factor_1_to_0.py` pass locally, as do the `tablets_test` and `network_topology_strategy_test` unit suites.

Test runtime impact (measured locally, dev mode):
- `test_change_replication_factor_1_to_0[tablets]` (newly enabled): **~8 s**
- for reference, the already-running variants: `[vnodes]` ~9 s, `_and_decommission[vnodes]` ~7 s, `_and_decommission[tablets]` ~6.9 s

Fixes: SCYLLADB-1228
Fixes #20625
Fixes #20282


Backport: since this is a real issue a customer could face, PR should be backported to all supported versions.


