### PR TITLE
Compaction: LCS: drop redundant ctor allocation and cache per-level byte totals

### DIFF
--- a/compaction/compaction_manager.cc
+++ b/compaction/compaction_manager.cc
@@ -1534,7 +1534,8 @@ protected:
                     descriptor.sstables, compacting_table()->get_sstables_repaired_at(),
                     compacting_table()->token_range(), uuid, _compaction_data.compaction_uuid);
 
-            auto old_sstables = ::format("{}", descriptor.sstables);
+            // descriptor is moved into compact_sstables() below; keep a cheap (shared_ptr) copy for the later debug log.
+            auto old_sstables = descriptor.sstables;
 
             if (descriptor.sstables.empty() || !can_proceed() || t.is_auto_compaction_disabled_by_user()) {
                 cmlog.debug("{}: sstables={} can_proceed={} auto_compaction={}", *this, descriptor.sstables.size(), can_proceed(), t.is_auto_compaction_disabled_by_user());

--- a/compaction/leveled_manifest.hh
+++ b/compaction/leveled_manifest.hh
@@ -60,10 +60,6 @@ private:
         , _max_sstable_size_in_bytes(max_sstable_size_in_MB * 1024 * 1024)
         , _stcs_options(stcs_options)
     {
-        // allocate enough generations for a PB of data, with a 1-MB sstable size.  (Note that if maxSSTableSize is
-        // updated, we will still have sstables of the older, potentially smaller size.  So don't make this
-        // dependent on maxSSTableSize.)
-        _generations.resize(MAX_LEVELS);
     }
 public:
     static std::vector<std::vector<sstables::shared_sstable>> get_levels(const std::vector<sstables::shared_sstable>& sstables) {

--- a/compaction/leveled_manifest.hh
+++ b/compaction/leveled_manifest.hh
@@ -186,6 +186,15 @@ public:
         // This isn't a magic wand -- if you are consistently writing too fast for LCS to keep
         // up, you're still screwed.  But if instead you have intermittent bursts of activity,
         // it can help a lot.
+
+        // Cache each level's byte total.
+        std::array<std::optional<uint64_t>, MAX_LEVELS> level_bytes_cache;
+        auto level_bytes = [&] (size_t level) {
+            if (!level_bytes_cache[level]) {
+                level_bytes_cache[level] = get_total_bytes(get_level(level));
+            }
+            return *level_bytes_cache[level];
+        };
         for (auto i = _generations.size() - 1; i > 0; i--) {
             auto& sstables = get_level(i);
             if (sstables.empty()) {
@@ -196,7 +205,7 @@ public:
             Set<SSTableReader> sstablesInLevel = Sets.newHashSet(sstables);
             Set<SSTableReader> remaining = Sets.difference(sstablesInLevel, cfs.getDataTracker().getCompacting());
 #endif
-            double score = (double) get_total_bytes(sstables) / (double) max_bytes_for_level(i);
+            double score = (double) level_bytes(i) / (double) max_bytes_for_level(i);
 
             logger.debug("Compaction score for level {} is {}", i, score);
 
@@ -239,7 +248,7 @@ public:
             }
 
             // stop pushing data to higher levels once L is 10x (fan out) larger than L-1.
-            if (get_total_bytes(sstables) >= (get_total_bytes(sstables_prev_level) * leveled_fan_out)) {
+            if (level_bytes(i) >= (level_bytes(i - 1) * leveled_fan_out)) {
                 continue;
             }
 

--- a/test/boost/sstable_compaction_test.cc
+++ b/test/boost/sstable_compaction_test.cc
@@ -1171,6 +1171,42 @@ SEASTAR_FIXTURE_TEST_CASE(leveled_07_gcs, gcs_fixture, *tests::check_run_test_de
     return test_env::do_with_async([](test_env& env) { leveled_07_fn(env); }, test_env_config{.storage = make_test_object_storage_options("GS")});
 }
 
+// Regression test for get_compaction_candidates()'s cached per-level byte totals.
+SEASTAR_TEST_CASE(leveled_fan_out_cache) {
+    return test_env::do_with_async([](test_env& env) {
+        auto schema = table_for_tests::make_default_schema();
+        auto max_sstable_size_in_mb = 1;
+        auto max_sstable_size_in_bytes = uint64_t(max_sstable_size_in_mb) * 1024 * 1024;
+        auto max_bytes_for_l1 = compaction::leveled_manifest::max_bytes_for_level(1, max_sstable_size_in_bytes);
+
+        auto run_with_level2_size = [&] (uint64_t level1_size, uint64_t level2_size) {
+            auto cf = env.make_table_for_tests(schema);
+            auto stop_cf = deferred_stop(cf);
+            const auto keys = tests::generate_partition_keys(2, cf.schema());
+            add_sstable_for_leveled_test(env, cf, level1_size, /*level*/1, keys[0].key(), keys[1].key());
+            add_sstable_for_leveled_test(env, cf, level2_size, /*level*/2, keys[0].key(), keys[1].key());
+
+            auto candidates = get_candidates_for_leveled_strategy(*cf);
+            compaction::size_tiered_compaction_strategy_options stcs_options;
+            compaction::leveled_manifest manifest = compaction::leveled_manifest::create(cf.as_compaction_group_view(), candidates, max_sstable_size_in_mb, stcs_options);
+            std::vector<std::optional<dht::decorated_key>> last_compacted_keys(compaction::leveled_manifest::MAX_LEVELS);
+            std::vector<int> compaction_counter(compaction::leveled_manifest::MAX_LEVELS);
+            return manifest.get_compaction_candidates(last_compacted_keys, compaction_counter);
+        };
+
+        // Both levels stay under TARGET_SCORE, so control falls through to the fan-out loop.
+        auto level1_size = max_bytes_for_l1 / 20;
+
+        // Not too far ahead (level2 < level1 * fan_out): promotion expected.
+        auto promotes = run_with_level2_size(level1_size, level1_size * 2);
+        BOOST_REQUIRE(!promotes.sstables.empty());
+
+        // Too far ahead (level2 >= level1 * fan_out): no compaction expected.
+        auto skips = run_with_level2_size(level1_size, level1_size * compaction::leveled_manifest::leveled_fan_out);
+        BOOST_REQUIRE(skips.sstables.empty());
+    });
+}
+
 void leveled_invariant_fix_fn(test_env& env) {
     auto schema = table_for_tests::make_default_schema();
     auto cf = env.make_table_for_tests(schema);


### PR DESCRIPTION
**Motivation**

`leveled_manifest`'s constructor pre-sized `_generations`, a vector that `create()` (its only caller) immediately overwrites with `get_levels()`'s result before it's ever read. Separately, `get_compaction_candidates()`'s `get_total_bytes()` summed `data_size()` over an entire level's sstables, and was called repeatedly for the same level: once per level in the score loop, then twice more per adjacent-level pair in the fan-out loop below, redundantly resumming a level's sstables each time even though the manifest doesn't change during the call.
A same-shaped issue existed in `compaction_manager.cc`: `regular_compaction_task_executor::do_run()` eagerly `::format()`-ed the compacting sstable list into a string on every compaction round, even though the result is only used by a later debug log.

**Change description**

- Drop the constructor's redundant `_generations.resize(MAX_LEVELS)`; it's always discarded before being read.
- Cache each level's byte total the first time it's needed in `get_compaction_candidates()` and reuse it across the score and fan-out loops instead of resumming.
- In `compaction_manager.cc`, keep a cheap copy of `descriptor.sstables` for the later debug log instead of eagerly formatting it to a string; formatting now only happens inside the `debug()` call itself if the level is enabled.

**Tests**

Added `leveled_fan_out_cache` to pin the fan-out loop's promote/skip decision across the cached comparison. No behavior change otherwise; existing LCS tests pass unmodified.

---
backport: no, improvement
Signed-off-by: Yaniv Kaul <yaniv.kaul@scylladb.com>
