### PR TITLE
Compaction: TWCS: skip idle backlog map allocation and cache reshaping overlap count

### DIFF
--- a/compaction/compaction_strategy.cc
+++ b/compaction/compaction_strategy.cc
@@ -345,6 +345,18 @@ public:
     {}
 
     virtual double backlog(const compaction_backlog_tracker::ongoing_writes& ow, const compaction_backlog_tracker::ongoing_compactions& oc) const override {
+        auto no_ow = compaction_backlog_tracker::ongoing_writes();
+        auto no_oc = compaction_backlog_tracker::ongoing_compactions();
+
+        // Common case: nothing in flight, skip building the per-window write/compaction maps.
+        if (ow.empty() && oc.empty()) {
+            double b = 0;
+            for (auto& windows : _windows) {
+                b += windows.second.backlog(no_ow, no_oc);
+            }
+            return b;
+        }
+
         std::unordered_map<api::timestamp_type, compaction_backlog_tracker::ongoing_writes> writes_per_window;
         std::unordered_map<api::timestamp_type, compaction_backlog_tracker::ongoing_compactions> compactions_per_window;
         double b = 0;
@@ -359,8 +371,6 @@ public:
             compactions_per_window[bound].insert(cp);
         }
 
-        auto no_ow = compaction_backlog_tracker::ongoing_writes();
-        auto no_oc = compaction_backlog_tracker::ongoing_compactions();
         // Match the in-progress backlogs to existing windows. Compactions should always match an
         // existing windows. Writes in progress can fall into an non-existent window.
         for (auto& windows : _windows) {

--- a/compaction/time_window_compaction_strategy.cc
+++ b/compaction/time_window_compaction_strategy.cc
@@ -253,15 +253,15 @@ time_window_compaction_strategy::get_reshaping_job(std::vector<sstables::shared_
         }
     }
 
-    auto is_disjoint = [&schema, mode, max_sstables] (const std::vector<sstables::shared_sstable>& ssts) {
-        size_t tolerance = (mode == reshape_mode::relaxed) ? max_sstables : 0;
-        return sstable_set_overlapping_count(schema, ssts) <= tolerance;
+    // sstable_set_overlapping_count() is an O(n) schema-aware scan; the count is cached below and
+    // reused for both the debug log and the real disjoint check, instead of computed for each.
+    auto overlap_count = [&schema] (const std::vector<sstables::shared_sstable>& ssts) {
+        return sstable_set_overlapping_count(schema, ssts);
     };
-
-    clogger.debug("time_window_compaction_strategy::get_reshaping_job: offstrategy_threshold={} max_sstables={} multi_window={} disjoint={} single_window={} disjoint={}",
-            offstrategy_threshold, max_sstables,
-            multi_window.size(), !multi_window.empty() && sstable_set_overlapping_count(schema, multi_window) == 0,
-            single_window.size(), !single_window.empty() && sstable_set_overlapping_count(schema, single_window) == 0);
+    auto is_disjoint = [mode, max_sstables] (size_t count) {
+        size_t tolerance = (mode == reshape_mode::relaxed) ? max_sstables : 0;
+        return count <= tolerance;
+    };
 
     auto get_job_size = [] (const std::vector<sstables::shared_sstable>& ssts) {
         return std::ranges::fold_left(ssts | std::views::transform(std::mem_fn(&sstables::sstable::bytes_on_disk)), uint64_t(0), std::plus{});
@@ -286,7 +286,10 @@ time_window_compaction_strategy::get_reshaping_job(std::vector<sstables::shared_
     };
 
     if (!multi_window.empty()) {
-        auto disjoint = is_disjoint(multi_window);
+        auto overlap = overlap_count(multi_window);
+        auto disjoint = is_disjoint(overlap);
+        clogger.debug("time_window_compaction_strategy::get_reshaping_job: offstrategy_threshold={} max_sstables={} multi_window={} disjoint={}",
+                offstrategy_threshold, max_sstables, multi_window.size(), overlap == 0);
         auto job_size = get_job_size(multi_window);
         // Everything that spans multiple windows will need reshaping
         if (need_trimming(multi_window, job_size, disjoint)) {
@@ -305,7 +308,13 @@ time_window_compaction_strategy::get_reshaping_job(std::vector<sstables::shared_
     }
 
     // For things that don't span multiple windows, we compact windows that are individually too big
-    auto all_disjoint = !single_window.empty() && is_disjoint(single_window);
+    std::optional<size_t> single_window_overlap;
+    if (!single_window.empty()) {
+        single_window_overlap = overlap_count(single_window);
+    }
+    auto all_disjoint = single_window_overlap && is_disjoint(*single_window_overlap);
+    clogger.debug("time_window_compaction_strategy::get_reshaping_job: offstrategy_threshold={} max_sstables={} single_window={} disjoint={}",
+            offstrategy_threshold, max_sstables, single_window.size(), single_window_overlap == 0);
     auto all_buckets = get_buckets(single_window, _options);
     single_window.clear();
     for (auto& [bucket, ssts] : all_buckets.first) {


### PR DESCRIPTION
**Motivation**

`time_window_backlog_tracker::backlog()` is polled periodically (every 250ms per table by default) and unconditionally built two `unordered_map`s before matching them against existing windows, even though there's usually nothing in flight. Separately, `time_window_compaction_strategy::get_reshaping_job()` computed `sstable_set_overlapping_count()` (an O(n) schema-aware scan) twice per window set: once as a debug-log argument (evaluated unconditionally regardless of the logger's level, since C++ evaluates call arguments before the call), and again for the real disjoint check.

**Change description**

- Add a fast path to `time_window_backlog_tracker::backlog()` that skips both per-window map allocations when there are no ongoing writes or compactions.
- In `get_reshaping_job()`, compute the overlap count once per window set, at the point the real trimming logic already needs it unconditionally, and derive both the debug-log's strict (`== 0`) check and the real logic's relaxed (`<= tolerance`) check from that cached value. This also splits the previously-combined log line into one per branch, matching `multi_window`/`single_window`'s actual mutually-exclusive control flow (`multi_window` returns early, so `single_window`'s count was previously scanned even when unreachable).

**Tests**

No behavior change; verified via `twcs_reshape_with_disjoint_set_test`, `twcs_major_compaction_test`, `test_twcs_compaction_across_buckets`, and `test_offstrategy_sstable_compaction`, all passing unmodified.

---
backport: no, improvement
Signed-off-by: Yaniv Kaul <yaniv.kaul@scylladb.com>
