### PR TITLE
test: write dockerized service logs to the archived testlog dir

### DIFF
--- a/test/cluster/conftest.py
+++ b/test/cluster/conftest.py
@@ -396,9 +396,9 @@ async def scylla_2025_1(request, build_mode, internet_dependency_enabled) -> Asy
     yield await get_scylla_2025_1_description(build_mode)
 
 @pytest.fixture(scope="function", params=list(KeyProvider))
-async def key_provider(request, tmpdir, scylla_binary):
+async def key_provider(request, tmpdir, suite_log_dir, scylla_binary):
     """Encryption providers fixture"""
-    async with make_key_provider_factory(request.param, tmpdir, scylla_binary) as res:
+    async with make_key_provider_factory(request.param, tmpdir, suite_log_dir, scylla_binary) as res:
         yield res
 
 
@@ -407,7 +407,7 @@ def failure_detector_timeout(build_mode):
     return 5000 * MODES_TIMEOUT_FACTOR[build_mode]
 
 @pytest.fixture(params=[None, 's3', 'gs'], ids=['local', 's3', 'gs'])
-async def storage(request, pytestconfig, tmpdir):
+async def storage(request, pytestconfig, tmpdir, suite_log_dir):
     """Parametrize tests over local / S3 / GCS storage.
 
     When storage is None the test runs with local (filesystem) storage.
@@ -417,5 +417,5 @@ async def storage(request, pytestconfig, tmpdir):
         yield None
         return
 
-    async with make_object_storage(request.param, pytestconfig, tmpdir, request.node.name) as server:
+    async with make_object_storage(request.param, pytestconfig, tmpdir, suite_log_dir, request.node.name) as server:
         yield server

--- a/test/cluster/object_store/conftest.py
+++ b/test/cluster/object_store/conftest.py
@@ -29,11 +29,17 @@ def pytest_addoption(parser):
 
 
 @asynccontextmanager
-async def make_object_storage(kind, pytestconfig, tmpdir, test_name):
+async def make_object_storage(kind, pytestconfig, tmpdir, log_dir, test_name):
+    """Start an object-storage backend for a test.
+
+    `tmpdir` holds the server's scratch data (per-test, discarded by CI), while
+    `log_dir` must be a CI-archived directory (testlog) so that container logs
+    survive for post-mortem analysis.
+    """
     if kind == 'gs':
-        server = create_gs_server(tmpdir)
+        server = create_gs_server(log_dir)
     else:
-        server = create_s3_server(pytestconfig, tmpdir)
+        server = create_s3_server(pytestconfig, tmpdir, log_dir)
 
     bucket_created = False
     try:
@@ -48,18 +54,18 @@ async def make_object_storage(kind, pytestconfig, tmpdir, test_name):
 
 
 @pytest.fixture(scope="function", params=['s3', 'gs'])
-async def object_storage(request, pytestconfig, tmpdir):
-    async with make_object_storage(request.param, pytestconfig, tmpdir, request.node.name) as server:
+async def object_storage(request, pytestconfig, tmpdir, suite_log_dir):
+    async with make_object_storage(request.param, pytestconfig, tmpdir, suite_log_dir, request.node.name) as server:
         yield server
 
 
 @pytest.fixture(scope="function")
-async def s3_storage(request, pytestconfig, tmpdir):
-    async with make_object_storage('s3', pytestconfig, tmpdir, request.node.name) as server:
+async def s3_storage(request, pytestconfig, tmpdir, suite_log_dir):
+    async with make_object_storage('s3', pytestconfig, tmpdir, suite_log_dir, request.node.name) as server:
         yield server
 
 
 @pytest.fixture(scope="function")
-async def gs_storage(request, pytestconfig, tmpdir):
-    async with make_object_storage('gs', pytestconfig, tmpdir, request.node.name) as server:
+async def gs_storage(request, pytestconfig, tmpdir, suite_log_dir):
+    async with make_object_storage('gs', pytestconfig, tmpdir, suite_log_dir, request.node.name) as server:
         yield server

--- a/test/cluster/test_encryption.py
+++ b/test/cluster/test_encryption.py
@@ -271,10 +271,10 @@ async def test_wrong_cipher_algorithm(manager, key_provider):
     assert len(expected_errors) == len(broken_ciphers), expected_errors
 
 @pytest.mark.parametrize(argnames="compression", argvalues=("LZ4", "Snappy", "Deflate"))
-async def test_encryption_table_compression(manager, tmpdir, compression, scylla_binary):
+async def test_encryption_table_compression(manager, tmpdir, suite_log_dir, compression, scylla_binary):
     """Test compression + ear"""
     logger.debug("---- Test with compression: %s -----", compression)
-    async with make_key_provider_factory(KeyProvider.local, tmpdir, scylla_binary) as key_provider:
+    async with make_key_provider_factory(KeyProvider.local, tmpdir, suite_log_dir, scylla_binary) as key_provider:
         await _smoke_test(manager, key_provider,
                           ciphers={"AES/CBC/PKCS5Padding": [128]},
                           compression=compression)
@@ -391,12 +391,12 @@ async def test_alter(manager, key_provider):
                       ciphers={"AES/CBC/PKCS5Padding": [128]},
                       restart=restart)
 
-async def test_per_table_master_key(manager: ManagerClient, tmpdir):
+async def test_per_table_master_key(manager: ManagerClient, tmpdir, suite_log_dir):
     """Test per table KMS master key"""
     class MultiAliasKMSProvider (KMSKeyProviderFactory):
         """Special KMS using different master keys for each table"""
-        def __init__(self, tmpdir):
-            super(MultiAliasKMSProvider, self).__init__(tmpdir)
+        def __init__(self, tmpdir, log_dir):
+            super(MultiAliasKMSProvider, self).__init__(tmpdir, log_dir)
             self.key_count: int = 0
             self.key_ids: list = []
             self.aliases: list = []
@@ -409,7 +409,7 @@ async def test_per_table_master_key(manager: ManagerClient, tmpdir):
             self.key_count += 1
             return super().additional_cf_options() | {"master_key": alias_name}
 
-    async with MultiAliasKMSProvider(tmpdir) as kp:
+    async with MultiAliasKMSProvider(tmpdir, suite_log_dir) as kp:
         async def restart(manager: ManagerClient, servers: list[ServerInfo],
                           table_names: list[str]):
             await manager.rolling_restart(servers)
@@ -435,14 +435,14 @@ async def test_per_table_master_key(manager: ManagerClient, tmpdir):
                           restart=restart)
 
 
-async def test_non_existant_table_master_key(manager: ManagerClient, tmpdir):
+async def test_non_existant_table_master_key(manager: ManagerClient, tmpdir, suite_log_dir):
     """Test we fail properly if using a non-existant master key"""
     class NoSuchKeyKMSProvider (KMSKeyProviderFactory):
         """Special KMS using nonexisting master key"""
         def additional_cf_options(self):
             return super().additional_cf_options() | {"master_key": "alias/NoSuchKey"}
 
-    async with NoSuchKeyKMSProvider(tmpdir) as kp:
+    async with NoSuchKeyKMSProvider(tmpdir, suite_log_dir) as kp:
         with pytest.raises(Exception):
             await _smoke_test(manager, kp, ciphers={"AES/CBC/PKCS5Padding": [128]})
 

--- a/test/pylib/dockerized_service.py
+++ b/test/pylib/dockerized_service.py
@@ -37,10 +37,16 @@ class _PortInUseError(RuntimeError):
 
 
 class DockerizedServer:
-    """class for running an external dockerized service image, typically mock server"""
+    """class for running an external dockerized service image, typically mock server
+
+    The container's stderr is written to ``<log_dir>/<logfilenamebase>-<uuid>.log``.
+    Callers must point ``log_dir`` at a directory CI archives (i.e. somewhere under
+    ``--tmpdir``/testlog), otherwise the container log is lost with the per-test
+    temporary directory and post-mortem analysis of a container failure is impossible.
+    """
     # pylint: disable=too-many-instance-attributes
 
-    def __init__(self, image, tmpdir, logfilenamebase, 
+    def __init__(self, image, log_dir, logfilenamebase,
                  success_string : Callable[[str, int], bool] | str,
                  failure_string : Callable[[str, int], bool] | str,
                  docker_args : Callable[[str, int], list[str]] | list[str] = [],
@@ -49,7 +55,7 @@ class DockerizedServer:
                  port = None):
         self.image = image
         self.host = host
-        self.tmpdir = tmpdir
+        self.log_dir = log_dir
         self.logfilenamebase = logfilenamebase
         self.docker_args: Callable[[str, int], list[str]] = (lambda host,port : docker_args) if isinstance(docker_args, list) else docker_args
         self.image_args: Callable[[str, int], list[str]] = (lambda host,port : image_args) if isinstance(image_args, list) else image_args
@@ -91,8 +97,13 @@ class DockerizedServer:
 
     async def _start_attempt(self, exe, name):
         """Launch the container once. Raises _PortInUseError if the host port could not be bound."""
-        logfilename = (pathlib.Path(self.tmpdir) / name).with_suffix(".log")
+        log_dir = pathlib.Path(self.log_dir)
+        log_dir.mkdir(parents=True, exist_ok=True)
+        logfilename = (log_dir / name).with_suffix(".log")
         self.logfile = logfilename.open("wb")
+        # Logged at INFO so the archived pytest log always points at the container
+        # log file, even when the container starts fine and only misbehaves later.
+        logger.info("Container %s stderr is captured in %s", name, logfilename)
 
         docker_args = self.docker_args(self.host, self.service_port)
         image_args = self.image_args(self.host, self.service_port)

--- a/test/pylib/encryption_provider.py
+++ b/test/pylib/encryption_provider.py
@@ -175,9 +175,10 @@ class KmipKeyProviderFactory(KeyProviderFactory):
 
 class KMSKeyProviderFactory(KeyProviderFactory):
     """KMSKeyProviderFactory proxy"""
-    def __init__(self, tmpdir):
+    def __init__(self, tmpdir, log_dir):
         super(KMSKeyProviderFactory, self).__init__(KeyProvider.kms, tmpdir)
         self.tmpdir = tmpdir
+        self.log_dir = log_dir
         self.master_key = "alias/Scylla-test"
         self.kms_host = "kms_test"
         self.endpoint_url = None
@@ -189,7 +190,7 @@ class KMSKeyProviderFactory(KeyProviderFactory):
         aws_region = os.getenv('KMS_AWS_REGION')
  
         if master_key is None:
-            self.server = DockerizedServer("docker.io/nsmithuk/local-kms:3", self.tmpdir,
+            self.server = DockerizedServer("docker.io/nsmithuk/local-kms:3", self.log_dir,
                                            logfilenamebase="local-kms",
                                            success_string="Local KMS started on",
                                            failure_string="address already in use",
@@ -378,8 +379,12 @@ class GcpKeyProviderFactory(KeyProviderFactory):
         return True
 
 
-def make_key_provider_factory(provider: KeyProvider, tmpdir, scylla_exe):
-    """Create key provider factory for enum"""
+def make_key_provider_factory(provider: KeyProvider, tmpdir, log_dir, scylla_exe):
+    """Create key provider factory for enum
+
+    `tmpdir` holds per-test scratch data, `log_dir` must be a CI-archived
+    directory (testlog) so that container logs survive the test run.
+    """
     res = None
     if provider == KeyProvider.local:
         res = LocalFileSystemKeyProviderFactory(tmpdir)
@@ -388,7 +393,7 @@ def make_key_provider_factory(provider: KeyProvider, tmpdir, scylla_exe):
     elif provider == KeyProvider.kmip:
         res = KmipKeyProviderFactory(tmpdir)
     elif provider == KeyProvider.kms:
-        res = KMSKeyProviderFactory(tmpdir)
+        res = KMSKeyProviderFactory(tmpdir, log_dir)
     elif provider == KeyProvider.azure:
         res = AzureKeyProviderFactory(tmpdir)
     elif provider == KeyProvider.gcp:

--- a/test/pylib/minio_server.py
+++ b/test/pylib/minio_server.py
@@ -37,7 +37,14 @@ class MinioServer:
 
     log_file: BufferedWriter
 
-    def __init__(self, tempdir_base, address, logger):
+    def __init__(self, tempdir_base, address, logger, log_dir=None):
+        """
+        `tempdir_base` holds the server's scratch data (per-test, discarded by
+        CI), while `log_dir`, if given, must be a CI-archived directory
+        (testlog) so that the server's log survives for post-mortem analysis.
+        Defaults to `tempdir_base` for callers that already pass an archived
+        directory in that argument.
+        """
         self.srv_exe = shutil.which('minio')
         self.address = address
         self.port = self.DEFAULT_PORT
@@ -54,7 +61,9 @@ class MinioServer:
         self.bucket_name = 'testbucket'
         self.access_key = os.environ.get(self.ENV_ACCESS_KEY, ''.join(random.choice(string.hexdigits) for i in range(16)))
         self.secret_key = os.environ.get(self.ENV_SECRET_KEY, ''.join(random.choice(string.hexdigits) for i in range(32)))
-        self.log_filename = (self.tempdir_base / 'minio').with_suffix(".log")
+        log_path = pathlib.Path(log_dir if log_dir is not None else self.tempdir_base)
+        log_path.mkdir(parents=True, exist_ok=True)
+        self.log_filename = log_path / f'minio-{self.tempdir.name}.log'
         self.old_env = dict()
         self.default_config = None
 

--- a/test/pylib/object_storage.py
+++ b/test/pylib/object_storage.py
@@ -115,10 +115,11 @@ S3_Server = S3Server
 
 
 class MinioWrapper(S3Server):
-    def __init__(self, tempdir):
+    def __init__(self, tempdir, log_dir=None):
         self.host_registry = HostRegistry()
         self.leased_host = None
         self.server = None
+        self.log_dir = log_dir
         # Fields are fully initialized by start(); base-class values are
         # placeholders until then.
         super().__init__(tempdir, '', 0, '', '', MinioServer.DEFAULT_REGION, '')
@@ -130,7 +131,8 @@ class MinioWrapper(S3Server):
         self.leased_host = await self.host_registry.lease_host()
         self.server = MinioServer(self.tempdir,
                                   self.leased_host,
-                                  logging.getLogger('minio'))
+                                  logging.getLogger('minio'),
+                                  log_dir=self.log_dir)
         try:
             await self.server.start()
         except Exception:
@@ -206,7 +208,7 @@ class GSFront:
 
 
 class GSServerImpl(GSFront):
-    def __init__(self, tmpdir):
+    def __init__(self, log_dir):
         super(GSServerImpl, self).__init__(None, 'testbucket', None)
         self.server = None
         self.host = None
@@ -216,7 +218,7 @@ class GSServerImpl(GSFront):
                       'GS_BUCKET_FOR_TEST': attrgetter('bucket_name'),
                       'GS_CREDENTIALS_FILE': attrgetter('credentials_file'),
                       }
-        self.tmpdir = tmpdir
+        self.log_dir = log_dir
 
     def publish(self):
         self.endpoint = f'http://{self.host}:{self.port}'
@@ -240,7 +242,7 @@ class GSServerImpl(GSFront):
         return ["-scheme", "http", "-log-level", "debug", "--port", f'{port}', '-public-host', '127.0.0.1']
 
     async def start(self):
-        self.server = DockerizedServer("docker.io/fsouza/fake-gcs-server:1.54.0", self.tmpdir,
+        self.server = DockerizedServer("docker.io/fsouza/fake-gcs-server:1.54.0", self.log_dir,
                                        logfilenamebase="fake-gcs-server",
                                        image_args=self._image_args,
                                        success_string="server started at",
@@ -289,7 +291,7 @@ class GSServerImpl(GSFront):
 GSServer = GSServerImpl
 
 
-def create_s3_server(pytestconfig, tmpdir):
+def create_s3_server(pytestconfig, tmpdir, log_dir=None):
     server = None
     s3_server_address = pytestconfig.getoption('--s3-server-address')
     s3_server_port = pytestconfig.getoption('--s3-server-port')
@@ -326,23 +328,23 @@ def create_s3_server(pytestconfig, tmpdir):
                           default_region,
                           default_bucket)
     else:
-        server = MinioWrapper(tempdir)
+        server = MinioWrapper(tempdir, log_dir)
     return server
 
 
-def create_gs_server(tmpdir):
+def create_gs_server(log_dir):
     endpoint = os.environ.get('GS_SERVER_ADDRESS_FOR_TEST')
     bucket = os.environ.get('GS_BUCKET_FOR_TEST')
     credentials_file = os.environ.get('GS_CREDENTIALS_FILE')
 
     if endpoint is not None and bucket is not None:
         return GSFront(endpoint, bucket, credentials_file)
-    return GSServerImpl(tmpdir)
+    return GSServerImpl(log_dir)
 
 
 @pytest.fixture(scope="function")
-async def s3_server(request, pytestconfig, tmpdir):
-    server = create_s3_server(pytestconfig, tmpdir)
+async def s3_server(request, pytestconfig, tmpdir, suite_log_dir):
+    server = create_s3_server(pytestconfig, tmpdir, suite_log_dir)
     await server.start()
     bucket_created = False
     try:


### PR DESCRIPTION
DockerizedServer wrote each container's stderr to <tmpdir>/<name>.log, where tmpdir was pytest's per-test temporary directory under /tmp. CI runs test.py with --tmpdir=testlog/<arch> and only archives testlog/**, so these container logs were discarded along with the temporary directory and were never available for post-mortem analysis.

A container that dies before signalling readiness already has its log dumped to the pytest log at ERROR level, but one that starts up fine and only misbehaves later logs via logger.debug, which is dropped at the default INFO level. In that case nothing about the container survived the run.

Rename the parameter to log_dir to reflect that it was only ever the log destination, create the directory if it is missing, and log its path at INFO. Callers now pass the suite_log_dir fixture (testlog/<arch>/<mode>), which CI archives, while genuine scratch data (minio's data dir, key material) keeps using tmpdir. This covers both the fake-gcs-server and the local-kms containers, which share the class and had the same bug.

Fixes: RELENG-714

**enhancement for CI, not backporting**