### PR TITLE
build: default LeakSanitizer off in the packaged binary wrapper

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -157,7 +157,7 @@ adjust_bin() {
 export GNUTLS_SYSTEM_PRIORITY_FILE="\${GNUTLS_SYSTEM_PRIORITY_FILE-$prefix/libreloc/gnutls.config}"
 export LD_LIBRARY_PATH="$prefix/libreloc"
 export UBSAN_OPTIONS="${UBSAN_OPTIONS:+$UBSAN_OPTIONS:}suppressions=$prefix/libexec/ubsan-suppressions.supp"
-export LSAN_OPTIONS="${LSAN_OPTIONS:+$LSAN_OPTIONS:}suppressions=$prefix/libexec/lsan-suppressions.supp"
+export LSAN_OPTIONS="detect_leaks=0:suppressions=$prefix/libexec/lsan-suppressions.supp\${LSAN_OPTIONS:+:\$LSAN_OPTIONS}"
 ${p11_trust_paths:+export SCYLLA_P11_TRUST_PATHS="$p11_trust_paths"}
 exec -a "\$0" "$prefix/libexec/$bin" "\$@"
 EOF


### PR DESCRIPTION
d0fd7699e512 ("build: suppress LeakSanitizer reports from liblttng-ust")
shipped lsan-suppressions.supp with a single "leak:liblttng-ust" entry
and pointed LSAN_OPTIONS at it from the generated bin/scylla wrapper.
That fixed x86 only. On aarch64 the debug Docker integration test still
fails on "scylla --version" - see
https://jenkins.scylladb.com/job/scylla-master/job/unified-deb/2133/.

Why the suppression is not enough on aarch64
--------------------------------------------

The suppression file is loaded and does match - partially:

  Direct leak of 56 byte(s) in 1 object(s) allocated from:
      #0 0x000004555304  (/opt/scylladb/libexec/scylla+0x4555304)
      #1 0xffffb6a2dd4c  (<unknown module>)
      #2 0x5bffffb6a36d50  (<unknown module>)
      ... every remaining frame <unknown module> ...

  -----------------------------------------------------
  Suppressions used:
    count      bytes template
        2        176 liblttng-ust
  -----------------------------------------------------

  SUMMARY: AddressSanitizer: 56 byte(s) leaked in 1 allocation(s).

Two of the three ARM leaks are suppressed; a third one is not, so the
process still exits non-zero.

There is no stable named frame left to key a suppression on. The only
modules that do get named in the surviving trace are libexec/scylla -
that is ASan's malloc interceptor, i.e. every allocation - and, on some
builds, libc.so.6; suppressing either is far too broad to be safe.
Making the suppression match for real would require
fast_unwind_on_malloc=0 so that the CFI unwinder is used, but that
applies to every allocation at run time and is a large slowdown for
debug packaged runs.

The fix
-------

Default the at-exit leak check off in the packaged wrapper. At-exit leak
reporting on a packaged Scylla is not actionable - Scylla leaks
intentionally at shutdown and nobody triages this output - while it does
make an invocation as trivial as "scylla --version" fail. It is
defaulted off the same way on every architecture, so it cannot be
defeated again by an unwinder quirk. AddressSanitizer stays fully
enabled for memory errors; only the leak report is affected.

detect_leaks=0 is a default, not a policy: the wrapper now puts its own
settings first and appends the caller's LSAN_OPTIONS last, and sanitizer
flag parsing is last-wins, so

  LSAN_OPTIONS=detect_leaks=1 scylla ...

turns the leak check back on, with lsan-suppressions.supp still in
effect to keep the known liblttng-ust reports out of the way. The
suppression file is therefore kept and still packaged.

While here, escape the caller expansion so it is evaluated when the
wrapper runs rather than when install.sh generates it.

Fixes: SCYLLADB-3664

**No backport is required.** The leak reports only exist where Scylla links liblttng-ust, which starts with https://github.com/scylladb/scylladb/commit/dafe9e9a802f5a0912ffb5578aa4de261e47ef63 - a commit that is on master only and was itself marked as not requiring a backport
