### PR TITLE
build: avoid fast unwind in the sanitizer

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -157,6 +157,7 @@ adjust_bin() {
 export GNUTLS_SYSTEM_PRIORITY_FILE="\${GNUTLS_SYSTEM_PRIORITY_FILE-$prefix/libreloc/gnutls.config}"
 export LD_LIBRARY_PATH="$prefix/libreloc"
 export UBSAN_OPTIONS="${UBSAN_OPTIONS:+$UBSAN_OPTIONS:}suppressions=$prefix/libexec/ubsan-suppressions.supp"
+export ASAN_OPTIONS="\${ASAN_OPTIONS:+\$ASAN_OPTIONS:}fast_unwind_on_malloc=0:symbolize=1"
 export LSAN_OPTIONS="${LSAN_OPTIONS:+$LSAN_OPTIONS:}suppressions=$prefix/libexec/lsan-suppressions.supp"
 ${p11_trust_paths:+export SCYLLA_P11_TRUST_PATHS="$p11_trust_paths"}
 exec -a "\$0" "$prefix/libexec/$bin" "\$@"


### PR DESCRIPTION
On aarch64, the fast unwinder run by the sanitizer doesn't work well with pointer authentication. This prevents the expected leak from liblttng-ust from being suppressed (see d0fd7699e512a4).

Claude suggests using compiler-rt instead of the default gcc-based runtime (which is a good idea for other reasons as well), but let's start with the smaller scope fix of disabling the fast unwinder (also suggested by Claude). With this, debug mode reports three suppressed leaks rather than two suppressed leaks and one unsuppressed leak with a strange backtrace.

Fixes https://scylladb.atlassian.net/browse/SCYLLADB-3664

Not backporting, this was introduced in dafe9e9a802f5a0912ffb5578aa4de261e47ef63 which is not in any release branch.