### PR TITLE
tablet hints should survive node loss during tablet aware restore

### DIFF
--- a/db/system_distributed_keyspace.cc
+++ b/db/system_distributed_keyspace.cc
@@ -1175,6 +1175,44 @@ future<> snapshot_table_helper::insert_snapshot_entries(std::string_view snapsho
 }
 
 /**
+ * Helper to build a snapshot_table_entry describing the current schema of the given table
+ */
+db::snapshot_table_entry snapshot_table_helper::make_snapshot_table_entry(std::string_view snapshot_name, const replica::table& table) const {
+    auto s = table.schema();
+
+    auto helper = replica::make_schema_describe_helper(s, _qp.db());
+    auto desc = s->describe(helper, cql3::describe_option::STMTS_AND_INTERNALS);
+
+    auto type = snapshot_table_type::cql_table;
+    table_id base_table_id;
+
+    if (s->is_view()) {
+        type = snapshot_table_type::cql_view;
+        base_table_id = s->view_info()->base_id();
+    }
+
+    std::string tablet_layout = "none";
+
+    if (table.uses_tablets()) {
+        auto erm = table.get_effective_replication_map();
+        auto& tm = erm->get_token_metadata().tablets().get_tablet_map(s->id());
+        tablet_layout = locator::tablet_layout_to_string(tm.get_layout());
+    }
+
+    // TODO: check alternator etc...
+    return db::snapshot_table_entry{
+        .snapshot_name = std::string(snapshot_name),
+        .keyspace_name = s->ks_name(),
+        .table_name = s->cf_name(),
+        .table_id = s->id(),
+        .type = type,
+        .base_table_id = base_table_id,
+        .table_schema = desc.create_statement->linearize(),
+        .tablet_layout = tablet_layout
+    };
+}
+
+/**
  * Helper to write snapshot base metadata
  */
 future<> snapshot_table_helper::insert_snapshot_info(std::string_view snapshot_name
@@ -1207,36 +1245,7 @@ future<> snapshot_table_helper::insert_snapshot_info(std::string_view snapshot_n
             });
        }
 
-       auto helper = replica::make_schema_describe_helper(s, _qp.db());
-       auto desc = s->describe(helper, cql3::describe_option::STMTS_AND_INTERNALS);
-
-       auto type = snapshot_table_type::cql_table;
-       table_id base_table_id;
-
-       if (s->is_view()) {
-           type = snapshot_table_type::cql_view;
-           base_table_id = s->view_info()->base_id();
-       }
-
-       std::string tablet_layout = "none";
-
-       if (t->uses_tablets()) {
-           auto erm = t->get_effective_replication_map();
-           auto& tm = erm->get_token_metadata().tablets().get_tablet_map(s->id());
-           tablet_layout = locator::tablet_layout_to_string(tm.get_layout());
-       }
-
-       // TODO: check alternator etc...
-       tables.emplace_back(db::snapshot_table_entry{
-            .snapshot_name = std::string(snapshot_name),
-            .keyspace_name = name,
-            .table_name = s->cf_name(),
-            .table_id = s->id(),
-            .type = type,
-            .base_table_id = base_table_id,
-            .table_schema = desc.create_statement->linearize(),
-            .tablet_layout = tablet_layout
-       });
+       tables.emplace_back(make_snapshot_table_entry(snapshot_name, *t));
     }
 
     co_await insert_snapshot_keyspaces(keyspaces | std::views::values | std::ranges::to<std::vector>(), cl);

--- a/db/system_distributed_keyspace.hh
+++ b/db/system_distributed_keyspace.hh
@@ -214,6 +214,11 @@ public:
     future<> insert_snapshot_tables(std::span<const snapshot_table_entry> tables, db::consistency_level cl = db::consistency_level::EACH_QUORUM);
 
     /**
+     * Helper to build a snapshot_table_entry describing the current schema of the given table
+     */
+    snapshot_table_entry make_snapshot_table_entry(std::string_view snapshot_name, const replica::table& table) const;
+
+    /**
      * Get all tables in snapshot, optionally restricted by keyspace
      */
     future<utils::chunked_vector<snapshot_table_entry>> get_snapshot_tables(std::string_view snapshot_name, std::string_view keyspace = {}, std::string_view table = {}, db::consistency_level cl = db::consistency_level::LOCAL_QUORUM);

--- a/sstables_loader.cc
+++ b/sstables_loader.cc
@@ -40,7 +40,7 @@
 
 #include "sstables/object_storage_client.hh"
 #include "utils/rjson.hh"
-#include "db/system_distributed_keyspace.hh"
+#include "table_helper.hh"
 
 #include <cfloat>
 #include <algorithm>
@@ -1338,9 +1338,47 @@ protected:
 
         auto& loader = _loader.local();
 
-        auto current_schema = loader.local_db().find_schema(_tid);
+        auto table = loader.local_db().get_tables_metadata().get_table_if_exists(_tid);
+        if (!table) {
+            throw replica::no_such_column_family(_tid);
+        }
+
+        // Persist the schema of the table in system_distributed.snapshot_tables before
+        // the tablet hints are pinned below, so the original hints survive a crash of
+        // this node. If an entry for this snapshot and table already exists, this
+        // restore either resumes an earlier attempt that may have already pinned the
+        // hints, or restores into the same table the snapshot was taken from; in both
+        // cases the original hints are recovered from the persisted schema instead of
+        // the live one.
+        db::snapshot_table_helper sth(loader._sys_dist_ks.qp());
+        auto entries = co_await sth.get_snapshot_tables(_snap_name, table->schema()->ks_name(), table->schema()->cf_name());
+
+        auto current_schema = table->schema();
         auto min_tablet_count = current_schema->tablet_options().min_tablet_count;
         auto max_tablet_count = current_schema->tablet_options().max_tablet_count;
+
+        if (entries.empty()) {
+            auto entry = sth.make_snapshot_table_entry(_snap_name, *table);
+            co_await sth.insert_snapshot_tables(std::span(&entry, 1));
+        } else {
+            const auto& entry = entries.front();
+            schema_ptr original_schema;
+            try {
+                if (entry.type != db::snapshot_table_type::cql_table) {
+                    throw std::runtime_error(fmt::format("the entry does not describe a CQL table (type={})", static_cast<int32_t>(entry.type)));
+                }
+                original_schema = table_helper::parse_new_cf_statement(loader._sys_dist_ks.qp(), entry.table_schema);
+            } catch (...) {
+                throw std::runtime_error(fmt::format("Failed to recover the pre-restore schema of table {}.{} stored for snapshot {}: {}",
+                    current_schema->ks_name(), current_schema->cf_name(), _snap_name, std::current_exception()));
+            }
+            min_tablet_count = original_schema->tablet_options().min_tablet_count;
+            max_tablet_count = original_schema->tablet_options().max_tablet_count;
+            // Refresh the TTL of the entry so that repeated crash/re-issue cycles
+            // spanning a long time do not outlive it.
+            co_await sth.insert_snapshot_tables(std::span(&entry, 1));
+        }
+
         co_await loader._ss.local().alter_table_with_tablet_hints(_tid, _tablet_count, _tablet_count);
 
         std::exception_ptr eptr;

--- a/table_helper.cc
+++ b/table_helper.cc
@@ -22,7 +22,7 @@
 
 static logging::logger tlogger("table_helper");
 
-static schema_ptr parse_new_cf_statement(cql3::query_processor& qp, const sstring& create_cql) {
+schema_ptr table_helper::parse_new_cf_statement(cql3::query_processor& qp, const sstring& create_cql) {
     auto db = qp.db();
 
     auto parsed = cql3::query_processor::parse_statement(create_cql, cql3::dialect{});

--- a/table_helper.cc
+++ b/table_helper.cc
@@ -25,13 +25,25 @@ static logging::logger tlogger("table_helper");
 schema_ptr table_helper::parse_new_cf_statement(cql3::query_processor& qp, const sstring& create_cql) {
     auto db = qp.db();
 
-    auto parsed = cql3::query_processor::parse_statement(create_cql, cql3::dialect{});
+    // The input may contain trailing statements after the leading CREATE TABLE one,
+    // e.g. a schema described with internals appends an ALTER TABLE statement for
+    // each dropped column.
+    auto parsed_statements = cql3::query_processor::parse_statements(create_cql, cql3::dialect{});
+    if (parsed_statements.empty()) {
+        throw std::runtime_error(format("Expected a CREATE TABLE statement, got no statements: {}", create_cql));
+    }
+    auto& parsed = parsed_statements.front();
 
-    cql3::statements::raw::cf_statement* parsed_cf_stmt = static_cast<cql3::statements::raw::cf_statement*>(parsed.get());
+    auto* parsed_cf_stmt = dynamic_cast<cql3::statements::raw::cf_statement*>(parsed.get());
+    if (!parsed_cf_stmt) {
+        throw std::runtime_error(format("Expected a CREATE TABLE statement: {}", create_cql));
+    }
     (void)parsed_cf_stmt->keyspace(); // This will SCYLLA_ASSERT if cql statement did not contain keyspace
-    ::shared_ptr<cql3::statements::create_table_statement> statement =
-                    static_pointer_cast<cql3::statements::create_table_statement>(
+    auto statement = dynamic_pointer_cast<cql3::statements::create_table_statement>(
                                     parsed_cf_stmt->prepare(db, qp.get_cql_stats(), qp.get_cql_config())->statement);
+    if (!statement) {
+        throw std::runtime_error(format("Expected a CREATE TABLE statement: {}", create_cql));
+    }
     auto schema = statement->get_cf_meta_data(db);
 
     // Generate the CF UUID based on its KF names. This is needed to ensure that

--- a/table_helper.hh
+++ b/table_helper.hh
@@ -10,6 +10,7 @@
 #pragma once
 
 #include "cql3/statements/prepared_statement.hh"
+#include "schema/schema_fwd.hh"
 #include "service/query_state.hh"
 
 namespace service {
@@ -127,6 +128,8 @@ public:
             return std::chrono::system_clock::time_point(nanoseconds((++last_event_nanos) * 100));
         }
     }
+
+    static schema_ptr parse_new_cf_statement(cql3::query_processor& qp, const sstring& create_cql);
 };
 
 struct bad_column_family : public std::exception {

--- a/test/cluster/object_store/test_backup.py
+++ b/test/cluster/object_store/test_backup.py
@@ -1190,6 +1190,61 @@ async def test_restore_tablets_with_different_tablet_hints(build_mode: str, mana
         assert f"'min_tablet_count': '{min_tablet_count_before_restore}'" in desc, f"Expected min_tablet_count={min_tablet_count_before_restore} in: {desc}"
         assert f"'max_tablet_count': '{max_tablet_count_before_restore}'" in desc, f"Expected max_tablet_count={max_tablet_count_before_restore} in: {desc}"
 
+
+@pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
+async def test_restore_tablets_hints_survive_node_loss(build_mode: str, manager: ManagerClient, object_storage):
+    '''Check that the tablet hints configured on the table before restore survive the
+    loss of the node driving the restore.
+
+    During tablet-aware restore, the table's tablet hints are pinned to the tablet
+    count from the backup manifest and altered back to their pre-restore values once
+    the restore is done. The pre-restore hints must be persisted before the pinning
+    so that they survive node crashes during restore.'''
+
+    topology = topo(rf = 2, nodes = 4, racks = 2, dcs = 1)
+    servers, host_ids = await create_cluster(topology, manager, logger, object_storage)
+    log = await manager.server_open_log(servers[0].server_id)
+    await log.wait_for("raft_topology - start topology coordinator fiber", timeout=10)
+
+    cql = manager.get_cql()
+
+    num_keys = 24
+    backup_tablet_count = 8
+    min_tablet_count_before_restore = 2
+    max_tablet_count_before_restore = 2
+
+    async with new_test_keyspace(manager, f"WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor': {topology.rf}}}") as ks:
+        await cql.run_async(f"CREATE TABLE {ks}.test ( pk text primary key, value int ) WITH tablets = {{'min_tablet_count': {backup_tablet_count}}};")
+        insert_stmt = cql.prepare(f"INSERT INTO {ks}.test (pk, value) VALUES (?, ?)")
+        insert_stmt.consistency_level = ConsistencyLevel.ALL
+        await asyncio.gather(*(cql.run_async(insert_stmt, (str(i), i)) for i in range(num_keys)))
+        snap_name, _ = await take_snapshot(ks, servers, manager, logger)
+        await asyncio.gather(*(do_backup(s, snap_name, f'{s.server_id}/{snap_name}', ks, 'test', object_storage, manager, logger) for s in servers))
+
+    async with new_test_keyspace(manager, f"WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor': {topology.rf}}}") as ks:
+        await cql.run_async(f"CREATE TABLE {ks}.test ( pk text primary key, value int ) WITH tablets = {{'min_tablet_count': {min_tablet_count_before_restore}, 'max_tablet_count': {max_tablet_count_before_restore}}};")
+
+        await manager.api.enable_injection(servers[2].ip_addr, "pause_tablet_restore", one_shot=True)
+
+        manifests = [ f'{s.server_id}/{snap_name}/manifest.json' for s in servers ]
+        tid = await manager.api.restore_tablets(servers[1].ip_addr, ks, 'test', snap_name, servers[1].datacenter, object_storage.address, object_storage.bucket_name, manifests)
+        await manager.api.wait_for_injection_enter(servers[2].ip_addr, "pause_tablet_restore", deadline=time.time() + 120)
+
+        await manager.server_stop(servers[1].server_id, convict=True)
+        with pytest.raises(aiohttp.client_exceptions.ClientConnectorError):
+            await manager.api.wait_task(servers[1].ip_addr, tid)
+
+        tid = await manager.api.restore_tablets(servers[3].ip_addr, ks, 'test', snap_name, servers[3].datacenter, object_storage.address, object_storage.bucket_name, manifests)
+        await manager.api.message_injection(servers[2].ip_addr, "pause_tablet_restore")
+        status = await asyncio.wait_for(manager.api.wait_task(servers[3].ip_addr, tid), timeout=120)
+        logger.info(f'Re-issued restore finished with: {status}')
+
+        host3 = (await wait_for_cql_and_get_hosts(cql, [servers[3]], time.time() + 60))[0]
+        desc = (await cql.run_async(f"DESC TABLE {ks}.test", host=host3))[0].create_statement
+        assert f"'min_tablet_count': '{min_tablet_count_before_restore}'" in desc, f"Expected min_tablet_count={min_tablet_count_before_restore} in: {desc}"
+        assert f"'max_tablet_count': '{max_tablet_count_before_restore}'" in desc, f"Expected max_tablet_count={max_tablet_count_before_restore} in: {desc}"
+
+
 async def test_restore_with_non_existing_sstable(manager: ManagerClient, object_storage):
     '''Check that restore task fails well when given a non-existing sstable'''
 


### PR DESCRIPTION
During tablet-aware restore, the table's tablet hints are pinned to min=max=manifest_tablet_count and altered back to their original values once the restore completes or fails. The original values were only captured in the memory of the node driving the restore: if that node died mid-restore, a re-issued restore would read the already-pinned hints from the live schema and "restore" those at the end, losing the user-configured values permanently.

Persist the schema of the table in system_distributed.snapshot_tables before pinning the hints, keyed by the snapshot name. If an entry for this snapshot and table already exists, the restore is either resuming an earlier attempt that may have already pinned the hints, or restoring into the very table the snapshot was taken from; in both cases the original hints are recovered from the persisted schema instead of the live one.

Fixes https://scylladb.atlassian.net/browse/SCYLLADB-3429