### PR TITLE
migration_manager: skip committed_by_group0 fixup scan once completed - to reduce boot time in scenarios with many tables

### DIFF
--- a/docs/dev/raft-in-scylla.md
+++ b/docs/dev/raft-in-scylla.md
@@ -283,3 +283,15 @@ the provided version instead of calculating a hash.
 When performing schema changes in Raft Recovery mode we're writing a tombstone
 for the `system.scylla_local` entry and we write `committed_by_group0 == false`
 for the `system_schema.scylla_tables` entries, forcing the old behavior.
+
+`migration_manager::ensure_committed_by_group0()` re-stamps `committed_by_group0`
+for such tables once the cluster is back to normal operation, but skips its scan
+on boot once a `system.scylla_local` marker (`ensure_committed_by_group0_done`)
+says no table is missing the flag. The recovery procedure above must also run
+
+```cql
+DELETE FROM system.scylla_local WHERE key = 'ensure_committed_by_group0_done';
+```
+
+on every node being recovered, or the fixup won't run again after recovery and
+the tables just marked `committed_by_group0 == false` will stay that way.

--- a/service/migration_manager.cc
+++ b/service/migration_manager.cc
@@ -1001,8 +1001,17 @@ future<group0_guard> migration_manager::start_group0_operation(std::optional<raf
 
 static thread_local std::default_random_engine random_engine{std::random_device{}()};
 
+// Lets later boots skip the scan below; the Raft manual recovery procedure must
+// tombstone this key to force a rescan (see docs/dev/raft-in-scylla.md).
+static constexpr auto ENSURE_COMMITTED_BY_GROUP0_DONE_KEY = "ensure_committed_by_group0_done";
+
 future<> migration_manager::ensure_committed_by_group0() {
     SCYLLA_ASSERT(this_shard_id() == 0);
+
+    if (co_await _sys_ks.local().get_scylla_local_param(ENSURE_COMMITTED_BY_GROUP0_DONE_KEY) == "true") {
+        mlogger.info("Skipping committed_by_group0 check ({} is set)", ENSURE_COMMITTED_BY_GROUP0_DONE_KEY);
+        co_return;
+    }
 
     // Find non-system tables where committed_by_group0 is not true in scylla_tables.
     // This includes tables that have no row in scylla_tables at all (very old tables).
@@ -1039,9 +1048,19 @@ future<> migration_manager::ensure_committed_by_group0() {
         co_return result;
     };
 
+    // Best-effort: a failed marker write must not fail the boot; the next boot just rescans.
+    auto set_done_marker = [this]() -> future<> {
+        try {
+            co_await _sys_ks.local().set_scylla_local_param(ENSURE_COMMITTED_BY_GROUP0_DONE_KEY, "true", false);
+        } catch (...) {
+            mlogger.warn("Failed to set {}: {}", ENSURE_COMMITTED_BY_GROUP0_DONE_KEY, std::current_exception());
+        }
+    };
+
     auto tables = co_await find_tables_missing_flag();
     if (tables.empty()) {
         mlogger.info("All non-system tables have committed_by_group0 set");
+        co_await set_done_marker();
         co_return;
     }
 
@@ -1054,6 +1073,7 @@ future<> migration_manager::ensure_committed_by_group0() {
         tables = co_await find_tables_missing_flag();
         if (tables.empty()) {
             mlogger.info("All tables now have committed_by_group0 set (fixed by another node)");
+            co_await set_done_marker();
             co_return;
         }
 
@@ -1083,6 +1103,7 @@ future<> migration_manager::ensure_committed_by_group0() {
         mlogger.info("Setting committed_by_group0 for {} table(s)", mutations.size());
         try {
             co_await announce<schema_change>(std::move(mutations), std::move(guard), "ensure committed_by_group0");
+            co_await set_done_marker();
             co_return;
         } catch (const group0_concurrent_modification&) {
             mlogger.info("Concurrent schema change detected while setting committed_by_group0, retrying");

--- a/test/cluster/test_ensure_committed_by_group0.py
+++ b/test/cluster/test_ensure_committed_by_group0.py
@@ -4,7 +4,8 @@
 # SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
 #
 """
-Test that ensure_committed_by_group0() fixes tables missing the flag on boot.
+Test that ensure_committed_by_group0() fixes tables missing the flag on boot,
+and that it skips its scan once a "done" marker is persisted.
 """
 import pytest
 import logging
@@ -12,10 +13,16 @@ from test.pylib.manager_client import ManagerClient
 
 logger = logging.getLogger(__name__)
 
+DONE_MARKER_KEY = "ensure_committed_by_group0_done"
+FOUND_MISSING_LOG_MSG = "table\\(s\\) missing committed_by_group0"
+ALL_SET_LOG_MSG = "All non-system tables have committed_by_group0 set"
+SKIPPED_LOG_MSG = "Skipping committed_by_group0 check"
+
 
 @pytest.mark.asyncio
 async def test_ensure_committed_by_group0(manager: ManagerClient):
-    """Tables with committed_by_group0 = null or false get fixed on restart."""
+    """Tables with committed_by_group0 = null or false get fixed on restart,
+    and a plain restart afterwards doesn't rescan scylla_tables."""
     servers = await manager.servers_add(1)
     (cql, _) = await manager.get_ready_cql(servers)
 
@@ -31,17 +38,26 @@ async def test_ensure_committed_by_group0(manager: ManagerClient):
             f"WHERE keyspace_name = 'ks' AND table_name = '{tbl}'")
         assert rows[0].committed_by_group0 == True
 
-    # Simulate pre-group0 table (null) and recovery-mode table (false)
+    # Simulate pre-group0 table (null) and recovery-mode table (false), deleting the
+    # "done" marker like the recovery procedure does (see docs/dev/raft-in-scylla.md).
     await cql.run_async(
         "DELETE committed_by_group0 FROM system_schema.scylla_tables "
         "WHERE keyspace_name = 'ks' AND table_name = 'tbl_null'")
     await cql.run_async(
         "UPDATE system_schema.scylla_tables SET committed_by_group0 = false "
         "WHERE keyspace_name = 'ks' AND table_name = 'tbl_false'")
+    await cql.run_async(f"DELETE FROM system.scylla_local WHERE key = '{DONE_MARKER_KEY}'")
 
     # Restart — ensure_committed_by_group0() should fix both on boot
+    log = await manager.server_open_log(servers[0].server_id)
+    mark = await log.mark()
     await manager.server_restart(servers[0].server_id)
     (cql, _) = await manager.get_ready_cql(servers)
+
+    # Positive control: the scan really ran on this boot (keeps the absence
+    # assertions below honest if the log message text ever changes).
+    assert await log.grep(FOUND_MISSING_LOG_MSG, from_mark=mark), \
+        "expected ensure_committed_by_group0 to scan and find unflagged tables"
 
     # Verify fixup happened for both tables
     for tbl in ['tbl_null', 'tbl_false']:
@@ -50,3 +66,19 @@ async def test_ensure_committed_by_group0(manager: ManagerClient):
             f"WHERE keyspace_name = 'ks' AND table_name = '{tbl}'")
         assert rows[0].committed_by_group0 == True, \
             f"committed_by_group0 not fixed for {tbl}"
+
+    # The fixup above should have persisted the "done" marker.
+    rows = await cql.run_async(f"SELECT value FROM system.scylla_local WHERE key = '{DONE_MARKER_KEY}'")
+    assert rows and rows[0].value == "true", "ensure_committed_by_group0_done marker not set after fixup"
+
+    # A further plain restart, with nothing broken, should skip the scan entirely.
+    mark = await log.mark()
+    await manager.server_restart(servers[0].server_id)
+    await manager.get_ready_cql(servers)
+
+    assert await log.grep(SKIPPED_LOG_MSG, from_mark=mark), \
+        "ensure_committed_by_group0 did not take the skip path despite the done marker"
+    assert not await log.grep(FOUND_MISSING_LOG_MSG, from_mark=mark), \
+        "ensure_committed_by_group0 rescanned scylla_tables despite the done marker"
+    assert not await log.grep(ALL_SET_LOG_MSG, from_mark=mark), \
+        "ensure_committed_by_group0 rescanned scylla_tables despite the done marker"

--- a/test/cluster/test_ensure_committed_by_group0.py
+++ b/test/cluster/test_ensure_committed_by_group0.py
@@ -4,7 +4,8 @@
 # SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
 #
 """
-Test that ensure_committed_by_group0() fixes tables missing the flag on boot.
+Test that ensure_committed_by_group0() fixes tables missing the flag on boot,
+and that it skips its scan once a "done" marker is persisted.
 """
 import pytest
 import logging
@@ -12,10 +13,16 @@ from test.pylib.scylla_cluster_manager import ScyllaClusterManager
 
 logger = logging.getLogger(__name__)
 
+DONE_MARKER_KEY = "ensure_committed_by_group0_done"
+FOUND_MISSING_LOG_MSG = "table\\(s\\) missing committed_by_group0"
+ALL_SET_LOG_MSG = "All non-system tables have committed_by_group0 set"
+SKIPPED_LOG_MSG = "Skipping committed_by_group0 check"
+
 
 @pytest.mark.asyncio
 async def test_ensure_committed_by_group0(manager: ScyllaClusterManager):
-    """Tables with committed_by_group0 = null or false get fixed on restart."""
+    """Tables with committed_by_group0 = null or false get fixed on restart,
+    and a plain restart afterwards doesn't rescan scylla_tables."""
     servers = await manager.servers_add(1)
     (cql, _) = await manager.get_ready_cql(servers)
 
@@ -31,17 +38,26 @@ async def test_ensure_committed_by_group0(manager: ScyllaClusterManager):
             f"WHERE keyspace_name = 'ks' AND table_name = '{tbl}'")
         assert rows[0].committed_by_group0 == True
 
-    # Simulate pre-group0 table (null) and recovery-mode table (false)
+    # Simulate pre-group0 table (null) and recovery-mode table (false), deleting the
+    # "done" marker like the recovery procedure does (see docs/dev/raft-in-scylla.md).
     await cql.run_async(
         "DELETE committed_by_group0 FROM system_schema.scylla_tables "
         "WHERE keyspace_name = 'ks' AND table_name = 'tbl_null'")
     await cql.run_async(
         "UPDATE system_schema.scylla_tables SET committed_by_group0 = false "
         "WHERE keyspace_name = 'ks' AND table_name = 'tbl_false'")
+    await cql.run_async(f"DELETE FROM system.scylla_local WHERE key = '{DONE_MARKER_KEY}'")
 
     # Restart — ensure_committed_by_group0() should fix both on boot
+    log = await manager.server_open_log(servers[0].server_id)
+    mark = await log.mark()
     await manager.server_restart(servers[0].server_id)
     (cql, _) = await manager.get_ready_cql(servers)
+
+    # Positive control: the scan really ran on this boot (keeps the absence
+    # assertions below honest if the log message text ever changes).
+    assert await log.grep(FOUND_MISSING_LOG_MSG, from_mark=mark), \
+        "expected ensure_committed_by_group0 to scan and find unflagged tables"
 
     # Verify fixup happened for both tables
     for tbl in ['tbl_null', 'tbl_false']:
@@ -50,3 +66,19 @@ async def test_ensure_committed_by_group0(manager: ScyllaClusterManager):
             f"WHERE keyspace_name = 'ks' AND table_name = '{tbl}'")
         assert rows[0].committed_by_group0 == True, \
             f"committed_by_group0 not fixed for {tbl}"
+
+    # The fixup above should have persisted the "done" marker.
+    rows = await cql.run_async(f"SELECT value FROM system.scylla_local WHERE key = '{DONE_MARKER_KEY}'")
+    assert rows and rows[0].value == "true", "ensure_committed_by_group0_done marker not set after fixup"
+
+    # A further plain restart, with nothing broken, should skip the scan entirely.
+    mark = await log.mark()
+    await manager.server_restart(servers[0].server_id)
+    await manager.get_ready_cql(servers)
+
+    assert await log.grep(SKIPPED_LOG_MSG, from_mark=mark), \
+        "ensure_committed_by_group0 did not take the skip path despite the done marker"
+    assert not await log.grep(FOUND_MISSING_LOG_MSG, from_mark=mark), \
+        "ensure_committed_by_group0 rescanned scylla_tables despite the done marker"
+    assert not await log.grep(ALL_SET_LOG_MSG, from_mark=mark), \
+        "ensure_committed_by_group0 rescanned scylla_tables despite the done marker"


### PR DESCRIPTION
### Motivation
`ensure_committed_by_group0()` scans all of `system_schema.scylla_tables` plus every in-memory table on every boot, even though in the common case the fixup finished long ago and there is nothing to do. At thousands of tables this cost repeats on every restart across the fleet (SCYLLADB-3673).

### Change
Persist an `ensure_committed_by_group0_done` marker in `system.scylla_local` once no non-system table is missing the flag, and skip the scan on later boots when it is set. The marker write is best-effort — losing it only costs one rescan on the next boot. The Raft manual recovery procedure, which writes `committed_by_group0 = false` out of band, must now also tombstone the marker; documented in `docs/dev/raft-in-scylla.md` (the public recovery runbook needs the matching update).

### Test
Extended `test/cluster/test_ensure_committed_by_group0.py`: the recovery simulation now deletes the marker (as the documented procedure requires), asserts the marker is persisted after the fixup, and a subsequent clean restart positively asserts the skip-path log line and the absence of any scan messages.

### Results
Built and run under dbuild (dev mode): `1 passed in 13.05s`.

Fixes: https://scylladb.atlassian.net/browse/SCYLLADB-3673

Backport: none, improvement
