### PR TITLE
Use repair stream reason for nodetool refresh

### DIFF
--- a/db/view/view_update_generator.cc
+++ b/db/view/view_update_generator.cc
@@ -321,6 +321,8 @@ future<> view_update_generator::register_staging_sstable(sstables::shared_sstabl
     }
     inject_failure("view_update_generator_registering_staging_sstable");
     _progress_tracker->on_sstable_registration(sst);
+    vug_logger.debug("Registering staging sstable {} for {}.{}", sst->get_filename(),
+                     table->schema()->ks_name(), table->schema()->cf_name());
     _sstables_with_tables[table].push_back(std::move(sst));
 
     _pending_sstables.signal();

--- a/docs/features/backup-and-restore.rst
+++ b/docs/features/backup-and-restore.rst
@@ -44,10 +44,8 @@ Backup Process
      best to limit io-scheduling. See :ref:`backup_io_throughput_mb_per_sec <confprop_backup_io_throughput_mb_per_sec>` for details.
    * For `native` backup to work, ScyllaDB node must have access to the S3 bucket.
      See :ref:`Configuring Object Storage <object-storage-configuration>` for details.
-   * The restore process, as well as :doc:`nodetool refresh </operating-scylla/nodetool-commands/refresh>`
-     (with or without :ref:`--load-and-stream <nodetool-refresh-load-and-stream>`), run in the same I/O
-     scheduling group as backup and are throttled by the same
-     :ref:`backup_io_throughput_mb_per_sec <confprop_backup_io_throughput_mb_per_sec>` setting.
+   * The restore process runs in the same I/O scheduling group as backup and is throttled
+     by the same :ref:`backup_io_throughput_mb_per_sec <confprop_backup_io_throughput_mb_per_sec>` setting.
 
 Restore Process
 ---------------

--- a/docs/operating-scylla/nodetool-commands/refresh.rst
+++ b/docs/operating-scylla/nodetool-commands/refresh.rst
@@ -7,10 +7,11 @@ Copy the files to the table's upload directory, by default it is located under `
 
 If the table has any :doc:`Materialized Views (MV)</cql/mv/>` or :doc:`Secondary Indexes (SI)</cql/secondary-indexes/>`, content view updates will be generated from the uploaded SSTables. Uploading MV or SI SSTables is not required and will fail.
 
-.. note:: ``nodetool refresh`` (with or without ``--load-and-stream``) runs in the same I/O scheduling
-   group as backup and restore, and is therefore throttled by the
-   :ref:`backup_io_throughput_mb_per_sec <confprop_backup_io_throughput_mb_per_sec>` setting rather than
-   :ref:`stream_io_throughput_mb_per_sec <confprop_stream_io_throughput_mb_per_sec>`.
+.. note:: ``nodetool refresh`` (with or without ``--load-and-stream``) runs in the streaming
+   scheduling group, so its I/O is throttled by the
+   :ref:`stream_io_throughput_mb_per_sec <confprop_stream_io_throughput_mb_per_sec>` setting.
+   That group is part of the maintenance supergroup, which is capped in turn by
+   :ref:`maintenance_io_throughput_mb_per_sec <confprop_maintenance_io_throughput_mb_per_sec>`.
 
 .. _nodetool-refresh-local:
 

--- a/sstables_loader.cc
+++ b/sstables_loader.cc
@@ -156,9 +156,11 @@ protected:
     const primary_replica_only _primary_replica_only;
     const unlink_sstables _unlink_sstables;
     const stream_scope _stream_scope;
+    const streaming::stream_reason _reason;
 public:
     sstable_streamer(netw::messaging_service& ms, replica::database& db, ::table_id table_id, locator::effective_replication_map_ptr erm,
-                     std::vector<sstables::shared_sstable> sstables, primary_replica_only primary, unlink_sstables unlink, stream_scope scope)
+                     std::vector<sstables::shared_sstable> sstables, primary_replica_only primary, unlink_sstables unlink, stream_scope scope,
+                     streaming::stream_reason reason)
             : _ms(ms)
             , _db(db)
             , _table(db.find_column_family(table_id))
@@ -167,6 +169,7 @@ public:
             , _primary_replica_only(primary)
             , _unlink_sstables(unlink)
             , _stream_scope(scope)
+            , _reason(reason)
     {
         // By sorting SSTables by their primary key, we allow SSTable runs to be
         // incrementally streamed.
@@ -196,8 +199,9 @@ class tablet_sstable_streamer : public sstable_streamer {
     const locator::tablet_map& _tablet_map;
 public:
     tablet_sstable_streamer(netw::messaging_service& ms, sharded<replica::database>& db, ::table_id table_id, locator::effective_replication_map_ptr erm,
-                            std::vector<sstables::shared_sstable> sstables, primary_replica_only primary, unlink_sstables unlink, stream_scope scope)
-        : sstable_streamer(ms, db.local(), table_id, std::move(erm), std::move(sstables), primary, unlink, scope)
+                            std::vector<sstables::shared_sstable> sstables, primary_replica_only primary, unlink_sstables unlink, stream_scope scope,
+                            streaming::stream_reason reason)
+        : sstable_streamer(ms, db.local(), table_id, std::move(erm), std::move(sstables), primary, unlink, scope, reason)
         , _db(db)
         , _tablet_map(_erm->get_token_metadata().tablets().get_tablet_map(table_id)) {
     }
@@ -501,7 +505,6 @@ future<> sstable_streamer::stream_sstable_mutations(streaming::plan_id ops_uuid,
     const auto token_range = pr.transform(std::mem_fn(&dht::ring_position::token));
     auto s = _table.schema();
     const auto cf_id = s->id();
-    const auto reason = streaming::stream_reason::restore;
 
     auto sst_set = make_lw_shared<sstables::sstable_set>(sstables::make_partitioned_sstable_set(s, std::move(token_range)));
     size_t estimated_partitions = 0;
@@ -534,7 +537,7 @@ future<> sstable_streamer::stream_sstable_mutations(streaming::plan_id ops_uuid,
                 for (auto& node : current_targets) {
                     if (!metas.contains(node)) {
                         auto [sink, source] = co_await _ms.make_sink_and_source_for_stream_mutation_fragments(reader.schema()->version(),
-                                ops_uuid, cf_id, estimated_partitions, reason, service::default_session_id, node);
+                                ops_uuid, cf_id, estimated_partitions, _reason, service::default_session_id, node);
                         bool abort_supported = _ms.supports_load_and_stream_abort_rpc_message();
                         llog.debug("load_and_stream: ops_uuid={}, make sink and source for node={}", ops_uuid, node);
                         metas.emplace(node, send_meta_data(node, std::move(sink), std::move(source), abort_supported));
@@ -641,7 +644,7 @@ future<locator::effective_replication_map_ptr> sstables_loader::await_topology_q
 
 future<> sstables_loader::load_and_stream(sstring ks_name, sstring cf_name,
         ::table_id table_id, std::vector<sstables::shared_sstable> sstables, primary_replica_only primary, bool unlink, stream_scope scope,
-        shared_ptr<stream_progress> progress) {
+        streaming::stream_reason reason, shared_ptr<stream_progress> progress) {
     // streamer guarantees topology stability, for correctness, by holding effective_replication_map
     // throughout its lifetime.
     auto erm = co_await await_topology_quiesced_and_get_erm(table_id);
@@ -659,10 +662,10 @@ future<> sstables_loader::load_and_stream(sstring ks_name, sstring cf_name,
     std::unique_ptr<sstable_streamer> streamer;
     if (tbl.uses_tablets()) {
         streamer =
-            std::make_unique<tablet_sstable_streamer>(_messaging, _db, table_id, std::move(erm), std::move(sstables), primary, unlink_sstables(unlink), scope);
+            std::make_unique<tablet_sstable_streamer>(_messaging, _db, table_id, std::move(erm), std::move(sstables), primary, unlink_sstables(unlink), scope, reason);
     } else {
         streamer =
-            std::make_unique<sstable_streamer>(_messaging, _db.local(), table_id, std::move(erm), std::move(sstables), primary, unlink_sstables(unlink), scope);
+            std::make_unique<sstable_streamer>(_messaging, _db.local(), table_id, std::move(erm), std::move(sstables), primary, unlink_sstables(unlink), scope, reason);
     }
 
     co_await streamer->stream(progress);
@@ -709,7 +712,8 @@ future<> sstables_loader::load_new_sstables(sstring ks_name, sstring cf_name,
             };
             std::tie(table_id, sstables_on_shards) = co_await replica::distributed_loader::get_sstables_from_upload_dir(_db, ks_name, cf_name, cfg);
             co_await container().invoke_on_all([&sstables_on_shards, ks_name, cf_name, table_id, primary, scope] (sstables_loader& loader) mutable -> future<> {
-                co_await loader.load_and_stream(ks_name, cf_name, table_id, std::move(sstables_on_shards[this_shard_id()]), primary_replica_only(primary), true, scope, {});
+                co_await loader.load_and_stream(ks_name, cf_name, table_id, std::move(sstables_on_shards[this_shard_id()]), primary_replica_only(primary), true, scope,
+                                                streaming::stream_reason::restore, {});
             });
         } else {
             co_await replica::distributed_loader::process_upload_dir(_db, _view_builder, _view_building_worker, ks_name, cf_name, skip_cleanup, skip_reshape);
@@ -861,7 +865,7 @@ future<> sstables_loader::download_task_impl::run() {
         _progress_state = progress_state::initialized;
         co_await _loader.invoke_on_all([this, &sstables_on_shards, table_id] (sstables_loader& loader) mutable -> future<> {
             co_await loader.load_and_stream(_ks, _cf, table_id, std::move(sstables_on_shards[this_shard_id()]), _primary_replica, false, _scope,
-                                            _progress_per_shard.local().progress);
+                                            streaming::stream_reason::restore, _progress_per_shard.local().progress);
         });
     } catch (...) {
         ex = std::current_exception();

--- a/sstables_loader.cc
+++ b/sstables_loader.cc
@@ -682,7 +682,12 @@ future<> sstables_loader::load_new_sstables(sstring ks_name, sstring cf_name,
         _loading_new_sstables = true;
     }
 
-    co_await coroutine::switch_to(_sched_group);
+    // No switch_to(_sched_group) here: that group is the backup one and belongs to
+    // restore. Refresh instead inherits the group from its caller, the API server,
+    // which listens in the streaming group. The replica on the receiving end of the
+    // load-and-stream works in the streaming group too, because it switches to the
+    // backup one only for stream_reason::restore and refresh streams carry
+    // stream_reason::repair. So both ends of a refresh are throttled as streaming.
 
     sstring load_and_stream_desc = fmt::format("{}", load_and_stream);
     const auto& rs = _db.local().find_keyspace(ks_name).get_replication_strategy();
@@ -713,7 +718,7 @@ future<> sstables_loader::load_new_sstables(sstring ks_name, sstring cf_name,
             std::tie(table_id, sstables_on_shards) = co_await replica::distributed_loader::get_sstables_from_upload_dir(_db, ks_name, cf_name, cfg);
             co_await container().invoke_on_all([&sstables_on_shards, ks_name, cf_name, table_id, primary, scope] (sstables_loader& loader) mutable -> future<> {
                 co_await loader.load_and_stream(ks_name, cf_name, table_id, std::move(sstables_on_shards[this_shard_id()]), primary_replica_only(primary), true, scope,
-                                                streaming::stream_reason::restore, {});
+                                                streaming::stream_reason::repair, {});
             });
         } else {
             co_await replica::distributed_loader::process_upload_dir(_db, _view_builder, _view_building_worker, ks_name, cf_name, skip_cleanup, skip_reshape);

--- a/sstables_loader.hh
+++ b/sstables_loader.hh
@@ -19,6 +19,7 @@
 #include "db/consistency_level_type.hh"
 #include "locator/tablets.hh"
 #include "service/topology_guard.hh"
+#include "streaming/stream_reason.hh"
 
 using namespace seastar;
 
@@ -107,7 +108,7 @@ private:
     future<> load_and_stream(sstring ks_name, sstring cf_name,
             table_id, std::vector<sstables::shared_sstable> sstables,
             bool_class<struct primary_replica_only_tag> primary_replica_only, bool unlink_sstables, stream_scope scope,
-            shared_ptr<stream_progress> progress);
+            streaming::stream_reason reason, shared_ptr<stream_progress> progress);
 
     future<seastar::shared_ptr<const locator::effective_replication_map>> await_topology_quiesced_and_get_erm(table_id table_id);
     future<> download_tablet_sstables(locator::global_tablet_id tid, locator::tablet_metadata_guard&);

--- a/test/cluster/test_alternator.py
+++ b/test/cluster/test_alternator.py
@@ -23,6 +23,8 @@ import botocore
 from botocore.exceptions import ClientError, ConnectionClosedError, SSLError
 import requests
 import json
+import glob
+import shutil
 from cassandra.auth import PlainTextAuthProvider
 from cassandra.protocol import InvalidRequest
 import threading
@@ -31,7 +33,7 @@ import re
 
 from test.cluster.util import get_replication
 from test.pylib.manager_client import ManagerClient
-from test.pylib.util import wait_for
+from test.pylib.util import wait_for, wait_for_view, unique_name
 from test.pylib.rest_client import inject_error
 from test.pylib.tablets import get_all_tablet_replicas
 from test.pylib.tablets import get_tablet_replica
@@ -2085,3 +2087,109 @@ async def test_alternator_mtls_and_plain_http(manager: ManagerClient, tmp_path):
 
 
 
+
+
+# Alternator convenience function for fetching an entire scan, of the table
+# itself or of one of its indexes.
+def full_scan(table, ConsistentRead=True, **kwargs):
+    response = table.scan(ConsistentRead=ConsistentRead, **kwargs)
+    items = response['Items']
+    while 'LastEvaluatedKey' in response:
+        response = table.scan(ExclusiveStartKey=response['LastEvaluatedKey'],
+            ConsistentRead=ConsistentRead, **kwargs)
+        items.extend(response['Items'])
+    return items
+
+async def test_alternator_lsi_load_and_stream(manager: ManagerClient):
+    """Loading sstables into an Alternator table must populate its LSI.
+
+    The Alternator counterpart of test_refresh_generates_view_updates. An LSI is
+    colocated with its base table, so it is neither backed up nor repairable on
+    its own -- the way ScyllaDB Manager restores such a table is to recreate the
+    schema and load-and-stream the base table's sstables, leaving the index to
+    be filled in by the view updates generated as that data lands. If the
+    receiving node puts the sstables straight into the table instead of staging
+    them, the base table comes back while the index stays empty.
+    """
+    n_items = 100
+    index_name = 'lsi1'
+
+    # Alternator uses RF=3 once the cluster has three nodes, and a tablet table
+    # with an index needs the rack count to be 1 or 3 for that to be rack-valid.
+    servers = await manager.servers_add(3, config=alternator_config, auto_rack_dc='dc1')
+    cql, _ = await manager.get_ready_cql(servers)
+    await manager.disable_tablet_balancing()
+
+    alternator = get_alternator(servers[0].ip_addr)
+
+    def create_table(name):
+        return alternator.create_table(
+            TableName=name,
+            BillingMode='PAY_PER_REQUEST',
+            Tags=[{'Key': 'system:initial_tablets', 'Value': '1'}],
+            KeySchema=[
+                {'AttributeName': 'p', 'KeyType': 'HASH'},
+                {'AttributeName': 'c', 'KeyType': 'RANGE'},
+            ],
+            AttributeDefinitions=[
+                {'AttributeName': 'p', 'AttributeType': 'S'},
+                {'AttributeName': 'c', 'AttributeType': 'S'},
+                {'AttributeName': 'b', 'AttributeType': 'S'},
+            ],
+            LocalSecondaryIndexes=[
+                {
+                    'IndexName': index_name,
+                    'KeySchema': [
+                        {'AttributeName': 'p', 'KeyType': 'HASH'},
+                        {'AttributeName': 'b', 'KeyType': 'RANGE'},
+                    ],
+                    'Projection': {'ProjectionType': 'ALL'},
+                },
+            ])
+
+    # The items are written to a separate table and only its sstables are
+    # carried over, so the table under test never held them and nothing but the
+    # load-and-stream can account for them showing up in its index.
+    src_name = unique_table_name()
+    src_table = create_table(src_name)
+    with src_table.batch_writer() as batch:
+        for i in range(n_items):
+            batch.put_item(Item={'p': str(i), 'c': str(i), 'b': str(i)})
+
+    logger.info('Flush and snapshot the source base table')
+    src_ks = f'alternator_{src_name}'
+    snap_name = unique_name('restore_')
+    await manager.api.flush_keyspace(servers[0].ip_addr, src_ks)
+    await manager.api.take_snapshot(servers[0].ip_addr, src_ks, snap_name)
+
+    # The table under test has the same schema and is created empty, so its
+    # index is fully built and the view builder has nothing left to pick up by
+    # the time the sstables are loaded.
+    dst_name = unique_table_name()
+    dst_table = create_table(dst_name)
+    dst_ks = f'alternator_{dst_name}'
+    # An LSI is backed by a view named "<table>!:<index>", see lsi_name() in
+    # alternator/executor_util.cc.
+    dst_view = f'{dst_name}!:{index_name}'
+    await wait_for_view(cql, dst_view, len(servers), timeout=300)
+
+    async def base_table_dir(server, ks, table):
+        workdir = await manager.server_get_workdir(server.server_id)
+        return glob.glob(os.path.join(workdir, 'data', ks, f'{table}-*'))[0]
+
+    logger.info('Copy the base table sstables over and load-and-stream them')
+    # Only the base table is restored, as ScyllaDB Manager backs up only that.
+    snapshot_dir = os.path.join(await base_table_dir(servers[0], src_ks, src_name),
+                                'snapshots', snap_name)
+    upload_dir = os.path.join(await base_table_dir(servers[0], dst_ks, dst_name), 'upload')
+    os.makedirs(upload_dir, exist_ok=True)
+    for item in os.listdir(snapshot_dir):
+        if item not in ('manifest.json', 'schema.cql'):
+            shutil.copy2(os.path.join(snapshot_dir, item), os.path.join(upload_dir, item))
+    await manager.api.load_new_sstables(servers[0].ip_addr, dst_ks, dst_name,
+                                        load_and_stream=True)
+
+    # The base table is asserted first, so that a failure here is not mistaken
+    # for the data never having arrived.
+    assert len(full_scan(dst_table)) == n_items
+    assert len(full_scan(dst_table, IndexName=index_name)) == n_items

--- a/test/cluster/test_refresh.py
+++ b/test/cluster/test_refresh.py
@@ -7,6 +7,7 @@
 #!/usr/bin/env python3
 
 import os
+import glob
 import logging
 import asyncio
 import pytest
@@ -17,13 +18,14 @@ import uuid
 from collections import defaultdict
 
 from cassandra.cluster import ConsistencyLevel
+from cassandra.query import SimpleStatement
 from test.pylib.minio_server import MinioServer
 from test.pylib.manager_client import ManagerClient
 from test.pylib.object_storage import format_tuples
 from test.cluster.object_store.test_backup import topo, take_snapshot, do_test_streaming_scopes
 from test.cluster.util import new_test_keyspace
 from test.pylib.rest_client import read_barrier
-from test.pylib.util import unique_name, wait_for
+from test.pylib.util import unique_name, wait_for, wait_for_view
 
 logger = logging.getLogger(__name__)
 
@@ -172,3 +174,97 @@ async def test_refresh_deletes_uploaded_sstables(manager: ManagerClient):
             await wait_for_upload_dir_empty(upload_dir)
 
         shutil.rmtree(tmpbackup)
+
+
+async def wait_for_row_count_on_host(cql, host, ks, table, expected, timeout=120):
+    '''Wait until `table` reports `expected` rows when read through `host`.
+
+    View updates are generated asynchronously, off the staging sstables, so the
+    count has to be polled rather than read once.
+    '''
+    stmt = SimpleStatement(f"SELECT COUNT(*) FROM {ks}.{table}", consistency_level=ConsistencyLevel.LOCAL_ONE)
+    last = None
+    async def has_all_rows():
+        nonlocal last
+        last = (await cql.run_async(stmt, host=host))[0][0]
+        return True if last == expected else None
+    try:
+        await wait_for(has_all_rows, time.time() + timeout, period=1.0, label=f"row_count_{table}")
+    except AssertionError:
+        pytest.fail(f"Expected {expected} rows in {ks}.{table} on {host}, got {last}")
+
+
+@pytest.mark.parametrize("tablets", [False, True])
+async def test_refresh_generates_view_updates(manager: ManagerClient, tablets):
+    '''
+    Check that load-and-stream generates view updates for the data it brings in.
+
+    The mutations carried by the loaded sstables have never been seen by any replica,
+    so the receiving node must put them in the staging directory and let the view
+    update generator populate the views. The interesting case is a view that is
+    already fully built: there is nothing left for the view builder to pick up, so if
+    the sstable goes to the normal directory instead, the view stays empty forever.
+    '''
+    node_count = 2
+    expected_rows = 64
+    cf = 'cf'
+    mv = 'mv'
+    idx = 'value_idx'
+    schema = "(pk text primary key, value int)"
+
+    cmdline = ['--logger-log-level', 'view_update_generator=debug',
+               '--logger-log-level', 'view_building_worker=debug']
+    servers = await manager.servers_add(node_count, auto_rack_dc="dc1", cmdline=cmdline)
+    cql, hosts = await manager.get_ready_cql(servers)
+    await manager.disable_tablet_balancing()
+
+    ks_opts = "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 2}" \
+              f" AND tablets = {{'enabled': {str(tablets).lower()}}}"
+
+    async def table_dir(server, ks):
+        workdir = await manager.server_get_workdir(server.server_id)
+        return glob.glob(os.path.join(workdir, 'data', ks, f'{cf}-*'))[0]
+
+    # The data is produced in a separate keyspace and its sstables are then loaded into
+    # the keyspace under test. That way the table under test never held the rows, so
+    # nothing but the load-and-stream can account for them showing up in its views.
+    async with new_test_keyspace(manager, ks_opts) as src_ks, new_test_keyspace(manager, ks_opts) as ks:
+        await cql.run_async(f"CREATE TABLE {src_ks}.{cf} {schema}")
+
+        insert_stmt = cql.prepare(f"INSERT INTO {src_ks}.{cf} (pk, value) VALUES (?, ?)")
+        insert_stmt.consistency_level = ConsistencyLevel.ALL
+        await asyncio.gather(*(cql.run_async(insert_stmt, (str(k), k)) for k in range(expected_rows)))
+
+        # servers[0] holds every partition (RF == node count), so its sstables alone
+        # carry the whole table.
+        logger.info('Flush and snapshot the source table')
+        snap_name = unique_name('refresh_')
+        await manager.api.flush_keyspace(servers[0].ip_addr, src_ks)
+        await manager.api.take_snapshot(servers[0].ip_addr, src_ks, snap_name)
+        snapshot_dir = os.path.join(await table_dir(servers[0], src_ks), 'snapshots', snap_name)
+
+        # The views are created on an empty table, so they are fully built - and no build
+        # is in progress - by the time load-and-stream runs. This is what makes the view
+        # updates the only way for the loaded data to reach them.
+        logger.info('Create the table under test with its views, and wait for them to be built')
+        await cql.run_async(f"CREATE TABLE {ks}.{cf} {schema}")
+        await cql.run_async(f"CREATE MATERIALIZED VIEW {ks}.{mv} AS SELECT * FROM {ks}.{cf} "
+                            "WHERE pk IS NOT NULL AND value IS NOT NULL PRIMARY KEY (value, pk)")
+        await cql.run_async(f"CREATE INDEX {idx} ON {ks}.{cf} (value)")
+        await wait_for_view(cql, mv, node_count, timeout=300)
+        await wait_for_view(cql, f'{idx}_index', node_count, timeout=300)
+
+        logger.info('Copy the sstables to the upload dir and refresh')
+        upload_dir = os.path.join(await table_dir(servers[0], ks), 'upload')
+        os.makedirs(upload_dir, exist_ok=True)
+        for item in os.listdir(snapshot_dir):
+            if item not in ('manifest.json', 'schema.cql'):
+                shutil.copy2(os.path.join(snapshot_dir, item), os.path.join(upload_dir, item))
+        await manager.api.load_new_sstables(servers[0].ip_addr, ks, cf, scope='all', load_and_stream=True)
+
+        # The base table getting the rows proves the load itself worked; the views are
+        # what the regression broke.
+        for host in hosts:
+            await wait_for_row_count_on_host(cql, host, ks, cf, expected_rows)
+            await wait_for_row_count_on_host(cql, host, ks, mv, expected_rows)
+            await wait_for_row_count_on_host(cql, host, ks, f'{idx}_index', expected_rows)


### PR DESCRIPTION
In #30864 there was introduced a stream_reason::restore to facilitate the restoration code flow. The nodetool refresh backing code was also switched to use one for simplicity and uniformity. However, this broke the was views are generated for the refreshed sstables, so this PR restores this back and adds a missing unit test.

Another option would be to make refresh use yet another dedicated stream reason, but this would cause problems in mixed clusters -- "older" nodes that don't understand it would skip the view update just as well. Can be solved with the new cluster features, but it's a bigger change that we might want to consider for later.

Fixes SCYLLADB-3610

Fixing recently introduced regression, not backporting