### PR TITLE
build: suppress LeakSanitizer reports from liblttng-ust

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -157,6 +157,7 @@ adjust_bin() {
 export GNUTLS_SYSTEM_PRIORITY_FILE="\${GNUTLS_SYSTEM_PRIORITY_FILE-$prefix/libreloc/gnutls.config}"
 export LD_LIBRARY_PATH="$prefix/libreloc"
 export UBSAN_OPTIONS="${UBSAN_OPTIONS:+$UBSAN_OPTIONS:}suppressions=$prefix/libexec/ubsan-suppressions.supp"
+export LSAN_OPTIONS="${LSAN_OPTIONS:+$LSAN_OPTIONS:}suppressions=$prefix/libexec/lsan-suppressions.supp"
 ${p11_trust_paths:+export SCYLLA_P11_TRUST_PATHS="$p11_trust_paths"}
 exec -a "\$0" "$prefix/libexec/$bin" "\$@"
 EOF
@@ -446,6 +447,7 @@ for bin in libexec/*; do
     adjust_bin "${bin#libexec/}"
 done
 install -m644 ubsan-suppressions.supp -Dt "$rprefix/libexec"
+install -m644 lsan-suppressions.supp -Dt "$rprefix/libexec"
 
 install -d -m755 "$rdoc"/scylla
 install -m644 README.md -Dt "$rdoc"/scylla/

--- a/lsan-suppressions.supp
+++ b/lsan-suppressions.supp
@@ -1,0 +1,31 @@
+#
+# Copyright (C) 2026-present ScyllaDB
+#
+
+#
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
+#
+
+# liblttng-ust dlopen()s itself from its ELF constructors - both from
+# lttng_ust__tracepoints__init() (include/lttng/tracepoint.h, RTLD_NOW |
+# RTLD_GLOBAL) and from lttng_ust_ctor() (src/lib/lttng-ust/lttng-ust-comm.c,
+# RTLD_LAZY | RTLD_NODELETE). It does so deliberately: its ust_listener_threads
+# are detached and can never be joined, so the code they run must never be
+# unmapped, and the reference is never dropped (lttng-ust b2292d856737).
+#
+# What LeakSanitizer reports is therefore not lttng-ust's own state but the
+# glibc dynamic-loader bookkeeping allocated to service those dlopen()s. It is
+# referenced only from ld.so's private _rtld_global, which LeakSanitizer does
+# not scan, so it looks unreachable at exit even though it stays in use for the
+# whole lifetime of the process - and it is reported for a command as trivial
+# as "scylla --version".
+#
+# The allocations belong to the third-party library, not to Scylla. They only
+# became visible when we started linking lttng-ust: the seastar update in
+# dafe9e9a80 ("Update seastar submodule") pulled in seastar's LTTng-UST
+# tracepoints, which added liblttng-ust to the relocatable package for the
+# first time.
+#
+# The pattern is a substring match on the module name, so it covers both
+# liblttng-ust.so and liblttng-ust-tracepoint.so.
+leak:liblttng-ust

--- a/scripts/create-relocatable-package.py
+++ b/scripts/create-relocatable-package.py
@@ -237,6 +237,7 @@ ar.reloc_add('scylla-gdb.py')
 ar.reloc_add('bin/nodetool')
 ar.reloc_add(args.debian_dir, arcname='debian')
 ar.reloc_add('ubsan-suppressions.supp')
+ar.reloc_add('lsan-suppressions.supp')
 ar.reloc_add('fix_system_distributed_tables.py')
 
 # Complete the tar output, and wait for the gzip process to complete


### PR DESCRIPTION
Debug builds are compiled with -fsanitize=address, which turns on
LeakSanitizer at exit. Since dafe9e9a80 ("Update seastar submodule")
Scylla links liblttng-ust: that bump pulled in seastar's LTTng-UST
tracepoints (a19df7f06 "build: Add LTTng-UST as optional dependency",
f98cc0cfd "io: Add LTTng-UST tracepoints to IO subsystem", 7c25cf29e
"reactor: Add LTTng-UST tracepoints to task scheduling"), which added
lttng-ust to the relocatable package for the first time - the same
commit records it in _KNOWN_LIB_ASYMMETRIES in compare_build_systems.py.

Since then LeakSanitizer fires on every exit - even for a command as
trivial as "scylla --version". The debug Docker integration test runs
exactly that, and has failed ever since:

  ==1==ERROR: LeakSanitizer: detected memory leaks
```
  Direct leak of 504 byte(s) in 1 object(s) allocated from:
  #0 0x00000436c4b4  (/opt/scylladb/libexec/scylla+0x436c4b4)
  #1 0x7f15b14907a3  (<unknown module>)

  #13 0x7f15a697089a  (/opt/scylladb/libreloc/liblttng-ust-tracepoint.so.1+0x89a)

  Direct leak of 104 byte(s) in 1 object(s) allocated from:
  #0 0x00000436c4b4  (/opt/scylladb/libexec/scylla+0x436c4b4)
  #1 0x7f15b1487235  (<unknown module>)
 
  #13 0x7f15a9a0685a  (/opt/scylladb/libreloc/liblttng-ust.so.1+0x585a)

 ```
 SUMMARY: AddressSanitizer: 736 byte(s) leaked in 4 allocation(s).

  Triggered by: podman run --rm --cap-add SYS_PTRACE \
      localhost/ubuntu24.04-2026.4-nightly-master-debug-x86_64 scylla --version

What is being leaked
--------------------

The two innermost frames symbolize (against lttng-ust-2.14.0-5.fc44,
the exact build the relocatable package bundles) to:

  $ addr2line -f -i -C -e /usr/lib64/liblttng-ust-tracepoint.so.1 0x89a
  lttng_ust__tracepoints__init
  .../include/lttng/tracepoint.h:462

  $ addr2line -f -i -C -e /usr/lib64/liblttng-ust.so.1 0x585a
  lttng_ust_ctor
  .../src/lib/lttng-ust/lttng-ust-comm.c:2314

Both are return addresses of a dlopen() call issued from an ELF
constructor:

  tracepoint.h:462     dlopen("liblttng-ust.so.1", RTLD_NOW | RTLD_GLOBAL)
  lttng-ust-comm.c:2314 dlopen(LTTNG_UST_LIB_SONAME, RTLD_LAZY | RTLD_NODELETE)

So the leaked objects are not lttng-ust data structures at all - they
are glibc dynamic-loader bookkeeping (link-map search-scope arrays and
friends) allocated while servicing those two dlopen()s. Their only
reference lives in ld.so's private _rtld_global, which LeakSanitizer
does not scan; that is also why frame #1 reads "<unknown module>". The
blocks stay live and in use for the whole lifetime of the process.

lttng-ust takes those references on purpose and can never drop them:
its ust_listener_threads are created detached and so can never be
joined, meaning the code they execute must never be unmapped, so the
library pins itself into the address space - see lttng-ust commit
b2292d856737 ("Fix: dlopen() liblttng-ust.so from constructor to
prevent unloading"). There is therefore nothing to fix upstream and no
upstream bug to reference: LTTng's tracker has no report for this, and
the one sanitizer-side issue that names LTTng
(https://github.com/google/sanitizers/issues/1286) was closed without
resolution. Other projects that link lttng-ust carry the equivalent
Valgrind suppression instead (ceph/ceph src/valgrind.supp,
Ericsson/xcm test/src/lttng.supp).

The fix
-------

The allocations belong to the third-party library, not to Scylla, so
suppress them. This follows the existing ubsan-suppressions.supp
pattern: ship lsan-suppressions.supp in the relocatable package, install
it into libexec, and point LSAN_OPTIONS at it from the generated
bin/scylla wrapper. Wiring it into the wrapper rather than into the
failing test means the suppression applies to every packaged invocation
(Docker, deb and rpm), not just to the one check that happened to catch
it.

The suppression pattern is a substring match on the module name, so the
single "leak:liblttng-ust" entry covers both liblttng-ust.so and
liblttng-ust-tracepoint.so.

First seen in
https://jenkins.scylladb.com/job/scylla-master/job/unified-deb/2130/
(unified-deb #2129, scylla 3cf66209b090, was clean; #2130, scylla
c771d9d1a5ad, was not - dafe9e9a80 falls between the two).

Fixes: SCYLLADB-3635
Fixes: SCYLLADB-3636


**No backport is required. The leak reports only exist where Scylla links liblttng-ust, which starts with dafe9e9a80 - a commit that is on master only and was itself marked as not requiring a backport**
