### PR TITLE
strong consistency: retain commitlog segments of unapplied raft entries

### DIFF
--- a/db/commitlog/commitlog.cc
+++ b/db/commitlog/commitlog.cc
@@ -4088,7 +4088,7 @@ db::rp_handle::rp_handle(shared_ptr<cf_holder> h, cf_id_type cf, replay_position
 {}
 
 db::rp_handle::rp_handle(rp_handle&& v) noexcept
-    : _h(std::move(v._h)), _cf(v._cf), _rp(std::exchange(v._rp, {}))
+    : _h(std::move(v._h)), _cf(v._cf), _rp(std::exchange(v._rp, {})), _on_destruction(v._on_destruction)
 {}
 
 db::rp_handle& db::rp_handle::operator=(rp_handle&& v) noexcept {
@@ -4100,7 +4100,8 @@ db::rp_handle& db::rp_handle::operator=(rp_handle&& v) noexcept {
 }
 
 db::rp_handle::~rp_handle() {
-    if (_rp != replay_position() && _h) {
+    // retain_segment keeps the dirty count, like release() does, leaving the segment on disk.
+    if (_rp != replay_position() && _h && _on_destruction == destruction_policy::mark_clean) {
         _h->release_cf_count(_cf, _rp);
     }
 }

--- a/db/commitlog/replay_position.hh
+++ b/db/commitlog/replay_position.hh
@@ -70,12 +70,24 @@ using cf_id_type = table_id;
 
 class rp_handle {
 public:
+    // What ~rp_handle() does with the segment reference: mark_clean decrements the segment's
+    // dirty count so the segment can be recycled, retain_segment keeps it, which leaves the
+    // segment on disk to be replayed on the next startup. Survives moves.
+    enum class destruction_policy : uint8_t {
+        mark_clean,
+        retain_segment,
+    };
+
     rp_handle() noexcept;
     rp_handle(rp_handle&&) noexcept;
     rp_handle& operator=(rp_handle&&) noexcept;
     ~rp_handle();
 
     replay_position release();
+
+    void set_destruction_policy(destruction_policy p) noexcept {
+        _on_destruction = p;
+    }
 
     operator bool() const {
         return _h && _rp != replay_position();
@@ -94,6 +106,7 @@ private:
     ::shared_ptr<cf_holder> _h;
     cf_id_type _cf;
     replay_position _rp;
+    destruction_policy _on_destruction = destruction_policy::mark_clean;
 };
 
 }

--- a/service/strong_consistency/raft_commitlog.cc
+++ b/service/strong_consistency/raft_commitlog.cc
@@ -27,20 +27,28 @@ raft_commitlog::raft_commitlog(raft::group_id group_id, db::commitlog& commitlog
     : _group_id(group_id)
     , _table_id(target_table_id)
     , _commit_log(commitlog)
-    , _replay_positions(std::move(replayed_data.replay_positions))
     , _replayed_entries(std::move(replayed_data.entries)) {
+    // Entries recovered from a previous run were rewritten into the new commitlog during
+    // replay, and are tracked like the ones we write ourselves.
+    for (auto& entry : replayed_data.replay_positions) {
+        add_to_rp_list(entry.index, std::move(entry.replay_position_handle));
+    }
     logger.debug("starting raft_commitlog group_id={}, table_id={}, replayed_entries={}", _group_id, _table_id, _replayed_entries.size());
 }
 
 raft_commitlog::~raft_commitlog() {
-    // Release all remaining replay position handles without decrementing
-    // segment dirty counts. This keeps commitlog segments alive after this
-    // object is destroyed, ensuring uncommitted raft entries remain
-    // available for replay after restart.
-    for (auto& entry : _replay_positions) {
-        entry.replay_position_handle.release();
-    }
-    logger.debug("released {} replay position handles for group_id={}", _replay_positions.size(), _group_id);
+    // The handles we still hold are for entries that were never applied. They all retain
+    // their segments, so destroying them leaves the entries on disk for the next replay.
+    logger.debug("retaining segments for {} replay position handles for group_id={}", _replay_positions.size(), _group_id);
+}
+
+// An entry can be committed before the state machine applies it, and until then the
+// commitlog record is its only durable copy: losing the handle on an exception must not let
+// the segment be reclaimed. The paths that no longer need an entry set mark_clean
+// explicitly; a successful apply disarms the handle in rp_set::put().
+void raft_commitlog::add_to_rp_list(raft::index_t index, db::rp_handle&& handle) {
+    handle.set_destruction_policy(db::rp_handle::destruction_policy::retain_segment);
+    _replay_positions.push_back(index_and_replay_position{.index = index, .replay_position_handle = std::move(handle)});
 }
 
 seastar::future<> raft_commitlog::store_log_entries(const raft::log_entry_ptr_list& entries) {
@@ -57,9 +65,7 @@ seastar::future<> raft_commitlog::store_log_entries(const raft::log_entry_ptr_li
     auto replay_handles = co_await _commit_log.add_raft_entries(_table_id, std::move(writers));
 
     for (size_t i = 0; i < entries.size(); ++i) {
-        const auto& log_entry_ptr = entries[i];
-        _replay_positions.push_back(
-                index_and_replay_position{.index = log_entry_ptr->idx, .replay_position_handle = std::move(replay_handles[i])});
+        add_to_rp_list(entries[i]->idx, std::move(replay_handles[i]));
     }
     logger.debug("store_log_entries completed: total_entries_in_map={}", _replay_positions.size());
 }
@@ -69,20 +75,32 @@ raft::log_entries raft_commitlog::load_log() {
     return std::move(_replayed_entries);
 }
 
+// Undo the retain_segment policy for [first, last): these entries are not needed any more,
+// so erasing them should decrement the segment dirty counts as usual.
+static void mark_clean_on_destruction(replay_position_list::iterator first, replay_position_list::iterator last) {
+    for (auto it = first; it != last; ++it) {
+        it->replay_position_handle.set_destruction_policy(db::rp_handle::destruction_policy::mark_clean);
+    }
+}
+
 void raft_commitlog::truncate_log(const raft::index_t idx) {
     logger.debug("truncate_log: group_id={}, idx={}", _group_id, idx);
     // Remove entries with index >= idx (Raft semantics: truncate from idx onward).
     // The deque is sorted by index, so binary search finds the cut point.
+    // These entries were replaced by a new leader before they committed, so their
+    // commitlog records are garbage — give the segments back.
     auto it = std::ranges::lower_bound(_replay_positions, idx, {}, &index_and_replay_position::index);
+    mark_clean_on_destruction(it, _replay_positions.end());
     _replay_positions.erase(it, _replay_positions.end());
 }
 
 void raft_commitlog::truncate_log_tail(const raft::index_t index) {
     logger.debug("truncate_log_tail: group_id={}, index={}", _group_id, index);
-    // Remove entries with index <= the given index. The handles are destructed
-    // normally, decrementing segment dirty counts and allowing commitlog
-    // segments to be reclaimed once no other references hold them.
+    // Remove entries with index <= the given index. They are covered by a persisted
+    // snapshot, so raft will not replay them and the segments can be reclaimed once no
+    // other reference holds them.
     auto it = std::ranges::upper_bound(_replay_positions, index, {}, &index_and_replay_position::index);
+    mark_clean_on_destruction(_replay_positions.begin(), it);
     _replay_positions.erase(_replay_positions.begin(), it);
     logger.debug("truncate_log_tail completed: remaining_map_size={}", _replay_positions.size());
 }

--- a/service/strong_consistency/raft_commitlog.hh
+++ b/service/strong_consistency/raft_commitlog.hh
@@ -45,6 +45,11 @@ private:
     // The log entries that were loaded from database commit log on startup.
     raft::log_entries _replayed_entries;
 
+    // The only way into _replay_positions: takes over the handle and makes it retain its
+    // commitlog segment, so that an entry we still hold is never dropped from the commitlog
+    // before it is applied or truncated.
+    void add_to_rp_list(raft::index_t index, db::rp_handle&& handle);
+
 public:
     raft_commitlog(raft::group_id group_id, db::commitlog& commit_log, table_id target_table_id, replayed_data_per_group replayed_data);
 

--- a/service/strong_consistency/state_machine.cc
+++ b/service/strong_consistency/state_machine.cc
@@ -84,6 +84,12 @@ public:
             replay_positions = _persistence.acquire_replay_position_handles_for(command);
             // Make sure we got replay positions for all commands.
             throwing_assert(replay_positions.size() == command.size());
+            // Simulate what an abort between acquiring the handles and applying looks like
+            // (node shutdown or raft group removal aborting the group0 barrier below):
+            // apply() throws with all the batch's pins still held.
+            utils::get_local_injector().inject("sc_state_machine_abort_after_acquiring_rp_handles", [] {
+                throw abort_requested_exception();
+            });
             // Get schemas for all mutations (also upgrades mutations to current schema if needed).
             auto barrier = [this]() -> future<> {
                 if (utils::get_local_injector().enter("disable_raft_drop_append_entries_for_specified_group")) {

--- a/service/strong_consistency/state_machine.cc
+++ b/service/strong_consistency/state_machine.cc
@@ -30,6 +30,14 @@ namespace service::strong_consistency {
 
 static logging::logger logger("sc_state_machine");
 
+// Undo the retain_segment policy the handles carry: the caller has established that the
+// data behind them is not needed, so let the commitlog reclaim the segments.
+static void mark_clean_on_destruction(std::vector<index_and_replay_position>& positions) {
+    for (auto& position : positions) {
+        position.replay_position_handle.set_destruction_policy(db::rp_handle::destruction_policy::mark_clean);
+    }
+}
+
 class state_machine : public raft_state_machine {
     locator::global_tablet_id _tablet;
     raft::group_id _group_id;
@@ -58,6 +66,11 @@ public:
 
     future<> apply(raft::log_entry_ptr_list command) override {
         static thread_local logging::logger::rate_limit rate_limit(std::chrono::seconds(10));
+        // Declared outside the try so the handlers below can decide what happens to the
+        // segments. The handles carry retain_segment, so throwing anywhere before a mutation
+        // reaches its memtable leaves the committed entry in the commitlog for replay to
+        // re-apply. Handles of applied mutations are disarmed by then (SCYLLADB-3347).
+        std::vector<index_and_replay_position> replay_positions;
         try {
             co_await utils::get_local_injector().inject("strong_consistency_state_machine_wait_before_apply", utils::wait_for_message(20min));
             // Collect mutations from the command list.
@@ -68,7 +81,7 @@ public:
                 muts.emplace_back(std::move(mutation));
             }
             // Get replay positions for the commands.
-            auto replay_positions = _persistence.acquire_replay_position_handles_for(command);
+            replay_positions = _persistence.acquire_replay_position_handles_for(command);
             // Make sure we got replay positions for all commands.
             throwing_assert(replay_positions.size() == command.size());
             // Get schemas for all mutations (also upgrades mutations to current schema if needed).
@@ -95,6 +108,10 @@ public:
             // because the state machine is created only after the table is created
             // (see `schema_applier::commit_on_shard()` and `storage_service::commit_token_metadata_change()`).
             // In this case, we should just ignore mutations without throwing an error.
+            // The table is gone, so reclaim the segments instead of retaining them. This is
+            // also the only handler that resumes normal operation, so retaining here would
+            // accumulate.
+            mark_clean_on_destruction(replay_positions);
             logger.log(log_level::warn, rate_limit, "apply(): table {} was already dropped, ignoring mutations", _tablet.table);
         } catch (replica::no_such_keyspace&) {
             // Thrown when DROP KEYSPACE races with the raft applier fiber.
@@ -106,7 +123,8 @@ public:
             // database::find_keyspace() — and that throws no_such_keyspace
             // if the keyspace was concurrently dropped.
             // Safe to ignore: the table's raft group is about to be destroyed
-            // by schedule_raft_group_deletion() anyway.
+            // by schedule_raft_group_deletion() anyway. As above, reclaim the segments.
+            mark_clean_on_destruction(replay_positions);
             logger.log(log_level::warn, rate_limit, "apply(): keyspace for table {} was already dropped, ignoring mutations", _tablet.table);
         } catch (const abort_requested_exception& ex) {
             // The exception can be thrown by get_schema_and_upgrade_mutations.

--- a/test/boost/commitlog_raft_replay_test.cc
+++ b/test/boost/commitlog_raft_replay_test.cc
@@ -1810,4 +1810,132 @@ SEASTAR_TEST_CASE(test_raft_commitlog_load_log_one_shot) {
     });
 }
 
+// =============================================================================
+// Regression tests for SCYLLADB-3347: commitlog segments backing raft entries
+// must survive an exception between obtaining an rp_handle and applying the
+// mutation.
+//
+// The observable is commitlog::get_num_dirty_segments(): it counts sealed
+// segments that still hold a dirty reference, i.e. segments that stay on disk
+// and get replayed on the next startup. A segment whose last dirty reference is
+// dropped becomes clean and is reclaimed, taking the raft entries with it.
+// =============================================================================
+
+// Test: dropping the handles that state_machine::apply() acquired — which is what an
+// exception between acquire_replay_position_handles_for() and apply_in_memory() does —
+// keeps the commitlog segment alive, because the entries may already be committed and
+// the commitlog record is then their only durable copy.
+SEASTAR_TEST_CASE(test_raft_commitlog_retains_segment_when_apply_drops_handles) {
+    return cl_test([](commitlog& log) -> future<> {
+        auto gid = make_group_id();
+        auto tid = make_table_id();
+
+        service::strong_consistency::replayed_data_per_group replayed_data;
+        service::strong_consistency::raft_commitlog persistence(gid, log, tid, std::move(replayed_data));
+
+        raft::log_entry_ptr_list entries = {
+                make_command_entry(raft::term_t(1), raft::index_t(1)),
+                make_command_entry(raft::term_t(1), raft::index_t(2)),
+        };
+        co_await persistence.store_log_entries(entries);
+        co_await log.force_new_active_segment();
+        co_await log.sync_all_segments();
+        BOOST_REQUIRE_EQUAL(log.get_num_dirty_segments(), 1);
+
+        {
+            // apply() acquired the handles and then threw before applying anything.
+            auto handles = persistence.acquire_replay_position_handles_for(entries);
+            BOOST_REQUIRE_EQUAL(handles.size(), 2);
+        }
+        BOOST_REQUIRE_EQUAL(log.get_num_dirty_segments(), 1);
+    });
+}
+
+// Test: handles for entries recovered from a previous run reach raft_commitlog through its
+// constructor rather than store_log_entries(), and must be retained the same way.
+SEASTAR_TEST_CASE(test_raft_commitlog_retains_replayed_segments) {
+    return cl_test([](commitlog& log) -> future<> {
+        auto gid = make_group_id();
+        auto tid = make_table_id();
+
+        auto handle = co_await write_raft_entry_to_commitlog(log, tid, gid, make_command_entry(raft::term_t(1), raft::index_t(1)));
+        co_await log.force_new_active_segment();
+        co_await log.sync_all_segments();
+        BOOST_REQUIRE_EQUAL(log.get_num_dirty_segments(), 1);
+
+        // Replay hands over plain handles, as commitlog::add() produced them.
+        service::strong_consistency::replayed_data_per_group replayed_data;
+        replayed_data.replay_positions.push_back(service::strong_consistency::index_and_replay_position{
+                .index = raft::index_t(1), .replay_position_handle = std::move(handle)});
+        {
+            service::strong_consistency::raft_commitlog persistence(gid, log, tid, std::move(replayed_data));
+        }
+        BOOST_REQUIRE_EQUAL(log.get_num_dirty_segments(), 1);
+    });
+}
+
+// Test: destroying raft_commitlog (raft group teardown, node shutdown) retains the
+// segments of the entries it still holds — they have not been applied to a memtable, so
+// they must remain available for replay after a restart.
+SEASTAR_TEST_CASE(test_raft_commitlog_destructor_retains_segments) {
+    return cl_test([](commitlog& log) -> future<> {
+        auto gid = make_group_id();
+        auto tid = make_table_id();
+
+        {
+            service::strong_consistency::replayed_data_per_group replayed_data;
+            service::strong_consistency::raft_commitlog persistence(gid, log, tid, std::move(replayed_data));
+
+            raft::log_entry_ptr_list entries = {
+                    make_command_entry(raft::term_t(1), raft::index_t(1)),
+                    make_dummy_entry(raft::term_t(1), raft::index_t(2)),
+            };
+            co_await persistence.store_log_entries(entries);
+            co_await log.force_new_active_segment();
+            co_await log.sync_all_segments();
+            BOOST_REQUIRE_EQUAL(log.get_num_dirty_segments(), 1);
+        }
+        BOOST_REQUIRE_EQUAL(log.get_num_dirty_segments(), 1);
+    });
+}
+
+// A free coroutine rather than a capturing lambda: cl_test() does not keep the callback
+// alive across suspension points, while a coroutine's parameters live in its own frame.
+static future<> check_truncate_reclaims_segment(commitlog& log, bool tail) {
+    auto gid = make_group_id();
+    auto tid = make_table_id();
+
+    service::strong_consistency::replayed_data_per_group replayed_data;
+    service::strong_consistency::raft_commitlog persistence(gid, log, tid, std::move(replayed_data));
+
+    raft::log_entry_ptr_list entries;
+    for (int i = 1; i <= 3; ++i) {
+        entries.push_back(make_command_entry(raft::term_t(1), raft::index_t(i)));
+    }
+    co_await persistence.store_log_entries(entries);
+    co_await log.force_new_active_segment();
+    co_await log.sync_all_segments();
+    BOOST_REQUIRE_EQUAL(log.get_num_dirty_segments(), 1);
+
+    if (tail) {
+        // Covered by a snapshot.
+        persistence.truncate_log_tail(raft::index_t(3));
+    } else {
+        // Replaced by a new leader before committing.
+        persistence.truncate_log(raft::index_t(1));
+    }
+    BOOST_REQUIRE_EQUAL(log.get_num_dirty_segments(), 0);
+}
+
+// Test: the two paths that legitimately give segments back do reclaim them. Retaining is
+// the default now, so a missing mark_clean here would leak commitlog space until restart.
+SEASTAR_TEST_CASE(test_raft_commitlog_truncate_reclaims_segments) {
+    co_await cl_test([](commitlog& log) {
+        return check_truncate_reclaims_segment(log, false);
+    });
+    co_await cl_test([](commitlog& log) {
+        return check_truncate_reclaims_segment(log, true);
+    });
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/boost/commitlog_test.cc
+++ b/test/boost/commitlog_test.cc
@@ -2904,4 +2904,162 @@ SEASTAR_TEST_CASE(test_descriptor_roundtrip) {
     return make_ready_future<>();
 }
 
+// Write one entry and seal the segment holding it, so the segment's fate depends only on
+// its dirty count: an active segment is never reclaimed, regardless of that count.
+static future<rp_handle> write_and_seal_segment(commitlog& log, const table_id& id) {
+    sstring tmp = "hej bubba cow";
+    auto handle = co_await log.add_mutation(id, tmp.size(), db::commitlog::force_sync::yes,
+            [&tmp](db::commitlog::output& dst) {
+        dst.write(tmp.data(), tmp.size());
+    });
+    co_await log.force_new_active_segment();
+    co_await log.sync_all_segments();
+    co_return handle;
+}
+
+// An empty handle owns nothing: it converts to false, carries no replay position, and
+// destroying or releasing it is a no-op whatever its policy.
+SEASTAR_TEST_CASE(test_rp_handle_empty) {
+    rp_handle h;
+    BOOST_REQUIRE(!h);
+    BOOST_REQUIRE(h.rp() == replay_position());
+    BOOST_REQUIRE(static_cast<const replay_position&>(h) == h.rp());
+    h.set_destruction_policy(rp_handle::destruction_policy::retain_segment);
+    BOOST_REQUIRE(h.release() == replay_position());
+    BOOST_REQUIRE(!h);
+    return make_ready_future<>();
+}
+
+// release() hands the replay position out and empties the handle without touching the
+// segment's dirty count -- the segment stays behind, which is how callers that only need
+// the position keep it from being reclaimed.
+SEASTAR_TEST_CASE(test_rp_handle_release_keeps_segment) {
+    return cl_test([](commitlog& log) -> future<> {
+        auto handle = co_await write_and_seal_segment(log, make_table_id());
+        BOOST_REQUIRE(handle);
+        const auto rp = handle.rp();
+        BOOST_REQUIRE(rp != replay_position());
+        BOOST_REQUIRE_EQUAL(log.get_num_dirty_segments(), 1);
+
+        {
+            auto h = std::move(handle);
+            BOOST_REQUIRE(h.release() == rp);
+            BOOST_REQUIRE(!h);
+            BOOST_REQUIRE(h.rp() == replay_position());
+        }
+        BOOST_REQUIRE_EQUAL(log.get_num_dirty_segments(), 1);
+    });
+}
+
+// Moving a handle transfers ownership of the segment reference: the source is left empty,
+// the destination accounts for the segment, and the reference is given back exactly once.
+SEASTAR_TEST_CASE(test_rp_handle_move_transfers_ownership) {
+    return cl_test([](commitlog& log) -> future<> {
+        auto a = co_await write_and_seal_segment(log, make_table_id());
+        const auto rp = a.rp();
+        BOOST_REQUIRE_EQUAL(log.get_num_dirty_segments(), 1);
+
+        {
+            auto moved = std::move(a);
+            BOOST_REQUIRE(!a);
+            BOOST_REQUIRE(moved);
+            BOOST_REQUIRE(moved.rp() == rp);
+            BOOST_REQUIRE_EQUAL(log.get_num_dirty_segments(), 1);
+        }
+        // Given back once by the destination; the emptied source has nothing left to give,
+        // and a second release would trip the dirty count assertion in mark_clean().
+        BOOST_REQUIRE_EQUAL(log.get_num_dirty_segments(), 0);
+
+        // Move assignment: the destination gives back what it held before taking over.
+        auto b = co_await write_and_seal_segment(log, make_table_id());
+        auto c = co_await write_and_seal_segment(log, make_table_id());
+        BOOST_REQUIRE_EQUAL(log.get_num_dirty_segments(), 2);
+        b = std::move(c);
+        BOOST_REQUIRE(!c);
+        BOOST_REQUIRE_EQUAL(log.get_num_dirty_segments(), 1);
+    });
+}
+
+// rp_set::put() takes over the segment reference and empties the handle, so the segment is
+// held by the set until discard_completed_segments() gives it back. This is how a memtable
+// ends up owning the reference.
+SEASTAR_TEST_CASE(test_rp_handle_rp_set_takes_over) {
+    return cl_test([](commitlog& log) -> future<> {
+        const auto id = make_table_id();
+        auto handle = co_await write_and_seal_segment(log, id);
+        BOOST_REQUIRE_EQUAL(log.get_num_dirty_segments(), 1);
+
+        rp_set set;
+        set.put(std::move(handle));
+        BOOST_REQUIRE(!handle);
+        BOOST_REQUIRE_EQUAL(set.size(), 1);
+        BOOST_REQUIRE_EQUAL(log.get_num_dirty_segments(), 1);
+
+        log.discard_completed_segments(id, set);
+        BOOST_REQUIRE_EQUAL(log.get_num_dirty_segments(), 0);
+    });
+}
+
+// A handle destroyed with destruction_policy::retain_segment keeps its segment's dirty count,
+// so the segment stays on disk -- and is replayed on the next startup -- instead of being
+// reclaimed (SCYLLADB-3347). get_num_dirty_segments() counts exactly those segments: sealed
+// and still dirty.
+//
+// Parameterized bodies are free coroutines rather than capturing lambdas: cl_test() does not
+// keep the callback alive across suspension points, while a coroutine's parameters live in
+// its own frame.
+static future<> check_destruction_policy(commitlog& log, rp_handle::destruction_policy policy,
+        uint64_t expected_dirty_after_drop) {
+    auto handle = co_await write_and_seal_segment(log, make_table_id());
+    BOOST_REQUIRE_EQUAL(log.get_num_dirty_segments(), 1);
+
+    {
+        auto h = std::move(handle);
+        h.set_destruction_policy(policy);
+    }
+    BOOST_REQUIRE_EQUAL(log.get_num_dirty_segments(), expected_dirty_after_drop);
+}
+
+// Both policies, over a sealed segment: mark_clean reclaims it, retain_segment does not.
+SEASTAR_TEST_CASE(test_rp_handle_destruction_policy) {
+    co_await cl_test([](commitlog& log) {
+        return check_destruction_policy(log, rp_handle::destruction_policy::mark_clean, 0);
+    });
+    co_await cl_test([](commitlog& log) {
+        return check_destruction_policy(log, rp_handle::destruction_policy::retain_segment, 1);
+    });
+}
+
+// The destruction policy has to survive moves: handles are moved by value on the write path
+// (into continuations and lambdas), so the frame that destroys a handle is not necessarily
+// the one that chose the policy.
+SEASTAR_TEST_CASE(test_rp_handle_destruction_policy_survives_moves) {
+    return cl_test([](commitlog& log) -> future<> {
+        auto id = make_table_id();
+        // Three sealed segments, one dirty reference each.
+        auto a = co_await write_and_seal_segment(log, id);
+        auto b = co_await write_and_seal_segment(log, id);
+        auto c = co_await write_and_seal_segment(log, id);
+        BOOST_REQUIRE_EQUAL(log.get_num_dirty_segments(), 3);
+
+        a.set_destruction_policy(rp_handle::destruction_policy::retain_segment);
+        {
+            // Move construction carries the policy: destroying the moved-to handle retains.
+            auto moved = std::move(a);
+        }
+        BOOST_REQUIRE_EQUAL(log.get_num_dirty_segments(), 3);
+
+        b.set_destruction_policy(rp_handle::destruction_policy::retain_segment);
+        // Move assignment destroys the overwritten handle, which must retain b's segment, and
+        // takes over c's reference together with c's policy.
+        b = std::move(c);
+        BOOST_REQUIRE_EQUAL(log.get_num_dirty_segments(), 3);
+        {
+            auto sink = std::move(b);
+        }
+        // c's segment is the only one reclaimed: it kept the default policy through two moves.
+        BOOST_REQUIRE_EQUAL(log.get_num_dirty_segments(), 2);
+    });
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/cluster/test_strong_consistency_commitlog.py
+++ b/test/cluster/test_strong_consistency_commitlog.py
@@ -303,3 +303,54 @@ async def test_crash_recovery_after_flush(manager: ManagerClient):
             assert rows[0].c == pk * 10, f"pk={pk}: expected c={pk * 10}, got c={rows[0].c}"
 
     await manager.server_stop_gracefully(server.server_id)
+
+
+@pytest.mark.asyncio
+@pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
+async def test_committed_entry_survives_apply_abort(manager: ManagerClient):
+    """Regression test for SCYLLADB-3347. A raft entry is committed before the state
+    machine applies it, so until then the commitlog record is its only durable copy. Abort
+    apply() after it acquired the replay position handles (what node shutdown or raft group
+    removal does) and verify the entry is recovered from the commitlog after a restart.
+
+    A graceful stop is what makes this observable: it flushes the memtables and then
+    reclaims every segment without a dirty reference, so a segment whose handle was
+    dropped is deleted, taking the committed entry with it."""
+    config = {
+        'experimental_features': ['strongly-consistent-tables'],
+        # Keep data in the commitlog: no automatic flush before the stop.
+        'commitlog_total_space_in_mb': 10000,
+    }
+    cmdline = ['--logger-log-level', 'sc_state_machine=debug']
+    server = await manager.server_add(config=config, cmdline=cmdline)
+    (cql, hosts) = await manager.get_ready_cql([server])
+    log = await manager.server_open_log(server.server_id)
+
+    async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 1} AND consistency = 'global'") as ks:
+        await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int);")
+        applied_pks = list(range(3))
+        for pk in applied_pks:
+            await cql.run_async(f"INSERT INTO {ks}.test (pk, c) VALUES ({pk}, {pk * 10})")
+        # Read them back, so they are known to be applied before the injection is armed.
+        for pk in applied_pks:
+            assert len(await cql.run_async(f"SELECT * FROM {ks}.test WHERE pk = {pk};")) == 1
+
+        # This entry gets committed, then apply() is aborted with its handles held. The
+        # write itself is acknowledged on commit, so it does not report an error.
+        aborted_pk = 3
+        mark = await log.mark()
+        await manager.api.enable_injection(server.ip_addr, "sc_state_machine_abort_after_acquiring_rp_handles", one_shot=True)
+        await cql.run_async(f"INSERT INTO {ks}.test (pk, c) VALUES ({aborted_pk}, {aborted_pk * 10})")
+        await log.wait_for("apply\\(\\): execution for tablet .* aborted due to", from_mark=mark)
+
+        await manager.server_stop_gracefully(server.server_id)
+        await manager.server_start(server.server_id)
+        await reconnect_driver(manager)
+        cql = manager.get_cql()
+
+        for pk in applied_pks + [aborted_pk]:
+            rows = await cql.run_async(f"SELECT * FROM {ks}.test WHERE pk = {pk};")
+            assert len(rows) == 1, f"Expected 1 row for pk={pk}, got {len(rows)}"
+            assert rows[0].c == pk * 10, f"pk={pk}: expected c={pk * 10}, got c={rows[0].c}"
+
+    await manager.server_stop_gracefully(server.server_id)


### PR DESCRIPTION
Raft commits a log entry before `state_machine::apply()` hands the mutation to a
memtable, and in that window the commitlog record is the only durable copy.
`~rp_handle()` releases the segment reference, so any exception there — an abort on
shutdown, a failing schema lookup, a failure mid-batch or inside
`apply_in_memory()` — lets the segment be reclaimed, and the committed entry is
lost instead of being replayed after a restart. A clean shutdown makes that
certain: the memtables flush, the segment becomes clean, and it is deleted.

Not always silently, either: with the entry gone while
`system.raft_groups.commit_idx` still counts it, the node fails to start —
"committed index cannot be larger then persisted one". That is what the new
cluster test hits without this fix.

## Fix

`rp_handle` gets a `destruction_policy`. `retain_segment` makes the destructor
drop the handle without decrementing the segment's dirty count (what `release()`
does), so the segment survives to the next startup. `mark_clean` stays the
default, so other writers are unaffected. It is a member rather than a wrapper
type or a subclass because the apply path moves the handle by value — only a
value that travels with it through those moves covers the third case above.

`raft_commitlog` marks the handles it owns `retain_segment` (replacing the
explicit `release()` loop in its destructor), and the paths that legitimately
give a segment back now say so: `truncate_log()`, `truncate_log_tail()` and
`apply()`'s dropped table / keyspace handlers. A successful hand-over to a
memtable is unaffected either way — `rp_set::put()` disarms the handle first.

No on-disk format, protocol, serialization or API change. `sizeof(rp_handle)`
grows by one alignment unit (48 -> 56 bytes on x86-64). The trade-off is commitlog
space until the process restarts instead of losing committed data.

## Limitation: mutations spanning several segments

The guarantee starts at the moment the entry is written to the commitlog, and it
covers one segment per handle. A mutation larger than `max_mutation_size` is
written as fragments across several segments (`allow_fragmented_entries` is true
for the data commitlog), and the caller only gets a handle for the primary
segment — the continuation segments are held by handles parked in the primary
`segment::_extended_segments`.

By inspection that still works: a retained primary never calls
`release_cf_count(cf, rp)`, so `_extended_segments` is not erased and the
continuation segments stay dirty too, and startup replay reassembles fragments
across files through the per-shard `commitlog::replay_state`. But nothing tests
it, and the space cost of retaining such an entry is proportional to its size
rather than one segment. Filed as SCYLLADB-3748.

## Tests

`rp_handle` had no tests of its own, so the first commit adds a group covering the
class: empty handles, `release()`, ownership transfer on move, the `rp_set`
hand-over, and both policies, including through moves. The SC unit tests then use
`get_num_dirty_segments()` — sealed segments that still hold a dirty reference —
to check that dropping the handles `apply()` acquired keeps the segment, that the
same holds for handles recovered by replay and for the ones `raft_commitlog` is
still holding when it is destroyed, and the other direction: both truncate paths
do reclaim.

A cluster test aborts `apply()` right after it acquired the handles, through a new
error injection, stops the node gracefully and requires the committed row after a
restart. The retention tests and the cluster test were both confirmed to fail with
the fix reverted — the cluster test by the node refusing to start.

Expected runtime impact: unit tests sub-second each; the cluster test is a single
node, about 4s.

Fixes: SCYLLADB-3347
