### PR TITLE
compaction: calculate the default min_sstable_size for tablets

### DIFF
--- a/compaction/compaction_strategy.cc
+++ b/compaction/compaction_strategy.cc
@@ -606,10 +606,17 @@ public:
     }
 };
 
-leveled_compaction_strategy::leveled_compaction_strategy(const std::map<sstring, sstring>& options)
+uint64_t strategy_options_defaults::min_sstable_size() const {
+    if (!expected_memtable_size) {
+        return default_min_sstable_size;
+    }
+    return std::clamp<uint64_t>(expected_memtable_size / 2, min_sstable_size_lower_bound, default_min_sstable_size);
+}
+
+leveled_compaction_strategy::leveled_compaction_strategy(const std::map<sstring, sstring>& options, const strategy_options_defaults& defaults)
         : compaction_strategy_impl(options)
         , _max_sstable_size_in_mb(calculate_max_sstable_size_in_mb(compaction_strategy_impl::get_value(options, SSTABLE_SIZE_OPTION)))
-        , _stcs_options(options)
+        , _stcs_options(options, defaults)
 {
 }
 
@@ -646,10 +653,10 @@ leveled_compaction_strategy::calculate_max_sstable_size_in_mb(std::optional<sstr
     return max_size;
 }
 
-time_window_compaction_strategy::time_window_compaction_strategy(const std::map<sstring, sstring>& options)
+time_window_compaction_strategy::time_window_compaction_strategy(const std::map<sstring, sstring>& options, const strategy_options_defaults& defaults)
     : compaction_strategy_impl(options)
     , _options(options)
-    , _stcs_options(options)
+    , _stcs_options(options, defaults)
 {
     if (!options.contains(TOMBSTONE_COMPACTION_INTERVAL_OPTION) && !options.contains(TOMBSTONE_THRESHOLD_OPTION)) {
         _disable_tombstone_compaction = true;
@@ -672,9 +679,9 @@ std::unique_ptr<compaction_backlog_tracker::impl> time_window_compaction_strateg
     return std::make_unique<time_window_backlog_tracker>(_options, _stcs_options);
 }
 
-size_tiered_compaction_strategy::size_tiered_compaction_strategy(const std::map<sstring, sstring>& options)
+size_tiered_compaction_strategy::size_tiered_compaction_strategy(const std::map<sstring, sstring>& options, const strategy_options_defaults& defaults)
     : compaction_strategy_impl(options)
-    , _options(options)
+    , _options(options, defaults)
 {}
 
 size_tiered_compaction_strategy::size_tiered_compaction_strategy(const size_tiered_compaction_strategy_options& options)
@@ -759,7 +766,8 @@ compaction_strategy::make_sstable_set(const compaction::compaction_group_view& t
             _compaction_strategy_impl->make_sstable_set(ts));
 }
 
-compaction_strategy make_compaction_strategy(compaction_strategy_type strategy, const std::map<sstring, sstring>& options) {
+compaction_strategy make_compaction_strategy(compaction_strategy_type strategy, const std::map<sstring, sstring>& options,
+        const strategy_options_defaults& defaults) {
     ::shared_ptr<compaction_strategy_impl> impl;
 
     switch (strategy) {
@@ -767,13 +775,13 @@ compaction_strategy make_compaction_strategy(compaction_strategy_type strategy, 
         impl = ::make_shared<null_compaction_strategy>();
         break;
     case compaction_strategy_type::size_tiered:
-        impl = ::make_shared<size_tiered_compaction_strategy>(options);
+        impl = ::make_shared<size_tiered_compaction_strategy>(options, defaults);
         break;
     case compaction_strategy_type::leveled:
-        impl = ::make_shared<leveled_compaction_strategy>(options);
+        impl = ::make_shared<leveled_compaction_strategy>(options, defaults);
         break;
     case compaction_strategy_type::time_window:
-        impl = ::make_shared<time_window_compaction_strategy>(options);
+        impl = ::make_shared<time_window_compaction_strategy>(options, defaults);
         break;
     case compaction_strategy_type::in_memory:
         compaction_strategy_logger.warn(
@@ -783,7 +791,7 @@ compaction_strategy make_compaction_strategy(compaction_strategy_type strategy, 
         impl = ::make_shared<null_compaction_strategy>();
         break;
     case compaction_strategy_type::incremental:
-        impl = make_shared<incremental_compaction_strategy>(incremental_compaction_strategy(options));
+        impl = make_shared<incremental_compaction_strategy>(incremental_compaction_strategy(options, defaults));
         break;
     default:
         throw std::runtime_error("strategy not supported");

--- a/compaction/compaction_strategy.hh
+++ b/compaction/compaction_strategy.hh
@@ -30,6 +30,40 @@ class compaction_backlog_tracker;
 class compaction_strategy_impl;
 struct compaction_descriptor;
 
+/// Default value of the min_sstable_size option of the size-tiered-like compaction
+/// strategies, used when the expected memtable size isn't known.
+static constexpr uint64_t default_min_sstable_size = 50L * 1024L * 1024L;
+
+/// Don't derive a min_sstable_size smaller than this, so that it stays meaningful
+/// no matter how little memtable memory a single memtable gets.
+static constexpr uint64_t min_sstable_size_lower_bound = 4 * 1024;
+
+/// Provides the default values of compaction strategy options that cannot be plain
+/// constants, since they depend on the resources available to the memtable the
+/// sstables are flushed from.
+///
+/// The defaults are used only for options that aren't set in the table's schema.
+struct strategy_options_defaults {
+    /// The expected size, in bytes, of the memtable the sstables are flushed from,
+    /// or zero when it isn't known.
+    ///
+    /// It is derived by the table from the memtable memory available to the shard
+    /// and the number of memtables sharing it, so that the compaction strategies
+    /// don't need to know how the table's data is distributed across the shard.
+    uint64_t expected_memtable_size = 0;
+
+    /// @return the default value of the min_sstable_size option, in bytes.
+    ///
+    /// SSTables smaller than min_sstable_size are all put in the same size tier, so
+    /// it is meant to capture the sstables that are too small to be tiered by size,
+    /// not the ones a full memtable is flushed into.  Half of the expected memtable
+    /// size satisfies that, and it is clamped to
+    /// [min_sstable_size_lower_bound, default_min_sstable_size].
+    ///
+    /// Returns default_min_sstable_size when the expected memtable size isn't known.
+    uint64_t min_sstable_size() const;
+};
+
 class compaction_strategy {
     ::shared_ptr<compaction_strategy_impl> _compaction_strategy_impl;
 public:
@@ -132,8 +166,13 @@ public:
 
 };
 
-// Creates a compaction_strategy object from one of the strategies available.
-compaction_strategy make_compaction_strategy(compaction_strategy_type strategy, const std::map<sstring, sstring>& options);
+/// Creates a compaction_strategy object from one of the strategies available.
+///
+/// @param defaults provides the values of the options that aren't set in @param options.
+/// It isn't referenced after this call returns. Defaults to the values used when
+/// the expected memtable size isn't known.
+compaction_strategy make_compaction_strategy(compaction_strategy_type strategy, const std::map<sstring, sstring>& options,
+        const strategy_options_defaults& defaults = {});
 
 future<reshape_config> make_reshape_config(const sstables::storage& storage, reshape_mode mode);
 

--- a/compaction/incremental_compaction_strategy.cc
+++ b/compaction/incremental_compaction_strategy.cc
@@ -17,11 +17,12 @@ namespace compaction {
 
 extern logging::logger clogger;
 
-static long validate_min_sstable_size(const std::map<sstring, sstring>& options) {
+static long validate_min_sstable_size(const std::map<sstring, sstring>& options,
+        uint64_t default_value = incremental_compaction_strategy_options::DEFAULT_MIN_SSTABLE_SIZE) {
     auto tmp_value = compaction_strategy_impl::get_value(options,
         incremental_compaction_strategy_options::MIN_SSTABLE_SIZE_KEY);
     auto min_sstable_size = cql3::statements::property_definitions::to_long(incremental_compaction_strategy_options::MIN_SSTABLE_SIZE_KEY,
-        tmp_value, incremental_compaction_strategy_options::DEFAULT_MIN_SSTABLE_SIZE);
+        tmp_value, default_value);
     if (min_sstable_size < 0) {
         throw exceptions::configuration_exception(fmt::format("{} value ({}) must be non negative",
             incremental_compaction_strategy_options::MIN_SSTABLE_SIZE_KEY, min_sstable_size));
@@ -126,8 +127,8 @@ static std::optional<double> validate_space_amplification_goal(const std::map<ss
     return space_amplification_goal;
 }
 
-incremental_compaction_strategy_options::incremental_compaction_strategy_options(const std::map<sstring, sstring>& options) {
-    min_sstable_size = validate_min_sstable_size(options);
+incremental_compaction_strategy_options::incremental_compaction_strategy_options(const std::map<sstring, sstring>& options, const strategy_options_defaults& defaults) {
+    min_sstable_size = validate_min_sstable_size(options, defaults.min_sstable_size());
     min_sstable_age = validate_min_sstable_age(options);
     bucket_low = validate_bucket_low(options);
     bucket_high = validate_bucket_high(options);
@@ -542,9 +543,9 @@ incremental_compaction_strategy::make_backlog_tracker() const {
     return std::make_unique<incremental_backlog_tracker>(_options);
 }
 
-incremental_compaction_strategy::incremental_compaction_strategy(const std::map<sstring, sstring>& options)
+incremental_compaction_strategy::incremental_compaction_strategy(const std::map<sstring, sstring>& options, const strategy_options_defaults& defaults)
     : compaction_strategy_impl(options)
-    , _options(options)
+    , _options(options, defaults)
 {
     auto fragment_size_in_mb = validate_fragment_size(options);
     _fragment_size = fragment_size_in_mb*1024*1024;

--- a/compaction/incremental_compaction_strategy.hh
+++ b/compaction/incremental_compaction_strategy.hh
@@ -16,7 +16,7 @@ class incremental_backlog_tracker;
 
 class incremental_compaction_strategy_options {
 public:
-    static constexpr uint64_t DEFAULT_MIN_SSTABLE_SIZE = 50L * 1024L * 1024L;
+    static constexpr uint64_t DEFAULT_MIN_SSTABLE_SIZE = default_min_sstable_size;
     static constexpr std::chrono::seconds DEFAULT_MIN_SSTABLE_AGE = std::chrono::hours(1);
     static constexpr double DEFAULT_BUCKET_LOW = 0.7071;
     static constexpr double DEFAULT_BUCKET_HIGH = 1.4142;
@@ -31,7 +31,10 @@ private:
     double bucket_low = DEFAULT_BUCKET_LOW;
     double bucket_high = DEFAULT_BUCKET_HIGH;
 public:
-    incremental_compaction_strategy_options(const std::map<sstring, sstring>& options);
+    /// @param defaults provides the values of the options that aren't set in @param options.
+    /// Defaults to the values used when the expected memtable size isn't known.
+    incremental_compaction_strategy_options(const std::map<sstring, sstring>& options,
+            const strategy_options_defaults& defaults = {});
 
     incremental_compaction_strategy_options() {
         min_sstable_size = DEFAULT_MIN_SSTABLE_SIZE;
@@ -82,7 +85,10 @@ private:
 public:
     incremental_compaction_strategy() = default;
 
-    incremental_compaction_strategy(const std::map<sstring, sstring>& options);
+    /// @param defaults provides the values of the options that aren't set in @param options.
+    /// Defaults to the values used when the expected memtable size isn't known.
+    incremental_compaction_strategy(const std::map<sstring, sstring>& options,
+            const strategy_options_defaults& defaults = {});
 
     static void validate_options(const std::map<sstring, sstring>& options, std::map<sstring, sstring>& unchecked_options);
 

--- a/compaction/leveled_compaction_strategy.hh
+++ b/compaction/leveled_compaction_strategy.hh
@@ -52,7 +52,11 @@ public:
     static unsigned ideal_level_for_input(const std::vector<sstables::shared_sstable>& input, uint64_t max_sstable_size);
     static void validate_options(const std::map<sstring, sstring>& options, std::map<sstring, sstring>& unchecked_options);
 
-    leveled_compaction_strategy(const std::map<sstring, sstring>& options);
+    /// @param defaults provides the values of the options that aren't set in @param options,
+    /// for the size-tiered compaction this strategy performs in level 0.
+    /// Defaults to the values used when the expected memtable size isn't known.
+    leveled_compaction_strategy(const std::map<sstring, sstring>& options,
+            const strategy_options_defaults& defaults = {});
     virtual future<compaction_descriptor> get_sstables_for_compaction(compaction_group_view& table_s, strategy_control& control) override;
 
     virtual std::vector<compaction_descriptor> get_cleanup_compaction_jobs(compaction_group_view& table_s, std::vector<sstables::shared_sstable> candidates) const override;

--- a/compaction/size_tiered_compaction_strategy.cc
+++ b/compaction/size_tiered_compaction_strategy.cc
@@ -14,9 +14,9 @@
 
 namespace compaction {
 
-static long validate_sstable_size(const std::map<sstring, sstring>& options) {
+static long validate_sstable_size(const std::map<sstring, sstring>& options, uint64_t default_value = size_tiered_compaction_strategy_options::DEFAULT_MIN_SSTABLE_SIZE) {
     auto tmp_value = compaction_strategy_impl::get_value(options, size_tiered_compaction_strategy_options::MIN_SSTABLE_SIZE_KEY);
-    auto min_sstables_size = cql3::statements::property_definitions::to_long(size_tiered_compaction_strategy_options::MIN_SSTABLE_SIZE_KEY, tmp_value, size_tiered_compaction_strategy_options::DEFAULT_MIN_SSTABLE_SIZE);
+    auto min_sstables_size = cql3::statements::property_definitions::to_long(size_tiered_compaction_strategy_options::MIN_SSTABLE_SIZE_KEY, tmp_value, default_value);
     if (min_sstables_size < 0) {
         throw exceptions::configuration_exception(fmt::format("{} value ({}) must be non negative", size_tiered_compaction_strategy_options::MIN_SSTABLE_SIZE_KEY, min_sstables_size));
     }
@@ -90,10 +90,10 @@ static double validate_cold_reads_to_omit(const std::map<sstring, sstring>& opti
     return cold_reads_to_omit;
 }
 
-size_tiered_compaction_strategy_options::size_tiered_compaction_strategy_options(const std::map<sstring, sstring>& options) {
+size_tiered_compaction_strategy_options::size_tiered_compaction_strategy_options(const std::map<sstring, sstring>& options, const strategy_options_defaults& defaults) {
     using namespace cql3::statements;
 
-    min_sstable_size = validate_sstable_size(options);
+    min_sstable_size = validate_sstable_size(options, defaults.min_sstable_size());
     min_sstable_age = validate_min_sstable_age(options);
     bucket_low = validate_bucket_low(options);
     bucket_high = validate_bucket_high(options);

--- a/compaction/size_tiered_compaction_strategy.hh
+++ b/compaction/size_tiered_compaction_strategy.hh
@@ -19,7 +19,7 @@ class size_tiered_backlog_tracker;
 
 class size_tiered_compaction_strategy_options {
 public:
-    static constexpr uint64_t DEFAULT_MIN_SSTABLE_SIZE = 50L * 1024L * 1024L;
+    static constexpr uint64_t DEFAULT_MIN_SSTABLE_SIZE = default_min_sstable_size;
     static constexpr std::chrono::seconds DEFAULT_MIN_SSTABLE_AGE = std::chrono::hours(1);
     static constexpr double DEFAULT_BUCKET_LOW = 0.5;
     static constexpr double DEFAULT_BUCKET_HIGH = 1.5;
@@ -36,7 +36,10 @@ private:
     double bucket_high = DEFAULT_BUCKET_HIGH;
     double cold_reads_to_omit =  DEFAULT_COLD_READS_TO_OMIT;
 public:
-    size_tiered_compaction_strategy_options(const std::map<sstring, sstring>& options);
+    /// @param defaults provides the values of the options that aren't set in @param options.
+    /// Defaults to the values used when the expected memtable size isn't known.
+    size_tiered_compaction_strategy_options(const std::map<sstring, sstring>& options,
+            const strategy_options_defaults& defaults = {});
 
     size_tiered_compaction_strategy_options();
     size_tiered_compaction_strategy_options(const size_tiered_compaction_strategy_options&) = default;
@@ -73,7 +76,10 @@ class size_tiered_compaction_strategy : public compaction_strategy_impl {
 public:
     size_tiered_compaction_strategy() = default;
 
-    size_tiered_compaction_strategy(const std::map<sstring, sstring>& options);
+    /// @param defaults provides the values of the options that aren't set in @param options.
+    /// Defaults to the values used when the expected memtable size isn't known.
+    size_tiered_compaction_strategy(const std::map<sstring, sstring>& options,
+            const strategy_options_defaults& defaults = {});
     explicit size_tiered_compaction_strategy(const size_tiered_compaction_strategy_options& options);
     static void validate_options(const std::map<sstring, sstring>& options, std::map<sstring, sstring>& unchecked_options);
 

--- a/compaction/time_window_compaction_strategy.hh
+++ b/compaction/time_window_compaction_strategy.hh
@@ -82,7 +82,11 @@ public:
     using bucket_t = std::vector<sstables::shared_sstable>;
     enum class bucket_compaction_mode { none, size_tiered, major };
 public:
-    time_window_compaction_strategy(const std::map<sstring, sstring>& options);
+    /// @param defaults provides the values of the options that aren't set in @param options,
+    /// for the size-tiered compaction this strategy performs within a time window.
+    /// Defaults to the values used when the expected memtable size isn't known.
+    time_window_compaction_strategy(const std::map<sstring, sstring>& options,
+            const strategy_options_defaults& defaults = {});
     virtual future<compaction_descriptor> get_sstables_for_compaction(compaction_group_view& table_s, strategy_control& control) override;
 
     virtual std::vector<compaction_descriptor> get_cleanup_compaction_jobs(compaction_group_view& table_s, std::vector<sstables::shared_sstable> candidates) const override;

--- a/docs/cql/compaction.rst
+++ b/docs/cql/compaction.rst
@@ -124,6 +124,22 @@ The following options only apply to SizeTieredCompactionStrategy:
 ``min_sstable_size`` (default: 52,428,800)
    All SSTables smaller than this number of bytes are eligible to be put into the same bucket, provided they are at least ``min_sstable_age`` old.
 
+   Rather than being a fixed value, the default is derived from the size a memtable of the table is expected to reach before it is
+   flushed, so that it captures the SSTables that are too small to be tiered by their size, rather than the ones a full memtable is
+   flushed into. It is half of that expected size, clamped to the range of 4,096 to 52,428,800 bytes.
+
+   The expected memtable size is the memtable memory of the shard, divided by the number of memtables sharing it. The memtable
+   memory is ``available memory per shard * 0.5 * unspooled_dirty_soft_limit``, which is the amount of dirty memory the memtables
+   are expected to use before flushing starts. A table that uses tablets has one memtable per tablet replica, and the number of
+   replicas per shard varies between ``tablets_per_shard_goal`` and twice as much, so it is divided by ``tablets_per_shard_goal *
+   1.5``.
+
+   For example, on a shard with 8 GiB of available memory and the default ``unspooled_dirty_soft_limit`` of 0.6, the memtable
+   memory is 2.4 GiB. With the default ``tablets_per_shard_goal`` of 100, a table that uses tablets expects a memtable of 16 MiB,
+   so ``min_sstable_size`` defaults to 8 MiB.
+
+   If the expected memtable size cannot be determined, the default is 52,428,800 bytes.
+
 =====
 
 ``min_sstable_age`` (default: 3600)
@@ -232,8 +248,24 @@ The following options only apply to IncrementalCompactionStrategy:
 
 =====
 
-``min_sstable_size`` (default: 50)
-   All SSTables smaller than this number of megabytes are eligible to be put into the same bucket, provided they are at least ``min_sstable_age`` old.
+``min_sstable_size`` (default: 52,428,800)
+   All SSTables smaller than this number of bytes are eligible to be put into the same bucket, provided they are at least ``min_sstable_age`` old.
+
+   Rather than being a fixed value, the default is derived from the size a memtable of the table is expected to reach before it is
+   flushed, so that it captures the SSTables that are too small to be tiered by their size, rather than the ones a full memtable is
+   flushed into. It is half of that expected size, clamped to the range of 4,096 to 52,428,800 bytes.
+
+   The expected memtable size is the memtable memory of the shard, divided by the number of memtables sharing it. The memtable
+   memory is ``available memory per shard * 0.5 * unspooled_dirty_soft_limit``, which is the amount of dirty memory the memtables
+   are expected to use before flushing starts. A table that uses tablets has one memtable per tablet replica, and the number of
+   replicas per shard varies between ``tablets_per_shard_goal`` and twice as much, so it is divided by ``tablets_per_shard_goal *
+   1.5``.
+
+   For example, on a shard with 8 GiB of available memory and the default ``unspooled_dirty_soft_limit`` of 0.6, the memtable
+   memory is 2.4 GiB. With the default ``tablets_per_shard_goal`` of 100, a table that uses tablets expects a memtable of 16 MiB,
+   so ``min_sstable_size`` defaults to 8 MiB.
+
+   If the expected memtable size cannot be determined, the default is 52,428,800 bytes.
 
    Unlike Apache Cassandra, scylla uses **uncompressed** size when bucketing similar-sized tiers together.
    Since compaction works on uncompressed data, SSTables containing similar amounts of data should be compacted together, even when they have different compression ratios.

--- a/docs/cql/compaction.rst
+++ b/docs/cql/compaction.rst
@@ -132,11 +132,13 @@ The following options only apply to SizeTieredCompactionStrategy:
    memory is ``available memory per shard * 0.5 * unspooled_dirty_soft_limit``, which is the amount of dirty memory the memtables
    are expected to use before flushing starts. A table that uses tablets has one memtable per tablet replica, and the number of
    replicas per shard varies between ``tablets_per_shard_goal`` and twice as much, so it is divided by ``tablets_per_shard_goal *
-   1.5``.
+   1.5``. A table that uses vnodes has a single memtable per shard, covering the shard's whole token range, so it is divided by
+   the number of tables on the shard, which all share the same memtable memory.
 
    For example, on a shard with 8 GiB of available memory and the default ``unspooled_dirty_soft_limit`` of 0.6, the memtable
    memory is 2.4 GiB. With the default ``tablets_per_shard_goal`` of 100, a table that uses tablets expects a memtable of 16 MiB,
-   so ``min_sstable_size`` defaults to 8 MiB.
+   so ``min_sstable_size`` defaults to 8 MiB. A node holding 24 tables that use vnodes expects a memtable of 100 MiB, so
+   ``min_sstable_size`` defaults to 50 MiB, i.e. the maximum.
 
    If the expected memtable size cannot be determined, the default is 52,428,800 bytes.
 
@@ -259,11 +261,13 @@ The following options only apply to IncrementalCompactionStrategy:
    memory is ``available memory per shard * 0.5 * unspooled_dirty_soft_limit``, which is the amount of dirty memory the memtables
    are expected to use before flushing starts. A table that uses tablets has one memtable per tablet replica, and the number of
    replicas per shard varies between ``tablets_per_shard_goal`` and twice as much, so it is divided by ``tablets_per_shard_goal *
-   1.5``.
+   1.5``. A table that uses vnodes has a single memtable per shard, covering the shard's whole token range, so it is divided by
+   the number of tables on the shard, which all share the same memtable memory.
 
    For example, on a shard with 8 GiB of available memory and the default ``unspooled_dirty_soft_limit`` of 0.6, the memtable
    memory is 2.4 GiB. With the default ``tablets_per_shard_goal`` of 100, a table that uses tablets expects a memtable of 16 MiB,
-   so ``min_sstable_size`` defaults to 8 MiB.
+   so ``min_sstable_size`` defaults to 8 MiB. A node holding 24 tables that use vnodes expects a memtable of 100 MiB, so
+   ``min_sstable_size`` defaults to 50 MiB, i.e. the maximum.
 
    If the expected memtable size cannot be determined, the default is 52,428,800 bytes.
 

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -1654,6 +1654,7 @@ keyspace::make_column_family_config(const schema& s, const database& db) const {
     cfg.tombstone_warn_threshold = db_config.tombstone_warn_threshold();
     cfg.view_update_memory_semaphore_limit = _config.view_update_memory_semaphore_limit;
     cfg.data_listeners = &db.data_listeners();
+    cfg.tablets_per_shard_goal = db_config.tablets_per_shard_goal;
     cfg.enable_compacting_data_for_streaming_and_repair = db_config.enable_compacting_data_for_streaming_and_repair;
     cfg.enable_tombstone_gc_for_streaming_and_repair = db_config.enable_tombstone_gc_for_streaming_and_repair;
     cfg.guardrail_config = db::guardrail_config{

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -1655,6 +1655,11 @@ keyspace::make_column_family_config(const schema& s, const database& db) const {
     cfg.view_update_memory_semaphore_limit = _config.view_update_memory_semaphore_limit;
     cfg.data_listeners = &db.data_listeners();
     cfg.tablets_per_shard_goal = db_config.tablets_per_shard_goal;
+    // The table is registered only once it has been constructed and started, and its
+    // compaction strategy is created before that, so count it while it isn't there yet.
+    cfg.table_count = [&db, id = s.id()] {
+        return db.get_tables_metadata().size() + !db.column_family_exists(id);
+    };
     cfg.enable_compacting_data_for_streaming_and_repair = db_config.enable_compacting_data_for_streaming_and_repair;
     cfg.enable_tombstone_gc_for_streaming_and_repair = db_config.enable_tombstone_gc_for_streaming_and_repair;
     cfg.guardrail_config = db::guardrail_config{

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -483,6 +483,10 @@ public:
         db::data_listeners* data_listeners = nullptr;
         uint32_t tombstone_warn_threshold{0};
         unsigned x_log2_compaction_groups{0};
+        // The goal for the number of tablet replicas per shard, used for estimating
+        // how many memtables share the shard's memtable memory.
+        // See table::expected_memtable_size().
+        utils::updateable_value<unsigned> tablets_per_shard_goal{0};
         utils::updateable_value<bool> enable_compacting_data_for_streaming_and_repair;
         utils::updateable_value<bool> enable_tombstone_gc_for_streaming_and_repair;
         db::guardrail_config guardrail_config;
@@ -510,6 +514,16 @@ private:
 
     lw_shared_ptr<memtable_list> make_memory_only_memtable_list();
     lw_shared_ptr<memtable_list> make_memtable_list(compaction_group& cg);
+
+    // Creates a compaction strategy of the given type, using the compaction options
+    // from the table's schema. The defaults of the options that aren't set there are
+    // derived from expected_memtable_size().
+    compaction::compaction_strategy create_compaction_strategy(compaction::compaction_strategy_type strategy) const;
+
+    // An estimate of the size a memtable of this table reaches before it is flushed,
+    // i.e. the shard's memtable memory divided by the number of memtables sharing it.
+    // Zero if it cannot be estimated.
+    uint64_t expected_memtable_size() const;
 
     compaction::compaction_manager& _compaction_manager;
     compaction::compaction_strategy _compaction_strategy;

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -483,10 +483,11 @@ public:
         db::data_listeners* data_listeners = nullptr;
         uint32_t tombstone_warn_threshold{0};
         unsigned x_log2_compaction_groups{0};
-        // The goal for the number of tablet replicas per shard, used for estimating
-        // how many memtables share the shard's memtable memory.
-        // See table::expected_memtable_size().
+        // The goal for the number of tablet replicas per shard, and the number of
+        // tables on this shard. Both are used for estimating how many memtables
+        // share the shard's memtable memory. See table::expected_memtable_size().
         utils::updateable_value<unsigned> tablets_per_shard_goal{0};
+        std::function<size_t()> table_count;
         utils::updateable_value<bool> enable_compacting_data_for_streaming_and_repair;
         utils::updateable_value<bool> enable_tombstone_gc_for_streaming_and_repair;
         db::guardrail_config guardrail_config;

--- a/replica/dirty_memory_manager.hh
+++ b/replica/dirty_memory_manager.hh
@@ -397,8 +397,8 @@ class dirty_memory_manager {
     // memory usage minus bytes that were already written to disk.
     dirty_memory_manager_logalloc::region_group _region_group;
 
-    size_t _threshold;
-    double _soft_limit;
+    size_t _threshold = 0;
+    double _soft_limit = 0;
 
     // We would like to serialize the flushing of memtables. While flushing many memtables
     // simultaneously can sustain high levels of throughput, the memory is not freed until the
@@ -524,6 +524,13 @@ public:
 
     size_t throttle_threshold() const {
         return _region_group.unspooled_throttle_threshold();
+    }
+
+    // The amount of dirty memory, in bytes, that the memtables in this group are
+    // expected to use before flushing kicks in, i.e. the soft limit in real,
+    // rather than unspooled, terms. Zero if no threshold was configured.
+    size_t flush_threshold() const noexcept {
+        return _threshold * _soft_limit;
     }
 
     future<> flush_one(replica::memtable_list& cf, flush_permit&& permit) noexcept;

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -2917,7 +2917,13 @@ uint64_t table::expected_memtable_size() const {
         return budget / tablets_per_shard;
     }
 
-    return 0;
+    // With vnodes, the table has a single memtable per shard, covering the shard's
+    // whole token range, so the budget is shared by the tables on this shard.
+    auto tables = _config.table_count ? _config.table_count() : 0;
+    if (!tables) {
+        return 0;
+    }
+    return budget / tables;
 }
 
 compaction::compaction_strategy table::create_compaction_strategy(compaction::compaction_strategy_type strategy) const {

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -2898,9 +2898,38 @@ void compaction_group::set_compaction_strategy_state(compaction::compaction_stra
     _compaction_strategy_state = std::move(compaction_strategy_state);
 }
 
+uint64_t table::expected_memtable_size() const {
+    // All memtables on this shard share the same memtable memory budget.
+    auto budget = _config.dirty_memory_manager->flush_threshold();
+    if (!budget) {
+        return 0;
+    }
+
+    if (uses_tablets()) {
+        // Each tablet replica has its own memtable. The number of replicas per shard
+        // is kept around tablets_per_shard_goal, but it varies between the goal and
+        // twice as much, as tablets are split when the table grows, and merged back
+        // once the count is brought down to the goal. Normalize by the average.
+        auto tablets_per_shard = _config.tablets_per_shard_goal() * 1.5;
+        if (tablets_per_shard < 1) {
+            return 0;
+        }
+        return budget / tablets_per_shard;
+    }
+
+    return 0;
+}
+
+compaction::compaction_strategy table::create_compaction_strategy(compaction::compaction_strategy_type strategy) const {
+    compaction::strategy_options_defaults defaults {
+        .expected_memtable_size = expected_memtable_size(),
+    };
+    return compaction::make_compaction_strategy(strategy, _schema->compaction_strategy_options(), defaults);
+}
+
 void table::set_compaction_strategy(compaction::compaction_strategy_type strategy) {
     tlogger.debug("Setting compaction strategy of {}.{} to {}", _schema->ks_name(), _schema->cf_name(), compaction::compaction_strategy::name(strategy));
-    auto new_cs = make_compaction_strategy(strategy, _schema->compaction_strategy_options());
+    auto new_cs = create_compaction_strategy(strategy);
 
     struct compaction_group_strategy_updater {
         table& t;
@@ -3466,7 +3495,7 @@ table::table(schema_ptr schema, config config, lw_shared_ptr<const storage_optio
                          column_family_label(_schema->cf_name())
                         )
     , _compaction_manager(compaction_manager)
-    , _compaction_strategy(make_compaction_strategy(_schema->compaction_strategy(), _schema->compaction_strategy_options()))
+    , _compaction_strategy(create_compaction_strategy(_schema->compaction_strategy()))
     , _sg_manager(make_storage_group_manager())
     , _sstables(make_compound_sstable_set())
     , _sstable_deletion_gate(format("[table {}.{}] sstable_deletion_gate", _schema->ks_name(), _schema->cf_name()))

--- a/test/boost/sstable_compaction_test.cc
+++ b/test/boost/sstable_compaction_test.cc
@@ -6881,4 +6881,77 @@ SEASTAR_TEST_CASE(test_compaction_output_is_not_leaked_when_attach_fails) {
     });
 }
 
+BOOST_AUTO_TEST_CASE(test_min_sstable_size_default_from_expected_memtable_size) {
+    constexpr uint64_t default_min_sstable_size = compaction::default_min_sstable_size;
+
+    auto min_sstable_size = [] (uint64_t expected_memtable_size) {
+        return compaction::strategy_options_defaults{.expected_memtable_size = expected_memtable_size}.min_sstable_size();
+    };
+
+    // Half of the expected memtable size, so that the sstables a full memtable is
+    // flushed into aren't considered too small to be tiered by their size.
+    BOOST_REQUIRE_EQUAL(min_sstable_size(24 * 1024 * 1024), 12 * 1024 * 1024);
+    BOOST_REQUIRE_EQUAL(min_sstable_size(1024 * 1024), 512 * 1024);
+
+    // Never larger than the value used when the expected memtable size isn't known,
+    // and never small enough to become meaningless.
+    BOOST_REQUIRE_EQUAL(min_sstable_size(4 * default_min_sstable_size), default_min_sstable_size);
+    BOOST_REQUIRE_EQUAL(min_sstable_size(2 * default_min_sstable_size), default_min_sstable_size);
+    BOOST_REQUIRE_EQUAL(min_sstable_size(1), 4 * 1024);
+
+    // Fall back to the default when the expected memtable size isn't known.
+    BOOST_REQUIRE_EQUAL(min_sstable_size(0), default_min_sstable_size);
+    BOOST_REQUIRE_EQUAL(compaction::strategy_options_defaults{}.min_sstable_size(), default_min_sstable_size);
+}
+
+SEASTAR_TEST_CASE(test_size_tiering_with_expected_memtable_size) {
+    return test_env::do_with_async([] (test_env& env) {
+        auto s = schema_builder(this_smp_shard_count(), "tests", "expected_memtable_size")
+                .with_column("id", utf8_type, column_kind::partition_key)
+                .with_column("value", int32_type)
+                .build();
+
+        auto make_sstable = [&] (uint64_t data_size) {
+            auto sst = env.make_sstable(s, "/nowhere/in/particular", env.new_generation(), sstable_version_types::md, big);
+            auto keys = tests::generate_partition_keys(2, s, local_shard_only::yes);
+            sstables::test(sst).set_values(keys[0].key(), keys[1].key(), stats_metadata{}, data_size);
+            // Old enough not to be considered a recently written tiny sstable.
+            sstables::test(sst).set_data_file_write_time(db_clock::now() - std::chrono::hours(24));
+            return sst;
+        };
+
+        // Both sstables are smaller than the default min_sstable_size (50M), but larger
+        // than the one derived from an expected memtable size of 1M.
+        auto small_sst = make_sstable(1 * 1024 * 1024);
+        auto large_sst = make_sstable(40 * 1024 * 1024);
+
+        std::vector<sstables::frozen_sstable_run> runs = {
+            make_lw_shared<const sstables::sstable_run>(sstables::sstable_run(small_sst)),
+            make_lw_shared<const sstables::sstable_run>(sstables::sstable_run(large_sst)),
+        };
+
+        auto expect_buckets = [&] (unsigned expected_bucket_count, const compaction::strategy_options_defaults& defaults,
+                const std::map<sstring, sstring>& options = {}) {
+            compaction::size_tiered_compaction_strategy_options stcs_options(options, defaults);
+            auto stcs_buckets = compaction::size_tiered_compaction_strategy::get_buckets({ small_sst, large_sst }, stcs_options);
+            BOOST_REQUIRE_EQUAL(stcs_buckets.size(), expected_bucket_count);
+
+            compaction::incremental_compaction_strategy_options ics_options(options, defaults);
+            auto ics_buckets = compaction::incremental_compaction_strategy::get_buckets(runs, ics_options);
+            BOOST_REQUIRE_EQUAL(ics_buckets.size(), expected_bucket_count);
+        };
+
+        // When the expected memtable size isn't known, both sstables are considered
+        // tiny, so they are put in the same tier.
+        expect_buckets(1, {});
+
+        // A memtable of 1M is flushed into sstables far smaller than either of them,
+        // so they are large enough to be tiered by their size.
+        expect_buckets(2, {.expected_memtable_size = 1024 * 1024});
+
+        // An explicitly configured min_sstable_size overrides the derived default.
+        expect_buckets(1, {.expected_memtable_size = 1024 * 1024}, {{ "min_sstable_size", "52428800" }});
+    });
+}
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
The default value of the `min_sstable_size` compaction option is a constant, 50M, shared by all tables. SSTables smaller than it are all put in the same size tier, so the option is meant to capture the sstables that are too small to be tiered by their size, not the ones a full memtable is flushed into.

The constant was sized for a shard that holds a single memtable per table, covering the shard's whole token range, and that can use all of the shard's memtable memory. That isn't the case when the table's data is distributed using tablets, where each tablet replica has a memtable of its own, nor when the shard holds many tables, which all share the same memtable memory. In both cases the sstables flushed from a memtable are much smaller than the constant, so the strategy considers them all tiny, and compacts sstables of widely different sizes together, increasing write amplification.

This series derives the default from the size a memtable of the table is expected to reach before it is flushed:

    min_sstable_size = clamp(expected_memtable_size / 2, 4K, 50M)

    expected_memtable_size = memtable memory of the shard / number of memtables sharing it

The memtable memory is `available memory per shard * 0.5 * unspooled_dirty_soft_limit`, i.e. the amount of dirty memory the memtables are expected to use before flushing starts, taken from the dirty memory manager rather than recomputed. The number of memtables sharing it is `tablets_per_shard_goal * 1.5` for a table that uses tablets, since the replica count per shard varies between the goal and twice as much until merges bring it back down, and the number of tables on the shard for a table that uses vnodes.

On a shard with 8 GiB of memory, the memtable memory is 2.4 GiB. With the default `tablets_per_shard_goal` of 100, a table that uses tablets expects a memtable of 16 MiB, so `min_sstable_size` defaults to 8 MiB. A shard holding up to 24 tables that use vnodes still gets the 50M maximum, and beyond that the default shrinks with the table count.

The derived default is used only when `min_sstable_size` isn't set in the table's schema, so an explicitly configured value still wins. When the expected memtable size can't be determined the default is the 50M constant, as before.

The patches are:

1. `compaction,test: derive the min_sstable_size default from the expected memtable size` - the mechanism. The table feeds an expected memtable size to the strategy, so the compaction strategies don't need to know how the table's data is distributed across the shard. No table provides one yet, so there is no change in behavior.
2. `replica,docs: derive the expected memtable size for tablet tables` - the tablets policy. Also exposes the memtable memory as `dirty_memory_manager::flush_threshold()`, and zero-initializes its `_threshold` and `_soft_limit` members, which the default constructor left indeterminate.
3. `replica,docs: derive the expected memtable size for vnode tables` - the vnodes policy, normalizing by the shard's table count. Separable from the rest.

Fixes https://scylladb.atlassian.net/browse/SCYLLADB-3657

Tests:
- unit (dev): `test/boost/sstable_compaction_test.cc` (275 passed), including the new `test_min_sstable_size_default_from_expected_memtable_size` and `test_size_tiering_with_expected_memtable_size`
- each patch builds `scylla` and `combined_tests` on its own

This is an enhancement, therefore no backport is required.
