### PR TITLE
Compaction: STCS: fix O(n^2) get_buckets and defer backlog contribution recompute

### DIFF
--- a/compaction/compaction_backlog_manager.hh
+++ b/compaction/compaction_backlog_manager.hh
@@ -73,7 +73,7 @@ public:
     compaction_backlog_tracker(const compaction_backlog_tracker&) = delete;
     ~compaction_backlog_tracker();
 
-    double backlog() const;
+    double backlog();
     // FIXME: Should provide strong exception safety guarantees
     void replace_sstables(const std::vector<sstables::shared_sstable>& old_ssts, const std::vector<sstables::shared_sstable>& new_ssts);
     void register_partially_written_sstable(sstables::shared_sstable sst, backlog_write_progress_manager& wp);

--- a/compaction/compaction_manager.cc
+++ b/compaction/compaction_manager.cc
@@ -2722,8 +2722,18 @@ void compaction_backlog_tracker::retire() {
     disable();
 }
 
-double compaction_backlog_tracker::backlog() const {
-    return disabled() ? compaction_controller::disable_backlog : _impl->backlog(_ongoing_writes, _ongoing_compactions);
+double compaction_backlog_tracker::backlog() {
+    if (disabled()) {
+        return compaction_controller::disable_backlog;
+    }
+    try {
+        return _impl->backlog(_ongoing_writes, _ongoing_compactions);
+    } catch (...) {
+        // Isolate the failure to this tracker instead of poisoning the whole shard's backlog poll.
+        cmlog.error("Disabling backlog tracker due to exception during backlog computation: {}", std::current_exception());
+        disable();
+        return compaction_controller::disable_backlog;
+    }
 }
 
 void compaction_backlog_tracker::replace_sstables(const std::vector<sstables::shared_sstable>& old_ssts, const std::vector<sstables::shared_sstable>& new_ssts) {

--- a/compaction/compaction_strategy.cc
+++ b/compaction/compaction_strategy.cc
@@ -263,6 +263,11 @@ size_tiered_backlog_tracker::sstables_backlog_contribution size_tiered_backlog_t
 }
 
 double size_tiered_backlog_tracker::backlog(const compaction_backlog_tracker::ongoing_writes& ow, const compaction_backlog_tracker::ongoing_compactions& oc) const {
+    if (_backlog_dirty) {
+        _contrib = calculate_sstables_backlog_contribution(_all | std::ranges::to<std::vector>(), _stcs_options);
+        _backlog_dirty = false;
+    }
+
     inflight_component compacted = compacted_backlog(oc);
 
     auto total_backlog_bytes = std::ranges::fold_left(_contrib.sstables | std::views::transform(std::mem_fn(&sstables::sstable::data_size)), uint64_t(0), std::plus{});
@@ -310,12 +315,11 @@ void size_tiered_backlog_tracker::replace_sstables(const std::vector<sstables::s
             }
         }
     }
-    auto tmp_contrib = calculate_sstables_backlog_contribution(tmp_all | std::ranges::to<std::vector>(), _stcs_options);
-
     std::invoke([&] () noexcept {
         _all = std::move(tmp_all);
         _total_bytes = tmp_total_bytes;
-        _contrib = std::move(tmp_contrib);
+        // Defer recalculation to the next backlog() call, mirroring incremental_backlog_tracker.
+        _backlog_dirty = true;
     });
 }
 

--- a/compaction/size_tiered_backlog_tracker.hh
+++ b/compaction/size_tiered_backlog_tracker.hh
@@ -72,7 +72,9 @@ class size_tiered_backlog_tracker final : public compaction_backlog_tracker::imp
 
     size_tiered_compaction_strategy_options _stcs_options;
     int64_t _total_bytes = 0;
-    sstables_backlog_contribution _contrib;
+    mutable sstables_backlog_contribution _contrib;
+    // Set by replace_sstables(), cleared by backlog() once _contrib is recomputed.
+    mutable bool _backlog_dirty = false;
     std::unordered_set<sstables::shared_sstable> _all;
 
     struct inflight_component {

--- a/compaction/size_tiered_compaction_strategy.cc
+++ b/compaction/size_tiered_compaction_strategy.cc
@@ -148,8 +148,10 @@ size_tiered_compaction_strategy::get_buckets(const std::vector<sstables::shared_
         return i.second < j.second;
     });
 
-    auto min_sstable_size_check = [&sstables, &options] (uint64_t size) {
-        return !tiny_sstables_written_recently(options.min_sstable_size, options.min_sstable_age, sstables) && size < options.min_sstable_size;
+    // Loop-invariant: compute once instead of rescanning all sstables per check (was O(n^2)).
+    bool recently_written = tiny_sstables_written_recently(options.min_sstable_size, options.min_sstable_age, sstables);
+    auto min_sstable_size_check = [&options, recently_written] (uint64_t size) {
+        return !recently_written && size < options.min_sstable_size;
     };
 
     using bucket_type = std::vector<sstables::shared_sstable>;

--- a/test/boost/sstable_compaction_test.cc
+++ b/test/boost/sstable_compaction_test.cc
@@ -4728,6 +4728,66 @@ SEASTAR_FIXTURE_TEST_CASE(basic_ics_controller_correctness_gcs_test, gcs_fixture
                                    test_env_config{.storage = make_test_object_storage_options("GS")});
 }
 
+// Backlog must be the same whether sstables are added one at a time or all at once.
+SEASTAR_TEST_CASE(size_tiered_backlog_deferred_matches_bulk) {
+    return test_env::do_with_async([](test_env& env) {
+        auto s = schema_builder(this_smp_shard_count(), "tests", "backlog_deferred_vs_bulk")
+                .with_column("id", utf8_type, column_kind::partition_key)
+                .with_column("value", int32_type)
+                .build();
+        auto keys = tests::generate_partition_keys(2, s, local_shard_only::yes);
+
+        constexpr int N = 50;
+        std::vector<sstables::shared_sstable> ssts;
+        for (int i = 0; i < N; i++) {
+            auto sst = sstable_for_overlapping_test(env, s, keys[0].key(), keys[1].key());
+            sstables::test(sst).set_data_file_size((i % 7 + 1) * 1024 * 1024);
+            ssts.push_back(sst);
+        }
+
+        compaction::size_tiered_compaction_strategy_options stcs_options;
+
+        compaction::size_tiered_backlog_tracker deferred(stcs_options);
+        for (auto& sst : ssts) {
+            deferred.replace_sstables({}, {sst});
+        }
+
+        compaction::size_tiered_backlog_tracker bulk(stcs_options);
+        bulk.replace_sstables({}, ssts);
+
+        BOOST_CHECK_CLOSE(deferred.backlog({}, {}), bulk.backlog({}, {}), 0.0001);
+    });
+}
+
+namespace {
+// Test double whose backlog() always throws.
+struct throwing_backlog_tracker_impl : public compaction::compaction_backlog_tracker::impl {
+    std::shared_ptr<int> calls;
+    explicit throwing_backlog_tracker_impl(std::shared_ptr<int> c) : calls(std::move(c)) {}
+    void replace_sstables(const std::vector<sstables::shared_sstable>&, const std::vector<sstables::shared_sstable>&) override {}
+    double backlog(const compaction::compaction_backlog_tracker::ongoing_writes&, const compaction::compaction_backlog_tracker::ongoing_compactions&) const override {
+        (*calls)++;
+        throw std::runtime_error("injected backlog computation failure");
+    }
+};
+}
+
+// A throwing impl must disable the tracker, not propagate to compaction_backlog_manager.
+BOOST_AUTO_TEST_CASE(compaction_backlog_tracker_isolates_backlog_exception) {
+    auto calls = std::make_shared<int>(0);
+    compaction::compaction_backlog_tracker tracker(std::make_unique<throwing_backlog_tracker_impl>(calls));
+
+    BOOST_REQUIRE_EQUAL(tracker.backlog(), compaction_controller::disable_backlog);
+    BOOST_REQUIRE_EQUAL(*calls, 1);
+
+    // Now disabled: a second call must not reach the (still-throwing) impl again.
+    BOOST_REQUIRE_EQUAL(tracker.backlog(), compaction_controller::disable_backlog);
+    BOOST_REQUIRE_EQUAL(*calls, 1);
+
+    // replace_sstables() on a disabled tracker must be a safe no-op.
+    tracker.replace_sstables({}, {});
+}
+
 void test_major_does_not_miss_data_in_memtable_fn(test_env& env) {
     auto builder = schema_builder(this_smp_shard_count(), "tests", "test_major_does_not_miss_data_in_memtable")
             .with_column("id", utf8_type, column_kind::partition_key)


### PR DESCRIPTION
**Motivation**

STCS's `get_buckets()` had the same redundant-rescan issue as ICS's: `tiny_sstables_written_recently()` was recomputed per candidate instead of once. Separately, `size_tiered_backlog_tracker::replace_sstables()` fully re-bucketed the entire tracked sstable set on every single add/remove (every flush, every compaction completion), even though `incremental_backlog_tracker` already avoids this by deferring the recompute to the next `backlog()` poll.

**Change description**

- Hoist `tiny_sstables_written_recently()` out of `get_buckets()`'s per-candidate check, same fix as the ICS counterpart.
- Defer `size_tiered_backlog_tracker`'s rebucket computation from `replace_sstables()` to the next `backlog()` call, mirroring `incremental_backlog_tracker`'s existing pattern (this also benefits `time_window_backlog_tracker`, which holds one `size_tiered_backlog_tracker` per time window).
- Moving the throwing rebucket computation into `backlog()` dropped the per-tracker exception isolation that `compaction_backlog_tracker::replace_sstables()` provided; restored by catching in `compaction_backlog_tracker::backlog()` itself and disabling just the failing tracker, matching `replace_sstables()`'s existing behavior (and fixing the same latent gap for `incremental_backlog_tracker`).
- Dropped `const` from `compaction_backlog_tracker::backlog()` instead of casting it away (review feedback).

**Tests**

Added `size_tiered_backlog_deferred_matches_bulk` (pins that the deferred computation yields the same result as a bulk update) and `compaction_backlog_tracker_isolates_backlog_exception` (pins the exception-isolation behavior with a throwing test double). Measured: 3000 sequential `replace_sstables()` calls followed by one `backlog()` call went from 497ms to 76ms (~6.5x), with the exact same resulting backlog value. Synthetic `get_buckets()` benchmark (4000 sstables, default thresholds): ~560x faster (560ms -> 1ms for 10 iterations).

---
backport: no, improvement
Signed-off-by: Yaniv Kaul <yaniv.kaul@scylladb.com>
