### PR TITLE
Fix 'Unable to remove input SSTable' crash for GC sstables during tablet merge

### DIFF
--- a/compaction/compaction.cc
+++ b/compaction/compaction.cc
@@ -722,9 +722,10 @@ protected:
     }
 
     compaction_completion_desc
-    get_compaction_completion_desc(std::vector<sstables::shared_sstable> input_sstables, std::vector<sstables::shared_sstable> output_sstables) {
+    get_compaction_completion_desc(std::vector<sstables::shared_sstable> input_sstables, std::vector<sstables::shared_sstable> output_sstables,
+                                   std::vector<sstables::shared_sstable> output_gc_sstables = {}) {
         auto ranges = get_ranges_for_invalidation(input_sstables);
-        return compaction_completion_desc{std::move(input_sstables), std::move(output_sstables), std::move(ranges)};
+        return compaction_completion_desc{std::move(input_sstables), std::move(output_sstables), std::move(output_gc_sstables), std::move(ranges)};
     }
 
     // Tombstone expiration is enabled based on the presence of sstable set.
@@ -1362,13 +1363,13 @@ private:
             // to SSTable set. GC SSTables should be added before compaction completes because
             // a failure could result in data resurrection if data is not made available.
             auto unused_gc_sstables = consume_unused_garbage_collected_sstables();
-            _new_unused_sstables.insert(_new_unused_sstables.end(), unused_gc_sstables.begin(), unused_gc_sstables.end());
 
             auto exhausted_ssts = std::vector<sstables::shared_sstable>(exhausted, _sstables.end());
-            log_debug("Replacing earlier exhausted sstable(s) [{}] by new sstable(s) [{}]",
+            log_debug("Replacing earlier exhausted sstable(s) [{}] by new sstable(s) [{}] and new gc sstable(s) [{}]",
                 fmt::join(exhausted_ssts | std::views::transform([] (auto sst) { return to_string(sst, false); }), ","),
-                fmt::join(_new_unused_sstables | std::views::transform([] (auto sst) { return to_string(sst, true); }), ","));
-            _replacer(get_compaction_completion_desc(exhausted_ssts, std::move(_new_unused_sstables)));
+                fmt::join(_new_unused_sstables | std::views::transform([] (auto sst) { return to_string(sst, true); }), ","),
+                fmt::join(unused_gc_sstables | std::views::transform([] (auto sst) { return to_string(sst, true); }), ","));
+            _replacer(get_compaction_completion_desc(exhausted_ssts, std::move(_new_unused_sstables), std::move(unused_gc_sstables)));
             _sstables.erase(exhausted, _sstables.end());
             dynamic_cast<compaction_read_monitor_generator&>(unwrap_monitor_generator()).remove_exhausted_sstables(exhausted_ssts);
         }

--- a/compaction/compaction_descriptor.hh
+++ b/compaction/compaction_descriptor.hh
@@ -40,6 +40,8 @@ struct compaction_completion_desc {
     std::vector<sstables::shared_sstable> old_sstables;
     // New, fresh SSTables that should be added to SSTable set, replacing the old ones.
     std::vector<sstables::shared_sstable> new_sstables;
+    // New, fresh GCed-data SSTables that should be added to SSTable set.
+    std::vector<sstables::shared_sstable> new_gc_sstables;
     // Set of compacted partition ranges that should be invalidated in the cache.
     utils::chunked_vector<dht::partition_range> ranges_for_cache_invalidation;
 };

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -2598,6 +2598,11 @@ compaction_group::do_update_sstable_sets_on_compaction_completion(compaction::co
                 auto& cg = _t.compaction_group_for_sstable(sst);
                 _cg_desc[&cg].desc.new_sstables.push_back(sst);
             }
+            // Insert all GCed-data sstables into the original compaction group, so
+            // when they're removed, they can be found there.
+            for (auto& sst : _desc.new_gc_sstables) {
+                _cg_desc[&_cg].desc.new_sstables.push_back(sst);
+            }
             // The group that triggered compaction is the only one to have sstables removed from it.
             _cg_desc[&_cg].desc.old_sstables = _desc.old_sstables;
             for (auto& [cg, d] : _cg_desc) {
@@ -2678,6 +2683,7 @@ compaction_group::update_sstable_sets_on_compaction_completion(compaction::compa
     // (finish() already moved them out of the compaction, and they are sealed so ~sstable()
     // won't unlink them either), so a failure here would otherwise leak them on disk forever.
     auto new_sstables = desc.new_sstables;
+    std::ranges::copy(desc.new_gc_sstables, std::back_inserter(new_sstables));
     bool attached = false;
     std::exception_ptr ex;
     try {

--- a/test/boost/incremental_compaction_test.cc
+++ b/test/boost/incremental_compaction_test.cc
@@ -592,8 +592,10 @@ SEASTAR_TEST_CASE(gc_sstable_incremental_release_test) {
                 }
             }
 
-            column_family_test(cf).rebuild_sstable_list(cf.as_compaction_group_view(), desc.new_sstables, desc.old_sstables).get();
-            env.test_compaction_manager().propagate_replacement(cf.as_compaction_group_view(), desc.old_sstables, desc.new_sstables);
+            auto new_sstables = desc.new_sstables;
+            std::ranges::copy(desc.new_gc_sstables, std::back_inserter(new_sstables));
+            column_family_test(cf).rebuild_sstable_list(cf.as_compaction_group_view(), new_sstables, desc.old_sstables).get();
+            env.test_compaction_manager().propagate_replacement(cf.as_compaction_group_view(), desc.old_sstables, std::move(new_sstables));
         };
 
         auto desc = compaction::compaction_descriptor(std::move(input_sstables), 1, 512);
@@ -725,8 +727,10 @@ SEASTAR_TEST_CASE(gc_sstable_no_premature_release_with_overlapping_inputs_test) 
                 std::erase(alive_inputs, old_sst);
             }
 
-            column_family_test(cf).rebuild_sstable_list(cf.as_compaction_group_view(), desc.new_sstables, desc.old_sstables).get();
-            env.test_compaction_manager().propagate_replacement(cf.as_compaction_group_view(), desc.old_sstables, desc.new_sstables);
+            auto new_sstables = desc.new_sstables;
+            std::ranges::copy(desc.new_gc_sstables, std::back_inserter(new_sstables));
+            column_family_test(cf).rebuild_sstable_list(cf.as_compaction_group_view(), new_sstables, desc.old_sstables).get();
+            env.test_compaction_manager().propagate_replacement(cf.as_compaction_group_view(), desc.old_sstables, std::move(new_sstables));
         };
 
         auto desc = compaction::compaction_descriptor(std::move(input_sstables), 1, 512);

--- a/test/boost/sstable_compaction_test.cc
+++ b/test/boost/sstable_compaction_test.cc
@@ -4704,15 +4704,15 @@ void incremental_compaction_data_resurrection_fn(test_env& env) {
     auto replacer = [&] (compaction::compaction_completion_desc desc) {
         auto old_sstables = std::move(desc.old_sstables);
         auto new_sstables = std::move(desc.new_sstables);
-        // expired_sst is exhausted, and new sstable is written with mut 2.
+        // expired_sst is exhausted, and a new sstable is written with mut 2.
+        // The expired tombstone is routed to a GC-only sstable.
         BOOST_REQUIRE_EQUAL(old_sstables.size(), 1);
         BOOST_REQUIRE(old_sstables.front() == expired_sst);
-        BOOST_REQUIRE_EQUAL(new_sstables.size() + desc.new_gc_sstables.size(), 2);
-        for (auto& new_sstable : new_sstables) {
-            assert_that(sstable_reader(new_sstable, s, env.make_reader_permit()))
-                .produces(mut2)
-                .produces_end_of_stream();
-        }
+        BOOST_REQUIRE_EQUAL(new_sstables.size(), 1);
+        BOOST_REQUIRE_EQUAL(desc.new_gc_sstables.size(), 1);
+        assert_that(sstable_reader(new_sstables.front(), s, env.make_reader_permit()))
+            .produces(mut2)
+            .produces_end_of_stream();
         new_sstables.insert(new_sstables.end(), desc.new_gc_sstables.begin(), desc.new_gc_sstables.end());
         column_family_test(cf).rebuild_sstable_list(cf.as_compaction_group_view(), new_sstables, old_sstables).get();
         // force compaction failure after sstable containing expired tombstone is removed from set.

--- a/test/boost/sstable_compaction_test.cc
+++ b/test/boost/sstable_compaction_test.cc
@@ -4707,15 +4707,13 @@ void incremental_compaction_data_resurrection_fn(test_env& env) {
         // expired_sst is exhausted, and new sstable is written with mut 2.
         BOOST_REQUIRE_EQUAL(old_sstables.size(), 1);
         BOOST_REQUIRE(old_sstables.front() == expired_sst);
-        BOOST_REQUIRE_EQUAL(new_sstables.size(), 2);
+        BOOST_REQUIRE_EQUAL(new_sstables.size() + desc.new_gc_sstables.size(), 2);
         for (auto& new_sstable : new_sstables) {
-            if (new_sstable->get_max_local_deletion_time() == deletion_time) { // Skipping GC SSTable.
-                continue;
-            }
             assert_that(sstable_reader(new_sstable, s, env.make_reader_permit()))
                 .produces(mut2)
                 .produces_end_of_stream();
         }
+        new_sstables.insert(new_sstables.end(), desc.new_gc_sstables.begin(), desc.new_gc_sstables.end());
         column_family_test(cf).rebuild_sstable_list(cf.as_compaction_group_view(), new_sstables, old_sstables).get();
         // force compaction failure after sstable containing expired tombstone is removed from set.
         throw std::runtime_error("forcing compaction failure on early replacement");

--- a/test/cluster/test_tablets_merge.py
+++ b/test/cluster/test_tablets_merge.py
@@ -652,3 +652,111 @@ async def test_background_merge_deadlock(manager: ManagerClient, feature_config:
     await wait_for(finished_merge, time.time() + 120)
 
     await manager.server_stop(servers[0].server_id, convict=False)
+
+
+@pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
+async def test_gc_sstable_release_during_tablet_merge(manager: ManagerClient):
+    """
+    Reproducer for the "Unable to remove input SSTable ... origin=garbage_collection"
+    crash during tablet merge.
+
+    The bug: sstable_list_updater::prepare() routes new sstables via the live
+    tablet map (compaction_group_for_sstable) but pins old sstables to _cg.
+    During merge the tablet map is swapped synchronously, so a GC sstable
+    produced AFTER the merge is routed to the new main CG, but on release
+    the code tries to remove it from _cg (the merging group) — crash.
+
+    Strategy:
+      1. Create multi-fragment run + tombstones (2 tablets)
+      2. Block merge_completion_fiber (prevents stopping compactions)
+      3. Trigger merge (tablet map swaps, groups become merging)
+      4. Start major compaction (runs on the merging group)
+      5. Compaction produces GC sstable → routed to new main CG
+      6. GC release → tries to remove from merging group → crash
+    """
+
+    logger.info('Bootstrapping cluster')
+    cfg = {'enable_tablets': True, 'tablet_load_stats_refresh_interval_in_seconds': 1}
+    cmdline = [
+        '--logger-log-level', 'compaction_manager=info',
+        '--logger-log-level', 'compaction=info',
+    ]
+    server = await manager.server_add(cmdline=cmdline, config=cfg)
+
+    cql = manager.get_cql()
+    await manager.disable_tablet_balancing()
+
+    initial_tablets = 2
+
+    async with new_test_keyspace(manager, f"WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor': 1}}") as ks:
+        # sstable_size_in_mb=1 forces writer rotation → multi-fragment runs.
+        # No compression so data sizes are predictable.
+        await cql.run_async(f"""CREATE TABLE {ks}.test (pk int PRIMARY KEY, c text)
+                               WITH compaction = {{'class': 'IncrementalCompactionStrategy',
+                                                   'sstable_size_in_mb': 1}}
+                               AND compression = {{}}
+                               AND tablets = {{'min_tablet_count': {initial_tablets}}}""")
+
+        # Disable auto-compaction via API (not via strategy 'enabled=false'
+        # which replaces ICS with NullCompactionStrategy).
+        await manager.api.disable_autocompaction(server.ip_addr, ks, 'test')
+
+        n_keys = 5000
+        blob_value = 'x' * 4096
+
+        # Step 1: Write live data, flush.
+        batch_size = n_keys // 10
+        for i in range(0, n_keys, batch_size):
+            await asyncio.gather(*[cql.run_async(f"INSERT INTO {ks}.test (pk, c) VALUES ({k}, '{blob_value}')")
+                                   for k in range(i, min(i + batch_size, n_keys))])
+        await manager.api.flush_keyspace(server.ip_addr, ks)
+
+        # Step 2: First major → produces multi-fragment run.
+        await manager.api.keyspace_compaction(server.ip_addr, ks)
+
+        # Step 3: Delete keys in batches (multiple tombstone sstables).
+        batch_size = n_keys // 10
+        for i in range(0, n_keys, batch_size):
+            await asyncio.gather(*[cql.run_async(f"DELETE FROM {ks}.test WHERE pk = {k}")
+                                   for k in range(i, min(i + batch_size, n_keys)) if k % 2 == 0])
+            await manager.api.flush_keyspace(server.ip_addr, ks)
+
+        # Step 4: Set gc_grace_seconds=0 + immediate mode so tombstones
+        # are purgeable (bypasses repair-time and commitlog checks).
+        await cql.run_async(f"""ALTER TABLE {ks}.test
+                               WITH gc_grace_seconds = 0
+                               AND tombstone_gc = {{'mode': 'immediate'}}""")
+        # Extra flush to advance commitlog
+        await manager.api.flush_keyspace(server.ip_addr, ks)
+
+        # Step 5: Block the merge_completion_fiber. This prevents it from
+        # stopping compactions on the merging groups after the merge fires.
+        await manager.api.enable_injection(server.ip_addr, "merge_completion_fiber", one_shot=True)
+
+        # Step 6: Trigger merge (2 → 1 tablet). The topology coordinator
+        # will swap the tablet map synchronously. The old groups become
+        # merging groups, but their compactions are NOT stopped (fiber is blocked).
+        target_tablets = 1
+        await cql.run_async(f"ALTER TABLE {ks}.test WITH tablets = {{'min_tablet_count': {target_tablets}}}")
+        await manager.enable_tablet_balancing()
+
+        # Wait for merge to be finalized (tablet count changes)
+        started = time.time()
+        while True:
+            tablet_count = await get_tablet_count(manager, server, ks, 'test')
+            if tablet_count == target_tablets:
+                break
+            assert time.time() - started < 120, f'Timeout waiting for merge (current={tablet_count}, target={target_tablets})'
+            await asyncio.sleep(0.5)
+
+        logger.info(f"Merge done, tablet count = {tablet_count}")
+
+        # Step 7: Now run major compaction with consider_only_existing_data=True
+        # (disables commitlog check so tombstones can actually be GC'd).
+        # The compaction will run on the merging group, produce GC sstables
+        # routed to the new main CG, and crash on GC release.
+        await manager.api.keyspace_compaction(server.ip_addr, ks, consider_only_existing_data=True)
+        logger.info("Compaction completed successfully (bug is fixed)")
+
+        # Unblock the merge fiber to let cleanup proceed
+        await manager.api.message_injection(server.ip_addr, "merge_completion_fiber")


### PR DESCRIPTION
When incremental compaction produces a garbage-collection (GC) sstable,
sstable_list_updater::prepare() adds it via compaction_group_for_sstable()
which routes through the live tablet map, and later removes it from _cg
(the compaction's own group). If a tablet merge swaps the tablet map
between the add and the remove, the two operations target different
groups and the removal crashes with 'Unable to remove input SSTable'.

Sequence:

1. Compaction starts on group G (which is the main CG).
2. The compaction produces a GC sstable via the incremental replacer.
   In sstable_list_updater::prepare(), the GC sstable is routed as a
   new_sstable via compaction_group_for_sstable() — the tablet map
   still points to G, so the GC sstable is added to G.
3. A tablet merge fires: update_effective_replication_map() swaps the
   tablet map synchronously. G becomes a merging group of a new storage
   group, and a new main CG (G') is created. From now on,
   compaction_group_for_sstable() returns G', not G.
   The merge_completion_fiber has not stopped the compaction yet.
4. The compaction continues on G. It produces another GC sstable.
   This time compaction_group_for_sstable() returns G' (the new main
   CG), so the GC sstable is added to G'.
5. Later, the GC sstable from step 4 is released: old_sstables={GC_sst},
   new_sstables={}. The old_sstables are pinned to _cg (= G, the
   merging group), but the GC sstable lives in G'.
   build_new_list tries to remove it from G — not found — crash.

The root cause is that old_sstables are blindly pinned to _cg, assuming
every sstable to be removed was added to the same group the compaction
runs on. This assumption breaks for GC sstables because their add and
remove happen in separate replacer calls, and the tablet map can change
in between.

The fix is to always add GC sstables to the compaction group that
originated the compaction, so the assumption doesn't break.

Fixes https://scylladb.atlassian.net/browse/SCYLLADB-3595.

Backporting to 2026.1, 2026.2, and 2026.3 since they're all vulnerable.
