### PR TITLE
docs/alternator: alternator supports multi attribute GSIs

### DIFF
--- a/docs/alternator/compatibility.md
+++ b/docs/alternator/compatibility.md
@@ -401,6 +401,17 @@ they should be easy to detect. Here is a list of these unimplemented features:
   are projected. This wastes some disk space when it is not needed.
   <https://github.com/scylladb/scylla/issues/5036>
 
+* The deprecated `KeyConditions` parameter of `Query` works only on
+  single-attribute keys. Using it to query a composite GSI fails with a
+  `ValidationException`carrying this message:
+
+  ```
+  Legacy KeyConditions are not supported for composite key GSIs in Alternator
+  ```
+
+  Use `KeyConditionExpression` instead - AWS recommends it for all new
+  applications anyway.
+
 * DynamoDB's multi-item transaction feature (TransactWriteItems,
   TransactGetItems) is not supported. Note that the older single-item
   conditional updates feature are fully supported.
@@ -504,7 +515,3 @@ they should be easy to detect. Here is a list of these unimplemented features:
   that can be used to achieve consistent reads on global (multi-region) tables.
   This table option was added as a preview to DynamoDB in December 2024.
   <https://github.com/scylladb/scylladb/issues/21852>
-
-* Alternator does not support multi-attribute (composite) keys in GSIs.
-  This feature was added to DynamoDB in November 2025.
-  <https://github.com/scylladb/scylladb/issues/27182>


### PR DESCRIPTION
### Note:
This patch is documentation update for when composite GSI feature is implemented i.e. after https://github.com/scylladb/scylladb/pull/30768 and https://github.com/scylladb/scylladb/pull/30818 are merged and should be closed only after these PRs.

Add multi attribute composite GSI feature documentation. Dev documentation regarding this feature is provided in inline comments. Explicitly state differences between DDB and Alternator without copying DDB documentation on this feature.

Fixes: SCYLLADB-394

**Documentation on new feature no backport needed**