### PR TITLE
utils: tuple_utils: avoid static template in header

### DIFF
--- a/utils/tuple_utils.hh
+++ b/utils/tuple_utils.hh
@@ -26,7 +26,7 @@ namespace utils {
     // SourceTuple and ResultTuple can be arbitrary specialisations of std::tuple or rpc::tuple.
     template<Tuple ResultTuple, Tuple SourceTuple, typename NewItem>
     requires (tuple_ex_size_v<SourceTuple> + 1 == tuple_ex_size_v<ResultTuple>)
-    static ResultTuple tuple_insert(SourceTuple&& source_tuple, NewItem&& new_item) {
+    ResultTuple tuple_insert(SourceTuple&& source_tuple, NewItem&& new_item) {
         constexpr auto source_size = tuple_ex_size_v<SourceTuple>;
         constexpr auto result_size = tuple_ex_size_v<ResultTuple>;
         constexpr auto match = std::invoke([]<std::size_t... Is>(std::index_sequence<Is...>) {


### PR DESCRIPTION
A static template that is not used will not compile under clang 24 (like an unused static function in older compilers). Since a header can't tell if its functions will be used or not, it must not mark them as static (not a good idea due to duplication as well).

Remove the static marker.

Closes scylladb/scylladb#31050

Minor cleanup in preparation for new clang, not backporting.