### PR TITLE
build: put -fpch-validate-input-files-content on the PCH target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -268,6 +268,10 @@ if (Scylla_USE_PRECOMPILED_HEADER)
     # Match configure.py: -fpch-validate-input-files-content tells the compiler
     # to check content of stdafx.hh if timestamps don't match (important for
     # ccache/git workflows where timestamps may not be preserved).
+    # scylla-precompiled-header needs the flag on its own: the content hashes
+    # are recorded when the PCH is written, and add_compile_options() below only
+    # applies to targets created after it.
+    target_compile_options(scylla-precompiled-header PRIVATE -fpch-validate-input-files-content)
     add_compile_options(-fpch-validate-input-files-content)
   endif()
 else()


### PR DESCRIPTION
### Problem

A local `dev` build failed with `fatal error: file '/usr/include/alloca.h' has been modified since the precompiled header '.../cmake_pch.hxx.pch' was built: mtime changed`, and `ninja` refused to rebuild the PCH. Two things combine to produce this. First, `rpm` preserves the package build time as the header's mtime, so after a `glibc` update the new header is *older* than the existing `.pch`; ninja only rebuilds when an input is newer than the output, so it sees nothing to do while clang compares the exact recorded value and fails. Second, `-fpch-validate-input-files-content` — the flag that exists precisely to tolerate an mtime-only change — never reaches the PCH.

`add_compile_options()` at `CMakeLists.txt:271` adds the flag to a directory property that applies only to targets created *after* the call, and `scylla-precompiled-header` is created 34 lines earlier at line 237. The result is visible in the generated `build.ninja`: every consumer object carries the flag, the `cmake_pch.hxx.pch` rule itself does not. Since clang records the per-input content hashes when it *writes* the PCH, no hashes are stored, and every consumer silently falls back to comparing mtimes.

`configure.py` is unaffected — it passes the flag via `CMAKE_CXX_FLAGS` (`configure.py:3263`), which reaches every compile including the PCH. Only trees configured with `cmake` directly are affected, which is why CI never sees this.

### Changes

Set `-fpch-validate-input-files-content` on the `scylla-precompiled-header` target explicitly, via `target_compile_options()`. The existing `add_compile_options()` call stays: the flag is required on both sides, since the producer records the hashes and the consumer opts into comparing them.


### Verification

Built both PCH variants from the same command line, differing only in the flag, then compiled `api/tasks.cc` against each after moving the mtime of an input header (`stdafx.hh`) while leaving its content byte-identical (`md5sum` unchanged):

No backport needed: this affects only local builds configured with `cmake` directly, and the fix changes no product behavior.
