### PR TITLE
cql3: hand each parsed statement only its own markers

### DIFF
--- a/cql3/Cql.g
+++ b/cql3/Cql.g
@@ -327,7 +327,14 @@ query returns [std::unique_ptr<raw::parsed_statement> stmnt]
     ;
 
 cqlStatement returns [std::unique_ptr<raw::parsed_statement> stmt]
-    @after{ if (stmt) { stmt->set_bound_variables(_bind_variable_names, _dialect); } }
+    @after{
+        if (stmt) { stmt->set_bound_variables(_bind_variable_names, _dialect); }
+        // A statement takes the markers of its own text with it; the next
+        // statement of a multi-statement parse numbers its own from zero,
+        // and a marker name it reuses is a marker of its own.
+        _bind_variable_names.clear();
+        _named_bind_variables_indexes.clear();
+    }
     : st1= selectStatement             { $stmt = std::move(st1); }
     | st2= insertStatement             { $stmt = std::move(st2); }
     | st3= updateStatement             { $stmt = std::move(st3); }

--- a/test/boost/cql_query_test.cc
+++ b/test/boost/cql_query_test.cc
@@ -7152,4 +7152,32 @@ SEASTAR_TEST_CASE(test_widening_value_into_wider_sink) {
     });
 }
 
+// The parser counts markers for one statement at a time, but used to hand
+// every statement of a multi-statement parse all the markers it had seen so
+// far, so a later statement inherited the markers of the ones before it.
+SEASTAR_TEST_CASE(test_a_parsed_statement_gets_only_the_markers_of_its_text) {
+    return do_with_cql_env_thread([] (cql_test_env& e) {
+        e.execute_cql("CREATE TABLE ks.tbl (pk int PRIMARY KEY)").get();
+
+        auto& qp = e.local_qp();
+        auto stmts = cql3::query_processor::parse_statements(
+                "INSERT INTO ks.tbl (pk) VALUES (?); SELECT * FROM ks.tbl;", cql3::internal_dialect());
+        BOOST_REQUIRE_EQUAL(stmts.size(), 2);
+        auto insert = stmts[0]->prepare(qp.db(), qp.get_cql_stats(), qp.get_cql_config());
+        BOOST_REQUIRE_EQUAL(insert->bound_names.size(), 1);
+        auto select = stmts[1]->prepare(qp.db(), qp.get_cql_stats(), qp.get_cql_config());
+        BOOST_REQUIRE_EQUAL(select->bound_names.size(), 0);
+
+        // A marker name is only a name within its own statement: reused in a
+        // later one, it is that statement's own marker, not a reference to
+        // the marker the name stood for before.
+        auto named = cql3::query_processor::parse_statements(
+                "INSERT INTO ks.tbl (pk) VALUES (:a); INSERT INTO ks.tbl (pk) VALUES (:a);", cql3::internal_dialect());
+        BOOST_REQUIRE_EQUAL(named.size(), 2);
+        for (auto& stmt : named) {
+            BOOST_REQUIRE_EQUAL(stmt->prepare(qp.db(), qp.get_cql_stats(), qp.get_cql_config())->bound_names.size(), 1);
+        }
+    });
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/boost/schema_loader_test.cc
+++ b/test/boost/schema_loader_test.cc
@@ -117,6 +117,25 @@ SEASTAR_THREAD_TEST_CASE(test_udts) {
     ).get().size(), 2);
 }
 
+SEASTAR_THREAD_TEST_CASE(test_bind_markers_rejected) {
+    db::config dbcfg;
+    dbcfg.rf_rack_valid_keyspaces(true);
+
+    // The loader never evaluates the USING attributes of a dropped-columns
+    // statement, so a marker there used to be swallowed silently. Nothing can
+    // ever bind a value in a schema file, so any marker must be refused.
+    BOOST_REQUIRE_THROW(tools::load_schemas(
+                dbcfg,
+                "CREATE TABLE ks.cf (pk int PRIMARY KEY, v1 int); "
+                "INSERT INTO system_schema.dropped_columns (keyspace_name, table_name, column_name, dropped_time, type) VALUES ('ks', 'cf', 'v2', 1631011979170675, 'int') USING TIMESTAMP ?; "
+    ).get(), std::exception);
+    BOOST_REQUIRE_THROW(tools::load_schemas(
+                dbcfg,
+                "CREATE TABLE ks.cf (pk int PRIMARY KEY, v1 int); "
+                "INSERT INTO system_schema.dropped_columns (keyspace_name, table_name, column_name, dropped_time, type) VALUES ('ks', 'cf', 'v2', 1631011979170675, 'int') USING TIMESTAMP :ts; "
+    ).get(), std::exception);
+}
+
 SEASTAR_THREAD_TEST_CASE(test_dropped_columns) {
     db::config dbcfg;
     dbcfg.rf_rack_valid_keyspaces(true);

--- a/tools/schema_loader.cc
+++ b/tools/schema_loader.cc
@@ -296,6 +296,9 @@ std::vector<schema_ptr> do_load_schemas(const db::config& cfg, std::string_view 
         throw std::runtime_error(format("tools:do_load_schemas(): failed to parse CQL statements: {}", std::current_exception()));
     }
     for (auto& raw_statement : raw_statements) {
+        if (raw_statement->get_prepare_context().bound_variables_size()) {
+            throw std::runtime_error("tools::do_load_schemas(): CQL statement uses bind markers, which a schema file cannot bind values for");
+        }
         auto cf_statement = dynamic_cast<cql3::statements::raw::cf_statement*>(raw_statement.get());
         if (!cf_statement) {
             continue; // we don't support any non-cf statements here


### PR DESCRIPTION
The parser keeps one list of the markers it has seen, and hands it to
every statement it finishes. Parsing one statement at a time, that is
the statement's own markers; parsing a script, a later statement is
also handed the markers of the ones before it. Its own markers get
numbered as if the earlier ones were its to bind, and a statement
that refuses markers refuses a whole script because an earlier
statement legitimately used one: a schema.cql whose dropped-columns
update carries a marker in USING TIMESTAMP makes "scylla sstable"
reject a later materialized view for parameters it does not have.

Nothing reads the list between two statements, so let a statement
take its markers with it: hand the list over and count afresh. The
names seen so far are forgotten with it, since a marker name is only
a name within its own statement: one reused later is a marker of its
own, not a reference to another statement's.

As a result, the following command works:
`scylla sstable dump-schema --schema-file script1.cql`
When `script1.cql` is as follows:
```
  CREATE KEYSPACE ks WITH replication = {'class': 'SimpleStrategy', 'replication_factor': '1'};
  CREATE TABLE ks.t (pk int PRIMARY KEY, v int);
  UPDATE system_schema.dropped_columns USING TIMESTAMP ? SET dropped_time = 1600000000000, type = 'int' WHERE keyspace_name = 'ks' AND table_name = 't' AND column_name = 'c';
```

But the following command fails:
`scylla sstable dump-schema --schema-file script2.cql`
```
  CREATE KEYSPACE ks WITH replication = {'class': 'SimpleStrategy', 'replication_factor': '1'};
  CREATE TABLE ks.t (pk int PRIMARY KEY, v int);
  UPDATE system_schema.dropped_columns USING TIMESTAMP ? SET dropped_time = 1600000000000, type = 'int' WHERE keyspace_name = 'ks' AND table_name = 't' AND column_name = 'c';
  CREATE MATERIALIZED VIEW ks.mv AS SELECT * FROM ks.t WHERE pk IS NOT NULL AND v IS NOT NULL PRIMARY KEY (v, pk);
```
with `exceptions::invalid_request_exception (Cannot use query parameters in CREATE MATERIALIZED VIEW statements)`

Fixes: SCYLLADB-3737

Backport: no backport, just a minor fix.