### PR TITLE
cql3: let a TRUNCATE timeout be bound like any other

### DIFF
--- a/cql3/statements/alter_table_statement.cc
+++ b/cql3/statements/alter_table_statement.cc
@@ -600,7 +600,7 @@ alter_table_statement::raw_statement::prepare(data_dictionary::database db, cql_
         mylogger.warn("{}", *warning);
     }
 
-    auto ctx = get_prepare_context();
+    prepare_context& ctx = get_prepare_context();
     auto prepared_attrs = _attrs->prepare(db, keyspace(), column_family());
     prepared_attrs->fill_prepare_context(ctx);
 

--- a/cql3/statements/truncate_statement.cc
+++ b/cql3/statements/truncate_statement.cc
@@ -38,18 +38,20 @@ truncate_statement::truncate_statement(cf_name name, std::unique_ptr<attributes:
 std::unique_ptr<prepared_statement> truncate_statement::prepare(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) {
     schema_ptr schema = validation::validate_column_family(db, keyspace(), column_family());
     auto prepared_attributes = _attrs->prepare(db, keyspace(), column_family());
-    auto ctx = get_prepare_context();
+    prepare_context& ctx = get_prepare_context();
     prepared_attributes->fill_prepare_context(ctx);
-    auto stmt = ::make_shared<cql3::statements::truncate_statement>(std::move(schema), std::move(prepared_attributes));
-    return std::make_unique<prepared_statement>(audit_info(), std::move(stmt));
+    auto stmt = ::make_shared<cql3::statements::truncate_statement>(std::move(schema), std::move(prepared_attributes), ctx.bound_variables_size());
+    // TRUNCATE has no restrictions, so no bind marker can stand for a partition key component.
+    return std::make_unique<prepared_statement>(audit_info(), std::move(stmt), ctx, std::vector<uint16_t>());
 }
 
 } // namespace raw
 
-truncate_statement::truncate_statement(schema_ptr schema, std::unique_ptr<attributes> prepared_attrs)
+truncate_statement::truncate_statement(schema_ptr schema, std::unique_ptr<attributes> prepared_attrs, uint32_t bound_terms)
     : cql_statement(&timeout_config::truncate_timeout)
     , _schema{std::move(schema)}
     , _attrs(std::move(prepared_attrs))
+    , _bound_terms(bound_terms)
 {
 }
 
@@ -57,6 +59,7 @@ truncate_statement::truncate_statement(const truncate_statement& ts)
     : cql_statement(ts)
     , _schema(ts._schema)
     , _attrs(std::make_unique<attributes>(*ts._attrs))
+    , _bound_terms(ts._bound_terms)
 { }
 
 const sstring& truncate_statement::keyspace() const {
@@ -69,7 +72,7 @@ const sstring& truncate_statement::column_family() const {
 
 uint32_t truncate_statement::get_bound_terms() const
 {
-    return 0;
+    return _bound_terms;
 }
 
 bool truncate_statement::depends_on(std::string_view ks_name, std::optional<std::string_view> cf_name) const

--- a/cql3/statements/truncate_statement.hh
+++ b/cql3/statements/truncate_statement.hh
@@ -23,8 +23,9 @@ namespace statements {
 class truncate_statement : public cql_statement {
     schema_ptr _schema;
     const std::unique_ptr<attributes> _attrs;
+    const uint32_t _bound_terms;
 public:
-    truncate_statement(schema_ptr schema, std::unique_ptr<attributes> prepared_attrs);
+    truncate_statement(schema_ptr schema, std::unique_ptr<attributes> prepared_attrs, uint32_t bound_terms);
     truncate_statement(const truncate_statement&);
 
     const sstring& keyspace() const;

--- a/docs/cql/ddl.rst
+++ b/docs/cql/ddl.rst
@@ -1334,7 +1334,8 @@ A table can be truncated using the ``TRUNCATE`` statement:
    
    truncate_statement: TRUNCATE [ TABLE ] `table_name`
                      : [ USING TIMEOUT `timeout` ]
-   timeout: `duration`
+   timeout: `duration` | `bind_marker`
+   bind_marker: '?' | ':' `identifier`
 
 Note that ``TRUNCATE TABLE foo`` is allowed for consistency with other DDL statements, but tables are the only object
 that can be truncated currently and so the ``TABLE`` keyword can be omitted.
@@ -1346,6 +1347,10 @@ The ``USING TIMEOUT`` clause allows specifying a timeout for a specific request.
 For example::
 
   TRUNCATE TABLE users USING TIMEOUT 5m;
+
+In a prepared statement, the timeout can be given as a bind marker::
+
+  TRUNCATE TABLE users USING TIMEOUT ?;
 
 .. caution:: Do not run any operation on a table that is being truncated. Truncate operation is an administrative operation, and running any other operation on the same table in parallel may cause the truncating table's data to end up in an undefined state.
 

--- a/test/cqlpy/test_using_timeout.py
+++ b/test/cqlpy/test_using_timeout.py
@@ -173,3 +173,25 @@ def test_truncate_using_timeout(scylla_only, cql, table1):
         cql.execute(f"TRUNCATE TABLE {table} USING TIMESTAMP 123456789")
     with pytest.raises(SyntaxException):
         cql.execute(f"TRUNCATE TABLE {table} USING TIMEOUT 1h AND TTL 42")
+
+# Regression test for SCYLLADB-3645: the timeout of a TRUNCATE can be a marker,
+# like the timeout of any other statement that takes a USING TIMEOUT clause.
+def test_truncate_using_timeout_prepared(scylla_only, cql, table1):
+    table = table1
+    key = unique_key_int()
+    cql.execute(f"INSERT INTO {table} (p,c,v) VALUES ({key},1,1)")
+    prep = cql.prepare(f"TRUNCATE TABLE {table} USING TIMEOUT ?")
+    cql.execute(prep, (Duration(nanoseconds=10**15),))
+    assert list(cql.execute(f"SELECT * FROM {table} WHERE p = {key} and c = 1")) == []
+    prep_named = cql.prepare(f"TRUNCATE TABLE {table} USING TIMEOUT :timeout")
+    # Timeout cannot be left unbound
+    with pytest.raises(InvalidRequest):
+        cql.execute(prep_named, {})
+    cql.execute(f"INSERT INTO {table} (p,c,v) VALUES ({key},1,1)")
+    cql.execute(prep_named, {'timeout': Duration(nanoseconds=10**15)})
+    assert list(cql.execute(f"SELECT * FROM {table} WHERE p = {key} and c = 1")) == []
+    # An unprepared statement carries no value the marker could be bound to
+    with pytest.raises(InvalidRequest):
+        cql.execute(f"TRUNCATE TABLE {table} USING TIMEOUT ?")
+    with pytest.raises(NoHostAvailable):
+        cql.execute(prep, (Duration(nanoseconds=0),))


### PR DESCRIPTION
The grammar accepts a marker as the timeout of a TRUNCATE, but the
prepared statement claimed it had no variables to bind. A driver was
then unable to bind the timeout at all, and running the statement
unprepared read past the values it was given and failed with an
internal error instead of a query error.

ALTER TABLE prepared its USING TIMESTAMP in the same confusing way,
though it happened to keep using the state it filled, so give both of
them the state they later read.

Fixes: SCYLLADB-3645

Backport: no backport, just a minor fix.