### PR TITLE
RFC: batch repair hash/row RPC frames to cut bytes-on-wire

### DIFF
--- a/compaction/compaction.cc
+++ b/compaction/compaction.cc
@@ -2107,7 +2107,8 @@ public:
         auto cfg = make_sstable_writer_config(compaction_type::Reshard);
         // sstables generated for a given shard will share the same run identifier.
         cfg.run_identifier = _run_identifiers.at(shard);
-        return compaction_writer{sst->get_writer(*_schema, partitions_per_sstable(shard), cfg, get_encoding_stats(), shard), sst};
+        cfg.shard = shard;
+        return compaction_writer{sst->get_writer(*_schema, partitions_per_sstable(shard), cfg, get_encoding_stats()), sst};
     }
 
     void stop_sstable_writer(compaction_writer* writer) override {

--- a/idl/repair.idl.hh
+++ b/idl/repair.idl.hh
@@ -42,6 +42,7 @@ struct get_sync_boundary_response {
 enum class row_level_diff_detect_algorithm : uint8_t {
     send_full_set,
     send_full_set_rpc_stream,
+    send_full_set_rpc_stream_batched,
 };
 
 enum class repair_stream_cmd : uint8_t {
@@ -53,6 +54,8 @@ enum class repair_stream_cmd : uint8_t {
     end_of_current_rows,
     get_full_row_hashes,
     put_rows_done,
+    hash_data_batch,
+    row_data_batch,
 };
 
 struct repair_hash_with_cmd {
@@ -63,6 +66,16 @@ struct repair_hash_with_cmd {
 struct repair_row_on_wire_with_cmd {
     repair_stream_cmd cmd;
     partition_key_and_mutation_fragments row;
+};
+
+struct repair_hash_with_cmd_batch {
+    repair_stream_cmd cmd;
+    std::vector<repair_hash> hashes;
+};
+
+struct repair_row_on_wire_with_cmd_batch {
+    repair_stream_cmd cmd;
+    std::list<partition_key_and_mutation_fragments> rows;
 };
 
 enum class repair_row_level_start_status: uint8_t {

--- a/message/messaging_service.cc
+++ b/message/messaging_service.cc
@@ -772,8 +772,11 @@ static constexpr unsigned do_get_rpc_client_idx(messaging_verb verb) {
     case messaging_verb::REPAIR_SET_ESTIMATED_PARTITIONS:
     case messaging_verb::REPAIR_GET_DIFF_ALGORITHMS:
     case messaging_verb::REPAIR_GET_ROW_DIFF_WITH_RPC_STREAM:
+    case messaging_verb::REPAIR_GET_ROW_DIFF_WITH_RPC_STREAM_BATCHED:
     case messaging_verb::REPAIR_PUT_ROW_DIFF_WITH_RPC_STREAM:
+    case messaging_verb::REPAIR_PUT_ROW_DIFF_WITH_RPC_STREAM_BATCHED:
     case messaging_verb::REPAIR_GET_FULL_ROW_HASHES_WITH_RPC_STREAM:
+    case messaging_verb::REPAIR_GET_FULL_ROW_HASHES_WITH_RPC_STREAM_BATCHED:
     case messaging_verb::REPAIR_UPDATE_SYSTEM_TABLE:
     case messaging_verb::REPAIR_FLUSH_HINTS_BATCHLOG:
     case messaging_verb::REPAIR_UPDATE_COMPACTION_CTRL:
@@ -1497,6 +1500,72 @@ void messaging_service::register_repair_get_full_row_hashes_with_rpc_stream(std:
 }
 future<> messaging_service::unregister_repair_get_full_row_hashes_with_rpc_stream() {
     return unregister_handler(messaging_verb::REPAIR_GET_FULL_ROW_HASHES_WITH_RPC_STREAM);
+}
+
+// Wrapper for REPAIR_GET_ROW_DIFF_WITH_RPC_STREAM_BATCHED
+future<std::tuple<rpc::sink<repair_hash_with_cmd_batch>, rpc::source<repair_row_on_wire_with_cmd_batch>>>
+messaging_service::make_sink_and_source_for_repair_get_row_diff_with_rpc_stream_batched(uint32_t repair_meta_id, shard_id dst_cpu_id, locator::host_id id) {
+    auto verb = messaging_verb::REPAIR_GET_ROW_DIFF_WITH_RPC_STREAM_BATCHED;
+    if (is_shutting_down()) {
+        return make_exception_future<std::tuple<rpc::sink<repair_hash_with_cmd_batch>, rpc::source<repair_row_on_wire_with_cmd_batch>>>(rpc::closed_error("local node is shutting down"));
+    }
+    auto rpc_client = get_rpc_client(verb, addr_for_host_id(id), id);
+    return do_make_sink_source<repair_hash_with_cmd_batch, repair_row_on_wire_with_cmd_batch>(verb, repair_meta_id, dst_cpu_id, std::move(rpc_client), rpc());
+}
+
+rpc::sink<repair_row_on_wire_with_cmd_batch> messaging_service::make_sink_for_repair_get_row_diff_with_rpc_stream_batched(rpc::source<repair_hash_with_cmd_batch>& source) {
+    return source.make_sink<netw::serializer, repair_row_on_wire_with_cmd_batch>();
+}
+
+void messaging_service::register_repair_get_row_diff_with_rpc_stream_batched(std::function<future<rpc::sink<repair_row_on_wire_with_cmd_batch>> (const rpc::client_info& cinfo, uint32_t repair_meta_id, rpc::source<repair_hash_with_cmd_batch> source, rpc::optional<shard_id> dst_cpu_id_opt)>&& func) {
+    register_handler(this, messaging_verb::REPAIR_GET_ROW_DIFF_WITH_RPC_STREAM_BATCHED, std::move(func));
+}
+future<> messaging_service::unregister_repair_get_row_diff_with_rpc_stream_batched() {
+    return unregister_handler(messaging_verb::REPAIR_GET_ROW_DIFF_WITH_RPC_STREAM_BATCHED);
+}
+
+// Wrapper for REPAIR_PUT_ROW_DIFF_WITH_RPC_STREAM_BATCHED
+future<std::tuple<rpc::sink<repair_row_on_wire_with_cmd_batch>, rpc::source<repair_stream_cmd>>>
+messaging_service::make_sink_and_source_for_repair_put_row_diff_with_rpc_stream_batched(uint32_t repair_meta_id, shard_id dst_cpu_id, locator::host_id id) {
+    auto verb = messaging_verb::REPAIR_PUT_ROW_DIFF_WITH_RPC_STREAM_BATCHED;
+    if (is_shutting_down()) {
+        return make_exception_future<std::tuple<rpc::sink<repair_row_on_wire_with_cmd_batch>, rpc::source<repair_stream_cmd>>>(rpc::closed_error("local node is shutting down"));
+    }
+    auto rpc_client = get_rpc_client(verb, addr_for_host_id(id), id);
+    return do_make_sink_source<repair_row_on_wire_with_cmd_batch, repair_stream_cmd>(verb, repair_meta_id, dst_cpu_id, std::move(rpc_client), rpc());
+}
+
+rpc::sink<repair_stream_cmd> messaging_service::make_sink_for_repair_put_row_diff_with_rpc_stream_batched(rpc::source<repair_row_on_wire_with_cmd_batch>& source) {
+    return source.make_sink<netw::serializer, repair_stream_cmd>();
+}
+
+void messaging_service::register_repair_put_row_diff_with_rpc_stream_batched(std::function<future<rpc::sink<repair_stream_cmd>> (const rpc::client_info& cinfo, uint32_t repair_meta_id, rpc::source<repair_row_on_wire_with_cmd_batch> source, rpc::optional<shard_id> dst_cpu_id_opt)>&& func) {
+    register_handler(this, messaging_verb::REPAIR_PUT_ROW_DIFF_WITH_RPC_STREAM_BATCHED, std::move(func));
+}
+future<> messaging_service::unregister_repair_put_row_diff_with_rpc_stream_batched() {
+    return unregister_handler(messaging_verb::REPAIR_PUT_ROW_DIFF_WITH_RPC_STREAM_BATCHED);
+}
+
+// Wrapper for REPAIR_GET_FULL_ROW_HASHES_WITH_RPC_STREAM_BATCHED
+future<std::tuple<rpc::sink<repair_stream_cmd>, rpc::source<repair_hash_with_cmd_batch>>>
+messaging_service::make_sink_and_source_for_repair_get_full_row_hashes_with_rpc_stream_batched(uint32_t repair_meta_id, shard_id dst_cpu_id, locator::host_id id) {
+    auto verb = messaging_verb::REPAIR_GET_FULL_ROW_HASHES_WITH_RPC_STREAM_BATCHED;
+    if (is_shutting_down()) {
+        return make_exception_future<std::tuple<rpc::sink<repair_stream_cmd>, rpc::source<repair_hash_with_cmd_batch>>>(rpc::closed_error("local node is shutting down"));
+    }
+    auto rpc_client = get_rpc_client(verb, addr_for_host_id(id), id);
+    return do_make_sink_source<repair_stream_cmd, repair_hash_with_cmd_batch>(verb, repair_meta_id, dst_cpu_id, std::move(rpc_client), rpc());
+}
+
+rpc::sink<repair_hash_with_cmd_batch> messaging_service::make_sink_for_repair_get_full_row_hashes_with_rpc_stream_batched(rpc::source<repair_stream_cmd>& source) {
+    return source.make_sink<netw::serializer, repair_hash_with_cmd_batch>();
+}
+
+void messaging_service::register_repair_get_full_row_hashes_with_rpc_stream_batched(std::function<future<rpc::sink<repair_hash_with_cmd_batch>> (const rpc::client_info& cinfo, uint32_t repair_meta_id, rpc::source<repair_stream_cmd> source, rpc::optional<shard_id> dst_cpu_id_opt)>&& func) {
+    register_handler(this, messaging_verb::REPAIR_GET_FULL_ROW_HASHES_WITH_RPC_STREAM_BATCHED, std::move(func));
+}
+future<> messaging_service::unregister_repair_get_full_row_hashes_with_rpc_stream_batched() {
+    return unregister_handler(messaging_verb::REPAIR_GET_FULL_ROW_HASHES_WITH_RPC_STREAM_BATCHED);
 }
 
 // Wrappers for verbs

--- a/message/messaging_service.hh
+++ b/message/messaging_service.hh
@@ -82,6 +82,8 @@ using wrapping_partition_range = wrapping_interval<dht::ring_position>;
 
 class repair_hash_with_cmd;
 class repair_row_on_wire_with_cmd;
+class repair_hash_with_cmd_batch;
+class repair_row_on_wire_with_cmd_batch;
 enum class repair_stream_cmd : uint8_t;
 class repair_stream_boundary;
 class frozen_mutation_fragment;
@@ -220,8 +222,11 @@ enum class messaging_verb : int32_t {
     FETCH_COLUMN_MAPPINGS = 91,
     REPAIR_GET_TABLE_SIZE = 92,
     BACKUP_SNAPSHOT_SSTABLES = 93,
+    REPAIR_GET_ROW_DIFF_WITH_RPC_STREAM_BATCHED = 94,
+    REPAIR_PUT_ROW_DIFF_WITH_RPC_STREAM_BATCHED = 95,
+    REPAIR_GET_FULL_ROW_HASHES_WITH_RPC_STREAM_BATCHED = 96,
 
-    LAST = 94,
+    LAST = 97,
 };
 
 } // namespace netw
@@ -449,6 +454,24 @@ public:
     rpc::sink<repair_hash_with_cmd> make_sink_for_repair_get_full_row_hashes_with_rpc_stream(rpc::source<repair_stream_cmd>& source);
     void register_repair_get_full_row_hashes_with_rpc_stream(std::function<future<rpc::sink<repair_hash_with_cmd>> (const rpc::client_info& cinfo, uint32_t repair_meta_id, rpc::source<repair_stream_cmd> source, rpc::optional<shard_id> dst_cpu_id_opt)>&& func);
     future<> unregister_repair_get_full_row_hashes_with_rpc_stream();
+
+    // Wrapper for REPAIR_GET_ROW_DIFF_WITH_RPC_STREAM_BATCHED
+    future<std::tuple<rpc::sink<repair_hash_with_cmd_batch>, rpc::source<repair_row_on_wire_with_cmd_batch>>> make_sink_and_source_for_repair_get_row_diff_with_rpc_stream_batched(uint32_t repair_meta_id, shard_id dst_cpu_id, locator::host_id id);
+    rpc::sink<repair_row_on_wire_with_cmd_batch> make_sink_for_repair_get_row_diff_with_rpc_stream_batched(rpc::source<repair_hash_with_cmd_batch>& source);
+    void register_repair_get_row_diff_with_rpc_stream_batched(std::function<future<rpc::sink<repair_row_on_wire_with_cmd_batch>> (const rpc::client_info& cinfo, uint32_t repair_meta_id, rpc::source<repair_hash_with_cmd_batch> source, rpc::optional<shard_id> dst_cpu_id_opt)>&& func);
+    future<> unregister_repair_get_row_diff_with_rpc_stream_batched();
+
+    // Wrapper for REPAIR_PUT_ROW_DIFF_WITH_RPC_STREAM_BATCHED
+    future<std::tuple<rpc::sink<repair_row_on_wire_with_cmd_batch>, rpc::source<repair_stream_cmd>>> make_sink_and_source_for_repair_put_row_diff_with_rpc_stream_batched(uint32_t repair_meta_id, shard_id dst_cpu_id, locator::host_id id);
+    rpc::sink<repair_stream_cmd> make_sink_for_repair_put_row_diff_with_rpc_stream_batched(rpc::source<repair_row_on_wire_with_cmd_batch>& source);
+    void register_repair_put_row_diff_with_rpc_stream_batched(std::function<future<rpc::sink<repair_stream_cmd>> (const rpc::client_info& cinfo, uint32_t repair_meta_id, rpc::source<repair_row_on_wire_with_cmd_batch> source, rpc::optional<shard_id> dst_cpu_id_opt)>&& func);
+    future<> unregister_repair_put_row_diff_with_rpc_stream_batched();
+
+    // Wrapper for REPAIR_GET_FULL_ROW_HASHES_WITH_RPC_STREAM_BATCHED
+    future<std::tuple<rpc::sink<repair_stream_cmd>, rpc::source<repair_hash_with_cmd_batch>>> make_sink_and_source_for_repair_get_full_row_hashes_with_rpc_stream_batched(uint32_t repair_meta_id, shard_id dst_cpu_id, locator::host_id id);
+    rpc::sink<repair_hash_with_cmd_batch> make_sink_for_repair_get_full_row_hashes_with_rpc_stream_batched(rpc::source<repair_stream_cmd>& source);
+    void register_repair_get_full_row_hashes_with_rpc_stream_batched(std::function<future<rpc::sink<repair_hash_with_cmd_batch>> (const rpc::client_info& cinfo, uint32_t repair_meta_id, rpc::source<repair_stream_cmd> source, rpc::optional<shard_id> dst_cpu_id_opt)>&& func);
+    future<> unregister_repair_get_full_row_hashes_with_rpc_stream_batched();
 
     void foreach_server_connection_stats(std::function<void(const rpc::client_info&, const rpc::stats&)>&& f) const;
 

--- a/repair/repair.cc
+++ b/repair/repair.cc
@@ -117,6 +117,8 @@ std::string_view format_as(row_level_diff_detect_algorithm algo) {
         return "send_full_set";
     case send_full_set_rpc_stream:
         return "send_full_set_rpc_stream";
+    case send_full_set_rpc_stream_batched:
+        return "send_full_set_rpc_stream_batched";
     };
     return "unknown";
 }

--- a/repair/repair.hh
+++ b/repair/repair.hh
@@ -243,6 +243,8 @@ enum class repair_stream_cmd : uint8_t {
     end_of_current_rows,
     get_full_row_hashes,
     put_rows_done,
+    hash_data_batch,
+    row_data_batch,
 };
 
 struct repair_hash_with_cmd {
@@ -255,9 +257,20 @@ struct repair_row_on_wire_with_cmd {
     repair_row_on_wire row;
 };
 
+struct repair_hash_with_cmd_batch {
+    repair_stream_cmd cmd;
+    std::vector<repair_hash> hashes;
+};
+
+struct repair_row_on_wire_with_cmd_batch {
+    repair_stream_cmd cmd;
+    std::list<repair_row_on_wire> rows;
+};
+
 enum class row_level_diff_detect_algorithm : uint8_t {
     send_full_set,
     send_full_set_rpc_stream,
+    send_full_set_rpc_stream_batched,
 };
 
 std::string_view format_as(row_level_diff_detect_algorithm);

--- a/repair/row_level.cc
+++ b/repair/row_level.cc
@@ -182,6 +182,9 @@ public:
 using sink_source_for_get_full_row_hashes = sink_source_for_repair<repair_stream_cmd, repair_hash_with_cmd>;
 using sink_source_for_get_row_diff = sink_source_for_repair<repair_hash_with_cmd, repair_row_on_wire_with_cmd>;
 using sink_source_for_put_row_diff = sink_source_for_repair<repair_row_on_wire_with_cmd, repair_stream_cmd>;
+using sink_source_for_get_full_row_hashes_batched = sink_source_for_repair<repair_stream_cmd, repair_hash_with_cmd_batch>;
+using sink_source_for_get_row_diff_batched = sink_source_for_repair<repair_hash_with_cmd_batch, repair_row_on_wire_with_cmd_batch>;
+using sink_source_for_put_row_diff_batched = sink_source_for_repair<repair_row_on_wire_with_cmd_batch, repair_stream_cmd>;
 
 struct row_level_repair_metrics {
     seastar::metrics::metric_groups _metrics;
@@ -227,25 +230,119 @@ struct row_level_repair_metrics {
 
 static thread_local row_level_repair_metrics _metrics;
 
+// Splits hashes into groups of at most hash_batch_max_count elements each, preserving
+// iteration order. Yields periodically like the rest of this file's hash/row loops (a full
+// round's hash set can be large) — kept separate from send_hashes_batched so the grouping
+// math is unit-testable without an rpc::sink.
+future<std::vector<std::vector<repair_hash>>> batch_hashes_for_wire(const repair_hash_set& hashes) {
+    std::vector<std::vector<repair_hash>> batches;
+    if (hashes.empty()) {
+        co_return batches;
+    }
+    batches.reserve((hashes.size() + hash_batch_max_count - 1) / hash_batch_max_count);
+    std::vector<repair_hash> batch;
+    batch.reserve(std::min(hash_batch_max_count, hashes.size()));
+    for (const repair_hash& hash : hashes) {
+        batch.push_back(hash);
+        if (batch.size() >= hash_batch_max_count) {
+            batches.push_back(std::move(batch));
+            batch = std::vector<repair_hash>();
+            batch.reserve(hash_batch_max_count);
+        }
+        co_await coroutine::maybe_yield();
+    }
+    if (!batch.empty()) {
+        batches.push_back(std::move(batch));
+    }
+    co_return batches;
+}
+
+// Sends hashes to sink grouped into hash_batch_max_count-sized repair_stream_cmd::hash_data_batch
+// frames. Caller still sends its own end_of_current_hash_set sentinel afterwards.
+static future<> send_hashes_batched(rpc::sink<repair_hash_with_cmd_batch>& sink, const repair_hash_set& hashes) {
+    for (auto& batch : co_await batch_hashes_for_wire(hashes)) {
+        rlogger.trace("send_hashes_batched: batch of {} hashes", batch.size());
+        co_await sink(repair_hash_with_cmd_batch{repair_stream_cmd::hash_data_batch, std::move(batch)});
+    }
+}
+
+static size_t estimated_wire_size(const repair_row_on_wire& row) {
+    size_t size = 0;
+    for (const frozen_mutation_fragment& mf : row.get_mutation_fragments()) {
+        size += mf.representation().size();
+    }
+    return size;
+}
+
+// Splits rows into groups capped by both row_batch_max_count and row_batch_max_bytes
+// (whichever limit is hit first), preserving iteration order and consuming `rows`. Yields
+// periodically for the same reason to_repair_rows_list/flush_rows do (a full round's row
+// list can be large) — kept separate from send_rows_batched so the grouping math is
+// unit-testable without an rpc::sink.
+future<std::vector<std::list<repair_row_on_wire>>> batch_rows_for_wire(repair_rows_on_wire& rows) {
+    std::vector<std::list<repair_row_on_wire>> batches;
+    std::list<repair_row_on_wire> batch;
+    size_t batch_bytes = 0;
+    for (repair_row_on_wire& row : rows) {
+        size_t row_bytes = estimated_wire_size(row);
+        // Flush before adding, not after, so a batch never grows past the caps - except a
+        // single row already over row_batch_max_bytes on its own, which still gets sent.
+        if (!batch.empty() && (batch.size() >= row_batch_max_count || batch_bytes + row_bytes > row_batch_max_bytes)) {
+            batches.push_back(std::move(batch));
+            batch = std::list<repair_row_on_wire>();
+            batch_bytes = 0;
+        }
+        batch_bytes += row_bytes;
+        batch.push_back(std::move(row));
+        co_await coroutine::maybe_yield();
+    }
+    if (!batch.empty()) {
+        batches.push_back(std::move(batch));
+    }
+    co_return batches;
+}
+
+// Sends rows to sink grouped into repair_stream_cmd::row_data_batch frames. Caller still
+// sends its own end_of_current_rows sentinel afterwards.
+//
+// Keeps the command object alive across the co_await and explicitly clear_gently()s its
+// payload afterwards (on both the success and exception paths), matching the pre-existing
+// single-row send path — sink() serializes from a const reference without consuming its
+// argument, so letting `cmd` just fall out of scope would free the batch synchronously.
+static future<> send_rows_batched(rpc::sink<repair_row_on_wire_with_cmd_batch>& sink, repair_rows_on_wire& rows) {
+    for (auto& batch : co_await batch_rows_for_wire(rows)) {
+        rlogger.trace("send_rows_batched: batch of {} rows", batch.size());
+        auto cmd = repair_row_on_wire_with_cmd_batch{repair_stream_cmd::row_data_batch, std::move(batch)};
+        std::exception_ptr ep;
+        try {
+            co_await sink(cmd);
+        } catch (...) {
+            ep = std::current_exception();
+        }
+        co_await utils::clear_gently(cmd.rows);
+        if (ep) {
+            std::rethrow_exception(ep);
+        }
+    }
+}
+
 static const std::vector<row_level_diff_detect_algorithm>& suportted_diff_detect_algorithms() {
     static std::vector<row_level_diff_detect_algorithm> _algorithms = {
         row_level_diff_detect_algorithm::send_full_set,
         row_level_diff_detect_algorithm::send_full_set_rpc_stream,
+        row_level_diff_detect_algorithm::send_full_set_rpc_stream_batched,
     };
     return _algorithms;
 };
 
-static row_level_diff_detect_algorithm get_common_diff_detect_algorithm(netw::messaging_service& ms, const host_id_vector_replica_set& nodes) {
-    std::vector<std::vector<row_level_diff_detect_algorithm>> nodes_algorithms(nodes.size());
-    parallel_for_each(std::views::iota(size_t(0), nodes.size()), coroutine::lambda([&] (size_t idx) -> future<> {
-        std::vector<row_level_diff_detect_algorithm> algorithms = co_await ser::repair_rpc_verbs::send_repair_get_diff_algorithms(&ms, nodes[idx]);
-        std::sort(algorithms.begin(), algorithms.end());
-        nodes_algorithms[idx] = std::move(algorithms);
-        rlogger.trace("Got node_algorithms={}, from node={}", nodes_algorithms[idx], nodes[idx]);
-    })).get();
-
+// Pure selection logic behind get_common_diff_detect_algorithm: picks the best common
+// algorithm given each peer's advertised list and whether batching is allowed. Exposed
+// for unit testing the vnode/tablet gating (allow_batched).
+row_level_diff_detect_algorithm select_diff_detect_algorithm(
+        std::vector<std::vector<row_level_diff_detect_algorithm>> nodes_algorithms, bool allow_batched) {
     auto common_algorithms = suportted_diff_detect_algorithms();
     for (auto& algorithms : nodes_algorithms) {
+        std::sort(algorithms.begin(), algorithms.end());
         std::sort(common_algorithms.begin(), common_algorithms.end());
         std::vector<row_level_diff_detect_algorithm> results;
         std::set_intersection(algorithms.begin(), algorithms.end(),
@@ -253,12 +350,30 @@ static row_level_diff_detect_algorithm get_common_diff_detect_algorithm(netw::me
                 std::back_inserter(results));
         common_algorithms = std::move(results);
     }
+    if (!allow_batched) {
+        common_algorithms.erase(std::remove(common_algorithms.begin(), common_algorithms.end(),
+                row_level_diff_detect_algorithm::send_full_set_rpc_stream_batched), common_algorithms.end());
+    }
+    // Logged unconditionally, before the throw below, so a negotiation failure still
+    // reports what each peer advertised.
     rlogger.trace("peer_algorithms={}, local_algorithms={}, common_diff_detect_algorithms={}",
             nodes_algorithms, suportted_diff_detect_algorithms(), common_algorithms);
     if (common_algorithms.empty()) {
         throw std::runtime_error("Can not find row level repair diff detect algorithm");
     }
     return common_algorithms.back();
+}
+
+// allow_batched gates send_full_set_rpc_stream_batched on the local table
+// being a tablet table (uses_tablets()) — vnode repair must never select it.
+static row_level_diff_detect_algorithm get_common_diff_detect_algorithm(netw::messaging_service& ms, const host_id_vector_replica_set& nodes, bool allow_batched) {
+    std::vector<std::vector<row_level_diff_detect_algorithm>> nodes_algorithms(nodes.size());
+    parallel_for_each(std::views::iota(size_t(0), nodes.size()), coroutine::lambda([&] (size_t idx) -> future<> {
+        std::vector<row_level_diff_detect_algorithm> algorithms = co_await ser::repair_rpc_verbs::send_repair_get_diff_algorithms(&ms, nodes[idx]);
+        nodes_algorithms[idx] = std::move(algorithms);
+        rlogger.trace("Got node_algorithms={}, from node={}", nodes_algorithms[idx], nodes[idx]);
+    })).get();
+    return select_diff_detect_algorithm(nodes_algorithms, allow_batched);
 }
 
 static bool is_rpc_stream_supported(row_level_diff_detect_algorithm algo) {
@@ -809,6 +924,9 @@ private:
     sink_source_for_get_full_row_hashes _sink_source_for_get_full_row_hashes;
     sink_source_for_get_row_diff _sink_source_for_get_row_diff;
     sink_source_for_put_row_diff _sink_source_for_put_row_diff;
+    sink_source_for_get_full_row_hashes_batched _sink_source_for_get_full_row_hashes_batched;
+    sink_source_for_get_row_diff_batched _sink_source_for_get_row_diff_batched;
+    sink_source_for_put_row_diff_batched _sink_source_for_put_row_diff_batched;
     tracker_link_type _tracker_link;
     row_level_repair* _row_level_repair_ptr;
     std::vector<repair_node_state> _all_node_states;
@@ -883,6 +1001,9 @@ public:
     bool use_rpc_stream() const {
         return is_rpc_stream_supported(_algo);
     }
+    bool use_batched_stream() const {
+        return _algo == row_level_diff_detect_algorithm::send_full_set_rpc_stream_batched;
+    }
 
 public:
     // master constructor
@@ -945,6 +1066,24 @@ public:
                         auto dst_cpu_id = dst_cpu_id_opt.value_or(repair_unspecified_shard);
                         rlogger.debug("put_row_diff: repair_meta_id={} dst_cpu_id={}", repair_meta_id, dst_cpu_id);
                         return rs.get_messaging().make_sink_and_source_for_repair_put_row_diff_with_rpc_stream(repair_meta_id, dst_cpu_id, addr);
+                })
+            , _sink_source_for_get_full_row_hashes_batched(_repair_meta_id, _nr_peer_nodes,
+                    [&rs] (uint32_t repair_meta_id, std::optional<shard_id> dst_cpu_id_opt, locator::host_id addr) {
+                        auto dst_cpu_id = dst_cpu_id_opt.value_or(repair_unspecified_shard);
+                        rlogger.debug("get_full_row_hashes_batched: repair_meta_id={} dst_cpu_id={}", repair_meta_id, dst_cpu_id);
+                        return rs.get_messaging().make_sink_and_source_for_repair_get_full_row_hashes_with_rpc_stream_batched(repair_meta_id, dst_cpu_id, addr);
+                })
+            , _sink_source_for_get_row_diff_batched(_repair_meta_id, _nr_peer_nodes,
+                    [&rs] (uint32_t repair_meta_id, std::optional<shard_id> dst_cpu_id_opt, locator::host_id addr) {
+                        auto dst_cpu_id = dst_cpu_id_opt.value_or(repair_unspecified_shard);
+                        rlogger.debug("get_row_diff_batched: repair_meta_id={} dst_cpu_id={}", repair_meta_id, dst_cpu_id);
+                        return rs.get_messaging().make_sink_and_source_for_repair_get_row_diff_with_rpc_stream_batched(repair_meta_id, dst_cpu_id, addr);
+                })
+            , _sink_source_for_put_row_diff_batched(_repair_meta_id, _nr_peer_nodes,
+                    [&rs] (uint32_t repair_meta_id, std::optional<shard_id> dst_cpu_id_opt, locator::host_id addr) {
+                        auto dst_cpu_id = dst_cpu_id_opt.value_or(repair_unspecified_shard);
+                        rlogger.debug("put_row_diff_batched: repair_meta_id={} dst_cpu_id={}", repair_meta_id, dst_cpu_id);
+                        return rs.get_messaging().make_sink_and_source_for_repair_put_row_diff_with_rpc_stream_batched(repair_meta_id, dst_cpu_id, addr);
                 })
             , _row_level_repair_ptr(row_level_repair_ptr)
             , _repair_hasher(_seed, _schema)
@@ -1028,9 +1167,12 @@ public:
         auto f1 = _sink_source_for_get_full_row_hashes.close();
         auto f2 = _sink_source_for_get_row_diff.close();
         auto f3 = _sink_source_for_put_row_diff.close();
+        auto f4 = _sink_source_for_get_full_row_hashes_batched.close();
+        auto f5 = _sink_source_for_get_row_diff_batched.close();
+        auto f6 = _sink_source_for_put_row_diff_batched.close();
         rlogger.debug("repair_meta::stop");
         // move to background.  waited on via _stopped->get_future.
-        when_all_succeed(std::move(gate_future), std::move(f1), std::move(f2), std::move(f3)).discard_result().finally([this] {
+        when_all_succeed(std::move(gate_future), std::move(f1), std::move(f2), std::move(f3), std::move(f4), std::move(f5), std::move(f6)).discard_result().finally([this] {
             return _repair_writer->wait_for_writer_done().finally([this] {
                 return close().then([this] {
                     return clear_gently();
@@ -1718,6 +1860,30 @@ private:
         throw std::runtime_error("get_full_row_hashes: Got unexpected end of stream");
     }
 
+    future<> get_full_row_hashes_source_op_batched(
+            lw_shared_ptr<repair_hash_set> current_hashes,
+            locator::host_id remote_node,
+            unsigned node_idx,
+            rpc::source<repair_hash_with_cmd_batch>& source) {
+        while (std::optional<std::tuple<repair_hash_with_cmd_batch>> hash_cmd_opt = co_await source()) {
+            repair_hash_with_cmd_batch hash_cmd = std::get<0>(hash_cmd_opt.value());
+            rlogger.trace("get_full_row_hashes: Got repair_hash_with_cmd_batch from peer={}, nr_hashes={}, cmd={}", remote_node, hash_cmd.hashes.size(), int(hash_cmd.cmd));
+            if (hash_cmd.cmd == repair_stream_cmd::hash_data_batch) {
+                for (const repair_hash& h : hash_cmd.hashes) {
+                    current_hashes->insert(h);
+                }
+            } else if (hash_cmd.cmd == repair_stream_cmd::end_of_current_hash_set) {
+                co_return;
+            } else if (hash_cmd.cmd == repair_stream_cmd::error) {
+                throw std::runtime_error("get_full_row_hashes: Peer failed to process");
+            } else {
+                throw std::runtime_error("get_full_row_hashes: Got unexpected repair_stream_cmd");
+            }
+        }
+        _sink_source_for_get_full_row_hashes_batched.mark_source_closed(node_idx);
+        throw std::runtime_error("get_full_row_hashes: Got unexpected end of stream");
+    }
+
     future<> get_full_row_hashes_sink_op(rpc::sink<repair_stream_cmd>& sink) {
         std::exception_ptr ep;
         try {
@@ -1739,11 +1905,19 @@ public:
             co_return co_await get_full_row_hashes_handler();
         }
         auto current_hashes = make_lw_shared<repair_hash_set>();
-        auto [sink, source] = co_await _sink_source_for_get_full_row_hashes.get_sink_source(remote_node, node_idx, dst_cpu_id);
-        co_await coroutine::all(
-            [&] { return get_full_row_hashes_source_op(current_hashes, remote_node, node_idx, source); },
-            [&] { return get_full_row_hashes_sink_op(sink); }
-        );
+        if (use_batched_stream()) {
+            auto [sink, source] = co_await _sink_source_for_get_full_row_hashes_batched.get_sink_source(remote_node, node_idx, dst_cpu_id);
+            co_await coroutine::all(
+                [&] { return get_full_row_hashes_source_op_batched(current_hashes, remote_node, node_idx, source); },
+                [&] { return get_full_row_hashes_sink_op(sink); }
+            );
+        } else {
+            auto [sink, source] = co_await _sink_source_for_get_full_row_hashes.get_sink_source(remote_node, node_idx, dst_cpu_id);
+            co_await coroutine::all(
+                [&] { return get_full_row_hashes_source_op(current_hashes, remote_node, node_idx, source); },
+                [&] { return get_full_row_hashes_sink_op(sink); }
+            );
+        }
         stats().rx_hashes_nr += current_hashes->size();
         _metrics.rx_hashes_nr += current_hashes->size();
         co_return std::move(*current_hashes);
@@ -1984,6 +2158,42 @@ private:
         }
     }
 
+    // Must run inside a seastar thread
+    void get_row_diff_source_op_batched(
+            update_peer_row_hash_sets update_hash_set,
+            locator::host_id remote_node,
+            unsigned node_idx,
+            rpc::sink<repair_hash_with_cmd_batch>& sink,
+            rpc::source<repair_row_on_wire_with_cmd_batch>& source) {
+        repair_rows_on_wire current_rows;
+        for (;;) {
+            std::optional<std::tuple<repair_row_on_wire_with_cmd_batch>> row_opt = source().get();
+            if (row_opt) {
+                if (inject_rpc_stream_error) {
+                    throw std::runtime_error("get_row_diff: Inject sender error in source loop");
+                }
+                auto row = std::move(std::get<0>(row_opt.value()));
+                if (row.cmd == repair_stream_cmd::row_data_batch) {
+                    rlogger.trace("get_row_diff: Got repair_row_on_wire_with_cmd_batch batch");
+                    for (auto& r : row.rows) {
+                        current_rows.push_back(std::move(r));
+                    }
+                } else if (row.cmd == repair_stream_cmd::end_of_current_rows) {
+                    rlogger.trace("get_row_diff: Got repair_row_on_wire_with_cmd_batch with nullopt");
+                    apply_rows_on_master_in_thread(std::move(current_rows), remote_node, update_working_row_buf::yes, update_hash_set, node_idx);
+                    break;
+                } else if (row.cmd == repair_stream_cmd::error) {
+                    throw std::runtime_error("get_row_diff: Peer failed to process");
+                } else {
+                    throw std::runtime_error("get_row_diff: Got unexpected repair_stream_cmd");
+                }
+            } else {
+                _sink_source_for_get_row_diff_batched.mark_source_closed(node_idx);
+                throw std::runtime_error("get_row_diff: Got unexpected end of stream");
+            }
+        }
+    }
+
     future<> get_row_diff_sink_op(
             repair_hash_set set_diff,
             needs_all_rows_t needs_all_rows,
@@ -2014,6 +2224,34 @@ private:
         }
     }
 
+    future<> get_row_diff_sink_op_batched(
+            repair_hash_set set_diff,
+            needs_all_rows_t needs_all_rows,
+            rpc::sink<repair_hash_with_cmd_batch>& sink,
+            locator::host_id remote_node) {
+        std::exception_ptr ep;
+        try {
+            if (inject_rpc_stream_error) {
+                throw std::runtime_error("get_row_diff: Inject sender error in sink loop");
+            }
+            if (needs_all_rows) {
+                rlogger.trace("get_row_diff: request with repair_stream_cmd::needs_all_rows");
+                co_await sink(repair_hash_with_cmd_batch{repair_stream_cmd::needs_all_rows, {}});
+                co_await sink.flush();
+                co_return;
+            }
+            co_await send_hashes_batched(sink, set_diff);
+            co_await sink(repair_hash_with_cmd_batch{repair_stream_cmd::end_of_current_hash_set, {}});
+            co_await sink.flush();
+        } catch (...) {
+            ep = std::current_exception();
+        }
+        if (ep) {
+            co_await sink.close();
+            std::rethrow_exception(ep);
+        }
+    }
+
 public:
     // Must run inside a seastar thread
     void get_row_diff_with_rpc_stream(
@@ -2034,12 +2272,21 @@ public:
                 _metrics.tx_hashes_nr += set_diff.size();
             }
             stats().rpc_call_nr++;
-            auto f = _sink_source_for_get_row_diff.get_sink_source(remote_node, node_idx, dst_cpu_id).get();
-            rpc::sink<repair_hash_with_cmd>& sink = std::get<0>(f);
-            rpc::source<repair_row_on_wire_with_cmd>& source = std::get<1>(f);
-            auto sink_op = get_row_diff_sink_op(std::move(set_diff), needs_all_rows, sink, remote_node);
-            get_row_diff_source_op(update_hash_set, remote_node, node_idx, sink, source);
-            sink_op.get();
+            if (use_batched_stream()) {
+                auto f = _sink_source_for_get_row_diff_batched.get_sink_source(remote_node, node_idx, dst_cpu_id).get();
+                rpc::sink<repair_hash_with_cmd_batch>& sink = std::get<0>(f);
+                rpc::source<repair_row_on_wire_with_cmd_batch>& source = std::get<1>(f);
+                auto sink_op = get_row_diff_sink_op_batched(std::move(set_diff), needs_all_rows, sink, remote_node);
+                get_row_diff_source_op_batched(update_hash_set, remote_node, node_idx, sink, source);
+                sink_op.get();
+            } else {
+                auto f = _sink_source_for_get_row_diff.get_sink_source(remote_node, node_idx, dst_cpu_id).get();
+                rpc::sink<repair_hash_with_cmd>& sink = std::get<0>(f);
+                rpc::source<repair_row_on_wire_with_cmd>& source = std::get<1>(f);
+                auto sink_op = get_row_diff_sink_op(std::move(set_diff), needs_all_rows, sink, remote_node);
+                get_row_diff_source_op(update_hash_set, remote_node, node_idx, sink, source);
+                sink_op.get();
+            }
         }
     }
 
@@ -2093,6 +2340,25 @@ private:
         throw std::runtime_error("put_row_diff: Got unexpected end of stream");
     }
 
+    future<> put_row_diff_source_op_batched(
+            locator::host_id remote_node,
+            unsigned node_idx,
+            rpc::source<repair_stream_cmd>& source) {
+        while (std::optional<std::tuple<repair_stream_cmd>> status_opt = co_await source()) {
+            repair_stream_cmd status = std::move(std::get<0>(status_opt.value()));
+            rlogger.trace("put_row_diff: Got status code from follower={} for put_row_diff, status={}", remote_node, int(status));
+            if (status == repair_stream_cmd::put_rows_done) {
+                co_return;
+            } else if (status == repair_stream_cmd::error) {
+                throw std::runtime_error(format("put_row_diff: Repair follower={} failed in put_row_diff handler, status={}", remote_node, int(status)));
+            } else {
+                throw std::runtime_error("put_row_diff: Got unexpected repair_stream_cmd");
+            }
+        }
+        _sink_source_for_put_row_diff_batched.mark_source_closed(node_idx);
+        throw std::runtime_error("put_row_diff: Got unexpected end of stream");
+    }
+
     future<> put_row_diff_sink_op(
             repair_rows_on_wire rows,
             rpc::sink<repair_row_on_wire_with_cmd>& sink,
@@ -2105,6 +2371,27 @@ private:
             }
             rlogger.trace("put_row_diff: send empty row");
             co_await sink(repair_row_on_wire_with_cmd{repair_stream_cmd::end_of_current_rows, repair_row_on_wire()});
+            rlogger.trace("put_row_diff: send done");
+            co_await sink.flush();
+        } catch (...) {
+            ep = std::current_exception();
+        }
+        if (ep) {
+            co_await sink.close();
+            std::rethrow_exception(ep);
+        }
+    }
+
+    future<> put_row_diff_sink_op_batched(
+            repair_rows_on_wire rows,
+            rpc::sink<repair_row_on_wire_with_cmd_batch>& sink,
+            locator::host_id remote_node) {
+        std::exception_ptr ep;
+        try {
+            rlogger.trace("put_row_diff: send row batches");
+            co_await send_rows_batched(sink, rows);
+            rlogger.trace("put_row_diff: send empty row");
+            co_await sink(repair_row_on_wire_with_cmd_batch{repair_stream_cmd::end_of_current_rows, {}});
             rlogger.trace("put_row_diff: send done");
             co_await sink.flush();
         } catch (...) {
@@ -2166,14 +2453,25 @@ public:
 
         repair_rows_on_wire rows = co_await to_repair_rows_on_wire(std::move(row_diff));
 
-        auto [sink, source] = co_await _sink_source_for_put_row_diff.get_sink_source(remote_node, node_idx, dst_cpu_id);
-        auto source_op = [&] () mutable -> future<> {
-            co_await put_row_diff_source_op(remote_node, node_idx, source);
-        };
-        auto sink_op = [&] () mutable -> future<> {
-            co_await put_row_diff_sink_op(std::move(rows), sink, remote_node);
-        };
-        co_await coroutine::all(source_op, sink_op);
+        if (use_batched_stream()) {
+            auto [sink, source] = co_await _sink_source_for_put_row_diff_batched.get_sink_source(remote_node, node_idx, dst_cpu_id);
+            auto source_op = [&] () mutable -> future<> {
+                co_await put_row_diff_source_op_batched(remote_node, node_idx, source);
+            };
+            auto sink_op = [&] () mutable -> future<> {
+                co_await put_row_diff_sink_op_batched(std::move(rows), sink, remote_node);
+            };
+            co_await coroutine::all(source_op, sink_op);
+        } else {
+            auto [sink, source] = co_await _sink_source_for_put_row_diff.get_sink_source(remote_node, node_idx, dst_cpu_id);
+            auto source_op = [&] () mutable -> future<> {
+                co_await put_row_diff_source_op(remote_node, node_idx, source);
+            };
+            auto sink_op = [&] () mutable -> future<> {
+                co_await put_row_diff_sink_op(std::move(rows), sink, remote_node);
+            };
+            co_await coroutine::all(source_op, sink_op);
+        }
     }
 
     // RPC handler
@@ -2378,7 +2676,87 @@ static future<> repair_get_row_diff_with_rpc_stream_process_op_slow_path(
         bool needs_all_rows = hash_cmd.cmd == repair_stream_cmd::needs_all_rows;
         _metrics.rx_hashes_nr += current_set_diff.size();
         auto fp = make_foreign(std::make_unique<repair_hash_set>(std::move(current_set_diff)));
-        repair_rows_on_wire rows_on_wire  = co_await repair.invoke_on(dst_cpu_id, [&] (repair_service& local_repair) -> future<repair_rows_on_wire> {
+        repair_rows_on_wire rows_on_wire = co_await repair.invoke_on(dst_cpu_id, [&] (repair_service& local_repair) -> future<repair_rows_on_wire> {
+            auto rm = local_repair.get_repair_meta(from, repair_meta_id);
+            rm->set_repair_state_for_local_node(repair_state::get_row_diff_with_rpc_stream_started);
+            if (fp.get_owner_shard() == this_shard_id()) {
+                repair_rows_on_wire rows = co_await rm->get_row_diff_handler(std::move(*fp), repair_meta::needs_all_rows_t(needs_all_rows));
+                rm->set_repair_state_for_local_node(repair_state::get_row_diff_with_rpc_stream_finished);
+                co_return rows;
+            } else {
+                repair_rows_on_wire rows = co_await rm->get_row_diff_handler(*fp, repair_meta::needs_all_rows_t(needs_all_rows));
+                rm->set_repair_state_for_local_node(repair_state::get_row_diff_with_rpc_stream_finished);
+                co_return rows;
+            }
+        });
+        for (repair_row_on_wire& row : rows_on_wire) {
+            auto cmd = repair_row_on_wire_with_cmd{repair_stream_cmd::row_data, std::move(row)};
+            co_await sink(cmd);
+            co_await cmd.row.clear_gently();
+        }
+        co_await sink(repair_row_on_wire_with_cmd{repair_stream_cmd::end_of_current_rows, repair_row_on_wire()});
+        co_await sink.flush();
+        co_return;
+    } else {
+        throw std::runtime_error("Got unexpected repair_stream_cmd");
+    }
+}
+
+static future<> repair_get_row_diff_with_rpc_stream_process_op_slow_path_batched(
+        sharded<repair_service>& repair,
+        locator::host_id from,
+        uint32_t src_cpu_id,
+        uint32_t dst_cpu_id,
+        uint32_t repair_meta_id,
+        rpc::sink<repair_row_on_wire_with_cmd_batch> sink,
+        rpc::source<repair_hash_with_cmd_batch> source,
+        bool &error,
+        repair_hash_set& current_set_diff,
+        std::optional<std::tuple<repair_hash_with_cmd_batch>> hash_cmd_opt);
+
+static future<> repair_get_row_diff_with_rpc_stream_process_op_batched(
+        sharded<repair_service>& repair,
+        locator::host_id from,
+        uint32_t src_cpu_id,
+        uint32_t dst_cpu_id,
+        uint32_t repair_meta_id,
+        rpc::sink<repair_row_on_wire_with_cmd_batch> sink,
+        rpc::source<repair_hash_with_cmd_batch> source,
+        bool &error,
+        repair_hash_set& current_set_diff,
+        std::optional<std::tuple<repair_hash_with_cmd_batch>> hash_cmd_opt) {
+    repair_hash_with_cmd_batch hash_cmd = std::get<0>(hash_cmd_opt.value());
+    rlogger.trace("Got repair_hash_with_cmd_batch from peer={}, nr_hashes={}, cmd={}", from, hash_cmd.hashes.size(), int(hash_cmd.cmd));
+    if (hash_cmd.cmd == repair_stream_cmd::hash_data_batch) {
+        for (const repair_hash& h : hash_cmd.hashes) {
+            current_set_diff.insert(h);
+        }
+        return make_ready_future<>();
+    } else {
+        return repair_get_row_diff_with_rpc_stream_process_op_slow_path_batched(repair, from, src_cpu_id, dst_cpu_id, repair_meta_id, std::move(sink), std::move(source), error, current_set_diff, std::move(hash_cmd_opt));
+    }
+}
+
+static future<> repair_get_row_diff_with_rpc_stream_process_op_slow_path_batched(
+        sharded<repair_service>& repair,
+        locator::host_id from,
+        uint32_t src_cpu_id,
+        uint32_t dst_cpu_id,
+        uint32_t repair_meta_id,
+        rpc::sink<repair_row_on_wire_with_cmd_batch> sink,
+        rpc::source<repair_hash_with_cmd_batch> source,
+        bool &error,
+        repair_hash_set& current_set_diff,
+        std::optional<std::tuple<repair_hash_with_cmd_batch>> hash_cmd_opt) {
+    repair_hash_with_cmd_batch hash_cmd = std::get<0>(hash_cmd_opt.value());
+    if (hash_cmd.cmd == repair_stream_cmd::end_of_current_hash_set || hash_cmd.cmd == repair_stream_cmd::needs_all_rows) {
+        if (inject_rpc_stream_error) {
+            throw std::runtime_error("get_row_diff_with_rpc_stream: Inject error in handler loop");
+        }
+        bool needs_all_rows = hash_cmd.cmd == repair_stream_cmd::needs_all_rows;
+        _metrics.rx_hashes_nr += current_set_diff.size();
+        auto fp = make_foreign(std::make_unique<repair_hash_set>(std::move(current_set_diff)));
+        repair_rows_on_wire rows_on_wire = co_await repair.invoke_on(dst_cpu_id, [&] (repair_service& local_repair) -> future<repair_rows_on_wire> {
             auto rm = local_repair.get_repair_meta(from, repair_meta_id);
             rm->set_repair_state_for_local_node(repair_state::get_row_diff_with_rpc_stream_started);
             if (fp.get_owner_shard() == this_shard_id()) {
@@ -2392,14 +2770,10 @@ static future<> repair_get_row_diff_with_rpc_stream_process_op_slow_path(
             }
         });
         if (rows_on_wire.empty()) {
-            co_await sink(repair_row_on_wire_with_cmd{repair_stream_cmd::end_of_current_rows, repair_row_on_wire()});
+            co_await sink(repair_row_on_wire_with_cmd_batch{repair_stream_cmd::end_of_current_rows, {}});
         } else {
-            for (repair_row_on_wire& row : rows_on_wire) {
-                auto cmd = repair_row_on_wire_with_cmd{repair_stream_cmd::row_data, std::move(row)};
-                co_await sink(cmd);
-                co_await cmd.row.clear_gently();
-            }
-            co_await sink(repair_row_on_wire_with_cmd{repair_stream_cmd::end_of_current_rows, repair_row_on_wire()});
+            co_await send_rows_batched(sink, rows_on_wire);
+            co_await sink(repair_row_on_wire_with_cmd_batch{repair_stream_cmd::end_of_current_rows, {}});
         }
         co_await sink.flush();
         co_return;
@@ -2457,6 +2831,48 @@ static future<> repair_put_row_diff_with_rpc_stream_process_op(
     }
 }
 
+static future<> repair_put_row_diff_with_rpc_stream_process_op_batched(
+        sharded<repair_service>& repair,
+        locator::host_id from,
+        uint32_t src_cpu_id,
+        uint32_t dst_cpu_id,
+        uint32_t repair_meta_id,
+        rpc::sink<repair_stream_cmd> sink,
+        rpc::source<repair_row_on_wire_with_cmd_batch> source,
+        bool& error,
+        repair_rows_on_wire& current_rows,
+        std::optional<std::tuple<repair_row_on_wire_with_cmd_batch>> row_opt) {
+    auto row = std::move(std::get<0>(row_opt.value()));
+    if (row.cmd == repair_stream_cmd::row_data_batch) {
+        rlogger.trace("Got repair_rows_on_wire from peer={}, got row_data_batch", from);
+        for (auto& r : row.rows) {
+            current_rows.push_back(std::move(r));
+        }
+        co_return;
+    } else if (row.cmd == repair_stream_cmd::end_of_current_rows) {
+        rlogger.trace("Got repair_rows_on_wire from peer={}, got end_of_current_rows", from);
+        auto fp = make_foreign(std::make_unique<repair_rows_on_wire>(std::move(current_rows)));
+        co_await repair.invoke_on(dst_cpu_id, [from, repair_meta_id, fp = std::move(fp)] (repair_service& local_repair) mutable -> future<> {
+            auto rm = local_repair.get_repair_meta(from, repair_meta_id);
+            rm->set_repair_state_for_local_node(repair_state::put_row_diff_with_rpc_stream_started);
+            if (fp.get_owner_shard() == this_shard_id()) {
+                co_await rm->put_row_diff_handler(std::move(*fp));
+                rm->set_repair_state_for_local_node(repair_state::put_row_diff_with_rpc_stream_finished);
+            } else {
+                // Gently clone to avoid copy stall on destination shard
+                repair_rows_on_wire local_rows = co_await clone_gently(*fp);
+                co_await seastar::when_all_succeed(rm->put_row_diff_handler(std::move(local_rows)), utils::clear_gently(fp));
+                rm->set_repair_state_for_local_node(repair_state::put_row_diff_with_rpc_stream_finished);
+            }
+        });
+        co_await sink(repair_stream_cmd::put_rows_done);
+        co_await sink.flush();
+        co_return;
+    } else {
+        throw std::runtime_error("Got unexpected repair_stream_cmd");
+    }
+}
+
 static future<stop_iteration> repair_get_full_row_hashes_with_rpc_stream_process_op(
         sharded<repair_service>& repair,
         locator::host_id from,
@@ -2482,6 +2898,36 @@ static future<stop_iteration> repair_get_full_row_hashes_with_rpc_stream_process
             co_await sink(repair_hash_with_cmd{repair_stream_cmd::hash_data, hash});
         }
         co_await sink(repair_hash_with_cmd{repair_stream_cmd::end_of_current_hash_set, repair_hash()});
+        co_await sink.flush();
+        co_return stop_iteration::no;
+    } else {
+        throw std::runtime_error("Got unexpected repair_stream_cmd");
+    }
+}
+
+static future<stop_iteration> repair_get_full_row_hashes_with_rpc_stream_process_op_batched(
+        sharded<repair_service>& repair,
+        locator::host_id from,
+        uint32_t src_cpu_id,
+        uint32_t dst_cpu_id,
+        uint32_t repair_meta_id,
+        rpc::sink<repair_hash_with_cmd_batch> sink,
+        rpc::source<repair_stream_cmd> source,
+        bool &error,
+        std::optional<std::tuple<repair_stream_cmd>> status_opt) {
+    repair_stream_cmd status = std::get<0>(status_opt.value());
+    rlogger.trace("Got register_repair_get_full_row_hashes_with_rpc_stream_batched from peer={}, status={}", from, int(status));
+    if (status == repair_stream_cmd::get_full_row_hashes) {
+        repair_hash_set hashes = co_await repair.invoke_on(dst_cpu_id, [from, repair_meta_id] (repair_service& local_repair) -> future<repair_hash_set> {
+            auto rm = local_repair.get_repair_meta(from, repair_meta_id);
+            rm->set_repair_state_for_local_node(repair_state::get_full_row_hashes_started);
+            repair_hash_set hashes = co_await rm->get_full_row_hashes_handler();
+            rm->set_repair_state_for_local_node(repair_state::get_full_row_hashes_started);
+            _metrics.tx_hashes_nr += hashes.size();
+            co_return hashes;
+        });
+        co_await send_hashes_batched(sink, hashes);
+        co_await sink(repair_hash_with_cmd_batch{repair_stream_cmd::end_of_current_hash_set, {}});
         co_await sink.flush();
         co_return stop_iteration::no;
     } else {
@@ -2614,6 +3060,142 @@ static future<> repair_get_full_row_hashes_with_rpc_stream_handler(
             }
             if (ep) {
                 co_await sink(repair_hash_with_cmd{repair_stream_cmd::error, repair_hash()});
+            }
+        }
+    } catch (...) {
+        outer_exception = std::current_exception();
+    }
+    co_await sink.close();
+    if (outer_exception) {
+        std::rethrow_exception(outer_exception);
+    }
+}
+
+static future<> repair_get_row_diff_with_rpc_stream_handler_batched(
+        sharded<repair_service>& repair,
+        locator::host_id from,
+        uint32_t src_cpu_id,
+        uint32_t dst_cpu_id,
+        uint32_t repair_meta_id,
+        rpc::sink<repair_row_on_wire_with_cmd_batch> sink,
+        rpc::source<repair_hash_with_cmd_batch> source) {
+    bool error = false;
+    repair_hash_set current_set_diff = repair_hash_set();
+    std::exception_ptr outer_exception;
+    try {
+        while (std::optional<std::tuple<repair_hash_with_cmd_batch>> hash_cmd_opt = co_await source()) {
+            std::exception_ptr ep;
+            try {
+                if (error) {
+                    continue;
+                }
+                co_await repair_get_row_diff_with_rpc_stream_process_op_batched(repair, from,
+                        src_cpu_id,
+                        dst_cpu_id,
+                        repair_meta_id,
+                        sink,
+                        source,
+                        error,
+                        current_set_diff,
+                        std::move(hash_cmd_opt));
+            } catch (...) {
+                    ep = std::current_exception();
+                    rlogger.warn("repair_get_row_diff_with_rpc_stream_handler_batched: from={} repair_meta_id={} error={}", from, repair_meta_id, ep);
+                    error = true;
+            }
+            if (ep) {
+                co_await sink(repair_row_on_wire_with_cmd_batch{repair_stream_cmd::error, {}});
+            }
+        }
+    } catch (...) {
+        outer_exception = std::current_exception();
+    }
+    co_await sink.close();
+    if (outer_exception) {
+        std::rethrow_exception(outer_exception);
+    }
+}
+
+static future<> repair_put_row_diff_with_rpc_stream_handler_batched(
+        sharded<repair_service>& repair,
+        locator::host_id from,
+        uint32_t src_cpu_id,
+        uint32_t dst_cpu_id,
+        uint32_t repair_meta_id,
+        rpc::sink<repair_stream_cmd> sink,
+        rpc::source<repair_row_on_wire_with_cmd_batch> source) {
+    std::exception_ptr outer_exception;
+    bool error = false;
+    repair_rows_on_wire current_rows = repair_rows_on_wire();
+    try {
+        while (std::optional<std::tuple<repair_row_on_wire_with_cmd_batch>> row_opt = co_await source()) {
+            std::exception_ptr ep;
+            try {
+                if (error) {
+                    continue;
+                }
+                co_await repair_put_row_diff_with_rpc_stream_process_op_batched(repair, from,
+                        src_cpu_id,
+                        dst_cpu_id,
+                        repair_meta_id,
+                        sink,
+                        source,
+                        error,
+                        current_rows,
+                        std::move(row_opt));
+            } catch (...) {
+                ep = std::current_exception();
+                rlogger.warn("repair_put_row_diff_with_rpc_stream_handler_batched: from={} repair_meta_id={} error={}", from, repair_meta_id, ep);
+                error = true;
+            }
+            if (ep) {
+                co_await sink(repair_stream_cmd::error);
+            }
+        }
+    } catch (...) {
+        outer_exception = std::current_exception();
+    }
+    co_await sink.close();
+    if (outer_exception) {
+        std::rethrow_exception(outer_exception);
+    }
+}
+
+static future<> repair_get_full_row_hashes_with_rpc_stream_handler_batched(
+        sharded<repair_service>& repair,
+        locator::host_id from,
+        uint32_t src_cpu_id,
+        uint32_t dst_cpu_id,
+        uint32_t repair_meta_id,
+        rpc::sink<repair_hash_with_cmd_batch> sink,
+        rpc::source<repair_stream_cmd> source) {
+    std::exception_ptr outer_exception;
+    try {
+        while (std::optional<std::tuple<repair_stream_cmd>> status_opt = co_await source()) {
+            bool error = false;
+            std::exception_ptr ep;
+            try {
+                if (error) {
+                    continue;
+                }
+                auto stop = co_await repair_get_full_row_hashes_with_rpc_stream_process_op_batched(repair, from,
+                        src_cpu_id,
+                        dst_cpu_id,
+                        repair_meta_id,
+                        sink,
+                        source,
+                        error,
+                        std::move(status_opt));
+                if (stop) {
+                    break;
+                }
+            } catch (...) {
+                ep = std::current_exception();
+                rlogger.warn("repair_get_full_row_hashes_with_rpc_stream_handler_batched: from={} repair_meta_id={} error={}", from, repair_meta_id, ep);
+                error = true;
+            }
+            if (ep) {
+                co_await sink(repair_hash_with_cmd_batch{repair_stream_cmd::error, {}});
             }
         }
     } catch (...) {
@@ -2786,6 +3368,42 @@ future<> repair_service::init_ms_handlers() {
             rlogger.warn("Failed to process get_full_row_hashes_with_rpc_stream_handler from={}, repair_meta_id={}: {}", from, repair_meta_id, ep);
         });
         return make_ready_future<rpc::sink<repair_hash_with_cmd>>(sink);
+    });
+    ms.register_repair_get_row_diff_with_rpc_stream_batched([this, &ms] (const rpc::client_info& cinfo, uint64_t repair_meta_id, rpc::source<repair_hash_with_cmd_batch> source, rpc::optional<shard_id> dst_cpu_id_opt) {
+        auto src_cpu_id = cinfo.retrieve_auxiliary<uint32_t>("src_cpu_id");
+        auto from = cinfo.retrieve_auxiliary<locator::host_id>("host_id");
+        auto sink = ms.make_sink_for_repair_get_row_diff_with_rpc_stream_batched(source);
+        // Start a new fiber.
+        auto shard = get_dst_shard_id(src_cpu_id, dst_cpu_id_opt);
+        (void)repair_get_row_diff_with_rpc_stream_handler_batched(container(), from, src_cpu_id, shard, repair_meta_id, sink, source).handle_exception(
+                [from, repair_meta_id, sink, source] (std::exception_ptr ep) {
+            rlogger.warn("Failed to process get_row_diff_with_rpc_stream_handler_batched from={}, repair_meta_id={}: {}", from, repair_meta_id, ep);
+        });
+        return make_ready_future<rpc::sink<repair_row_on_wire_with_cmd_batch>>(sink);
+    });
+    ms.register_repair_put_row_diff_with_rpc_stream_batched([this, &ms] (const rpc::client_info& cinfo, uint64_t repair_meta_id, rpc::source<repair_row_on_wire_with_cmd_batch> source, rpc::optional<shard_id> dst_cpu_id_opt) {
+        auto src_cpu_id = cinfo.retrieve_auxiliary<uint32_t>("src_cpu_id");
+        auto from = cinfo.retrieve_auxiliary<locator::host_id>("host_id");
+        auto sink = ms.make_sink_for_repair_put_row_diff_with_rpc_stream_batched(source);
+        // Start a new fiber.
+        auto shard = get_dst_shard_id(src_cpu_id, dst_cpu_id_opt);
+        (void)repair_put_row_diff_with_rpc_stream_handler_batched(container(), from, src_cpu_id, shard, repair_meta_id, sink, source).handle_exception(
+                [from, repair_meta_id, sink, source] (std::exception_ptr ep) {
+            rlogger.warn("Failed to process put_row_diff_with_rpc_stream_handler_batched from={}, repair_meta_id={}: {}", from, repair_meta_id, ep);
+        });
+        return make_ready_future<rpc::sink<repair_stream_cmd>>(sink);
+    });
+    ms.register_repair_get_full_row_hashes_with_rpc_stream_batched([this, &ms] (const rpc::client_info& cinfo, uint64_t repair_meta_id, rpc::source<repair_stream_cmd> source, rpc::optional<shard_id> dst_cpu_id_opt) {
+        auto src_cpu_id = cinfo.retrieve_auxiliary<uint32_t>("src_cpu_id");
+        auto from = cinfo.retrieve_auxiliary<locator::host_id>("host_id");
+        auto sink = ms.make_sink_for_repair_get_full_row_hashes_with_rpc_stream_batched(source);
+        // Start a new fiber.
+        auto shard = get_dst_shard_id(src_cpu_id, dst_cpu_id_opt);
+        (void)repair_get_full_row_hashes_with_rpc_stream_handler_batched(container(), from, src_cpu_id, shard, repair_meta_id, sink, source).handle_exception(
+                [from, repair_meta_id, sink, source] (std::exception_ptr ep) {
+            rlogger.warn("Failed to process get_full_row_hashes_with_rpc_stream_handler_batched from={}, repair_meta_id={}: {}", from, repair_meta_id, ep);
+        });
+        return make_ready_future<rpc::sink<repair_hash_with_cmd_batch>>(sink);
     });
     ser::repair_rpc_verbs::register_repair_get_full_row_hashes(&ms, [this] (const rpc::client_info& cinfo, uint32_t repair_meta_id, rpc::optional<shard_id> dst_cpu_id_opt) {
         auto src_cpu_id = cinfo.retrieve_auxiliary<uint32_t>("src_cpu_id");
@@ -2981,6 +3599,9 @@ future<> repair_service::uninit_ms_handlers() {
         ms.unregister_repair_get_row_diff_with_rpc_stream(),
         ms.unregister_repair_put_row_diff_with_rpc_stream(),
         ms.unregister_repair_get_full_row_hashes_with_rpc_stream(),
+        ms.unregister_repair_get_row_diff_with_rpc_stream_batched(),
+        ms.unregister_repair_put_row_diff_with_rpc_stream_batched(),
+        ms.unregister_repair_get_full_row_hashes_with_rpc_stream_batched(),
         ser::repair_rpc_verbs::unregister(&ms)
         ).discard_result();
 }
@@ -3438,9 +4059,9 @@ public:
         return seastar::async([this] {
             _shard_task.check_in_abort_or_shutdown();
             auto repair_meta_id = _shard_task.rs.get_next_repair_meta_id().get();
-            auto algorithm = get_common_diff_detect_algorithm(_shard_task.messaging.local(), _all_live_peer_nodes);
-            auto max_row_buf_size = get_max_row_buf_size(algorithm);
             auto& cf = _shard_task.db.local().find_column_family(_table_id);
+            auto algorithm = get_common_diff_detect_algorithm(_shard_task.messaging.local(), _all_live_peer_nodes, cf.uses_tablets());
+            auto max_row_buf_size = get_max_row_buf_size(algorithm);
             auto& sharder = cf.get_effective_replication_map()->get_sharder(*(cf.schema()));
             auto master_node_shard_config = shard_config {
                     this_shard_id(),

--- a/repair/row_level.cc
+++ b/repair/row_level.cc
@@ -283,8 +283,8 @@ future<std::vector<std::list<repair_row_on_wire>>> batch_rows_for_wire(repair_ro
     std::vector<std::list<repair_row_on_wire>> batches;
     std::list<repair_row_on_wire> batch;
     size_t batch_bytes = 0;
-    for (repair_row_on_wire& row : rows) {
-        size_t row_bytes = estimated_wire_size(row);
+    while (!rows.empty()) {
+        size_t row_bytes = estimated_wire_size(rows.front());
         // Flush before adding, not after, so a batch never grows past the caps - except a
         // single row already over row_batch_max_bytes on its own, which still gets sent.
         if (!batch.empty() && (batch.size() >= row_batch_max_count || batch_bytes + row_bytes > row_batch_max_bytes)) {
@@ -293,7 +293,8 @@ future<std::vector<std::list<repair_row_on_wire>>> batch_rows_for_wire(repair_ro
             batch_bytes = 0;
         }
         batch_bytes += row_bytes;
-        batch.push_back(std::move(row));
+        // splice: transfers the list node, no allocation and no moved-from husk left in rows.
+        batch.splice(batch.end(), rows, rows.begin());
         co_await coroutine::maybe_yield();
     }
     if (!batch.empty()) {
@@ -2175,9 +2176,7 @@ private:
                 auto row = std::move(std::get<0>(row_opt.value()));
                 if (row.cmd == repair_stream_cmd::row_data_batch) {
                     rlogger.trace("get_row_diff: Got repair_row_on_wire_with_cmd_batch batch");
-                    for (auto& r : row.rows) {
-                        current_rows.push_back(std::move(r));
-                    }
+                    current_rows.splice(current_rows.end(), row.rows);
                 } else if (row.cmd == repair_stream_cmd::end_of_current_rows) {
                     rlogger.trace("get_row_diff: Got repair_row_on_wire_with_cmd_batch with nullopt");
                     apply_rows_on_master_in_thread(std::move(current_rows), remote_node, update_working_row_buf::yes, update_hash_set, node_idx);
@@ -2845,9 +2844,7 @@ static future<> repair_put_row_diff_with_rpc_stream_process_op_batched(
     auto row = std::move(std::get<0>(row_opt.value()));
     if (row.cmd == repair_stream_cmd::row_data_batch) {
         rlogger.trace("Got repair_rows_on_wire from peer={}, got row_data_batch", from);
-        for (auto& r : row.rows) {
-            current_rows.push_back(std::move(r));
-        }
+        current_rows.splice(current_rows.end(), row.rows);
         co_return;
     } else if (row.cmd == repair_stream_cmd::end_of_current_rows) {
         rlogger.trace("Got repair_rows_on_wire from peer={}, got end_of_current_rows", from);

--- a/repair/row_level.hh
+++ b/repair/row_level.hh
@@ -360,6 +360,24 @@ future<std::list<repair_row>> to_repair_rows_list(repair_rows_on_wire rows,
         reader_permit permit, repair_hasher hasher);
 void flush_rows(schema_ptr s, std::list<repair_row>& rows, lw_shared_ptr<repair_writer>& writer, std::optional<small_table_optimization_params> small_table_optimization = std::nullopt, repair_meta* rm = nullptr);
 
+// Batch-size targets for send_full_set_rpc_stream_batched, ~8KiB/frame. Exposed here
+// (not as .cc-local statics) so unit tests reference the real values, not magic numbers.
+inline constexpr size_t hash_batch_max_count = 1024;   // 1024 * 8B hashes ~= 8KiB
+inline constexpr size_t row_batch_max_count = 32;      // rows vary in size; rough approximation
+// Secondary byte cap so large/wide rows can't balloon a batch past row_batch_max_count's
+// ~8KiB intent; matches the hash batch target.
+inline constexpr size_t row_batch_max_bytes = 8 * 1024;
+
+// Pure batch-grouping helpers behind send_hashes_batched/send_rows_batched (row_level.cc),
+// exposed for unit testing. repair_row_on_wire is declared in repair.hh (included above).
+future<std::vector<std::vector<repair_hash>>> batch_hashes_for_wire(const repair_hash_set& hashes);
+future<std::vector<std::list<repair_row_on_wire>>> batch_rows_for_wire(repair_rows_on_wire& rows);
+
+// Pure diff-detect-algorithm selection logic, exposed for unit testing (see
+// get_common_diff_detect_algorithm in row_level.cc for the RPC-fetching wrapper).
+row_level_diff_detect_algorithm select_diff_detect_algorithm(
+        std::vector<std::vector<row_level_diff_detect_algorithm>> nodes_algorithms, bool allow_batched);
+
 // A struct to hold the first and last token of a tablet.
 struct tablet_token_range {
     int64_t first_token;

--- a/sstables/mx/writer.cc
+++ b/sstables/mx/writer.cc
@@ -837,11 +837,10 @@ private:
 public:
 
     writer(sstable& sst, const schema& s, uint64_t estimated_partitions,
-        const sstable_writer_config& cfg, encoding_stats enc_stats,
-        shard_id shard = this_shard_id())
+        const sstable_writer_config& cfg, encoding_stats enc_stats)
         : sstable_writer::writer_impl(sst, s, cfg)
         , _enc_stats(enc_stats)
-        , _shard(shard)
+        , _shard(cfg.shard)
         , _tmp_bufs(_sst.sstable_buffer_size)
         , _sst_schema(make_sstable_schema(s, _enc_stats, _cfg))
         , _run_identifier(cfg.run_identifier)
@@ -893,7 +892,7 @@ public:
         _compression_enabled = !_sst.has_component(component_type::CRC);
         _delayed_filter = _sst.has_component(component_type::Filter) && !_sst.has_component(component_type::Index);
         init_file_writers();
-        _sst._shards = { shard };
+        _sst._shards = { _shard };
 
         _cfg.monitor->on_write_started(_data_writer->offset_tracker());
         if (!_delayed_filter) {
@@ -1894,9 +1893,8 @@ std::unique_ptr<sstable_writer::writer_impl> make_writer(sstable& sst,
         const schema& s,
         uint64_t estimated_partitions,
         const sstable_writer_config& cfg,
-        encoding_stats enc_stats,
-        shard_id shard) {
-    return std::make_unique<writer>(sst, s, estimated_partitions, cfg, enc_stats, shard);
+        encoding_stats enc_stats) {
+    return std::make_unique<writer>(sst, s, estimated_partitions, cfg, enc_stats);
 }
 
 }

--- a/sstables/mx/writer.hh
+++ b/sstables/mx/writer.hh
@@ -19,8 +19,7 @@ std::unique_ptr<sstable_writer::writer_impl> make_writer(sstable& sst,
     const schema& s,
     uint64_t estimated_partitions,
     const sstable_writer_config& cfg,
-    encoding_stats enc_stats,
-    shard_id shard);
+    encoding_stats enc_stats);
 
 }
 }

--- a/sstables/sstable_writer.hh
+++ b/sstables/sstable_writer.hh
@@ -28,8 +28,7 @@ private:
     std::unique_ptr<writer_impl> _impl;
 public:
     sstable_writer(sstable& sst, const schema& s, uint64_t estimated_partitions,
-            const sstable_writer_config&, encoding_stats enc_stats,
-            shard_id shard = this_shard_id());
+            const sstable_writer_config&, encoding_stats enc_stats);
 
     sstable_writer(sstable_writer&& o);
     sstable_writer& operator=(sstable_writer&& o);

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -2660,11 +2660,11 @@ future<> sstable::seal_sstable(bool backup)
 }
 
 sstable_writer sstable::get_writer(const schema& s, uint64_t estimated_partitions,
-        const sstable_writer_config& cfg, encoding_stats enc_stats, shard_id shard)
+        const sstable_writer_config& cfg, encoding_stats enc_stats)
 {
     // Mark sstable for implicit deletion if destructed before it is sealed.
     _marked_for_deletion = mark_for_deletion::implicit;
-    return sstable_writer(*this, s, estimated_partitions, cfg, enc_stats, shard);
+    return sstable_writer(*this, s, estimated_partitions, cfg, enc_stats);
 }
 
 future<uint64_t> sstable::validate(reader_permit permit, abort_source& abort,

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -127,6 +127,7 @@ struct sstable_writer_config {
     sstring origin;
     bool correct_pi_block_width = true;
     uint32_t large_data_records_per_sstable = 10;
+    shard_id shard = this_shard_id();
 
 private:
     explicit sstable_writer_config() {}
@@ -334,8 +335,7 @@ public:
     sstable_writer get_writer(const schema& s,
         uint64_t estimated_partitions,
         const sstable_writer_config&,
-        encoding_stats enc_stats,
-        shard_id shard = this_shard_id());
+        encoding_stats enc_stats);
 
     // Validates the content of the sstable and component digests.
     // Reports all errors via the provided error handler.

--- a/sstables/writer.cc
+++ b/sstables/writer.cc
@@ -14,11 +14,11 @@
 namespace sstables {
 
 sstable_writer::sstable_writer(sstable& sst, const schema& s, uint64_t estimated_partitions,
-        const sstable_writer_config& cfg, encoding_stats enc_stats, shard_id shard) {
+        const sstable_writer_config& cfg, encoding_stats enc_stats) {
     if (sst.get_version() < oldest_writable_sstable_format) {
         on_internal_error(sstlog, format("writing sstables with too old format: {}", static_cast<int>(sst.get_version())));
     }
-    _impl = mc::make_writer(sst, s, estimated_partitions, cfg, enc_stats, shard);
+    _impl = mc::make_writer(sst, s, estimated_partitions, cfg, enc_stats);
     if (cfg.replay_position) {
         _impl->_collector.set_replay_position(cfg.replay_position.value());
     }

--- a/test/boost/repair_test.cc
+++ b/test/boost/repair_test.cc
@@ -8,6 +8,7 @@
 
 #include "replica/memtable.hh"
 #include "readers/from_fragments.hh"
+#include "bytes_ostream.hh"
 #include "repair/hash.hh"
 #include "repair/row.hh"
 #include "repair/writer.hh"
@@ -406,6 +407,272 @@ SEASTAR_TEST_CASE(test_tablet_token_range_count) {
         BOOST_REQUIRE(co_await count_finished_tablets(r1, r2_empty) == 0);
         BOOST_REQUIRE(co_await count_finished_tablets(r1_empty, r2) == 0);
     }
+}
+
+// --- send_full_set_rpc_stream_batched wire-batching coverage ---
+//
+// batch_hashes_for_wire/batch_rows_for_wire are pure grouping functions (no rpc::sink,
+// no I/O) extracted specifically so these boundary conditions can be pinned down exactly,
+// which a full-cluster functional test cannot easily force (e.g. "exactly hash_batch_max_count
+// hashes", "a row big enough to trip the byte cap before the count cap").
+
+static repair_hash_set make_sequential_hashes(size_t n) {
+    repair_hash_set hashes;
+    for (size_t i = 0; i < n; i++) {
+        hashes.insert(repair_hash(i));
+    }
+    return hashes;
+}
+
+static std::vector<repair_hash> flatten(const std::vector<std::vector<repair_hash>>& batches) {
+    std::vector<repair_hash> flat;
+    for (auto& b : batches) {
+        flat.insert(flat.end(), b.begin(), b.end());
+    }
+    return flat;
+}
+
+SEASTAR_TEST_CASE(test_batch_hashes_for_wire_empty) {
+    return seastar::async([&] {
+        repair_hash_set hashes;
+        auto batches = batch_hashes_for_wire(hashes).get();
+        BOOST_REQUIRE(batches.empty());
+    });
+}
+
+SEASTAR_TEST_CASE(test_batch_hashes_for_wire_single) {
+    return seastar::async([&] {
+        auto hashes = make_sequential_hashes(1);
+        auto batches = batch_hashes_for_wire(hashes).get();
+        BOOST_REQUIRE_EQUAL(batches.size(), 1u);
+        BOOST_REQUIRE_EQUAL(batches[0].size(), 1u);
+    });
+}
+
+SEASTAR_TEST_CASE(test_batch_hashes_for_wire_exact_boundary) {
+    return seastar::async([&] {
+        // Exactly hash_batch_max_count hashes must produce ONE full batch, not a full
+        // batch plus an empty trailing one.
+        auto hashes = make_sequential_hashes(hash_batch_max_count);
+        auto batches = batch_hashes_for_wire(hashes).get();
+        BOOST_REQUIRE_EQUAL(batches.size(), 1u);
+        BOOST_REQUIRE_EQUAL(batches[0].size(), hash_batch_max_count);
+    });
+}
+
+SEASTAR_TEST_CASE(test_batch_hashes_for_wire_one_over_boundary) {
+    return seastar::async([&] {
+        auto hashes = make_sequential_hashes(hash_batch_max_count + 1);
+        auto batches = batch_hashes_for_wire(hashes).get();
+        BOOST_REQUIRE_EQUAL(batches.size(), 2u);
+        BOOST_REQUIRE_EQUAL(batches[0].size(), hash_batch_max_count);
+        BOOST_REQUIRE_EQUAL(batches[1].size(), 1u);
+    });
+}
+
+SEASTAR_TEST_CASE(test_batch_hashes_for_wire_one_under_boundary) {
+    return seastar::async([&] {
+        auto hashes = make_sequential_hashes(hash_batch_max_count - 1);
+        auto batches = batch_hashes_for_wire(hashes).get();
+        BOOST_REQUIRE_EQUAL(batches.size(), 1u);
+        BOOST_REQUIRE_EQUAL(batches[0].size(), hash_batch_max_count - 1);
+    });
+}
+
+SEASTAR_TEST_CASE(test_batch_hashes_for_wire_multiple_batches_plus_remainder) {
+    return seastar::async([&] {
+        const size_t n = 2 * hash_batch_max_count + 5;
+        auto hashes = make_sequential_hashes(n);
+        auto batches = batch_hashes_for_wire(hashes).get();
+        BOOST_REQUIRE_EQUAL(batches.size(), 3u);
+        BOOST_REQUIRE_EQUAL(batches[0].size(), hash_batch_max_count);
+        BOOST_REQUIRE_EQUAL(batches[1].size(), hash_batch_max_count);
+        BOOST_REQUIRE_EQUAL(batches[2].size(), 5u);
+
+        // Order is preserved end-to-end, matching the set's own ascending iteration order.
+        std::vector<repair_hash> expected(hashes.begin(), hashes.end());
+        BOOST_REQUIRE(flatten(batches) == expected);
+    });
+}
+
+static frozen_mutation_fragment make_dummy_frozen_mutation_fragment(size_t size) {
+    bytes_ostream bo;
+    std::string data(size, 'x');
+    bo.write(data.data(), data.size());
+    return frozen_mutation_fragment(std::move(bo));
+}
+
+// A minimal, schema-less wire row carrying one mutation fragment of a controlled byte
+// size, for pinning down batch_rows_for_wire's count/byte-cap boundaries precisely.
+// Not a valid row for anything that would try to unfreeze() it.
+static repair_row_on_wire make_dummy_wire_row(size_t fragment_size) {
+    utils::chunked_vector<frozen_mutation_fragment> mfs;
+    mfs.push_back(make_dummy_frozen_mutation_fragment(fragment_size));
+    return repair_row_on_wire(std::move(mfs));
+}
+
+static repair_rows_on_wire make_dummy_wire_rows(size_t n, size_t fragment_size) {
+    repair_rows_on_wire rows;
+    for (size_t i = 0; i < n; i++) {
+        rows.push_back(make_dummy_wire_row(fragment_size));
+    }
+    return rows;
+}
+
+SEASTAR_TEST_CASE(test_batch_rows_for_wire_empty) {
+    return seastar::async([&] {
+        repair_rows_on_wire rows;
+        auto batches = batch_rows_for_wire(rows).get();
+        BOOST_REQUIRE(batches.empty());
+    });
+}
+
+SEASTAR_TEST_CASE(test_batch_rows_for_wire_count_cap_boundaries) {
+    return seastar::async([&] {
+        // Tiny rows, far under the byte cap: only the count cap should be in play.
+        {
+            auto rows = make_dummy_wire_rows(row_batch_max_count, 4);
+            auto batches = batch_rows_for_wire(rows).get();
+            BOOST_REQUIRE_EQUAL(batches.size(), 1u);
+            BOOST_REQUIRE_EQUAL(batches[0].size(), row_batch_max_count);
+        }
+        {
+            auto rows = make_dummy_wire_rows(row_batch_max_count + 1, 4);
+            auto batches = batch_rows_for_wire(rows).get();
+            BOOST_REQUIRE_EQUAL(batches.size(), 2u);
+            BOOST_REQUIRE_EQUAL(batches[0].size(), row_batch_max_count);
+            BOOST_REQUIRE_EQUAL(batches[1].size(), 1u);
+        }
+        {
+            auto rows = make_dummy_wire_rows(row_batch_max_count - 1, 4);
+            auto batches = batch_rows_for_wire(rows).get();
+            BOOST_REQUIRE_EQUAL(batches.size(), 1u);
+            BOOST_REQUIRE_EQUAL(batches[0].size(), row_batch_max_count - 1);
+        }
+    });
+}
+
+SEASTAR_TEST_CASE(test_batch_rows_for_wire_byte_cap_triggers_before_count_cap) {
+    return seastar::async([&] {
+        // Each row is a quarter of row_batch_max_bytes, so the byte cap should split
+        // into batches of exactly 4 rows -- nowhere near row_batch_max_count (32).
+        const size_t fragment_size = row_batch_max_bytes / 4;
+        auto rows = make_dummy_wire_rows(3 * 4, fragment_size);
+        auto batches = batch_rows_for_wire(rows).get();
+        BOOST_REQUIRE_EQUAL(batches.size(), 3u);
+        for (auto& b : batches) {
+            BOOST_REQUIRE_EQUAL(b.size(), 4u);
+        }
+    });
+}
+
+SEASTAR_TEST_CASE(test_batch_rows_for_wire_byte_cap_never_overshoots) {
+    return seastar::async([&] {
+        // Each row is just over half the cap, so two of them would overshoot it - the
+        // batch must flush BEFORE adding the second row, not after.
+        auto rows = make_dummy_wire_rows(5, row_batch_max_bytes / 2 + 1);
+        auto batches = batch_rows_for_wire(rows).get();
+        BOOST_REQUIRE_EQUAL(batches.size(), 5u);
+        for (auto& b : batches) {
+            BOOST_REQUIRE_EQUAL(b.size(), 1u);
+        }
+    });
+}
+
+SEASTAR_TEST_CASE(test_batch_rows_for_wire_single_oversized_row) {
+    return seastar::async([&] {
+        // A single row bigger than row_batch_max_bytes on its own must still be sent --
+        // it gets its own batch rather than being dropped or looping forever.
+        auto rows = make_dummy_wire_rows(1, row_batch_max_bytes * 2);
+        auto batches = batch_rows_for_wire(rows).get();
+        BOOST_REQUIRE_EQUAL(batches.size(), 1u);
+        BOOST_REQUIRE_EQUAL(batches[0].size(), 1u);
+    });
+}
+
+SEASTAR_TEST_CASE(test_batch_rows_for_wire_total_row_count_preserved) {
+    return seastar::async([&] {
+        // Mix of small and large rows: every input row must show up exactly once,
+        // regardless of which cap ends up governing each batch.
+        repair_rows_on_wire rows;
+        for (size_t i = 0; i < 50; i++) {
+            rows.push_back(make_dummy_wire_row(i % 3 == 0 ? row_batch_max_bytes / 2 : 8));
+        }
+        auto batches = batch_rows_for_wire(rows).get();
+        size_t total = 0;
+        for (auto& b : batches) {
+            total += b.size();
+        }
+        BOOST_REQUIRE_EQUAL(total, 50u);
+    });
+}
+
+// --- diff-detect algorithm selection coverage ---
+//
+// select_diff_detect_algorithm is the pure negotiation logic behind
+// get_common_diff_detect_algorithm, exposed so the vnode/tablet gating (the one
+// invariant that must never regress: [[vnode-repair-legacy-dont-touch]]) can be
+// pinned down without a full cluster.
+
+SEASTAR_TEST_CASE(test_select_diff_detect_algorithm_vnode_never_selects_batched) {
+    return seastar::async([&] {
+        using algo = row_level_diff_detect_algorithm;
+        std::vector<std::vector<algo>> nodes_algorithms = {
+            {algo::send_full_set, algo::send_full_set_rpc_stream, algo::send_full_set_rpc_stream_batched},
+            {algo::send_full_set, algo::send_full_set_rpc_stream, algo::send_full_set_rpc_stream_batched},
+        };
+        // Even though every peer advertises batched support, a vnode (non-tablet) table
+        // must never select it -- this is allow_batched=false, the caller's contract for
+        // !cf.uses_tablets().
+        auto selected = select_diff_detect_algorithm(nodes_algorithms, false);
+        BOOST_REQUIRE(selected == algo::send_full_set_rpc_stream);
+    });
+}
+
+SEASTAR_TEST_CASE(test_select_diff_detect_algorithm_tablet_picks_batched_when_supported) {
+    return seastar::async([&] {
+        using algo = row_level_diff_detect_algorithm;
+        std::vector<std::vector<algo>> nodes_algorithms = {
+            {algo::send_full_set, algo::send_full_set_rpc_stream, algo::send_full_set_rpc_stream_batched},
+            {algo::send_full_set, algo::send_full_set_rpc_stream, algo::send_full_set_rpc_stream_batched},
+        };
+        auto selected = select_diff_detect_algorithm(nodes_algorithms, true);
+        BOOST_REQUIRE(selected == algo::send_full_set_rpc_stream_batched);
+    });
+}
+
+SEASTAR_TEST_CASE(test_select_diff_detect_algorithm_mixed_version_peer_excludes_batched) {
+    return seastar::async([&] {
+        using algo = row_level_diff_detect_algorithm;
+        // One peer is an older binary that never advertises the batched algorithm at all
+        // (the rolling-upgrade scenario) -- it must be excluded from the common set
+        // regardless of allow_batched, since the peer genuinely doesn't support it.
+        std::vector<std::vector<algo>> nodes_algorithms = {
+            {algo::send_full_set, algo::send_full_set_rpc_stream, algo::send_full_set_rpc_stream_batched},
+            {algo::send_full_set, algo::send_full_set_rpc_stream},
+        };
+        auto selected = select_diff_detect_algorithm(nodes_algorithms, true);
+        BOOST_REQUIRE(selected == algo::send_full_set_rpc_stream);
+    });
+}
+
+SEASTAR_TEST_CASE(test_select_diff_detect_algorithm_no_peers_falls_back_to_local_best) {
+    return seastar::async([&] {
+        using algo = row_level_diff_detect_algorithm;
+        std::vector<std::vector<algo>> nodes_algorithms = {};
+        BOOST_REQUIRE(select_diff_detect_algorithm(nodes_algorithms, true) == algo::send_full_set_rpc_stream_batched);
+        BOOST_REQUIRE(select_diff_detect_algorithm(nodes_algorithms, false) == algo::send_full_set_rpc_stream);
+    });
+}
+
+SEASTAR_TEST_CASE(test_select_diff_detect_algorithm_no_common_algorithm_throws) {
+    return seastar::async([&] {
+        using algo = row_level_diff_detect_algorithm;
+        std::vector<std::vector<algo>> nodes_algorithms = {
+            {},
+        };
+        BOOST_REQUIRE_THROW(select_diff_detect_algorithm(nodes_algorithms, true), std::runtime_error);
+    });
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/cluster/test_repair.py
+++ b/test/cluster/test_repair.py
@@ -17,7 +17,7 @@ from cassandra.query import SimpleStatement
 
 from test.pylib.manager_client import ManagerClient
 from test.pylib.rest_client import HTTPError
-from test.pylib.util import wait_for_cql_and_get_hosts
+from test.pylib.util import wait_for, wait_for_cql_and_get_hosts
 from test.cluster.util import new_test_keyspace
 
 
@@ -446,3 +446,95 @@ async def test_repair_rejects_equal_start_and_end_token(manager):
     with pytest.raises(HTTPError, match="Start and end tokens must be different"):
         await manager.api.client.post_json(f"/storage_service/repair_async/ks",
                                            host=servers[0].ip_addr, params=params)
+
+
+async def test_repair_batched_stream_rack_compression_and_dict(manager: ManagerClient) -> None:
+    """
+    Batched repair over the wire with real LZ4 compression and dict training enabled -
+    the unit tests only cover the grouping logic in isolation, no rpc::sink/compression.
+
+    internode_compression: rack (cross-rack/dc only, not 'all') with the two nodes in
+    different racks, so repair traffic between them is actually compressed. zstd stays
+    at its default-disabled 0 cpu fraction, so this is the LZ4 path specifically.
+    """
+    # Row counts kept minimal (debug builds are slow); batching itself doesn't need
+    # scale to be exercised - every send goes through a batch, even a "batch of 1".
+    # hinted_handoff_enabled disabled: otherwise node2's downtime writes get delivered as
+    # hints on restart, resyncing it before repair's row-level comparison ever runs -
+    # leaving no diff for the batched path to actually send.
+    cfg = {
+        'internode_compression': 'rack',
+        'internode_compression_enable_advanced': True,
+        'internode_compression_zstd_max_cpu_fraction': 0.0,
+        'rpc_dict_training_when': 'when_leader',
+        'rpc_dict_training_min_bytes': 8 * 1024,
+        'rpc_dict_training_min_time_seconds': 0,
+        'hinted_handoff_enabled': False,
+    }
+    cmdline = ['--logger-log-level=repair=trace']
+    node1, node2 = await manager.servers_add(2, config=cfg, cmdline=cmdline, auto_rack_dc="dc1")
+
+    cql = manager.get_cql()
+    await wait_for_cql_and_get_hosts(cql, [node1, node2], time.time() + 30)
+
+    async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 2}") as ks:
+        cql.execute(f"CREATE TABLE {ks}.tbl (pk int PRIMARY KEY, v text)")
+
+        write_stmt = cql.prepare(f"INSERT INTO {ks}.tbl (pk, v) VALUES (?, ?)")
+        row_value = "x" * 200
+        synced_rows = 300
+        diff_rows = 150
+
+        write_stmt.consistency_level = ConsistencyLevel.ALL
+        await asyncio.gather(*[cql.run_async(write_stmt, [pk, row_value]) for pk in range(synced_rows)])
+
+        # Seed the dict trainer before repair, so repair traffic is dict-compressed too.
+        async def dict_trained():
+            rows = list(cql.execute("SELECT data FROM system.dicts"))
+            return rows if rows else None
+        await wait_for(dict_trained, time.time() + 60)
+
+        await manager.server_stop_gracefully(node2.server_id)
+
+        # Diverge node1 only; > row_batch_max_count (32) so batching emits several frames.
+        write_stmt.consistency_level = ConsistencyLevel.ONE
+        await asyncio.gather(*[cql.run_async(write_stmt, [pk, row_value])
+                               for pk in range(synced_rows, synced_rows + diff_rows)])
+
+        await manager.server_start(node2.server_id, wait_others=1)
+        await wait_for_cql_and_get_hosts(cql, [node1, node2], time.time() + 30)
+
+        # node1 is master (repair is driven from it) and pushes the row diff to node2;
+        # node2 is follower and answers get_full_row_hashes - each logs a different
+        # batched-send trace line, so both logs need watching.
+        master_log = await manager.server_open_log(node1.server_id)
+        master_mark = await master_log.mark()
+        follower_log = await manager.server_open_log(node2.server_id)
+        follower_mark = await follower_log.mark()
+
+        metrics_before = await manager.metrics.query(node1.ip_addr)
+        await manager.api.repair(node1.ip_addr, ks, "tbl")
+        metrics_after = await manager.metrics.query(node1.ip_addr)
+
+        # Batched algorithm was negotiated and actually used to move real data, not just offered.
+        await master_log.wait_for(r"common_diff_detect_algorithms=.*send_full_set_rpc_stream_batched", from_mark=master_mark)
+        await follower_log.wait_for(r"send_hashes_batched: batch of", from_mark=follower_mark)
+        await master_log.wait_for(r"send_rows_batched: batch of", from_mark=master_mark)
+
+        # Compression (LZ4, zstd disabled) actually engaged on the wire.
+        def lz4_bytes(metrics, name):
+            return metrics.get(name, {"algorithm": "lz4"}) or 0
+        sent_delta = (lz4_bytes(metrics_after, "scylla_rpc_compression_bytes_sent")
+                      - lz4_bytes(metrics_before, "scylla_rpc_compression_bytes_sent"))
+        compressed_delta = (lz4_bytes(metrics_after, "scylla_rpc_compression_compressed_bytes_sent")
+                             - lz4_bytes(metrics_before, "scylla_rpc_compression_compressed_bytes_sent"))
+        assert sent_delta > 5_000, f"expected a meaningful volume of lz4-compressed repair traffic, got {sent_delta}"
+        assert compressed_delta < sent_delta
+
+        # Stop node1 so the read is served only by node2, and check it caught up.
+        await manager.server_stop_gracefully(node1.server_id)
+        count_stmt = SimpleStatement(f"SELECT count(*) FROM {ks}.tbl", consistency_level=ConsistencyLevel.ONE)
+        count = cql.execute(count_stmt).one()[0]
+        assert count == synced_rows + diff_rows
+        await manager.server_start(node1.server_id, wait_others=1)
+        await wait_for_cql_and_get_hosts(cql, [node1, node2], time.time() + 30)


### PR DESCRIPTION
## Motivation

Tablet repair's default diff algorithm (`send_full_set_rpc_stream`) puts exactly one hash or one row per RPC stream frame. Each frame is compressed and flushed independently, so:
- per-frame overhead (header/CRC/flush/semaphore bookkeeping) is paid once per 9-byte hash;
- almost every frame is far below the compressor's 1 KiB effectiveness floor, so it gets no benefit from compression, or worse.

This is gated to tablets only — vnode repair is legacy and keeps its existing wire behavior unchanged.

## Results

Measured on a 3-node loopback cluster, 500k-row / 150k-diff tablet repair:

- **LZ4** (`internode_compression: all`, no batching): counter-intuitively **worse** than no compression at all, +11-12% bytes-on-wire across repeated trials — per-frame overhead (algo byte, checksum, literal-encoding) on tiny, high-entropy frames outweighs any compression gain.
- **ZSTD** (`+ internode_compression_enable_advanced` + `zstd_max_cpu_fraction: 0.1`, no batching): roughly a wash vs. no compression, for the same reason — most frames never clear the 1 KiB zstd floor.
- **Batched + ZSTD** (this PR): **~3x reduction** in bytes-on-wire vs. the unbatched/uncompressed baseline (~19.2 MB → ~7.1 MB, averaged over 3 trials), since batched frames are large enough to actually clear the compression floor. Batching itself also helps independent of compression, by amortizing per-frame overhead.

A sweep of the row-batch size (16-512 rows) found no reliable improvement beyond the chosen default of 32; observed deltas were within run-to-run noise (~20%).

## Change

1. **Wire protocol** (additive, no behavior change): new `send_full_set_rpc_stream_batched` diff algorithm, new `hash_data_batch`/`row_data_batch` stream commands, and versioned `hashes`/`rows` collection fields on the existing frame structs (rolling-upgrade safe).
2. **Batched implementation, gated to tablets**: pure `batch_hashes_for_wire`/`batch_rows_for_wire` grouping functions (hash batches capped at ~8 KiB; row batches capped by count or byte size, whichever hits first) plus sink wrappers. Algorithm negotiation (`select_diff_detect_algorithm`) only offers the batched path when `cf.uses_tablets()` — vnode repair's code paths are byte-identical to before.

## Tests

- New unit tests (16 `SEASTAR_TEST_CASE`s) for the grouping functions' boundary conditions (exact/off-by-one batch limits, byte-cap vs count-cap precedence, oversized single row/hash set) and for algorithm negotiation (vnode never selects batched even if advertised; tablets do; mixed-version peers fall back correctly). All 22 boost repair tests pass.
- Functional cluster suite (`test.py`) exercised up to 1M-row repair scale, including a check for no reactor stalls during the batched send/receive window specifically.

---

Opening as an RFC to get early feedback on the wire protocol and batching approach before finishing off remaining follow-ups (cluster feature gate for the new algorithm, functional mixed-version tests, batch-size tuning knob). Moving to draft once CI has run.
