### PR TITLE
test: range_assert: avoid static template in header

### DIFF
--- a/test/boost/range_assert.hh
+++ b/test/boost/range_assert.hh
@@ -42,6 +42,6 @@ public:
 };
 
 template <typename Iterator>
-static range_assert<Iterator> assert_that_range(Iterator begin, Iterator end) {
+range_assert<Iterator> assert_that_range(Iterator begin, Iterator end) {
     return { begin, end };
 }


### PR DESCRIPTION
A static template that is not used will not compile under clang 24 (like an unused static function in older compilers). Since a header can't tell if its functions will be used or not, it must not mark them as static (not a good idea due to duplication as well).

Remove the static marker.

Minor cleanup, not backporting.