### PR TITLE
db/config: add speculative_retry_user_table_default option

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1753,6 +1753,7 @@ deps['test/boost/combined_tests'] += [
     'test/boost/secondary_index_test.cc',
     'test/boost/sessions_test.cc',
     'test/boost/simple_value_with_expiry_test.cc',
+    'test/boost/speculative_retry_config_test.cc',
     'test/boost/sstable_compaction_test.cc',
     'test/boost/sstable_compressor_factory_test.cc',
     'test/boost/sstable_compression_config_test.cc',

--- a/db/config.cc
+++ b/db/config.cc
@@ -1517,6 +1517,13 @@ db::config::config(std::shared_ptr<db::extensions> exts)
         "The minimum size a table has to reach before dictionaries will be trained for it.")
     , sstable_compression_dictionaries_min_training_improvement_factor(this, "sstable_compression_dictionaries_min_training_improvement_factor", liveness::LiveUpdate, value_status::Used, 0.95,
         "New dictionaries will be only published if the estimated compression ratio is smaller than current ratio multiplied by this factor.")
+    , speculative_retry_user_table_default(this, "speculative_retry_user_table_default", liveness::LiveUpdate, value_status::Used, "99.0PERCENTILE",
+        "Default value of the speculative_retry option for user tables, i.e., tables in non-internal keyspaces. "
+        "Applied when a table is created without specifying speculative_retry explicitly; existing tables are not affected. "
+        "Materialized views and secondary indexes created without an explicit value also use this default; they do not inherit the base table's value. "
+        "The value used for a new table is taken from the configuration of the node coordinating the table creation, so the option should be set identically on all nodes. "
+        "The option can be updated at runtime; the updated value applies to tables created after the update. "
+        "Accepted values are the same as for the table option: ALWAYS, NONE, <X>PERCENTILE (e.g. 99.0PERCENTILE) and <N>ms (e.g. 200ms).")
     , uuid_sstable_identifiers_enabled(this,
             "uuid_sstable_identifiers_enabled", value_status::Unused, true, "If set to true, each newly created sstable will have a UUID "
             "based generation identifier, and such files are not readable by previous Scylla versions.")

--- a/db/config.hh
+++ b/db/config.hh
@@ -473,6 +473,7 @@ public:
     named_value<float> sstable_compression_dictionaries_autotrainer_tick_period_in_seconds;
     named_value<uint64_t> sstable_compression_dictionaries_min_training_dataset_bytes;
     named_value<float> sstable_compression_dictionaries_min_training_improvement_factor;
+    named_value<sstring> speculative_retry_user_table_default;
     named_value<bool> uuid_sstable_identifiers_enabled;
     named_value<bool> table_digest_insensitive_to_expiry;
     named_value<bool> enable_dangerous_direct_import_of_cassandra_counters;

--- a/docs/cql/ddl.rst
+++ b/docs/cql/ddl.rst
@@ -950,6 +950,13 @@ This setting does not affect reads with consistency level ``ALL`` because they a
 Note that frequently reading from additional replicas can hurt cluster performance.
 When in doubt, keep the default ``99PERCENTILE``.
 
+The default value for newly created tables which do not specify ``speculative_retry``
+(``99PERCENTILE``) can be changed with the ``speculative_retry_user_table_default``
+configuration option in ``scylla.yaml``. The option applies at table creation time
+only; changing it does not affect already existing tables. The value used for a new
+table is taken from the node that coordinates its creation, so the option should be
+set identically on all nodes.
+
 
 .. _cql-compaction-options:
 

--- a/main.cc
+++ b/main.cc
@@ -138,6 +138,7 @@
 #include "utils/labels.hh"
 #include "tools/utils.hh"
 #include "schema/compression_initializer.hh"
+#include "schema/speculative_retry_initializer.hh"
 
 
 namespace fs = std::filesystem;
@@ -925,6 +926,11 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
             register_compression_initializer(*cfg, [&feature_service] {
                 return bool(feature_service.local().sstable_compression_dicts);
             });
+
+            // Register the default speculative_retry value for user tables.
+            // Registration parses the option value, so an invalid value fails
+            // startup.
+            register_speculative_retry_initializer(*cfg);
 
             cfg->setup_directories();
 

--- a/schema/schema.cc
+++ b/schema/schema.cc
@@ -20,6 +20,9 @@
 #include "cql3/util.hh"
 #include "schema.hh"
 #include "schema_builder.hh"
+#include "speculative_retry_initializer.hh"
+#include "db/config.hh"
+#include "db/extensions.hh"
 #include "db/marshal/type_parser.hh"
 #include "schema_registry.hh"
 #include <type_traits>
@@ -1788,6 +1791,39 @@ void schema_builder::restore_schema_initializers_checkpoint(schema_initializers_
         throw std::logic_error("Invalid schema initializer checkpoint");
     }
     initializers.resize(checkpoint.size);
+}
+
+void register_speculative_retry_initializer(db::config& cfg) {
+    if (cfg.speculative_retry_user_table_default.is_set()) {
+        try {
+            speculative_retry::from_sstring(cfg.speculative_retry_user_table_default());
+        } catch (const exceptions::configuration_exception& e) {
+            throw exceptions::configuration_exception(
+                format("Invalid speculative_retry_user_table_default: {}", e.what()));
+        }
+    }
+    schema_builder::register_schema_initializer([&cfg](schema_builder& builder) {
+        if (!cfg.speculative_retry_user_table_default.is_set()) {
+            return;
+        }
+        if (is_internal_keyspace(builder.ks_name()) || cfg.extensions().is_extension_internal_keyspace(builder.ks_name())) {
+            return;
+        }
+        static thread_local sstring last_value;
+        static thread_local std::optional<speculative_retry> last_retry;
+        const sstring& value = cfg.speculative_retry_user_table_default();
+        if (value != last_value) {
+            last_value = value;
+            try {
+                last_retry = speculative_retry::from_sstring(value);
+            } catch (const exceptions::configuration_exception& e) {
+                dblog.warn("Ignoring invalid speculative_retry_user_table_default value: {}", e.what());
+            }
+        }
+        if (last_retry) {
+            builder.set_speculative_retry(*last_retry);
+        }
+    });
 }
 
 void schema_builder::set_properties(schema::user_properties props) {

--- a/schema/schema.cc
+++ b/schema/schema.cc
@@ -42,6 +42,8 @@
 #include "utils/managed_string.hh"
 #include "alternator/ttl_tag.hh"
 
+#include <cmath>
+
 #include <boost/lexical_cast.hpp>
 
 extern logging::logger dblog;
@@ -85,10 +87,14 @@ speculative_retry::from_sstring(sstring str) {
     } else if (str.size() >= ms.size() && str.compare(str.size() - ms.size(), ms.size(), ms) == 0) {
         t = type::CUSTOM;
         v = convert(ms);
+        if (!std::isfinite(v) || v < 0.0) {
+            throw exceptions::configuration_exception(
+                format("Invalid value {} for option 'speculative_retry': the number of milliseconds must be non-negative and finite", str));
+        }
     } else if (str.size() >= percentile.size() && str.compare(str.size() - percentile.size(), percentile.size(), percentile) == 0) {
         t = type::PERCENTILE;
         v = convert(percentile) / 100;
-        if  (v < 0.0 || v > 1.0) {
+        if  (!std::isfinite(v) || v < 0.0 || v > 1.0) {
             throw exceptions::configuration_exception(
                 format("Invalid value {} for PERCENTILE option 'speculative_retry': must be between [0.0 and 100.0]", str));
         }

--- a/schema/schema.cc
+++ b/schema/schema.cc
@@ -82,10 +82,10 @@ speculative_retry::from_sstring(sstring str) {
         t = type::NONE;
     } else if (str == "ALWAYS") {
         t = type::ALWAYS;
-    } else if (str.compare(str.size() - ms.size(), ms.size(), ms) == 0) {
+    } else if (str.size() >= ms.size() && str.compare(str.size() - ms.size(), ms.size(), ms) == 0) {
         t = type::CUSTOM;
         v = convert(ms);
-    } else if (str.compare(str.size() - percentile.size(), percentile.size(), percentile) == 0) {
+    } else if (str.size() >= percentile.size() && str.compare(str.size() - percentile.size(), percentile.size(), percentile) == 0) {
         t = type::PERCENTILE;
         v = convert(percentile) / 100;
         if  (v < 0.0 || v > 1.0) {

--- a/schema/schema_builder.hh
+++ b/schema/schema_builder.hh
@@ -192,6 +192,11 @@ public:
         return *this;
     }
 
+    schema_builder& set_speculative_retry(const speculative_retry& retry) {
+        _raw._props.speculative_retry = retry;
+        return *this;
+    }
+
     const speculative_retry& get_speculative_retry() const {
         return _raw._props.speculative_retry;
     }

--- a/schema/speculative_retry_initializer.hh
+++ b/schema/speculative_retry_initializer.hh
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2026-present ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
+ */
+
+#pragma once
+
+namespace db {
+class config;
+}
+
+/**
+ * Registers a schema initializer that applies the configured default
+ * speculative_retry value to user tables.
+ *
+ * When the `speculative_retry_user_table_default` configuration option is not
+ * set, all tables keep the built-in default. System tables keep the built-in
+ * default in any case.
+ *
+ * The option is live-updatable: the current value applies to tables created
+ * after an update, and the parsed value is cached per shard. An invalid
+ * initial value throws configuration_exception here, failing startup. An
+ * invalid value set by a configuration update is ignored, keeping the last
+ * valid value (or the built-in default if there is none).
+ *
+ * User tables are all tables not belonging to internal keyspaces, namely
+ * CQL base tables, materialized views, secondary indexes, CDC log tables,
+ * Alternator base tables, Alternator GSIs, Alternator LSIs and Alternator Streams.
+ */
+void register_speculative_retry_initializer(db::config& cfg);

--- a/test/alternator/test_cql_schema.py
+++ b/test/alternator/test_cql_schema.py
@@ -22,6 +22,7 @@
 # configuring role-based access control, and test_service_levels.py for
 # configuring service levels - both need to be done through CQL.
 
+import json
 import string
 import pytest
 
@@ -161,3 +162,51 @@ def test_alternator_aux_tables(dynamodb, table1, option):
     # Check Streams log table:
     alternator_cdc_schema = scylla_get_schema(dynamodb, cql_table_for_cdclog(table1))
     assert alternator_base_schema[option] == alternator_cdc_schema[option]
+
+# Check that the speculative_retry_user_table_default configuration option
+# applies to Alternator tables - the base table and its auxiliary tables
+# holding a GSI, LSI and CDC log. The option is live-updatable, so the test
+# sets it through the system.config virtual table and restores the original
+# value when done. We can't use the table1 fixture here because the table
+# must be created while the option is set.
+def test_alternator_tables_respect_speculative_retry_config(dynamodb, cql):
+    option = 'speculative_retry_user_table_default'
+    original = json.loads(cql.execute(f"SELECT value FROM system.config WHERE name = '{option}'").one().value)
+    cql.execute(f"UPDATE system.config SET value = '200ms' WHERE name = '{option}'")
+    try:
+        with new_test_table(dynamodb,
+            KeySchema=[
+                # Must have both hash key and range key to allow LSI creation
+                { 'AttributeName': 'p', 'KeyType': 'HASH' },
+                { 'AttributeName': 'c', 'KeyType': 'RANGE' }
+            ],
+            AttributeDefinitions=[
+                { 'AttributeName': 'p', 'AttributeType': 'S' },
+                { 'AttributeName': 'c', 'AttributeType': 'S' },
+                { 'AttributeName': 'x', 'AttributeType': 'S' },
+            ],
+            LocalSecondaryIndexes=[
+                {   'IndexName': 'lsi_name',
+                    'KeySchema': [
+                        { 'AttributeName': 'p', 'KeyType': 'HASH' },
+                        { 'AttributeName': 'x', 'KeyType': 'RANGE' },
+                    ],
+                    'Projection': { 'ProjectionType': 'ALL' }
+                }
+            ],
+            GlobalSecondaryIndexes=[
+                {   'IndexName': 'gsi_name',
+                    'KeySchema': [{ 'AttributeName': 'x', 'KeyType': 'HASH' }],
+                    'Projection': { 'ProjectionType': 'ALL' }
+                }
+            ],
+            StreamSpecification={
+                'StreamEnabled': True, 'StreamViewType': 'KEYS_ONLY'
+            }
+            ) as table:
+            assert scylla_get_schema(dynamodb, cql_table_for(table))['speculative_retry'] == '200.00ms'
+            assert scylla_get_schema(dynamodb, cql_table_for_gsi(table, 'gsi_name'))['speculative_retry'] == '200.00ms'
+            assert scylla_get_schema(dynamodb, cql_table_for_lsi(table, 'lsi_name'))['speculative_retry'] == '200.00ms'
+            assert scylla_get_schema(dynamodb, cql_table_for_cdclog(table))['speculative_retry'] == '200.00ms'
+    finally:
+        cql.execute(f"UPDATE system.config SET value = '{original}' WHERE name = '{option}'")

--- a/test/boost/CMakeLists.txt
+++ b/test/boost/CMakeLists.txt
@@ -394,6 +394,7 @@ add_scylla_test(combined_tests
     secondary_index_test.cc
     sessions_test.cc
     simple_value_with_expiry_test.cc
+    speculative_retry_config_test.cc
     sstable_compaction_test.cc
     sstable_compressor_factory_test.cc
     sstable_compression_config_test.cc

--- a/test/boost/speculative_retry_config_test.cc
+++ b/test/boost/speculative_retry_config_test.cc
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2026-present ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
+ */
+
+#include <boost/test/unit_test.hpp>
+#include <seastar/core/shared_ptr.hh>
+
+#include "db/config.hh"
+#include "exceptions/exceptions.hh"
+#include "schema/speculative_retry_initializer.hh"
+
+BOOST_AUTO_TEST_SUITE(speculative_retry_config_test)
+
+// Test that registering the initializer with an invalid option value throws.
+// (In a full ScyllaDB instance this makes startup fail; see test/cluster.)
+BOOST_AUTO_TEST_CASE(test_invalid_speculative_retry_config) {
+    auto cfg = seastar::make_shared<db::config>();
+    cfg->read_from_yaml(R"foo(
+        speculative_retry_user_table_default: FOO
+        )foo");
+
+    BOOST_REQUIRE_THROW(register_speculative_retry_initializer(*cfg), exceptions::configuration_exception);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/test/cluster/test_speculative_retry_config.py
+++ b/test/cluster/test_speculative_retry_config.py
@@ -1,0 +1,22 @@
+#
+# Copyright (C) 2026-present ScyllaDB
+#
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
+#
+
+import pytest
+
+from test.pylib.manager_client import ManagerClient
+
+
+@pytest.mark.parametrize('cfg_source', ['yaml', 'cmdline'])
+async def test_invalid_speculative_retry_config(manager: ManagerClient, cfg_source: str):
+    """
+    Check that a node refuses to start when speculative_retry_user_table_default
+    is set to a value that does not parse as a speculative_retry option.
+    """
+    expected_error = 'Invalid speculative_retry_user_table_default'
+    if cfg_source == 'yaml':
+        await manager.server_add(config={'speculative_retry_user_table_default': 'dog'}, expected_error=expected_error)
+    else:
+        await manager.server_add(cmdline=['--speculative-retry-user-table-default', 'dog'], expected_error=expected_error)

--- a/test/cqlpy/test_alter_table.py
+++ b/test/cqlpy/test_alter_table.py
@@ -8,7 +8,7 @@ import re
 import pytest
 
 from cassandra.protocol import ConfigurationException
-from .util import new_test_table, unique_name
+from .util import is_scylla, new_test_table, unique_name
 from .nodetool import flush
 
 # Test checks only case of preparing `ALTER TABLE ... DROP ... USING TIMESTAMP ?` statement.
@@ -119,3 +119,37 @@ def test_invalid_percentile_speculative_retry_values(cql, test_keyspace, percent
     with new_test_table(cql, test_keyspace, "id UUID PRIMARY KEY, value TEXT") as table:
         with pytest.raises(ConfigurationException, match=message):
             cql.execute(f"ALTER TABLE {table} WITH speculative_retry = '{percentile}PERCENTILE'")
+
+def test_invalid_speculative_retry_values(cql, test_keyspace):
+    """
+    Verify that speculative_retry values that match none of the supported
+    formats (ALWAYS, NONE, XPERCENTILE, Yms) are rejected with a proper
+    configuration error, including values shorter than the "ms" and
+    "PERCENTILE" suffixes and non-finite or negative numbers.
+    """
+
+    with new_test_table(cql, test_keyspace, "id UUID PRIMARY KEY, value TEXT") as table:
+        for value in ["", "x", "ms", "percentile", "dog",
+                      "nanPERCENTILE", "infPERCENTILE", "-infPERCENTILE",
+                      "nanms", "infms", "-1ms"]:
+            with pytest.raises(ConfigurationException):
+                cql.execute(f"ALTER TABLE {table} WITH speculative_retry = '{value}'")
+
+def test_valid_speculative_retry_values(cql, test_keyspace):
+    """
+    Verify that all supported speculative_retry formats are accepted,
+    case-insensitively. On Scylla, also verify the canonical form the value
+    is normalized to in the schema tables; Cassandra normalizes to different
+    spellings (e.g. 99p), so that part of the check is Scylla-only.
+    """
+
+    with new_test_table(cql, test_keyspace, "id UUID PRIMARY KEY, value TEXT") as table:
+        ks, cf = table.split('.')
+        for value, canonical in [('NONE', 'NONE'), ('none', 'NONE'), ('ALWAYS', 'ALWAYS'),
+                                 ('200ms', '200.00ms'), ('0ms', '0.00ms'),
+                                 ('99PERCENTILE', '99.0PERCENTILE'), ('99.0percentile', '99.0PERCENTILE')]:
+            cql.execute(f"ALTER TABLE {table} WITH speculative_retry = '{value}'")
+            if is_scylla(cql):
+                r = list(cql.execute(f"SELECT speculative_retry FROM system_schema.tables WHERE keyspace_name = '{ks}' AND table_name = '{cf}'"))
+                assert len(r) == 1
+                assert r[0].speculative_retry == canonical

--- a/test/cqlpy/test_alter_table.py
+++ b/test/cqlpy/test_alter_table.py
@@ -71,8 +71,7 @@ def testDropColumnWithTimestampPreparedNonExistingSchema(scylla_only, cql, test_
     finally:
         cql.execute(f"DROP TABLE {table}")
 
-@pytest.mark.parametrize("percentile", ["-0", "0", "+0", "0.1", "0.01", "0.001", "99", "99.9", "99.999", "100", "+100"])
-def test_valid_percentile_speculative_retry_values(cql, test_keyspace, percentile):
+def test_valid_percentile_speculative_retry_values(cql, test_keyspace):
     """
     In test_valid_percentile_speculative_retry_values, we verify that valid values for the
     PERCENTILE option in the `speculative_retry` setting are accepted without errors. According to the
@@ -86,10 +85,10 @@ def test_valid_percentile_speculative_retry_values(cql, test_keyspace, percentil
     """
 
     with new_test_table(cql, test_keyspace, "id UUID PRIMARY KEY, value TEXT") as table:
-        cql.execute(f"ALTER TABLE {table} WITH speculative_retry = '{percentile}PERCENTILE'")
+        for percentile in ["-0", "0", "+0", "0.1", "0.01", "0.001", "99", "99.9", "99.999", "100", "+100"]:
+            cql.execute(f"ALTER TABLE {table} WITH speculative_retry = '{percentile}PERCENTILE'")
 
-@pytest.mark.parametrize("percentile", ["-1.1", "-1", "-0.1", "-0.01", "-0.001", "100.1", "100.01", "100.001", "101", "+101", "+101.1", "dog"])
-def test_invalid_percentile_speculative_retry_values(cql, test_keyspace, percentile):
+def test_invalid_percentile_speculative_retry_values(cql, test_keyspace):
     """
     In test_invalid_percentile_speculative_retry_values, we verify that invalid values for the
     PERCENTILE option in the `speculative_retry` setting are properly rejected. According to the
@@ -103,22 +102,23 @@ def test_invalid_percentile_speculative_retry_values(cql, test_keyspace, percent
     See issue #21825.
     """
 
-    percentile = percentile.upper()
-
-    # For negative values and zero, Cassandra returns a shortened error message compared to ScyllaDB.
-    # Therefore, a regular expression is used to match both formats of the error message.
-    message = (
-        f"(?:"
-        f"Invalid value {re.escape(percentile)}PERCENTILE "
-        r"for (?:PERCENTILE option|option) 'speculative_retry'"
-        r"(?:\: must be between \(0\.0 and 100\.0\))?"
-        f"|"
-        f"cannot convert {re.escape(percentile)}PERCENTILE to speculative_retry"
-        f")"
-    )
     with new_test_table(cql, test_keyspace, "id UUID PRIMARY KEY, value TEXT") as table:
-        with pytest.raises(ConfigurationException, match=message):
-            cql.execute(f"ALTER TABLE {table} WITH speculative_retry = '{percentile}PERCENTILE'")
+        for percentile in ["-1.1", "-1", "-0.1", "-0.01", "-0.001", "100.1", "100.01", "100.001", "101", "+101", "+101.1", "dog"]:
+            percentile = percentile.upper()
+
+            # For negative values and zero, Cassandra returns a shortened error message compared to ScyllaDB.
+            # Therefore, a regular expression is used to match both formats of the error message.
+            message = (
+                f"(?:"
+                f"Invalid value {re.escape(percentile)}PERCENTILE "
+                r"for (?:PERCENTILE option|option) 'speculative_retry'"
+                r"(?:\: must be between \(0\.0 and 100\.0\))?"
+                f"|"
+                f"cannot convert {re.escape(percentile)}PERCENTILE to speculative_retry"
+                f")"
+            )
+            with pytest.raises(ConfigurationException, match=message):
+                cql.execute(f"ALTER TABLE {table} WITH speculative_retry = '{percentile}PERCENTILE'")
 
 def test_invalid_speculative_retry_values(cql, test_keyspace):
     """

--- a/test/cqlpy/test_speculative_retry.py
+++ b/test/cqlpy/test_speculative_retry.py
@@ -1,0 +1,77 @@
+# Copyright 2026-present ScyllaDB
+#
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
+
+#############################################################################
+# Tests for the speculative_retry_user_table_default configuration option.
+# The option is live-updatable, so the tests set it through the system.config
+# virtual table and restore the original value when done. The tests are
+# scylla_only because the option (and system.config) do not exist in Cassandra.
+#############################################################################
+
+import json
+from contextlib import contextmanager
+
+from .util import new_test_table, new_materialized_view
+
+@contextmanager
+def temporary_config_value(cql, name, value):
+    original = json.loads(cql.execute(f"SELECT value FROM system.config WHERE name = '{name}'").one().value)
+    cql.execute(f"UPDATE system.config SET value = '{value}' WHERE name = '{name}'")
+    try:
+        yield
+    finally:
+        cql.execute(f"UPDATE system.config SET value = '{original}' WHERE name = '{name}'")
+
+def get_speculative_retry(cql, schema_table, name_column, ks, name):
+    r = list(cql.execute(f"SELECT speculative_retry FROM system_schema.{schema_table} WHERE keyspace_name = '{ks}' AND {name_column} = '{name}'"))
+    assert len(r) == 1
+    return r[0].speculative_retry
+
+# Check that the configured default applies to a base table and all its
+# auxiliary tables (materialized view, secondary index and CDC log), and that
+# an explicit speculative_retry table option overrides it.
+def test_tables_respect_speculative_retry_config(cql, test_keyspace, scylla_only):
+    with temporary_config_value(cql, 'speculative_retry_user_table_default', '200ms'):
+        with new_test_table(cql, test_keyspace, "p int primary key, v int", "with cdc = {'enabled': true}") as table:
+            with new_materialized_view(cql, table, '*', 'v, p', 'v is not null and p is not null') as mv:
+                cql.execute(f'CREATE INDEX ON {table}(v)')
+                ks, cf = table.split('.')
+                assert get_speculative_retry(cql, 'tables', 'table_name', ks, cf) == '200.00ms'
+                _, view = mv.split('.')
+                assert get_speculative_retry(cql, 'views', 'view_name', ks, view) == '200.00ms'
+                assert get_speculative_retry(cql, 'views', 'view_name', ks, f'{cf}_v_idx_index') == '200.00ms'
+                assert get_speculative_retry(cql, 'tables', 'table_name', ks, f'{cf}_scylla_cdc_log') == '200.00ms'
+        with new_test_table(cql, test_keyspace, "p int primary key, v int", "with speculative_retry = '37.0PERCENTILE'") as table:
+            ks, cf = table.split('.')
+            assert get_speculative_retry(cql, 'tables', 'table_name', ks, cf) == '37.0PERCENTILE'
+            # ALTER TABLE overrides the configured default as well
+            cql.execute(f"ALTER TABLE {table} WITH speculative_retry = '50ms'")
+            assert get_speculative_retry(cql, 'tables', 'table_name', ks, cf) == '50.00ms'
+            # and the value is retained when altering an unrelated property
+            cql.execute(f"ALTER TABLE {table} WITH comment = 'test comment'")
+            assert get_speculative_retry(cql, 'tables', 'table_name', ks, cf) == '50.00ms'
+
+# Check that the option is live-updatable: an updated value applies to tables
+# created after the update, and an invalid updated value is ignored, keeping
+# the last valid value.
+def test_live_update_speculative_retry_config(cql, test_keyspace, scylla_only):
+    with temporary_config_value(cql, 'speculative_retry_user_table_default', '200ms'):
+        with new_test_table(cql, test_keyspace, "p int primary key, v int") as t1:
+            ks, cf1 = t1.split('.')
+            assert get_speculative_retry(cql, 'tables', 'table_name', ks, cf1) == '200.00ms'
+            cql.execute("UPDATE system.config SET value = 'NONE' WHERE name = 'speculative_retry_user_table_default'")
+            with new_test_table(cql, test_keyspace, "p int primary key, v int") as t2:
+                _, cf2 = t2.split('.')
+                assert get_speculative_retry(cql, 'tables', 'table_name', ks, cf2) == 'NONE'
+                # Tables created before the update are not affected
+                assert get_speculative_retry(cql, 'tables', 'table_name', ks, cf1) == '200.00ms'
+            cql.execute("UPDATE system.config SET value = 'dog' WHERE name = 'speculative_retry_user_table_default'")
+            with new_test_table(cql, test_keyspace, "p int primary key, v int") as t3:
+                _, cf3 = t3.split('.')
+                assert get_speculative_retry(cql, 'tables', 'table_name', ks, cf3) == 'NONE'
+            # A subsequent valid update applies again
+            cql.execute("UPDATE system.config SET value = '50ms' WHERE name = 'speculative_retry_user_table_default'")
+            with new_test_table(cql, test_keyspace, "p int primary key, v int") as t4:
+                _, cf4 = t4.split('.')
+                assert get_speculative_retry(cql, 'tables', 'table_name', ks, cf4) == '50.00ms'

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -50,6 +50,7 @@
 #include "db/batchlog_manager.hh"
 #include "schema/schema_builder.hh"
 #include "schema/compression_initializer.hh"
+#include "schema/speculative_retry_initializer.hh"
 #include "db/view/view_building_state.hh"
 #include "test/lib/tmpdir.hh"
 #include "test/lib/log.hh"
@@ -615,6 +616,7 @@ private:
             register_compression_initializer(*cfg, [this] {
                 return bool(_feature_service.local().sstable_compression_dicts);
             });
+            register_speculative_retry_initializer(*cfg);
 
             // Important to restore schema initializers during shutdown to
             // support tests that repeatedly create `cql_test_env` instances.

--- a/tools/scylla-sstable.cc
+++ b/tools/scylla-sstable.cc
@@ -39,6 +39,7 @@
 #include "readers/multi_range.hh"
 #include "schema/schema_builder.hh"
 #include "schema/compression_initializer.hh"
+#include "schema/speculative_retry_initializer.hh"
 #include "sstables/index_reader.hh"
 #include "sstables/sstables_manager.hh"
 #include "sstables/sstable_directory.hh"
@@ -3112,6 +3113,10 @@ $ scylla sstable validate /path/to/md-123456-big-Data.db /path/to/md-123457-big-
         // Since scylla-sstable has no context about features, we optimistically
         // assume that the feature is enabled.
         register_compression_initializer(dbcfg, true);
+
+        // Apply the configured default speculative_retry value to user
+        // tables, so that schemas built here match the node's.
+        register_speculative_retry_initializer(dbcfg);
 
         {
             unsigned schema_sources = 0;


### PR DESCRIPTION
Add a scylla.yaml option, `speculative_retry_user_table_default`, that sets the default `speculative_retry` value (e.g. `200ms` or `NONE`) for newly created user tables, following the pattern of `sstable_compression_user_table_options`. It is applied through a schema initializer, so it uniformly covers CQL base tables, materialized views, secondary indexes, CDC log tables and Alternator tables.

Tables with an explicit `speculative_retry` and already existing tables are not affected. The value is parsed once at startup and a node refuses to boot on an invalid value; when the option is not set, behavior is unchanged. The shipped default remains `99.0PERCENTILE`.

The first two patches fix pre-existing validation gaps in `speculative_retry::from_sstring`: values shorter than the `ms`/`PERCENTILE` suffixes failed with `std::out_of_range` instead of a configuration error, and NaN, infinite and negative numbers were accepted (a NaN percentile aborts the node on the first speculative read).

Unlike the request in #7472, the default itself is not changed, only made configurable: reducing availability stays a conscious per-cluster decision.

Fixes SCYLLADB-3670

This is an enhancement. No backport needed.