### PR TITLE
Compaction: all: skip compaction_info vector build for ongoing-compaction count

### DIFF
--- a/compaction/compaction_manager.cc
+++ b/compaction/compaction_manager.cc
@@ -1291,7 +1291,11 @@ future<> compaction_manager::await_tasks(std::vector<shared_ptr<compaction_task_
 
 std::vector<shared_ptr<compaction_task_executor>>
 compaction_manager::do_stop_ongoing_compactions(sstring reason, std::function<bool(const compaction_group_view*)> filter, std::optional<compaction_type> type_opt) noexcept {
-    auto ongoing_compactions = get_compactions(filter).size();
+    // Avoid get_compactions(filter): it builds a vector<compaction_info>, copying ks_name/cf_name
+    // for every matching task, just to be discarded here for its count.
+    auto ongoing_compactions = std::ranges::count_if(_tasks, [&filter] (const compaction_task_executor& task) {
+        return filter(task.compacting_table());
+    });
     auto tasks = _tasks
             | std::views::filter([&filter, type_opt] (const auto& task) {
                 return filter(task.compacting_table()) && (!type_opt || task.compaction_type() == *type_opt);


### PR DESCRIPTION
**Motivation**

`compaction_manager::do_stop_ongoing_compactions()` called `get_compactions(filter).size()` just to get a count, but `get_compactions()` builds a full `vector<compaction_info>`, copying `ks_name`/`cf_name` for every matching task, only to have the result discarded right after for its size.

This isn't a hot path -- it only runs on table truncate, disabling auto-compaction, and tablet split/merge/migration-cleanup -- so the fix is a no-downside cleanup rather than a targeted perf win. Under tablets it does run once per tablet on those events rather than once per table, so the wasted copies scale with tablet count for no benefit.

**Change description**

Count matching tasks directly with `std::ranges::count_if()` over `_tasks` instead of materializing and discarding a `vector<compaction_info>`.

**Tests**

No behavior change; the resulting count is identical, just computed without the intermediate allocation and copies.

---
backport: no, improvement
Signed-off-by: Yaniv Kaul <yaniv.kaul@scylladb.com>
