### PR TITLE
db/view/view: flush base tables while starting view builder

### DIFF
--- a/db/view/view.cc
+++ b/db/view/view.cc
@@ -25,6 +25,7 @@
 #include <seastar/core/coroutine.hh>
 #include <seastar/coroutine/all.hh>
 #include <seastar/coroutine/maybe_yield.hh>
+#include <seastar/coroutine/as_future.hh>
 #include <flat_map>
 
 #include "db/config.hh"
@@ -2509,13 +2510,13 @@ future<> view_builder::calculate_shard_build_step(view_builder_init_state& vbi) 
         vbi.bookkeeping_ops.push_back(add_new_view(view, get_or_create_build_step(view->view_info()->base_id())));
     }
 
-    return parallel_for_each(_base_to_build_step, [this] (auto& p) {
+    co_await parallel_for_each(_base_to_build_step, [this] (auto& p) {
         return initialize_reader_at_current_token(p.second);
-    }).then([&vbi] {
-        return seastar::when_all_succeed(vbi.bookkeeping_ops.begin(), vbi.bookkeeping_ops.end()).handle_exception([] (std::exception_ptr ep) {
-            vlogger.warn("Failed to update materialized view bookkeeping while synchronizing view builds on all shards ({}), continuing anyway.", ep);
-        });
     });
+    auto bookkeeping_fut = co_await coroutine::as_future(seastar::when_all_succeed(vbi.bookkeeping_ops.begin(), vbi.bookkeeping_ops.end()));
+    if (bookkeeping_fut.failed()) {
+        vlogger.warn("Failed to update materialized view bookkeeping while synchronizing view builds on all shards ({}), continuing anyway.", bookkeeping_fut.get_exception());
+    }
 }
 
 service::query_state& view_builder_query_state() {

--- a/db/view/view.cc
+++ b/db/view/view.cc
@@ -2495,7 +2495,6 @@ future<> view_builder::calculate_shard_build_step(view_builder_init_state& vbi) 
         }
     }
 
-    auto all_views = _db.get_views();
     auto doesnt_use_tablets = [&] (const view_ptr& v) {
         return !_db.find_keyspace(v->ks_name()).uses_tablets();
     };
@@ -2506,7 +2505,26 @@ future<> view_builder::calculate_shard_build_step(view_builder_init_state& vbi) 
         return _db.column_family_exists(v->view_info()->base_id()) && !loaded_views.contains(v->id())
                 && !vbi.built_views.contains(v->id());
     };
-    for (auto&& view : all_views | std::views::filter(doesnt_use_tablets) | std::views::filter(is_new)) {
+    auto new_views = _db.get_views() | std::views::filter(doesnt_use_tablets) | std::views::filter(is_new) | std::ranges::to<std::vector>();
+    auto base_ids = new_views | std::views::transform([] (const auto& view) {
+        return view->view_info()->base_id();
+    }) | std::ranges::to<std::set>();
+
+    // The view builder subscribes to schema change events just before this method is called,
+    // so a view created earlier gets no `on_create_view()` notification and never goes through
+    // `dispatch_create_view()`. Such a view is picked up here instead and treated as an existing,
+    // unfinished one, so we have to flush its base table here, the way `handle_create_view_local()`
+    // does for newly created views. Otherwise the view would miss some updates.
+    for (auto& base_id: base_ids) {
+        auto& step = get_or_create_build_step(base_id);
+        co_await coroutine::all(
+            [&step] -> future<> {
+                co_await step.base->await_pending_writes(); },
+            [&step] -> future<> {
+                co_await step.base->await_pending_streams(); });
+        co_await flush_base(step.base, _as);
+    }
+    for (auto&& view : new_views) {
         vbi.bookkeeping_ops.push_back(add_new_view(view, get_or_create_build_step(view->view_info()->base_id())));
     }
 


### PR DESCRIPTION
Before view builder subscribes itself to schema change events (to handle `on_create_view()` event), it waits for schema agreement and creates build steps for already existing views. But when building process is started for existing non-finished view, its base table isn't flushed because we assume that the view existed before node restart and the base table was already flushed.

However, this isn't always true.
View builder startup process may be stuck on schema agreement for a short period of time, especially in many test cases when we're doing multiple schema operations at the beginning. If the schema agreement check won't be passed before creating a MV, then a build step for the view will be created from the "existing view" path, its base table won't be flushed and view updates won't be generated.

This patch fixes it by flushing base tables when the view builder is initializing build steps for existing view.

Fixes SCYLLADB-3623

This is mostly testing infrastructure bug and it was observed while I was migrating dtest to test.py in https://github.com/scylladb/scylladb/pull/30024, so there is no reason to backport it.