### PR TITLE
repair: fix get_full_row_hashes handler setting the wrong repair_state

### DIFF
--- a/repair/row_level.cc
+++ b/repair/row_level.cc
@@ -2474,7 +2474,7 @@ static future<stop_iteration> repair_get_full_row_hashes_with_rpc_stream_process
             auto rm = local_repair.get_repair_meta(from, repair_meta_id);
             rm->set_repair_state_for_local_node(repair_state::get_full_row_hashes_started);
             repair_hash_set hashes = co_await rm->get_full_row_hashes_handler();
-            rm->set_repair_state_for_local_node(repair_state::get_full_row_hashes_started);
+            rm->set_repair_state_for_local_node(repair_state::get_full_row_hashes_finished);
             _metrics.tx_hashes_nr += hashes.size();
             co_return hashes;
         });


### PR DESCRIPTION
## Motivation

`repair_get_full_row_hashes_with_rpc_stream_process_op`'s handler sets `repair_state::get_full_row_hashes_started` twice - once before calling `get_full_row_hashes_handler()`, once after - instead of transitioning to `get_full_row_hashes_finished` on completion. Every other started/finished pair in this file (`get_row_diff`, `put_row_diff`, `get_combined_row_hash`, ...) transitions correctly; this one has been stuck reporting "started" since it was introduced (commit 61e6a77a99b, 2024-08-25).

Found by CodeRabbit while reviewing an unrelated PR (#31041) that happened to touch the same enclosing lambda.

## Change

One-line fix: the second `set_repair_state_for_local_node` call now uses `get_full_row_hashes_finished` instead of repeating `get_full_row_hashes_started`.

## Tests

`repair_state` is diagnostic-only (surfaced when dumping stuck/hung repair state), not read by any test or API today, so no new test is added - this is a one-line correction with no functional/wire behavior change.


Backport: no, probably benign. No one complained thus far.