### PR TITLE
alternator: fix use-after-free in batch_write_item

### DIFF
--- a/alternator/executor.cc
+++ b/alternator/executor.cc
@@ -55,6 +55,7 @@
 #include <seastar/core/coroutine.hh>
 #include <seastar/core/sleep.hh>
 #include <seastar/core/loop.hh>
+#include <seastar/core/when_all.hh>
 #include <seastar/coroutine/maybe_yield.hh>
 #include <boost/range/algorithm/find_end.hpp>
 #include <unordered_set>
@@ -3562,8 +3563,17 @@ future<executor::request_return_type> executor::batch_write_item(client_state& c
         previous_items_sizes.reserve(mutation_builders.size());
 
         // Parallel get all previous item sizes
+        // Note - after starting we need to wait for all the `get_previous_item_size` requests to
+        // complete first before processing the results.
+        // This needs to be done, because `get_previous_item_size` fiber contains reference to `client_state`, which
+        // is allocated on heap in `server::handle_api_request` and partition / clustering key from `mutation_builders`.
+        // If it throws an error and `co_await` returns early (either here or when `.get()` is called) without
+        // waiting for other fibers the function will conclude and those objects be deleted.
+        // Once remaining `get_previous_item_size` fibers resume, they will access deleted memory and crash.
+        // We use `futurize_invoke` to avoid early returning here and `when_all_succeed` below to wait for all fibers to finish
+        // before processing any results.
         for (const auto& b : mutation_builders) {
-            previous_items_sizes.emplace_back(get_previous_item_size(
+            previous_items_sizes.emplace_back(futurize_invoke(get_previous_item_size,
                 _proxy,
                 client_state,
                 b.first,
@@ -3571,11 +3581,14 @@ future<executor::request_return_type> executor::batch_write_item(client_state& c
                 b.second.ck(),
                 permit));
         }
-        size_t pos = 0;
-        // We are going to wait for all the requests
-        for (auto&& pi : previous_items_sizes) {
-            auto res_result = co_await std::move(pi);
 
+        // We are going to wait for all the requests.
+        // This will throw if any fiber throws an error, but other fibers will be waited for and their results collected
+        // or `ignore_ready_future()` will be called.
+        auto results = co_await when_all_succeed(std::move(previous_items_sizes));
+
+        size_t pos = 0;
+        for (auto&& res_result : results) {
             if (auto error = std::get_if<api_error>(&res_result)) {
                 co_return std::move(*error);
             }


### PR DESCRIPTION
Fix use-after-free in `batch_write_item` function. The function at one point spawns a set of fibers of `get_previous_item_size()` functions. Each call contains a reference to a `client_state` object, which is allocated on heap in `server::handle_api_request()` function. The original code returns early after detecting first error, not waiting for other fibers to complete. It's possible the `server::handle_api_request()` function to complete and `client_state` object be destroyed and then some
`get_previous_item_size()` fiber to resume, try to access already deleted `client_state` object.

The fix here is - in case of an error - to store a first error, ignore other errors, wait for all `get_previous_item_size()` fibers to complete and then return the stored error.

The fix is behaviour preserving - just like an original, the first spotted error will be returned. No change will be observed, if the error don't happen.

Fixes: SCYLLADB-3675

Backport: bug-fix, so yes.