### PR TITLE
test.py: call the cluster manager directly instead of over HTTP

### DIFF
--- a/docs/dev/testing.md
+++ b/docs/dev/testing.md
@@ -326,11 +326,11 @@ and support topology operations. A standard `manager`
 fixture is available for these. Through this fixture,
 you can access individual nodes, start, stop
 and restart instances, add and remove instances from the cluster.
-The `manager` fixture connects to the cluster by sending
-`test.py` HTTP/REST commands over a unix-domain socket.
-This guarantees that `test.py` is fully aware of all topology
-operations and can clean up resources, including added
-servers, when tests end.
+The `manager` fixture drives the cluster through the cluster
+manager, an in-process Python object running on its own event
+loop; calls are bridged to that loop. This guarantees that the
+test framework is fully aware of all topology operations and can
+clean up resources, including added servers, when tests end.
 `test.py` automatically detects if a cluster can not be shared with a
 subsequent test because it was manipulated with. Today the check
 is quite simple: any cluster that has nodes added or removed,

--- a/test/cluster/conftest.py
+++ b/test/cluster/conftest.py
@@ -10,10 +10,10 @@ from __future__ import annotations
 
 import asyncio
 import aiohttp
+import concurrent.futures
 import ssl
-import tempfile
+import threading
 from concurrent.futures.thread import ThreadPoolExecutor
-from multiprocessing import Event
 from pathlib import Path
 from typing import TYPE_CHECKING
 from test import TOP_SRC_DIR, MODES_TIMEOUT_FACTOR, path_to
@@ -156,20 +156,27 @@ def cluster_con(hosts: list[IPAddress | EndPoint], port: int = 9042, use_ssl: bo
 
 
 @pytest.fixture(scope="module")
-async def manager_api_sock_path(suite_log_dir: Path,
-                                testpy_cluster_factory: ClusterFactory,
-                                testpy_uname: str) -> AsyncGenerator[str]:
-    sock_path = f"{tempfile.mkdtemp(prefix='manager-', dir='/tmp')}/api"
+async def manager_server(suite_log_dir: Path,
+                         testpy_cluster_factory: ClusterFactory,
+                         testpy_uname: str,
+                         ) -> AsyncGenerator[tuple[ScyllaClusterManager, asyncio.AbstractEventLoop]]:
+    """Run the cluster manager and publish it together with its event loop.
 
-    start_event = Event()
-    stop_event = Event()
+    The manager owns loop-bound state -- the Scylla subprocess transports and
+    the per-server asyncio locks -- so all of its coroutines have to run on one
+    loop, and that loop has to keep running: tests reach the manager from
+    pytest's event loops and, in dtest, from plain worker threads.  Hence a
+    dedicated thread whose loop is idle but alive until teardown.
+    """
+    ready: concurrent.futures.Future[tuple[ScyllaClusterManager, asyncio.AbstractEventLoop]] = \
+        concurrent.futures.Future()
+    stop_event = threading.Event()
 
     async def run_manager() -> None:
         mgr = ScyllaClusterManager(
             test_uname=testpy_uname,
             create_cluster=testpy_cluster_factory,
             base_dir=str(suite_log_dir),
-            sock_path=sock_path,
         )
         try:
             await mgr.start()
@@ -178,33 +185,36 @@ async def manager_api_sock_path(suite_log_dir: Path,
             # created before the API site failed to start.
             await mgr.stop()
             raise
-        start_event.set()
+        ready.set_result((mgr, asyncio.get_running_loop()))
         try:
             await asyncio.get_running_loop().run_in_executor(None, stop_event.wait)
         finally:
             await mgr.stop()
-    with ThreadPoolExecutor(max_workers=1) as executor:
+
+    with ThreadPoolExecutor(max_workers=1, thread_name_prefix="cluster-manager") as executor:
         future = executor.submit(asyncio.run, run_manager())
-        # Wake up also when the manager dies before signaling readiness
-        # (e.g. cluster creation failed) instead of waiting forever.
-        # The callback fires only after the future is done, so a
-        # completed future here always means a startup failure.
-        future.add_done_callback(lambda _: start_event.set())
-        start_event.wait()
-        if future.done():
-            future.result()  # propagate the startup failure
-            raise RuntimeError("ScyllaClusterManager exited before signaling readiness")
-
-        yield sock_path
-
-        stop_event.set()
-        future.result()
+        # Fail instead of waiting forever when the manager dies before it
+        # signals readiness, e.g. because creating the first cluster failed.
+        # The callback fires only once the future is done, so reaching it
+        # without a result always means a startup failure.
+        future.add_done_callback(
+            lambda f: None if ready.done() else ready.set_exception(
+                f.exception() or RuntimeError("ScyllaClusterManager exited before signaling readiness")))
+        # ready.result() blocks, so hand it to a thread rather than stalling
+        # the loop this fixture runs on.
+        server = await asyncio.get_running_loop().run_in_executor(None, ready.result)
+        try:
+            yield server
+        finally:
+            stop_event.set()
+            future.result()
 
 
 @pytest.fixture(scope="module")
-async def manager_internal(request: pytest.FixtureRequest, manager_api_sock_path: str) -> Callable[[], ManagerClient]:
-    """Session fixture to prepare client object for communicating with the Cluster API.
-       Pass the Unix socket path where the Manager server API is listening.
+async def manager_internal(request: pytest.FixtureRequest,
+                           manager_server: tuple[ScyllaClusterManager, asyncio.AbstractEventLoop],
+                           ) -> Callable[[], ManagerClient]:
+    """Module fixture to prepare client object for communicating with the Cluster API.
        Pass a function to create driver connections.
        Test cases (functions) should not use this fixture.
     """
@@ -216,8 +226,9 @@ async def manager_internal(request: pytest.FixtureRequest, manager_api_sock_path
         auth_provider = PlainTextAuthProvider(username=auth_username, password=auth_password)
     else:
         auth_provider = None
+    manager, _ = manager_server
     return lambda: ManagerClient(
-        sock_path=manager_api_sock_path,
+        sock_path=manager.sock_path,
         port=port,
         use_ssl=use_ssl,
         auth_provider=auth_provider,

--- a/test/cluster/conftest.py
+++ b/test/cluster/conftest.py
@@ -9,7 +9,6 @@
 from __future__ import annotations
 
 import asyncio
-import aiohttp
 import concurrent.futures
 import ssl
 import threading
@@ -226,9 +225,10 @@ async def manager_internal(request: pytest.FixtureRequest,
         auth_provider = PlainTextAuthProvider(username=auth_username, password=auth_password)
     else:
         auth_provider = None
-    manager, _ = manager_server
+    manager, manager_loop = manager_server
     return lambda: ManagerClient(
-        sock_path=manager.sock_path,
+        cluster_manager=manager,
+        manager_loop=manager_loop,
         port=port,
         use_ssl=use_ssl,
         auth_provider=auth_provider,
@@ -253,12 +253,8 @@ async def manager(request: pytest.FixtureRequest,
     logger.debug("before_test for %s", test_case_name)
     if await manager_client.is_dirty():
         manager_client.driver_close()  # Close driver connection to old cluster
-    try:
-        cluster_str = await manager_client.client.put_json(f"/cluster/before-test/{test_case_name}", timeout=600,
-                                                           response_type="json")
-        logger.info(f"Using cluster: {cluster_str} for test {test_case_name}")
-    except aiohttp.ClientError as exc:
-        raise RuntimeError(f"Failed before test check {exc}") from exc
+    cluster_str = await manager_client.before_test(test_case_name)
+    logger.info(f"Using cluster: {cluster_str} for test {test_case_name}")
     servers = await manager_client.running_servers()
     if manager_client.cql is None and servers:
         await manager_client.driver_connect()  # Connect driver to new cluster
@@ -292,13 +288,10 @@ async def manager(request: pytest.FixtureRequest,
             # here we only need the dir for the manager-specific found_errors files below.
             failed_test_dir_path = make_failed_test_dir(request.config, build_mode, test_case_name)
 
-        # Tear down (after test): notify the Manager server that the test finished
-        # We grab the raw per-loop client here because the `client` property becomes inaccessible
-        # once test_finished_event is set.
-        manager_client.test_finished_event.set()
-        _client = manager_client.client_for_asyncio_loop.get(asyncio.get_running_loop())
+        # Tear down (after test): notify the manager that the test finished.
+        # This also cuts off manager access for tasks leaked by the test.
         logger.debug("after_test for %s (success: %s)", test_case_name, not failed)
-        cluster_status = await _client.put_json(f"/cluster/after-test/{not failed}", response_type="json")
+        cluster_status = await manager_client.after_test(success=not failed)
         logger.info("Cluster after test %s (success: %s): %s", test_case_name, not failed, cluster_status)
     finally:
         # Drop the stash entry before closing the client so a teardown-phase

--- a/test/cluster/conftest.py
+++ b/test/cluster/conftest.py
@@ -235,7 +235,7 @@ async def manager(request: pytest.FixtureRequest,
     Per test fixture to notify Manager client object when tests begin so it can perform checks for cluster state.
     """
     test_case_name = request.node.name
-    # this should be consistent with scylla_cluster.py handler name in _before_test method
+    # this should be consistent with scylla_cluster.py ScyllaClusterManager.before_test()
     test_py_log_test = suite_log_dir / f"{Path(testpy_uname).stem}.{test_case_name}_cluster.log"
 
     manager_client = manager_internal()  # set up client object in fixture with scope function

--- a/test/cluster/test_tablets.py
+++ b/test/cluster/test_tablets.py
@@ -12,7 +12,7 @@ from test.cluster.test_tablets2 import safe_rolling_restart
 from test.pylib.internal_types import ServerInfo, ServerUpState
 from test.pylib.manager_client import ManagerClient
 from test.pylib.repair import create_table_insert_data_for_repair
-from test.pylib.rest_client import HTTPError, read_barrier
+from test.pylib.rest_client import read_barrier
 from test.pylib.scylla_cluster import ReplaceConfig
 from test.pylib.tablets import get_tablet_replica, get_all_tablet_replicas
 from test.pylib.util import unique_name, wait_for, wait_for_first_completed
@@ -95,7 +95,7 @@ async def test_tablet_cannot_decommision_below_replication_factor(manager: Manag
         logger.info("Decommission some node")
         await manager.decommission_node(servers[0].server_id)
 
-        with pytest.raises(HTTPError, match="Decommission failed"):
+        with pytest.raises(RuntimeError, match="Decommission failed"):
             logger.info("Decommission another node")
             await manager.decommission_node(servers[1].server_id)
 

--- a/test/pylib/manager_client.py
+++ b/test/pylib/manager_client.py
@@ -248,21 +248,9 @@ class ManagerClient:
             allure.attach(log.read_bytes(), name=name, attachment_type=allure.attachment_type.TEXT)
             shutil.copyfile(log, failed_test_path_dir / name)
 
-    async def is_manager_up(self) -> bool:
-        """Check if Manager server is up"""
-        return await self.client.get_json("/up")
-
-    async def is_cluster_up(self) -> bool:
-        """Check if cluster is up"""
-        return await self.client.get_json("/cluster/up")
-
     async def is_dirty(self) -> bool:
         """Check if current cluster dirty."""
         return await self.client.get_json("/cluster/is-dirty")
-
-    async def replicas(self) -> int:
-        """Get number of configured replicas for the cluster (replication factor)"""
-        return await self.client.get_json("/cluster/replicas")
 
     async def running_servers(self) -> list[ServerInfo]:
         """Get List of server info (id and IP address) of running servers"""

--- a/test/pylib/manager_client.py
+++ b/test/pylib/manager_client.py
@@ -4,8 +4,8 @@
 # SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
 #
 """Manager client.
-   Communicates with Manager server via socket.
-   Provides helper methods to test cases.
+   A facade in front of ScyllaClusterManager: calls it directly as a Python
+   object and provides helper methods to test cases.
    Manages driver refresh when cluster is cycled.
 """
 from collections import defaultdict
@@ -14,14 +14,15 @@ import re
 import shutil
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
-from typing import List, Optional, Callable, Any, Awaitable, Dict, Tuple, Union
+from collections.abc import Coroutine
+from typing import List, Optional, Callable, Any, Awaitable, Dict, Union
 from time import time
 import logging
 from test.pylib.log_browsing import ScyllaLogFile
-from test.pylib.rest_client import UnixRESTClient, ScyllaRESTAPIClient, ScyllaMetricsClient
+from test.pylib.rest_client import ScyllaRESTAPIClient, ScyllaMetricsClient
 from test.pylib.util import gather_safely, wait_for, wait_for_cql_and_get_hosts, universalasync_typed_wrap, Host
 from test.pylib.internal_types import ServerNum, IPAddress, HostID, ServerInfo, ServerUpState
-from test.pylib.scylla_cluster import ReplaceConfig, ScyllaServer, ScyllaVersionDescription
+from test.pylib.scylla_cluster import ReplaceConfig, ScyllaClusterManager, ScyllaServer, ScyllaVersionDescription
 from test.pylib.driver_utils import safe_driver_shutdown
 from cassandra.cluster import Session as CassandraSession, \
     ExecutionProfile, EXEC_PROFILE_DEFAULT  # type: ignore # pylint: disable=no-name-in-module
@@ -43,12 +44,14 @@ class NoSuchProcess(Exception):
 class ManagerClient:
     """Helper Manager API client
     Args:
-        sock_path (str): path to an AF_UNIX socket where Manager server is listening
+        cluster_manager (ScyllaClusterManager): the manager to drive
+        manager_loop: the event loop the manager runs on
         con_gen (Callable): generator function for CQL driver connection to a cluster
     """
     # pylint: disable=too-many-public-methods
 
-    def __init__(self, sock_path: str, port: int, use_ssl: bool, auth_provider: Any|None,
+    def __init__(self, cluster_manager: ScyllaClusterManager, manager_loop: asyncio.AbstractEventLoop,
+                 port: int, use_ssl: bool, auth_provider: Any|None,
                  con_gen: Callable[[List[IPAddress], int, bool, Any, LoadBalancingPolicy], CassandraCluster]) \
                          -> None:
         self.port = port
@@ -59,45 +62,47 @@ class ManagerClient:
         self.ccluster: Optional[CassandraCluster] = None
         self.cql: Optional[CassandraSession] = None
         self.exclusive_clusters: List[CassandraCluster] = []
-        # A client for communicating with ScyllaClusterManager (server)
-        self.sock_path = sock_path
-        self.client_for_asyncio_loop = {asyncio.get_running_loop(): UnixRESTClient(sock_path)}
+        self._cluster_manager = cluster_manager
+        self._manager_loop = manager_loop
+        self._test_finished = False
         self.api = ScyllaRESTAPIClient()
         self.metrics = ScyllaMetricsClient()
         self.thread_pool = ThreadPoolExecutor()
-        self.test_finished_event = asyncio.Event()
         self.ignore_log_patterns = []  # patterns to ignore in server logs when checking for errors
         self.ignore_cores_log_patterns = []  # patterns to ignore in server logs when checking for core files
 
     @property
-    def client(self):
-        if self.test_finished_event.is_set():
-            raise Exception("ManagerClient client object is not accessible after the test finished")
-            # there are still can be issue when some task first obtains the client object,
-            # but usually, tests obtains the manager and uses the client as manager.client
-            # and there is an actual workaround for this case.
-            # It is better to fix the task rather than every time doing
-            # close all clients in after_test->create new during after_test->close again after after_test.
-        _client = self.client_for_asyncio_loop.get(asyncio.get_running_loop(), None)
-        if _client is None:
-            _client = UnixRESTClient(self.sock_path)
-            self.client_for_asyncio_loop[asyncio.get_running_loop()] = _client
-        return _client
+    def _manager(self) -> ScyllaClusterManager:
+        """The manager, guarded: fail loudly when a task leaked by the test
+        touches the manager after the test finished."""
+        if self._test_finished:
+            raise Exception("ManagerClient is not accessible after the test finished")
+        return self._cluster_manager
+
+    async def _call(self, op: Coroutine, timeout: float | None = None) -> Any:
+        """Run a manager operation on the manager's own event loop.
+
+        The manager owns loop-bound state -- the Scylla subprocess transports
+        and the per-server asyncio locks -- so its coroutines must run on its
+        loop, not on whichever loop the caller happens to have.  Callers get
+        their loop from pytest, or, when a synchronous dtest test calls in from
+        a worker thread, from universalasync, which creates a fresh one per
+        thread; awaiting a manager coroutine there would fail with "got Future
+        attached to a different loop".
+
+        The operation is capped at 300 s unless the caller passes a timeout,
+        the same ceiling the HTTP client used to apply to every request.  A
+        timed-out or cancelled caller does not abort the operation: manager_op
+        shields it, so it runs to completion and after_test() drains it, just
+        as an abandoned HTTP request used to leave its handler running.
+        """
+        future = asyncio.run_coroutine_threadsafe(op, self._manager_loop)
+        async with asyncio.timeout(300 if timeout is None else timeout):
+            return await asyncio.wrap_future(future, loop=asyncio.get_running_loop())
 
     async def stop(self):
         """Close driver"""
         self.driver_close()
-        # remove non-running event loops from the dict
-        for loop in list(self.client_for_asyncio_loop.keys()):
-            if not loop.is_running():
-                del self.client_for_asyncio_loop[loop]
-        # Only shutdown the client for the current event loop
-        _client = self.client_for_asyncio_loop.get(asyncio.get_running_loop())
-        if _client:
-            await _client.shutdown()
-            del self.client_for_asyncio_loop[asyncio.get_running_loop()]
-        # Check no clients are left
-        assert len(self.client_for_asyncio_loop.keys()) == 0 , f"Some clients were not closed: {self.client_for_asyncio_loop}"
 
     async def driver_connect(self, server: Optional[ServerInfo] = None, auth_provider: Optional[AuthProvider] = None) -> None:
         """Connect to cluster"""
@@ -248,27 +253,31 @@ class ManagerClient:
             allure.attach(log.read_bytes(), name=name, attachment_type=allure.attachment_type.TEXT)
             shutil.copyfile(log, failed_test_path_dir / name)
 
+    async def before_test(self, test_case_name: str) -> str:
+        """Before-test hook of the manager fixture: lease a cluster for the test."""
+        return await self._call(self._manager.before_test(test_case_name), timeout=600)
+
+    async def after_test(self, success: bool) -> dict[str, Any]:
+        """After-test hook of the manager fixture.
+
+        Marks this client as finished first, so a task leaked by the test
+        cannot reach the manager anymore, then reports the test result to
+        the manager (bypassing that very guard).
+        """
+        self._test_finished = True
+        return await self._call(self._cluster_manager.after_test(success))
+
     async def is_dirty(self) -> bool:
         """Check if current cluster dirty."""
-        return await self.client.get_json("/cluster/is-dirty")
+        return await self._call(self._manager.is_dirty())
 
     async def running_servers(self) -> list[ServerInfo]:
         """Get List of server info (id and IP address) of running servers"""
-        try:
-            server_info_list = await self.client.get_json("/cluster/running-servers")
-        except RuntimeError as exc:
-            raise Exception("Failed to get list of running servers") from exc
-        assert isinstance(server_info_list, list), "running_servers got unknown data type"
-        return [ServerInfo(*info) for info in server_info_list]
+        return await self._call(self._manager.running_servers())
 
     async def all_servers(self) -> list[ServerInfo]:
         """Get List of server info (id and IP address) of all servers"""
-        try:
-            server_info_list = await self.client.get_json("/cluster/all-servers")
-        except RuntimeError as exc:
-            raise Exception("Failed to get list of servers") from exc
-        assert isinstance(server_info_list, list), "all_servers got unknown data type"
-        return [ServerInfo(*info) for info in server_info_list]
+        return await self._call(self._manager.all_servers())
 
     async def all_servers_by_host_id(self) -> Dict[HostID, ServerInfo]:
         result = dict()
@@ -292,22 +301,17 @@ class ManagerClient:
            which a test started in the background but now doesn't expect to
            ever finish booting successfully.
         """
-        try:
-            server_info_list = await self.client.get_json("/cluster/starting-servers")
-        except RuntimeError as exc:
-            raise Exception("Failed to get list of starting servers") from exc
-        assert isinstance(server_info_list, list), "starting_servers got unknown data type"
-        return [ServerInfo(*info) for info in server_info_list]
+        return await self._call(self._manager.starting_servers())
 
     async def mark_dirty(self) -> None:
         """Manually mark current cluster dirty.
            To be used when a server was modified outside of this API."""
-        await self.client.put_json("/cluster/mark-dirty")
+        await self._call(self._manager.mark_dirty())
 
     async def mark_clean(self) -> None:
         """Manually mark current cluster not dirty.
            To be used when a current cluster wants to be reused."""
-        await self.client.put_json("/cluster/mark-clean")
+        await self._call(self._manager.mark_clean())
 
     async def server_stop(self, server_id: ServerNum, convict: bool) -> None:
         """Stop specified server.
@@ -329,7 +333,7 @@ class ManagerClient:
                 # Skip conviction in this case.
                 pass
         logger.debug("ManagerClient stopping %s", server_id)
-        await self.client.put_json(f"/cluster/server/{server_id}/stop")
+        await self._call(self._manager.server_stop(server_id))
         if host_id is not None:
             try:
                 await self.convict_on_all(host_id)
@@ -341,7 +345,7 @@ class ManagerClient:
     async def server_stop_gracefully(self, server_id: ServerNum, timeout: float = 180) -> None:
         """Stop specified server gracefully"""
         logger.debug("ManagerClient stopping gracefully %s", server_id)
-        await self.client.put_json(f"/cluster/server/{server_id}/stop_gracefully", timeout=timeout)
+        await self._call(self._manager.server_stop_gracefully(server_id), timeout=timeout)
 
     async def disable_tablet_balancing(self):
         """
@@ -416,15 +420,15 @@ class ManagerClient:
             expected_server_up_state = min(expected_server_up_state, ServerUpState.HOST_ID_QUERIED)
 
         logger.debug("ManagerClient starting %s", server_id)
-        data = {
-            "expected_error": expected_error,
-            "seeds": seeds,
-            "expected_server_up_state": expected_server_up_state.name,
-            "cmdline_options_override": cmdline_options_override,
-            "append_env_override": append_env_override,
-            "auth_provider": auth_provider,
-        }
-        await self.client.put_json(f"/cluster/server/{server_id}/start", data, timeout=timeout)
+        await self._call(self._manager.server_start(
+            server_id,
+            expected_error=expected_error,
+            seeds=seeds,
+            expected_server_up_state=expected_server_up_state,
+            cmdline_options_override=cmdline_options_override,
+            append_env_override=append_env_override,
+            auth_provider=auth_provider,
+        ), timeout=timeout)
         await self.server_sees_others(server_id, wait_others, interval = wait_interval)
         if expected_error is None and connect_driver:
             if self.cql:
@@ -474,18 +478,17 @@ class ManagerClient:
     async def server_pause(self, server_id: ServerNum) -> None:
         """Pause the specified server."""
         logger.debug("ManagerClient pausing %s", server_id)
-        await self.client.put_json(f"/cluster/server/{server_id}/pause")
+        await self._call(self._manager.server_pause(server_id))
 
     async def server_unpause(self, server_id: ServerNum) -> None:
         """Unpause the specified server."""
         logger.debug("ManagerClient unpausing %s", server_id)
-        await self.client.put_json(f"/cluster/server/{server_id}/unpause")
+        await self._call(self._manager.server_unpause(server_id))
 
     async def server_switch_executable(self, server_id: ServerNum, path: str) -> None:
         """Switch the executable path of a stopped server"""
-        logger.debug("ManagerClient starting %s", server_id)
-        data = {"path": path}
-        await self.client.put_json(f"/cluster/server/{server_id}/switch_executable", data)
+        logger.debug("ManagerClient switching executable of %s to %s", server_id, path)
+        await self._call(self._manager.server_switch_executable(server_id, path))
 
     async def server_change_version(self, server_id: ServerNum, exe: str):
         """ Upgrades a running Scylla node by switching it to a new binary version 
@@ -498,11 +501,11 @@ class ManagerClient:
     async def server_wipe_sstables(self, server_id: ServerNum, keyspace: str, table: str) -> None:
         """Delete all files for the given table from the data directory"""
         logger.debug("ManagerClient wiping sstables on %s, keyspace=%s, table=%s", server_id, keyspace, table)
-        await self.client.put_json(f"/cluster/server/{server_id}/wipe_sstables", {"keyspace": keyspace, "table": table})
+        await self._call(self._manager.server_wipe_sstables(server_id, keyspace, table))
 
     async def server_get_sstables_disk_usage(self, server_id: ServerNum, keyspace: str, table: str) -> int:
         """Get the total size of all sstable files for the given table"""
-        return await self.client.get_json(f"/cluster/server/{server_id}/sstables_disk_usage", params={"keyspace": keyspace, "table": table})
+        return await self._call(self._manager.server_get_sstables_disk_usage(server_id, keyspace, table))
 
     async def _get_ignored_ip_addresses(self, ignore_dead: List[IPAddress | HostID]) -> List[IPAddress]:
         """
@@ -520,38 +523,6 @@ class ManagerClient:
                 ignored_server = await self.find_server_by_host_id(servers, ignored)
                 ignored_ips.append(ignored_server.ip_addr)
         return ignored_ips
-
-    def _create_server_add_data(self,
-                                replace_cfg: Optional[ReplaceConfig],
-                                cmdline: Optional[List[str]],
-                                config: Optional[dict[str, Any]],
-                                version: Optional[ScyllaVersionDescription],
-                                property_file: Union[List[dict[str, Any]], dict[str, Any], None],
-                                start: bool,
-                                seeds: Optional[List[IPAddress]],
-                                expected_error: Optional[str],
-                                server_encryption: Optional[str],
-                                expected_server_up_state: Optional[ServerUpState]) -> dict[str, Any]:
-        data: dict[str, Any] = {'start': start}
-        if replace_cfg:
-            data['replace_cfg'] = replace_cfg._asdict()
-        if cmdline:
-            data['cmdline'] = cmdline
-        if config:
-            data['config'] = config
-        if version:
-            data['version'] = version._asdict()
-        if property_file:
-            data['property_file'] = property_file
-        if seeds:
-            data['seeds'] = seeds
-        if expected_error:
-            data['expected_error'] = expected_error
-        if server_encryption:
-            data['server_encryption'] = server_encryption
-        if expected_server_up_state:
-            data['expected_server_up_state'] = expected_server_up_state.name
-        return data
 
     async def server_add(self,
                          replace_cfg: Optional[ReplaceConfig] = None,
@@ -581,19 +552,6 @@ class ManagerClient:
             expected_server_up_state = min(expected_server_up_state, ServerUpState.HOST_ID_QUERIED)
 
         try:
-            data = self._create_server_add_data(
-                replace_cfg,
-                cmdline,
-                config,
-                version,
-                property_file,
-                start,
-                seeds,
-                expected_error,
-                server_encryption,
-                expected_server_up_state,
-            )
-
             # We should wait until all running nodes see the node being replaced
             # and all ignored nodes as dead. Replace could be rejected otherwise.
             # We make this waiting default and optional to allow testing expected
@@ -604,14 +562,20 @@ class ManagerClient:
                 dead_ips = [replaced_ip] + ignored_ips
                 await gather_safely(*(self.others_not_see_server(ip) for ip in dead_ips))
 
-            server_info = await self.client.put_json("/cluster/addserver", data, response_type="json",
-                                                     timeout=timeout)
+            s_info = await self._call(self._manager.server_add(
+                replace_cfg=replace_cfg,
+                cmdline=cmdline,
+                config=config,
+                version=version,
+                property_file=property_file,
+                start=start,
+                seeds=seeds,
+                server_encryption=server_encryption,
+                expected_error=expected_error,
+                expected_server_up_state=expected_server_up_state,
+            ), timeout=timeout)
         except Exception as exc:
             raise Exception("Failed to add server") from exc
-        try:
-            s_info = ServerInfo(**server_info)
-        except Exception as exc:
-            raise RuntimeError(f"server_add got invalid server data {server_info}") from exc
         logger.debug("ManagerClient added %s", s_info)
         if expected_error is None and connect_driver:
             if self.cql:
@@ -651,23 +615,22 @@ class ManagerClient:
             property_file = [{"dc":auto_rack_dc, "rack":f"rack{i+1}"} for i in range(servers_num)]
 
         try:
-            data = self._create_server_add_data(None, cmdline, config, version, property_file, start, seeds, expected_error, server_encryption, None)
-            data['servers_num'] = servers_num
-            server_infos = await self.client.put_json("/cluster/addservers", data, response_type="json",
-                                                      timeout=ScyllaServer.TOPOLOGY_TIMEOUT * servers_num)
+            s_infos = await self._call(self._manager.servers_add(
+                servers_num=servers_num,
+                cmdline=cmdline,
+                config=config,
+                version=version,
+                property_file=property_file,
+                start=start,
+                seeds=seeds,
+                server_encryption=server_encryption,
+                expected_error=expected_error,
+            ), timeout=ScyllaServer.TOPOLOGY_TIMEOUT * servers_num)
         except Exception as exc:
             raise Exception("Failed to add servers") from exc
 
-        assert len(server_infos) == servers_num, f"servers_add requested adding {servers_num} servers but " \
-                                    f"got server data about {len(server_infos)} servers: {server_infos}"
-        s_infos = list[ServerInfo]()
-        for server_info in server_infos:
-            try:
-                s_info = ServerInfo(**server_info)
-                s_infos.append(s_info)
-            except Exception as exc:
-                raise RuntimeError(f"servers_add got invalid server data {server_info}") from exc
-
+        assert len(s_infos) == servers_num, f"servers_add requested adding {servers_num} servers but " \
+                                    f"got server data about {len(s_infos)} servers: {s_infos}"
         logger.debug("ManagerClient added %s", s_infos)
         if expected_error is None:
             if self.cql:
@@ -697,9 +660,9 @@ class ManagerClient:
             dead_ips = [removed_ip] + ignored_ips
             await gather_safely(*(self.others_not_see_server(ip) for ip in dead_ips))
 
-        data = {"server_id": server_id, "ignore_dead": ignore_dead, "expected_error": expected_error}
-        await self.client.put_json(f"/cluster/remove-node/{initiator_id}", data,
-                                   timeout=timeout)
+        await self._call(self._manager.remove_node(
+            initiator_id, server_id, ignore_dead=ignore_dead, expected_error=expected_error,
+        ), timeout=timeout)
         self._driver_update()
 
     async def decommission_node(self, server_id: ServerNum,
@@ -710,9 +673,8 @@ class ManagerClient:
             self.ignore_log_patterns.append(re.escape(expected_error))
 
         logger.debug("ManagerClient decommission %s", server_id)
-        data = {"expected_error": expected_error}
-        await self.client.put_json(f"/cluster/decommission-node/{server_id}", data,
-                                   timeout=timeout)
+        await self._call(self._manager.decommission_node(server_id, expected_error=expected_error),
+                         timeout=timeout)
         self._driver_update()
 
     async def rebuild_node(self, server_id: ServerNum,
@@ -720,15 +682,12 @@ class ManagerClient:
                            timeout: Optional[float] = ScyllaServer.TOPOLOGY_TIMEOUT) -> None:
         """Tell a node to rebuild with Scylla REST API"""
         logger.debug("ManagerClient rebuild %s", server_id)
-        data = {"expected_error": expected_error}
-        await self.client.put_json(f"/cluster/rebuild-node/{server_id}", data,
-                                   timeout=timeout)
+        await self._call(self._manager.rebuild_node(server_id, expected_error=expected_error),
+                         timeout=timeout)
         self._driver_update()
 
     async def server_get_config(self, server_id: ServerNum) -> dict[str, Any]:
-        data = await self.client.get_json(f"/cluster/server/{server_id}/get_config")
-        assert isinstance(data, dict), f"server_get_config: got {type(data)} expected dict"
-        return data
+        return await self._call(self._manager.server_get_config(server_id))
 
     async def server_update_config(self,
                                    server_id: ServerNum,
@@ -749,42 +708,27 @@ class ManagerClient:
             config_options = {key: value}
         elif not isinstance(config_options, dict):
             raise RuntimeError(f"`config_options` is expected to be a dict, not {type(config_options)}")
-        await self.client.put_json(
-            resource_uri=f"/cluster/server/{server_id}/update_config",
-            data={"config_options": config_options},
-        )
+        await self._call(self._manager.server_update_config(server_id, config_options))
 
     async def server_remove_config_option(self, server_id: ServerNum, key: str) -> None:
         """Remove the provided option from the server's configuration file."""
-        await self.client.put_json(
-            resource_uri=f"/cluster/server/{server_id}/remove_config_option",
-            data={"key": key},
-        )
+        await self._call(self._manager.server_remove_config_option(server_id, key))
 
     async def server_update_cmdline(self, server_id: ServerNum, cmdline_options: List[str]) -> None:
-        await self.client.put_json(f"/cluster/server/{server_id}/update_cmdline",
-                                   {"cmdline_options": cmdline_options})
+        await self._call(self._manager.server_update_cmdline(server_id, cmdline_options))
 
     async def server_change_ip(self, server_id: ServerNum) -> IPAddress:
         """Change server IP address. Applicable only to a stopped server"""
-        ret = await self.client.put_json(f"/cluster/server/{server_id}/change_ip", {},
-                                         response_type="json")
-        return IPAddress(ret["ip_addr"])
+        return await self._call(self._manager.server_change_ip(server_id))
 
     async def server_change_rpc_address(self, server_id: ServerNum) -> IPAddress:
         """Change server RPC IP address.
 
         Applicable only to a stopped server.
         """
-        ret = await self.client.put_json(
-            resource_uri=f"/cluster/server/{server_id}/change_rpc_address",
-            data={},
-            response_type="json",
-        )
-        rpc_address = ret["rpc_address"]
-
+        rpc_address = await self._call(self._manager.server_change_rpc_address(server_id))
         logger.debug("ManagerClient has changed RPC IP for server %s to %s", server_id, rpc_address)
-        return IPAddress(rpc_address)
+        return rpc_address
 
     async def wait_for_host_known(self, dst_server_ip: IPAddress, expect_host_id: HostID,
                                   deadline: Optional[float] = None) -> None:
@@ -801,7 +745,7 @@ class ManagerClient:
                                              deadline: Optional[float] = None) -> str:
         """Wait for Scylla's process status for server_id will be as expected, with timeout."""
         async def process_status_is_as_expected() -> str | None:
-            current_status = await self.client.get_json(f"/cluster/server/{server_id}/process_status")
+            current_status = await self._call(self._manager.server_get_process_status(server_id))
             if current_status in expected_statuses:
                 return current_status
 
@@ -810,18 +754,16 @@ class ManagerClient:
     async def get_host_ip(self, server_id: ServerNum) -> IPAddress:
         """Get host IP Address"""
         try:
-            server_ip = await self.client.get_json(f"/cluster/host-ip/{server_id}")
+            return await self._call(self._manager.get_host_ip(server_id))
         except Exception as exc:
             raise Exception(f"Failed to get host IP address for server {server_id}") from exc
-        return IPAddress(server_ip)
 
     async def get_host_id(self, server_id: ServerNum) -> HostID:
         """Get local host id of a server"""
         try:
-            host_id = await self.client.get_json(f"/cluster/host-id/{server_id}")
+            return await self._call(self._manager.get_host_id(server_id))
         except Exception as exc:
             raise Exception(f"Failed to get local host id address for server {server_id}") from exc
-        return HostID(host_id)
 
     async def get_table_id(self, keyspace: str, table: str):
         rows = await self.cql.run_async(f"select id from system_schema.tables where keyspace_name = '{keyspace}' and table_name = '{table}'")
@@ -879,20 +821,20 @@ class ManagerClient:
 
     async def server_open_log(self, server_id: ServerNum) -> ScyllaLogFile:
         logger.debug("ManagerClient getting log filename for %s", server_id)
-        log_filename = await self.client.get_json(f"/cluster/server/{server_id}/get_log_filename")
+        log_filename = await self._call(self._manager.server_get_log_filename(server_id))
         return ScyllaLogFile(self.thread_pool, log_filename)
 
     async def server_get_workdir(self, server_id: ServerNum) -> str:
-        return await self.client.get_json(f"/cluster/server/{server_id}/workdir")
+        return await self._call(self._manager.server_get_workdir(server_id))
 
     async def server_get_maintenance_socket_path(self, server_id: ServerNum) -> str:
-        return await self.client.get_json(f"/cluster/server/{server_id}/maintenance_socket_path")
+        return await self._call(self._manager.server_get_maintenance_socket_path(server_id))
 
     async def server_get_exe(self, server_id: ServerNum) -> str:
-        return await self.client.get_json(f"/cluster/server/{server_id}/exe")
+        return await self._call(self._manager.server_get_exe(server_id))
 
     async def server_get_returncode(self, server_id: ServerNum) -> int | None:
-        match await self.client.get_json(f"/cluster/server/{server_id}/returncode"):
+        match await self._call(self._manager.server_get_returncode(server_id)):
             case "NO_SUCH_PROCESS":
                 raise NoSuchProcess(f"No process found for {server_id=}")
             case "RUNNING":

--- a/test/pylib/rest_client.py
+++ b/test/pylib/rest_client.py
@@ -8,7 +8,6 @@
 from __future__ import annotations                           # Type hints as strings
 
 import logging
-import os.path
 import time
 from urllib.parse import quote
 from abc import ABCMeta
@@ -17,7 +16,7 @@ from contextlib import asynccontextmanager
 from typing import Any, Optional, AsyncIterator
 
 import universalasync
-from aiohttp import request, BaseConnector, UnixConnector, ClientTimeout
+from aiohttp import request, BaseConnector, ClientTimeout
 from cassandra.pool import Host                          # type: ignore # pylint: disable=no-name-in-module
 
 from test.pylib.skip_types import skip_env
@@ -128,20 +127,6 @@ class RESTClient(metaclass=ABCMeta):
                      json: Optional[Mapping] = None, timeout: Optional[float] = None) -> None:
         await self._fetch("DELETE", resource_uri, host = host, port = port, params = params,
                           json = json, timeout = timeout)
-
-
-class UnixRESTClient(RESTClient):
-    """An async helper for REST API operations using AF_UNIX socket"""
-
-    def __init__(self, sock_path: str):
-        # NOTE: using Python requests style URI for Unix domain sockets to avoid using "localhost"
-        #       host parameter is ignored but set to socket name as convention
-        self.uri_scheme: str = "http"
-        self.default_host: str = f"{os.path.basename(sock_path)}"
-        self.connector = UnixConnector(path=sock_path)
-
-    async def shutdown(self):
-        await self.connector.close()
 
 
 class TCPRESTClient(RESTClient):

--- a/test/pylib/scylla_cluster.py
+++ b/test/pylib/scylla_cluster.py
@@ -1835,10 +1835,7 @@ class ScyllaClusterManager:
         def add_put(route: str, handler: Callable):
             app.router.add_put(route, make_catching_handler(route_history_wrapper(True)(handler)))
 
-        add_get('/up', self._manager_up)
-        add_get('/cluster/up', self._cluster_up)
         add_get('/cluster/is-dirty', self._is_dirty)
-        add_get('/cluster/replicas', self._cluster_replicas)
         add_get('/cluster/running-servers', self._cluster_running_servers)
         add_get('/cluster/all-servers', self._cluster_all_servers)
         add_get('/cluster/starting-servers', self._cluster_starting_servers)
@@ -1874,22 +1871,10 @@ class ScyllaClusterManager:
         add_get('/cluster/server/{server_id}/process_status', self._server_get_process_status)
         add_get('/cluster/server/{server_id}/returncode', self._server_get_returncode)
 
-    async def _manager_up(self, _request) -> bool:
-        return self.is_running
-
-    async def _cluster_up(self, _request) -> bool:
-        """Is cluster running"""
-        return self.cluster is not None and self.cluster.is_running
-
     async def _is_dirty(self, _request) -> bool:
         """Report if current cluster is dirty"""
         assert self.cluster
         return self.cluster.is_dirty
-
-    async def _cluster_replicas(self, _request) -> int:
-        """Return cluster's configured number of replicas (replication factor)"""
-        assert self.cluster
-        return self.cluster.replicas
 
     async def _cluster_running_servers(self, _request) -> list[tuple[ServerNum, IPAddress, IPAddress]]:
         """Return a dict of running server ids to IPs"""

--- a/test/pylib/scylla_cluster.py
+++ b/test/pylib/scylla_cluster.py
@@ -9,6 +9,7 @@
 from functools import wraps
 import asyncio
 import concurrent.futures
+import copy
 from asyncio.subprocess import Process
 from collections import ChainMap
 import itertools
@@ -565,8 +566,12 @@ class ScyllaServer:
             raise
 
     def get_config(self) -> dict[str, object]:
-        """Return the contents of conf/scylla.yaml as a dict."""
-        return self.config
+        """Return the contents of conf/scylla.yaml as a dict.
+
+        Returns a copy: mutating it doesn't affect the server; use
+        update_config() for that.
+        """
+        return copy.deepcopy(self.config)
 
     def update_config(self, config_options: dict[str, Any]) -> None:
         """Update conf/scylla.yaml with `config_options` dict.
@@ -1281,7 +1286,10 @@ class ScyllaCluster:
         assert start or not expected_error, \
             f"add_server: cannot add a stopped server and expect an error"
 
-        extra_config: dict[str, Any] = config.copy() if config else {}
+        # Deep copy: the test keeps the dict (and add_servers() shares it between
+        # servers), while ScyllaServer.__init__ writes to it and the server keeps
+        # mutating nested values (e.g. change_seeds()).
+        extra_config: dict[str, Any] = copy.deepcopy(config) if config else {}
         if replace_cfg:
             replaced_id = replace_cfg.replaced_id
             assert expected_error or replaced_id in self.servers, \

--- a/test/pylib/scylla_cluster.py
+++ b/test/pylib/scylla_cluster.py
@@ -1759,7 +1759,7 @@ class ScyllaClusterManager:
         await self.site.start()
         self.is_running = True
 
-    async def _before_test(self, test_case_name: str) -> str:
+    async def before_test(self, test_case_name: str) -> str:
         self.current_test_case_full_name = f'{self.test_uname}::{test_case_name}'
         root_logger = logging.getLogger()
         # file handler file name should be consistent with topology/conftest.py:manager test_py_log_test variable
@@ -1798,6 +1798,366 @@ class ScyllaClusterManager:
         if os.path.exists(self.manager_dir):
             await async_rmtree(self.manager_dir)
         self.is_running = False
+
+    async def is_dirty(self) -> bool:
+        """Report if current cluster is dirty"""
+        assert self.cluster
+        return self.cluster.is_dirty
+
+    async def running_servers(self) -> list[ServerInfo]:
+        """Return server info for running servers"""
+        assert self.cluster
+        return self.cluster.running_servers()
+
+    async def all_servers(self) -> list[ServerInfo]:
+        """Return server info for all servers"""
+        assert self.cluster
+        return self.cluster.all_servers()
+
+    async def starting_servers(self) -> list[ServerInfo]:
+        """Return server info for servers which are currently starting"""
+        assert self.cluster
+        return self.cluster.starting_servers()
+
+    async def get_host_ip(self, server_id: ServerNum) -> IPAddress:
+        """IP address of a server"""
+        assert self.cluster
+        return self.cluster.servers[server_id].ip_addr
+
+    async def get_host_id(self, server_id: ServerNum) -> HostID:
+        """Host ID of a server."""
+        assert self.cluster
+        return await self.cluster.servers[server_id].get_host_id(self.cluster.api)
+
+    async def after_test(self, success: bool) -> dict[str, Any]:
+        assert self.cluster is not None
+        assert self.current_test_case_full_name
+        self.logger.info(self.repr_tasks_history())
+        self.tasks_history.pop(asyncio.current_task(), None)
+        # copy current tasks
+        tasks = [key for key in self.tasks_history.keys()]
+        # wait for all other tasks in ScyllaClusterManager
+        try:
+            for task in tasks:
+                request = self.tasks_history.pop(task)
+                if not task.done():
+                    self.logger.info("wait for task:%s, request:%s", task, request)
+                    await asyncio.wait_for(task, timeout=120)
+        except asyncio.TimeoutError:
+            self.break_manager(f"error on waiting coro {task.get_name()}", self.current_test_case_full_name)
+
+        # check on tasks leakage
+        await asyncio.sleep(0.1)
+        if self.tasks_history:
+            self.break_manager(f"tasks leakage found  {self.tasks_history}", self.current_test_case_full_name)
+
+        self.logger.info("Test %s %s, cluster: %s", self.current_test_case_full_name,
+                         "SUCCEEDED" if success else "FAILED", self.cluster)
+        try:
+            self.cluster.after_test(self.current_test_case_full_name, success)
+        finally:
+            logging.getLogger().removeHandler(self.test_case_log_fh)
+            if success:
+                pathlib.Path(self.test_case_log_fh.baseFilename).unlink()
+            self.current_test_case_full_name = ''
+        self.is_after_test_ok = True
+        cluster_str = str(self.cluster)
+
+        return {"cluster_str":cluster_str, "server_broken":self.server_broken_event.is_set(), "message": self.server_broken_reason }
+
+    def break_manager(self, reason, test):
+        # make ScyllaClusterManager not operatable from client side
+        self.server_broken_reason = f"{reason}, test case {test} BROKE ScyllaClusterManager"
+        self.logger.error(self.server_broken_reason)
+        self.server_broken_event.set()
+
+    async def mark_dirty(self) -> None:
+        """Mark current cluster dirty"""
+        assert self.cluster
+        self.cluster.is_dirty = True
+
+    async def mark_clean(self) -> None:
+        """Mark current cluster clean"""
+        assert self.cluster
+        self.cluster.is_dirty = False
+        self.cluster.keyspace_count = self.cluster._get_keyspace_count()
+
+    async def server_stop(self, server_id: ServerNum) -> None:
+        """Stop a server. No-op if already stopped."""
+        assert self.cluster
+        await self.cluster.server_stop(server_id, gracefully=False)
+
+    async def server_stop_gracefully(self, server_id: ServerNum) -> None:
+        """Stop a server gracefully. No-op if already stopped."""
+        assert self.cluster
+        await self.cluster.server_stop(server_id, gracefully=True)
+
+    async def server_start(self, server_id: ServerNum, *,
+                           expected_error: str | None = None,
+                           seeds: list[IPAddress] | None = None,
+                           expected_server_up_state: ServerUpState = ServerUpState.SERVING,
+                           cmdline_options_override: list[str] | None = None,
+                           append_env_override: dict[str, str] | None = None,
+                           auth_provider: dict[str, str] | None = None) -> None:
+        """Start a specified server (must be stopped)"""
+        assert self.cluster
+        await self.cluster.server_start(
+            server_id=server_id,
+            expected_error=expected_error,
+            seeds=seeds,
+            expected_server_up_state=expected_server_up_state,
+            cmdline_options_override=cmdline_options_override,
+            append_env_override=append_env_override,
+            auth_provider=auth_provider,
+        )
+
+    async def server_pause(self, server_id: ServerNum) -> None:
+        """Pause the specified server."""
+        assert self.cluster
+        self.cluster.server_pause(server_id)
+
+    async def server_unpause(self, server_id: ServerNum) -> None:
+        """Unpause the specified server."""
+        assert self.cluster
+        self.cluster.server_unpause(server_id)
+
+    async def server_add(self,
+                         replace_cfg: ReplaceConfig | None = None,
+                         cmdline: list[str] | None = None,
+                         config: dict[str, Any] | None = None,
+                         version: ScyllaVersionDescription | None = None,
+                         property_file: dict[str, Any] | None = None,
+                         start: bool = True,
+                         seeds: list[IPAddress] | None = None,
+                         server_encryption: str = "none",
+                         expected_error: str | None = None,
+                         expected_server_up_state: ServerUpState = ServerUpState.SERVING) -> ServerInfo:
+        """Add a new server."""
+        assert self.cluster
+        return await self.cluster.add_server(
+            replace_cfg=replace_cfg,
+            cmdline=cmdline,
+            config=config,
+            version=version,
+            property_file=property_file,
+            start=start,
+            seeds=seeds,
+            server_encryption=server_encryption,
+            expected_error=expected_error,
+            expected_server_up_state=expected_server_up_state,
+        )
+
+    async def servers_add(self,
+                          servers_num: int = 1,
+                          cmdline: list[str] | None = None,
+                          config: dict[str, Any] | None = None,
+                          version: ScyllaVersionDescription | None = None,
+                          property_file: list[dict[str, Any]] | dict[str, Any] | None = None,
+                          start: bool = True,
+                          seeds: list[IPAddress] | None = None,
+                          server_encryption: str = "none",
+                          expected_error: str | None = None) -> list[ServerInfo]:
+        """Add new servers concurrently"""
+        assert self.cluster
+        return await self.cluster.add_servers(servers_num, cmdline, config, version, property_file,
+                                              start, seeds, server_encryption, expected_error)
+
+    async def remove_node(self, initiator_id: ServerNum, server_id: ServerNum,
+                          ignore_dead: list[IPAddress], expected_error: str | None) -> None:
+        """Run remove node on Scylla REST API for a specified server"""
+        assert self.cluster
+        assert initiator_id in self.cluster.running, f"Initiator {initiator_id} is not running"
+        if server_id in self.cluster.running:
+            self.logger.warning("remove_node %s is a running node", server_id)
+        else:
+            assert server_id in self.cluster.stopped, f"remove_node: {server_id} unknown"
+        to_remove = self.cluster.servers[server_id]
+        initiator = self.cluster.servers[initiator_id]
+        self.logger.info("remove_node %s with initiator %s", to_remove, initiator)
+
+        # initiate remove
+        try:
+            await self.cluster.api.remove_node(initiator.ip_addr,
+                                               await to_remove.get_host_id(self.cluster.api),
+                                               ignore_dead,
+                                               timeout=ScyllaServer.TOPOLOGY_TIMEOUT)
+        except (RuntimeError, HTTPError) as exc:
+            if expected_error:
+                if expected_error not in str(exc):
+                    raise RuntimeError(
+                        f"removenode failed (initiator: {initiator}, to_remove: {to_remove},"
+                        f" ignore_dead: {ignore_dead}) but did not contain expected error (\"{expected_error}\"),"
+                        f"check log file at {initiator.log_filename}, error: \"{exc}\"")
+                else:
+                    self.logger.info(f"removenode (initiator: {initiator}, to_remove: {to_remove}, ignore_dead: {ignore_dead})"
+                                     f" failed as expected: {exc}")
+            else:
+                raise RuntimeError(
+                    f"removenode failed (initiator: {initiator}, to_remove: {to_remove},"
+                    f" ignore_dead: {ignore_dead}), check log file at {initiator.log_filename},"
+                    f" error: \"{exc}\"")
+        else:
+            self.cluster.server_mark_removed(server_id)
+            if expected_error:
+                raise RuntimeError(
+                    f"removenode succeeded when it should have failed (initiator: {initiator},"
+                    f"to_remove: {to_remove}, ignore_dead: {ignore_dead}, expected error: \"{expected_error}\"),"
+                    f" check log file at {initiator.log_filename}")
+            self.logger.info(f"removenode (initiator: {initiator}, to_remove: {to_remove}, ignore_dead: {ignore_dead}) succeeded")
+
+    async def decommission_node(self, server_id: ServerNum, expected_error: str | None) -> None:
+        """Run decommission node on Scylla REST API for a specified server"""
+        assert self.cluster
+        self.logger.info("decommission_node %s", server_id)
+        assert server_id in self.cluster.running, "Can't decommission not running node"
+        if len(self.cluster.running) == 1:
+            self.logger.warning("decommission_node %s is only running node left", server_id)
+        server = self.cluster.running[server_id]
+        try:
+            await self.cluster.api.decommission_node(server.ip_addr, timeout=ScyllaServer.TOPOLOGY_TIMEOUT)
+        except (RuntimeError, HTTPError) as exc:
+            if expected_error:
+                if expected_error not in str(exc):
+                    raise RuntimeError(
+                        f"decommission failed (server: {server}) but did not contain expected error"
+                        f"(\"{expected_error}\", check log file at {server.log_filename}, error: \"{exc}\"")
+                else:
+                    return
+            else:
+                raise RuntimeError(
+                    f"decommission failed (server: {server}), check log at {server.log_filename},"
+                    f" error: \"{exc}\"")
+        else:
+            if expected_error:
+                await self.cluster.server_stop(server_id, gracefully=True)
+                raise RuntimeError(
+                    f"decommission succeeded when it should have failed (server: {server},"
+                    f" expected_error: \"{expected_error}\"), check log file at {server.log_filename}")
+
+        await self.cluster.server_stop(server_id, gracefully=True)
+
+    async def rebuild_node(self, server_id: ServerNum, expected_error: str | None) -> None:
+        """Run rebuild node on Scylla REST API for a specified server"""
+        assert self.cluster
+        self.logger.info("rebuild_node %s", server_id)
+        assert server_id in self.cluster.running, "Can't rebuild not running node"
+        server = self.cluster.running[server_id]
+        try:
+            await self.cluster.api.rebuild_node(server.ip_addr, timeout=ScyllaServer.TOPOLOGY_TIMEOUT)
+        except (RuntimeError, HTTPError) as exc:
+            if expected_error:
+                if expected_error not in str(exc):
+                    raise RuntimeError(
+                            f"rebuild failed (server: {server}) but did not contain expected error"
+                            f"(\"{expected_error}\", check log file at {server.log_filename}, error: \"{exc}\"")
+                else:
+                    return
+            else:
+                raise RuntimeError(
+                    f"rebuild failed (server: {server}), check log at {server.log_filename},"
+                    f" error: \"{exc}\"")
+        else:
+            if expected_error:
+                raise RuntimeError(
+                    f"rebuild succeeded when it should have failed (server: {server},"
+                    f" expected_error: \"{expected_error}\"), check log file at {server.log_filename}")
+
+        await self.cluster.server_stop(server_id, gracefully=True)
+
+    async def server_get_config(self, server_id: ServerNum) -> dict[str, object]:
+        """Get conf/scylla.yaml of the given server as a dictionary."""
+        assert self.cluster
+        return self.cluster.get_config(server_id)
+
+    async def server_update_config(self, server_id: ServerNum, config_options: dict[str, Any]) -> None:
+        """Update conf/scylla.yaml of the given server with `config_options` dict.
+
+        If the server is running, reload the config with a SIGHUP.
+        Mark the cluster as dirty.
+        """
+        assert self.cluster
+        self.cluster.update_config(server_id=server_id, config_options=config_options)
+
+    async def server_remove_config_option(self, server_id: ServerNum, key: str) -> None:
+        """Remove an option from conf/scylla.yaml of the given server.
+
+        If the server is running, reload the config with a SIGHUP.
+        Mark the cluster as dirty.
+        """
+        assert self.cluster
+        self.cluster.remove_config_option(server_id=server_id, key=key)
+
+    async def server_update_cmdline(self, server_id: ServerNum, cmdline_options: list[str]) -> None:
+        """Update the command-line options of the given server by merging the new options into the existing ones.
+           The update only takes effect after restart.
+           Marks the cluster as dirty."""
+        assert self.cluster
+        self.cluster.update_cmdline(server_id, cmdline_options)
+
+    async def server_switch_executable(self, server_id: ServerNum, path: str) -> None:
+        """Switch the executable of the server to the one specified by 'path'
+           Marks the cluster as dirty."""
+        assert self.cluster
+        self.cluster.server_switch_executable(server_id, path)
+
+    async def server_change_ip(self, server_id: ServerNum) -> IPAddress:
+        """Pass change_ip command for the given server to the cluster"""
+        assert self.cluster
+        return await self.cluster.change_ip(server_id)
+
+    async def server_change_rpc_address(self, server_id: ServerNum) -> IPAddress:
+        """Pass change_rpc_address command for the given server to the cluster"""
+        assert self.cluster
+        return await self.cluster.change_rpc_address(server_id)
+
+    def _server_get_attribute(self, server_id: ServerNum, attribute: str):
+        """Get a particular attribute of a ScyllaServer instance
+
+        To be used to implement concrete entry points, not for direct use.
+        """
+        assert self.cluster
+        assert server_id in self.cluster.servers, f"Server {server_id} unknown"
+        return getattr(self.cluster.servers[server_id], attribute)
+
+    async def server_get_log_filename(self, server_id: ServerNum) -> str:
+        return str(self._server_get_attribute(server_id, "log_filename"))
+
+    async def server_get_workdir(self, server_id: ServerNum) -> str:
+        return str(self._server_get_attribute(server_id, "workdir"))
+
+    async def server_get_maintenance_socket_path(self, server_id: ServerNum) -> str:
+        return str(self._server_get_attribute(server_id, "maintenance_socket_path"))
+
+    async def server_get_exe(self, server_id: ServerNum) -> str:
+        return str(self._server_get_attribute(server_id, "exe"))
+
+    async def server_get_returncode(self, server_id: ServerNum) -> str | int:
+        if cmd := self._server_get_attribute(server_id, "cmd"):
+            returncode = cmd.returncode
+            if returncode is None:
+                return "RUNNING"
+            return returncode
+        return "NO_SUCH_PROCESS"
+
+    async def server_wipe_sstables(self, server_id: ServerNum, keyspace: str, table: str):
+        assert self.cluster
+        return self.cluster.wipe_sstables(server_id, keyspace, table)
+
+    async def server_get_sstables_disk_usage(self, server_id: ServerNum, keyspace: str, table: str) -> int:
+        assert self.cluster
+        return self.cluster.get_sstables_disk_usage(server_id, keyspace, table)
+
+    async def server_get_process_status(self, server_id: ServerNum) -> str | None:
+        assert self.cluster
+        return self.cluster.server_get_process_status(server_id)
+
+    # ------------------------------------------------------------------
+    # HTTP API.
+    #
+    # Thin adapters translating the REST routes into the methods above.
+    # ManagerClient is the only client, and it is about to call those
+    # methods directly, at which point this whole section goes away.
+    # ------------------------------------------------------------------
 
     def _setup_routes(self, app: aiohttp.web.Application) -> None:
         def make_catching_handler(handler: Callable) -> Callable:
@@ -1842,7 +2202,7 @@ class ScyllaClusterManager:
         add_get('/cluster/host-ip/{server_id}', self._cluster_server_ip_addr)
         add_get('/cluster/host-id/{server_id}', self._cluster_host_id)
         add_put('/cluster/before-test/{test_case_name}', self._before_test_req)
-        add_put('/cluster/after-test/{success}', self._after_test)
+        add_put('/cluster/after-test/{success}', self._after_test_req)
         add_put('/cluster/mark-dirty', self._mark_dirty)
         add_put('/cluster/mark-clean', self._mark_clean)
         add_put('/cluster/server/{server_id}/stop', self._cluster_server_stop)
@@ -1872,115 +2232,45 @@ class ScyllaClusterManager:
         add_get('/cluster/server/{server_id}/returncode', self._server_get_returncode)
 
     async def _is_dirty(self, _request) -> bool:
-        """Report if current cluster is dirty"""
-        assert self.cluster
-        return self.cluster.is_dirty
+        return await self.is_dirty()
 
-    async def _cluster_running_servers(self, _request) -> list[tuple[ServerNum, IPAddress, IPAddress]]:
-        """Return a dict of running server ids to IPs"""
-        return self.cluster.running_servers()
+    async def _cluster_running_servers(self, _request) -> list[ServerInfo]:
+        return await self.running_servers()
 
-    async def _cluster_all_servers(self, _request) -> list[tuple[ServerNum, IPAddress, IPAddress]]:
-        """Return a dict of all server ids to IPs"""
-        return self.cluster.all_servers()
+    async def _cluster_all_servers(self, _request) -> list[ServerInfo]:
+        return await self.all_servers()
 
-    async def _cluster_starting_servers(self, _request) -> list[tuple[ServerNum, IPAddress, IPAddress]]:
-        """Return a dict of starting server ids to IPs"""
-        return self.cluster.starting_servers()
+    async def _cluster_starting_servers(self, _request) -> list[ServerInfo]:
+        return await self.starting_servers()
 
     async def _cluster_server_ip_addr(self, request) -> IPAddress:
-        """IP address of a server"""
-        server_id = ServerNum(int(request.match_info["server_id"]))
-        return self.cluster.servers[server_id].ip_addr
+        return await self.get_host_ip(ServerNum(int(request.match_info["server_id"])))
 
     async def _cluster_host_id(self, request) -> HostID:
-        """Host ID of a server."""
-
-        server = self.cluster.servers[ServerNum(int(request.match_info["server_id"]))]
-        return await server.get_host_id(self.cluster.api)
+        return await self.get_host_id(ServerNum(int(request.match_info["server_id"])))
 
     async def _before_test_req(self, request) -> str:
-        cluster_str = await self._before_test(request.match_info['test_case_name'])
-        return cluster_str
+        return await self.before_test(request.match_info['test_case_name'])
 
-    async def _after_test(self, _request) -> dict[str, bool]:
-        assert self.cluster is not None
-        assert self.current_test_case_full_name
-        self.logger.info(self.repr_tasks_history())
-        self.tasks_history.pop(asyncio.current_task())
-        # copy current tasks
-        tasks = [key for key in self.tasks_history.keys()]
-        # wait for all other tasks in ScyllaClusterManager
-        try:
-            for task in tasks:
-                request = self.tasks_history.pop(task)
-                if not task.done():
-                    self.logger.info("wait for task:%s, request:%s", task, request.path_qs)
-                    await asyncio.wait_for(task, timeout=120)
-        except asyncio.TimeoutError:
-            self.break_manager(f"error on waiting coro {task.get_name()}", self.current_test_case_full_name)
-
-        # check on tasks leakage
-        await asyncio.sleep(0.1)
-        if self.tasks_history:
-            self.break_manager(f"tasks leakage found  {self.tasks_history}", self.current_test_case_full_name)
-
-        success = _request.match_info["success"] == "True"
-        self.logger.info("Test %s %s, cluster: %s", self.current_test_case_full_name,
-                         "SUCCEEDED" if success else "FAILED", self.cluster)
-        try:
-            self.cluster.after_test(self.current_test_case_full_name, success)
-        finally:
-            logging.getLogger().removeHandler(self.test_case_log_fh)
-            if success:
-                pathlib.Path(self.test_case_log_fh.baseFilename).unlink()
-            self.current_test_case_full_name = ''
-        self.is_after_test_ok = True
-        cluster_str = str(self.cluster)
-
-        return {"cluster_str":cluster_str, "server_broken":self.server_broken_event.is_set(), "message": self.server_broken_reason }
-
-    def break_manager(self, reason, test):
-        # make ScyllaClusterManager not operatable from client side
-        self.server_broken_reason = f"{reason}, test case {test} BROKE ScyllaClusterManager"
-        self.logger.error(self.server_broken_reason)
-        self.server_broken_event.set()
+    async def _after_test_req(self, request) -> dict[str, Any]:
+        return await self.after_test(request.match_info["success"] == "True")
 
     async def _mark_dirty(self, _request) -> None:
-        """Mark current cluster dirty"""
-        assert self.cluster
-        self.cluster.is_dirty = True
+        await self.mark_dirty()
 
     async def _mark_clean(self, _request) -> None:
-        """Mark current cluster clean"""
-        assert self.cluster
-        self.cluster.is_dirty = False
-        self.cluster.keyspace_count = self.cluster._get_keyspace_count()
-
-    async def _server_stop(self, request: aiohttp.web.Request, gracefully: bool) -> None:
-        """Stop a server. No-op if already stopped."""
-        assert self.cluster
-        server_id = ServerNum(int(request.match_info["server_id"]))
-        await self.cluster.server_stop(server_id, gracefully)
+        await self.mark_clean()
 
     async def _cluster_server_stop(self, request) -> None:
-        """Stop a specified server"""
-        assert self.cluster
-        await self._server_stop(request, gracefully = False)
+        await self.server_stop(ServerNum(int(request.match_info["server_id"])))
 
     async def _cluster_server_stop_gracefully(self, request) -> None:
-        """Stop a specified server gracefully"""
-        assert self.cluster
-        await self._server_stop(request, gracefully = True)
+        await self.server_stop_gracefully(ServerNum(int(request.match_info["server_id"])))
 
     async def _cluster_server_start(self, request) -> None:
-        """Start a specified server (must be stopped)"""
-        assert self.cluster
-
-        server_id = ServerNum(int(request.match_info["server_id"]))
         data = await request.json()
-        await self.cluster.server_start(
-            server_id=server_id,
+        await self.server_start(
+            ServerNum(int(request.match_info["server_id"])),
             expected_error=data.get("expected_error"),
             seeds=data.get("seeds"),
             expected_server_up_state=getattr(ServerUpState, data.get("expected_server_up_state", "SERVING")),
@@ -1990,29 +2280,18 @@ class ScyllaClusterManager:
         )
 
     async def _cluster_server_pause(self, request) -> None:
-        """Pause the specified server."""
-        assert self.cluster
-        server_id = ServerNum(int(request.match_info["server_id"]))
-        self.cluster.server_pause(server_id)
+        await self.server_pause(ServerNum(int(request.match_info["server_id"])))
 
     async def _cluster_server_unpause(self, request) -> None:
-        """Pause the specified server."""
-        assert self.cluster
-        server_id = ServerNum(int(request.match_info["server_id"]))
-        self.cluster.server_unpause(server_id)
+        await self.server_unpause(ServerNum(int(request.match_info["server_id"])))
 
     async def _cluster_server_add(self, request) -> dict[str, object]:
-        """Add a new server."""
-        assert self.cluster
-
         data = await request.json()
-        replace_cfg = ReplaceConfig(**data["replace_cfg"]) if "replace_cfg" in data else None
-        version = ScyllaVersionDescription(**data["version"]) if "version" in data else None
-        s_info = await self.cluster.add_server(
-            replace_cfg=replace_cfg,
+        s_info = await self.server_add(
+            replace_cfg=ReplaceConfig(**data["replace_cfg"]) if "replace_cfg" in data else None,
             cmdline=data.get("cmdline"),
             config=data.get("config"),
-            version=version,
+            version=ScyllaVersionDescription(**data["version"]) if "version" in data else None,
             property_file=data.get("property_file"),
             start=data.get("start", True),
             seeds=data.get("seeds"),
@@ -2023,232 +2302,98 @@ class ScyllaClusterManager:
         return s_info.as_dict()
 
     async def _cluster_servers_add(self, request) -> list[dict[str, object]]:
-        """Add new servers concurrently"""
-        assert self.cluster
         data = await request.json()
-        version = ScyllaVersionDescription(**data["version"]) if "version" in data else None
-        s_infos = await self.cluster.add_servers(data.get('servers_num'), data.get('cmdline'), data.get('config'), version,
-                                                 data.get('property_file'), data.get('start', True),
-                                                 data.get('seeds', None), data.get('server_encryption'), data.get('expected_error', None))
+        s_infos = await self.servers_add(
+            servers_num=data.get('servers_num'),
+            cmdline=data.get('cmdline'),
+            config=data.get('config'),
+            version=ScyllaVersionDescription(**data["version"]) if "version" in data else None,
+            property_file=data.get('property_file'),
+            start=data.get('start', True),
+            seeds=data.get('seeds', None),
+            server_encryption=data.get('server_encryption'),
+            expected_error=data.get('expected_error', None),
+        )
         return [s_info.as_dict() for s_info in s_infos]
 
     async def _cluster_remove_node(self, request: aiohttp.web.Request) -> None:
-        """Run remove node on Scylla REST API for a specified server"""
-        assert self.cluster
         data = await request.json()
-        initiator_id = ServerNum(int(request.match_info["initiator"]))
-        server_id = ServerNum(int(data["server_id"]))
         assert isinstance(data["ignore_dead"], list), "Invalid list of dead IP addresses"
-        ignore_dead = [IPAddress(ip_addr) for ip_addr in data["ignore_dead"]]
-        assert initiator_id in self.cluster.running, f"Initiator {initiator_id} is not running"
-        if server_id in self.cluster.running:
-            self.logger.warning("_cluster_remove_node %s is a running node", server_id)
-        else:
-            assert server_id in self.cluster.stopped, f"_cluster_remove_node: {server_id} unknown"
-        to_remove = self.cluster.servers[server_id]
-        initiator = self.cluster.servers[initiator_id]
-        expected_error = data["expected_error"]
-        self.logger.info("_cluster_remove_node %s with initiator %s", to_remove, initiator)
-
-        # initiate remove
-        try:
-            await self.cluster.api.remove_node(initiator.ip_addr,
-                                               await to_remove.get_host_id(self.cluster.api),
-                                               ignore_dead,
-                                               timeout=ScyllaServer.TOPOLOGY_TIMEOUT)
-        except (RuntimeError, HTTPError) as exc:
-            if expected_error:
-                if expected_error not in str(exc):
-                    raise RuntimeError(
-                        f"removenode failed (initiator: {initiator}, to_remove: {to_remove},"
-                        f" ignore_dead: {ignore_dead}) but did not contain expected error (\"{expected_error}\"),"
-                        f"check log file at {initiator.log_filename}, error: \"{exc}\"")
-                else:
-                    self.logger.info(f"removenode (initiator: {initiator}, to_remove: {to_remove}, ignore_dead: {ignore_dead})"
-                                     f" failed as expected: {exc}")
-            else:
-                raise RuntimeError(
-                    f"removenode failed (initiator: {initiator}, to_remove: {to_remove},"
-                    f" ignore_dead: {ignore_dead}), check log file at {initiator.log_filename},"
-                    f" error: \"{exc}\"")
-        else:
-            self.cluster.server_mark_removed(server_id)
-            if expected_error:
-                raise RuntimeError(
-                    f"removenode succeeded when it should have failed (initiator: {initiator},"
-                    f"to_remove: {to_remove}, ignore_dead: {ignore_dead}, expected error: \"{expected_error}\"),"
-                    f" check log file at {initiator.log_filename}")
-            self.logger.info(f"removenode (initiator: {initiator}, to_remove: {to_remove}, ignore_dead: {ignore_dead}) succeeded")
+        await self.remove_node(
+            initiator_id=ServerNum(int(request.match_info["initiator"])),
+            server_id=ServerNum(int(data["server_id"])),
+            ignore_dead=[IPAddress(ip_addr) for ip_addr in data["ignore_dead"]],
+            expected_error=data["expected_error"],
+        )
 
     async def _cluster_decommission_node(self, request) -> None:
-        """Run decommission node on Scylla REST API for a specified server"""
-        assert self.cluster
         data = await request.json()
-        server_id = ServerNum(int(request.match_info["server_id"]))
-        self.logger.info("_cluster_decommission_node %s", server_id)
-        assert server_id in self.cluster.running, "Can't decommission not running node"
-        if len(self.cluster.running) == 1:
-            self.logger.warning("_cluster_decommission_node %s is only running node left", server_id)
-        server = self.cluster.running[server_id]
-        expected_error = data["expected_error"]
-        try:
-            await self.cluster.api.decommission_node(server.ip_addr, timeout=ScyllaServer.TOPOLOGY_TIMEOUT)
-        except (RuntimeError, HTTPError) as exc:
-            if expected_error:
-                if expected_error not in str(exc):
-                    raise RuntimeError(
-                        f"decommission failed (server: {server}) but did not contain expected error"
-                        f"(\"{expected_error}\", check log file at {server.log_filename}, error: \"{exc}\"")
-                else:
-                    return
-            else:
-                raise RuntimeError(
-                    f"decommission failed (server: {server}), check log at {server.log_filename},"
-                    f" error: \"{exc}\"")
-        else:
-            if expected_error:
-                await self.cluster.server_stop(server_id, gracefully=True)
-                raise RuntimeError(
-                    f"decommission succeeded when it should have failed (server: {server},"
-                    f" expected_error: \"{expected_error}\"), check log file at {server.log_filename}")
-
-        await self.cluster.server_stop(server_id, gracefully=True)
+        await self.decommission_node(
+            server_id=ServerNum(int(request.match_info["server_id"])),
+            expected_error=data["expected_error"],
+        )
 
     async def _cluster_rebuild_node(self, request) -> None:
-        """Run rebuild node on Scylla REST API for a specified server"""
-        assert self.cluster
         data = await request.json()
-        server_id = ServerNum(int(request.match_info["server_id"]))
-        self.logger.info("_cluster_rebuild_node %s", server_id)
-        assert server_id in self.cluster.running, "Can't rebuild not running node"
-        server = self.cluster.running[server_id]
-        expected_error = data["expected_error"]
-        try:
-            await self.cluster.api.rebuild_node(server.ip_addr, timeout=ScyllaServer.TOPOLOGY_TIMEOUT)
-        except (RuntimeError, HTTPError) as exc:
-            if expected_error:
-                if expected_error not in str(exc):
-                    raise RuntimeError(
-                            f"rebuild failed (server: {server}) but did not contain expected error"
-                            f"(\"{expected_error}\", check log file at {server.log_filename}, error: \"{exc}\"")
-                else:
-                    return
-            else:
-                raise RuntimeError(
-                    f"rebuild failed (server: {server}), check log at {server.log_filename},"
-                    f" error: \"{exc}\"")
-        else:
-            if expected_error:
-                raise RuntimeError(
-                    f"rebuild succeeded when it should have failed (server: {server},"
-                    f" expected_error: \"{expected_error}\"), check log file at {server.log_filename}")
-
-        await self.cluster.server_stop(server_id, gracefully=True)
+        await self.rebuild_node(
+            server_id=ServerNum(int(request.match_info["server_id"])),
+            expected_error=data["expected_error"],
+        )
 
     async def _server_get_config(self, request: aiohttp.web.Request) -> dict[str, object]:
-        """Get conf/scylla.yaml of the given server as a dictionary."""
-        assert self.cluster
-        return self.cluster.get_config(ServerNum(int(request.match_info["server_id"])))
+        return await self.server_get_config(ServerNum(int(request.match_info["server_id"])))
 
     async def _server_update_config(self, request: aiohttp.web.Request) -> None:
-        """Update conf/scylla.yaml of the given server with `config_options` dict.
-
-        If the server is running, reload the config with a SIGHUP.
-        Mark the cluster as dirty.
-        """
-        assert self.cluster
         data = await request.json()
-        self.cluster.update_config(
-            server_id=ServerNum(int(request.match_info["server_id"])),
-            config_options=data["config_options"],
-        )
+        await self.server_update_config(ServerNum(int(request.match_info["server_id"])),
+                                        data["config_options"])
 
     async def _server_remove_config_option(self, request: aiohttp.web.Request) -> None:
-        """Remove an option from conf/scylla.yaml of the given server.
-
-        If the server is running, reload the config with a SIGHUP.
-        Mark the cluster as dirty.
-        """
-        assert self.cluster
         data = await request.json()
-        self.cluster.remove_config_option(
-            server_id=ServerNum(int(request.match_info["server_id"])),
-            key=data["key"],
-        )
+        await self.server_remove_config_option(ServerNum(int(request.match_info["server_id"])),
+                                               data["key"])
 
     async def _server_update_cmdline(self, request: aiohttp.web.Request) -> None:
-        """Update the command-line options of the given server by merging the new options into the existing ones.
-           The update only takes effect after restart.
-           Marks the cluster as dirty."""
-        assert self.cluster
         data = await request.json()
-        self.cluster.update_cmdline(ServerNum(int(request.match_info["server_id"])),
-                                    data['cmdline_options'])
+        await self.server_update_cmdline(ServerNum(int(request.match_info["server_id"])),
+                                         data['cmdline_options'])
 
     async def _server_switch_executable(self, request: aiohttp.web.Request) -> None:
-        """Switch the executable of the server to the one specified by 'path'
-           Marks the cluster as dirty."""
-        assert self.cluster
         path = (await request.json())["path"]
-        server_id = ServerNum(int(request.match_info["server_id"]))
-        self.cluster.server_switch_executable(server_id, path)
+        await self.server_switch_executable(ServerNum(int(request.match_info["server_id"])), path)
 
     async def _server_change_ip(self, request: aiohttp.web.Request) -> dict[str, object]:
-        """Pass change_ip command for the given server to the cluster"""
-        assert self.cluster
-        server_id = ServerNum(int(request.match_info["server_id"]))
-        ip_addr = await self.cluster.change_ip(server_id)
+        ip_addr = await self.server_change_ip(ServerNum(int(request.match_info["server_id"])))
         return {"ip_addr": ip_addr}
 
     async def _server_change_rpc_address(self, request: aiohttp.web.Request) -> dict[str, object]:
-        """Pass change_ip command for the given server to the cluster"""
-        assert self.cluster
-        server_id = ServerNum(int(request.match_info["server_id"]))
-        rpc_address = await self.cluster.change_rpc_address(server_id)
+        rpc_address = await self.server_change_rpc_address(ServerNum(int(request.match_info["server_id"])))
         return {"rpc_address": rpc_address}
 
-    async def _server_get_attribute(self, request: aiohttp.web.Request, attribute: str):
-        """Generic request handler which gets a particular attribute of a ScyllaServer instance
-
-        To be used to implement concrete handlers, not for direct use.
-        """
-        assert self.cluster
-        server_id = ServerNum(int(request.match_info["server_id"]))
-        assert server_id in self.cluster.servers, f"Server {server_id} unknown"
-        server = self.cluster.servers[server_id]
-        return getattr(server, attribute)
-
     async def _server_get_log_filename(self, request: aiohttp.web.Request) -> str:
-        return str(await self._server_get_attribute(request, "log_filename"))
+        return await self.server_get_log_filename(ServerNum(int(request.match_info["server_id"])))
 
     async def _server_get_workdir(self, request: aiohttp.web.Request) -> str:
-        return str(await self._server_get_attribute(request, "workdir"))
+        return await self.server_get_workdir(ServerNum(int(request.match_info["server_id"])))
 
     async def _server_get_maintenance_socket_path(self, request: aiohttp.web.Request) -> str:
-        return str(await self._server_get_attribute(request, "maintenance_socket_path"))
+        return await self.server_get_maintenance_socket_path(ServerNum(int(request.match_info["server_id"])))
 
     async def _server_get_exe(self, request: aiohttp.web.Request) -> str:
-        return str(await self._server_get_attribute(request, "exe"))
+        return await self.server_get_exe(ServerNum(int(request.match_info["server_id"])))
 
-    async def _server_get_returncode(self, request: aiohttp.web.Request) -> str:
-        if cmd := await self._server_get_attribute(request=request, attribute="cmd"):
-            returncode = cmd.returncode
-            if returncode is None:
-                return "RUNNING"
-            return cmd.returncode
-        return "NO_SUCH_PROCESS"
+    async def _server_get_returncode(self, request: aiohttp.web.Request) -> str | int:
+        return await self.server_get_returncode(ServerNum(int(request.match_info["server_id"])))
 
     async def _cluster_server_wipe_sstables(self, request: aiohttp.web.Request):
         data = await request.json()
-        server_id = ServerNum(int(request.match_info["server_id"]))
-        return self.cluster.wipe_sstables(server_id, data["keyspace"], data["table"])
+        return await self.server_wipe_sstables(ServerNum(int(request.match_info["server_id"])),
+                                               data["keyspace"], data["table"])
 
     async def _server_get_sstables_disk_usage(self, request: aiohttp.web.Request) -> int:
         data = request.query
-        server_id = ServerNum(int(request.match_info["server_id"]))
-        return self.cluster.get_sstables_disk_usage(server_id, data["keyspace"], data["table"])
+        return await self.server_get_sstables_disk_usage(ServerNum(int(request.match_info["server_id"])),
+                                                         data["keyspace"], data["table"])
 
     async def _server_get_process_status(self, request: aiohttp.web.Request) -> Optional[str]:
-        assert self.cluster
-        server_id = ServerNum(int(request.match_info["server_id"]))
-        return self.cluster.server_get_process_status(server_id)
+        return await self.server_get_process_status(ServerNum(int(request.match_info["server_id"])))

--- a/test/pylib/scylla_cluster.py
+++ b/test/pylib/scylla_cluster.py
@@ -1703,6 +1703,43 @@ class ScyllaCluster:
         return server.get_sstables_disk_usage(keyspace, table)
 
 
+def manager_op(entry_point: Callable | None = None, *, blockable: bool = False):
+    """Run a ScyllaClusterManager entry point as its own task and track it.
+
+    Usable bare, as @manager_op, or with arguments, as @manager_op(blockable=True).
+
+    Every entry point works on the current cluster, so the check that there is
+    one lives here instead of being repeated in each of them.
+
+    The rest mirrors what the aiohttp server used to do for request handlers:
+    - refuse the operation on a broken manager (blockable=True, which the
+      server applied to every mutating route);
+    - register the operation in tasks_history, so after_test() can drain
+      operations a test left running;
+    - shield the operation from the caller's cancellation: a timed-out or
+      cancelled caller orphans the operation -- like an HTTP client
+      disconnect used to, since the server never cancelled handlers -- and
+      after_test() picks the orphan up;
+    - log failures with their traceback into the per-test cluster log
+      (see _op_finished), which the server's catching handler used to do.
+    """
+    def decorator(fn: Callable) -> Callable:
+        @wraps(fn)
+        async def wrapper(self, *args, **kwargs):
+            assert self.cluster, "ScyllaClusterManager is not running"
+            if blockable and self.server_broken_event.is_set():
+                raise RuntimeError(f"ScyllaClusterManager BROKEN, Previous test broke ScyllaClusterManager server,"
+                                   f" server_broken_reason: {self.server_broken_reason}")
+            descr = f"{fn.__name__}{args}"
+            op = asyncio.ensure_future(fn(self, *args, **kwargs))
+            self.logger.info("[ScyllaClusterManager][%s] %s", op.get_name(), descr)
+            self.tasks_history[op] = descr
+            op.add_done_callback(partial(self._op_finished, descr=descr))
+            return await asyncio.shield(op)
+        return wrapper
+    return decorator if entry_point is None else decorator(entry_point)
+
+
 class ScyllaClusterManager:
     """Manages a Scylla cluster for running test cases
        Provides an async API for tests to request changes in the Cluster.
@@ -1767,6 +1804,7 @@ class ScyllaClusterManager:
         await self.site.start()
         self.is_running = True
 
+    @manager_op(blockable=True)
     async def before_test(self, test_case_name: str) -> str:
         self.current_test_case_full_name = f'{self.test_uname}::{test_case_name}'
         root_logger = logging.getLogger()
@@ -1807,54 +1845,60 @@ class ScyllaClusterManager:
             await async_rmtree(self.manager_dir)
         self.is_running = False
 
+    @manager_op
     async def is_dirty(self) -> bool:
         """Report if current cluster is dirty"""
-        assert self.cluster
         return self.cluster.is_dirty
 
+    @manager_op
     async def running_servers(self) -> list[ServerInfo]:
         """Return server info for running servers"""
-        assert self.cluster
         return self.cluster.running_servers()
 
+    @manager_op
     async def all_servers(self) -> list[ServerInfo]:
         """Return server info for all servers"""
-        assert self.cluster
         return self.cluster.all_servers()
 
+    @manager_op
     async def starting_servers(self) -> list[ServerInfo]:
         """Return server info for servers which are currently starting"""
-        assert self.cluster
         return self.cluster.starting_servers()
 
+    @manager_op
     async def get_host_ip(self, server_id: ServerNum) -> IPAddress:
         """IP address of a server"""
-        assert self.cluster
         return self.cluster.servers[server_id].ip_addr
 
+    @manager_op
     async def get_host_id(self, server_id: ServerNum) -> HostID:
         """Host ID of a server."""
-        assert self.cluster
         return await self.cluster.servers[server_id].get_host_id(self.cluster.api)
 
+    @manager_op(blockable=True)
     async def after_test(self, success: bool) -> dict[str, Any]:
-        assert self.cluster is not None
         assert self.current_test_case_full_name
         self.logger.info(self.repr_tasks_history())
+        # Drop our own entry: the drain below must not wait for itself.
         self.tasks_history.pop(asyncio.current_task(), None)
-        # copy current tasks
-        tasks = [key for key in self.tasks_history.keys()]
-        # wait for all other tasks in ScyllaClusterManager
-        try:
-            for task in tasks:
-                request = self.tasks_history.pop(task)
-                if not task.done():
-                    self.logger.info("wait for task:%s, request:%s", task, request)
+        # wait for the operations the test left running
+        for task, descr in list(self.tasks_history.items()):
+            if not task.done():
+                self.logger.info("wait for task:%s, op:%s", task, descr)
+                try:
                     await asyncio.wait_for(task, timeout=120)
-        except asyncio.TimeoutError:
-            self.break_manager(f"error on waiting coro {task.get_name()}", self.current_test_case_full_name)
+                except asyncio.TimeoutError:
+                    self.break_manager(f"error on waiting coro {task.get_name()}", self.current_test_case_full_name)
+                    break
+                except Exception:
+                    # The operation failed after its caller went away.  It was
+                    # already logged by _op_finished; completing is all the
+                    # drain needs.
+                    pass
 
-        # check on tasks leakage
+        # check on tasks leakage: finished operations remove themselves from
+        # tasks_history, so anything left after the drain is a new operation
+        # started behind our back while the test was already over.
         await asyncio.sleep(0.1)
         if self.tasks_history:
             self.break_manager(f"tasks leakage found  {self.tasks_history}", self.current_test_case_full_name)
@@ -1879,27 +1923,43 @@ class ScyllaClusterManager:
         self.logger.error(self.server_broken_reason)
         self.server_broken_event.set()
 
+    def _op_finished(self, op: asyncio.Task, descr: str) -> None:
+        """Done callback of manager_op operations.
+
+        Drops the finished operation from tasks_history and logs its
+        failure, if any.  Retrieving the exception here also keeps an
+        operation orphaned by a cancelled caller from warning "exception
+        was never retrieved".
+        """
+        self.tasks_history.pop(op, None)
+        if op.cancelled():
+            return
+        if (exc := op.exception()) is not None:
+            self.logger.error("Exception when executing %s: %s\n%s",
+                              descr, exc, "".join(traceback.format_exception(exc)))
+
+    @manager_op(blockable=True)
     async def mark_dirty(self) -> None:
         """Mark current cluster dirty"""
-        assert self.cluster
         self.cluster.is_dirty = True
 
+    @manager_op(blockable=True)
     async def mark_clean(self) -> None:
         """Mark current cluster clean"""
-        assert self.cluster
         self.cluster.is_dirty = False
         self.cluster.keyspace_count = self.cluster._get_keyspace_count()
 
+    @manager_op(blockable=True)
     async def server_stop(self, server_id: ServerNum) -> None:
         """Stop a server. No-op if already stopped."""
-        assert self.cluster
         await self.cluster.server_stop(server_id, gracefully=False)
 
+    @manager_op(blockable=True)
     async def server_stop_gracefully(self, server_id: ServerNum) -> None:
         """Stop a server gracefully. No-op if already stopped."""
-        assert self.cluster
         await self.cluster.server_stop(server_id, gracefully=True)
 
+    @manager_op(blockable=True)
     async def server_start(self, server_id: ServerNum, *,
                            expected_error: str | None = None,
                            seeds: list[IPAddress] | None = None,
@@ -1908,7 +1968,6 @@ class ScyllaClusterManager:
                            append_env_override: dict[str, str] | None = None,
                            auth_provider: dict[str, str] | None = None) -> None:
         """Start a specified server (must be stopped)"""
-        assert self.cluster
         await self.cluster.server_start(
             server_id=server_id,
             expected_error=expected_error,
@@ -1919,16 +1978,17 @@ class ScyllaClusterManager:
             auth_provider=auth_provider,
         )
 
+    @manager_op(blockable=True)
     async def server_pause(self, server_id: ServerNum) -> None:
         """Pause the specified server."""
-        assert self.cluster
         self.cluster.server_pause(server_id)
 
+    @manager_op(blockable=True)
     async def server_unpause(self, server_id: ServerNum) -> None:
         """Unpause the specified server."""
-        assert self.cluster
         self.cluster.server_unpause(server_id)
 
+    @manager_op(blockable=True)
     async def server_add(self,
                          replace_cfg: ReplaceConfig | None = None,
                          cmdline: list[str] | None = None,
@@ -1941,7 +2001,6 @@ class ScyllaClusterManager:
                          expected_error: str | None = None,
                          expected_server_up_state: ServerUpState = ServerUpState.SERVING) -> ServerInfo:
         """Add a new server."""
-        assert self.cluster
         return await self.cluster.add_server(
             replace_cfg=replace_cfg,
             cmdline=cmdline,
@@ -1955,6 +2014,7 @@ class ScyllaClusterManager:
             expected_server_up_state=expected_server_up_state,
         )
 
+    @manager_op(blockable=True)
     async def servers_add(self,
                           servers_num: int = 1,
                           cmdline: list[str] | None = None,
@@ -1966,14 +2026,13 @@ class ScyllaClusterManager:
                           server_encryption: str = "none",
                           expected_error: str | None = None) -> list[ServerInfo]:
         """Add new servers concurrently"""
-        assert self.cluster
         return await self.cluster.add_servers(servers_num, cmdline, config, version, property_file,
                                               start, seeds, server_encryption, expected_error)
 
+    @manager_op(blockable=True)
     async def remove_node(self, initiator_id: ServerNum, server_id: ServerNum,
                           ignore_dead: list[IPAddress], expected_error: str | None) -> None:
         """Run remove node on Scylla REST API for a specified server"""
-        assert self.cluster
         assert initiator_id in self.cluster.running, f"Initiator {initiator_id} is not running"
         if server_id in self.cluster.running:
             self.logger.warning("remove_node %s is a running node", server_id)
@@ -2013,9 +2072,9 @@ class ScyllaClusterManager:
                     f" check log file at {initiator.log_filename}")
             self.logger.info(f"removenode (initiator: {initiator}, to_remove: {to_remove}, ignore_dead: {ignore_dead}) succeeded")
 
+    @manager_op(blockable=True)
     async def decommission_node(self, server_id: ServerNum, expected_error: str | None) -> None:
         """Run decommission node on Scylla REST API for a specified server"""
-        assert self.cluster
         self.logger.info("decommission_node %s", server_id)
         assert server_id in self.cluster.running, "Can't decommission not running node"
         if len(self.cluster.running) == 1:
@@ -2044,9 +2103,9 @@ class ScyllaClusterManager:
 
         await self.cluster.server_stop(server_id, gracefully=True)
 
+    @manager_op(blockable=True)
     async def rebuild_node(self, server_id: ServerNum, expected_error: str | None) -> None:
         """Run rebuild node on Scylla REST API for a specified server"""
-        assert self.cluster
         self.logger.info("rebuild_node %s", server_id)
         assert server_id in self.cluster.running, "Can't rebuild not running node"
         server = self.cluster.running[server_id]
@@ -2072,50 +2131,50 @@ class ScyllaClusterManager:
 
         await self.cluster.server_stop(server_id, gracefully=True)
 
+    @manager_op
     async def server_get_config(self, server_id: ServerNum) -> dict[str, object]:
         """Get conf/scylla.yaml of the given server as a dictionary."""
-        assert self.cluster
         return self.cluster.get_config(server_id)
 
+    @manager_op(blockable=True)
     async def server_update_config(self, server_id: ServerNum, config_options: dict[str, Any]) -> None:
         """Update conf/scylla.yaml of the given server with `config_options` dict.
 
         If the server is running, reload the config with a SIGHUP.
         Mark the cluster as dirty.
         """
-        assert self.cluster
         self.cluster.update_config(server_id=server_id, config_options=config_options)
 
+    @manager_op(blockable=True)
     async def server_remove_config_option(self, server_id: ServerNum, key: str) -> None:
         """Remove an option from conf/scylla.yaml of the given server.
 
         If the server is running, reload the config with a SIGHUP.
         Mark the cluster as dirty.
         """
-        assert self.cluster
         self.cluster.remove_config_option(server_id=server_id, key=key)
 
+    @manager_op(blockable=True)
     async def server_update_cmdline(self, server_id: ServerNum, cmdline_options: list[str]) -> None:
         """Update the command-line options of the given server by merging the new options into the existing ones.
            The update only takes effect after restart.
            Marks the cluster as dirty."""
-        assert self.cluster
         self.cluster.update_cmdline(server_id, cmdline_options)
 
+    @manager_op(blockable=True)
     async def server_switch_executable(self, server_id: ServerNum, path: str) -> None:
         """Switch the executable of the server to the one specified by 'path'
            Marks the cluster as dirty."""
-        assert self.cluster
         self.cluster.server_switch_executable(server_id, path)
 
+    @manager_op(blockable=True)
     async def server_change_ip(self, server_id: ServerNum) -> IPAddress:
         """Pass change_ip command for the given server to the cluster"""
-        assert self.cluster
         return await self.cluster.change_ip(server_id)
 
+    @manager_op(blockable=True)
     async def server_change_rpc_address(self, server_id: ServerNum) -> IPAddress:
         """Pass change_rpc_address command for the given server to the cluster"""
-        assert self.cluster
         return await self.cluster.change_rpc_address(server_id)
 
     def _server_get_attribute(self, server_id: ServerNum, attribute: str):
@@ -2127,18 +2186,23 @@ class ScyllaClusterManager:
         assert server_id in self.cluster.servers, f"Server {server_id} unknown"
         return getattr(self.cluster.servers[server_id], attribute)
 
+    @manager_op
     async def server_get_log_filename(self, server_id: ServerNum) -> str:
         return str(self._server_get_attribute(server_id, "log_filename"))
 
+    @manager_op
     async def server_get_workdir(self, server_id: ServerNum) -> str:
         return str(self._server_get_attribute(server_id, "workdir"))
 
+    @manager_op
     async def server_get_maintenance_socket_path(self, server_id: ServerNum) -> str:
         return str(self._server_get_attribute(server_id, "maintenance_socket_path"))
 
+    @manager_op
     async def server_get_exe(self, server_id: ServerNum) -> str:
         return str(self._server_get_attribute(server_id, "exe"))
 
+    @manager_op
     async def server_get_returncode(self, server_id: ServerNum) -> str | int:
         if cmd := self._server_get_attribute(server_id, "cmd"):
             returncode = cmd.returncode
@@ -2147,16 +2211,16 @@ class ScyllaClusterManager:
             return returncode
         return "NO_SUCH_PROCESS"
 
+    @manager_op(blockable=True)
     async def server_wipe_sstables(self, server_id: ServerNum, keyspace: str, table: str):
-        assert self.cluster
         return self.cluster.wipe_sstables(server_id, keyspace, table)
 
+    @manager_op
     async def server_get_sstables_disk_usage(self, server_id: ServerNum, keyspace: str, table: str) -> int:
-        assert self.cluster
         return self.cluster.get_sstables_disk_usage(server_id, keyspace, table)
 
+    @manager_op
     async def server_get_process_status(self, server_id: ServerNum) -> str | None:
-        assert self.cluster
         return self.cluster.server_get_process_status(server_id)
 
     # ------------------------------------------------------------------

--- a/test/pylib/scylla_cluster.py
+++ b/test/pylib/scylla_cluster.py
@@ -36,7 +36,6 @@ from test.pylib.internal_types import ServerNum, IPAddress, HostID, ServerInfo, 
 from test.pylib.version_fetch_utils import fetch_and_install_scylla_version
 from functools import partial
 import aiohttp
-import aiohttp.web
 import yaml
 import signal
 import glob
@@ -1747,14 +1746,12 @@ class ScyllaClusterManager:
     """
     # pylint: disable=too-many-instance-attributes
     cluster: ScyllaCluster
-    site: aiohttp.web.UnixSite
     is_after_test_ok: bool
 
     def __init__(self,
                  test_uname: str,
                  create_cluster: ClusterFactory,
-                 base_dir: str,
-                 sock_path: str | None = None) -> None:
+                 base_dir: str) -> None:
         self.test_uname: str = test_uname
         self.base_dir: str = base_dir
         logger = logging.getLogger(self.test_uname)
@@ -1763,24 +1760,10 @@ class ScyllaClusterManager:
         # test_topology.1::test_add_server_add_column
         self.current_test_case_full_name: str = ''
         self.cluster: ScyllaCluster | None = None
-        self.site: aiohttp.web.UnixSite | None = None
         self.create_cluster: ClusterFactory = create_cluster
         self.is_running: bool = False
         self.is_before_test_ok: bool = False
         self.is_after_test_ok: bool = False
-        # API
-        # NOTE: need to make a safe temp dir as tempfile can't make a safe temp sock name
-        # Put the socket in /tmp, not base_dir, to avoid going over the length
-        # limit of UNIX-domain socket addresses (issue #12622).
-        if sock_path is None:
-            self.manager_dir: str = tempfile.mkdtemp(prefix="manager-", dir="/tmp")
-            self.sock_path: str = f"{self.manager_dir}/api"
-        else:
-            self.manager_dir = os.path.dirname(sock_path)
-            self.sock_path = sock_path
-        app = aiohttp.web.Application()
-        self._setup_routes(app)
-        self.runner = aiohttp.web.AppRunner(app)
         self.tasks_history = dict()
         self.server_broken_event = asyncio.Event()
         self.server_broken_reason = ""
@@ -1792,16 +1775,13 @@ class ScyllaClusterManager:
         return out
 
     async def start(self) -> None:
-        """Get first cluster, setup API"""
+        """Get first cluster"""
         if self.is_running:
             self.logger.warning("ScyllaClusterManager already running")
             return
         self.cluster = await self.create_cluster(self.logger)
         self.logger.info("First Scylla cluster: %s", self.cluster)
         self.cluster.setLogger(self.logger)
-        await self.runner.setup()
-        self.site = aiohttp.web.UnixSite(self.runner, path=self.sock_path)
-        await self.site.start()
         self.is_running = True
 
     @manager_op(blockable=True)
@@ -1831,18 +1811,13 @@ class ScyllaClusterManager:
         return str(self.cluster)
 
     async def stop(self) -> None:
-        """Stop the API server and dispose of the last cluster if present"""
+        """Dispose of the last cluster if present"""
         self.logger.info("ScyllaManager stopping for test %s", self.test_uname)
-        if self.site:
-            await self.site.stop()
-            self.site = None
         if self.cluster:
             self.logger.info("ScyllaManager: stopping Scylla cluster %s after %s",
                              self.cluster, self.test_uname)
             await self.cluster.recycle()
             self.cluster = None
-        if os.path.exists(self.manager_dir):
-            await async_rmtree(self.manager_dir)
         self.is_running = False
 
     @manager_op
@@ -2222,250 +2197,3 @@ class ScyllaClusterManager:
     @manager_op
     async def server_get_process_status(self, server_id: ServerNum) -> str | None:
         return self.cluster.server_get_process_status(server_id)
-
-    # ------------------------------------------------------------------
-    # HTTP API.
-    #
-    # Thin adapters translating the REST routes into the methods above.
-    # ManagerClient is the only client, and it is about to call those
-    # methods directly, at which point this whole section goes away.
-    # ------------------------------------------------------------------
-
-    def _setup_routes(self, app: aiohttp.web.Application) -> None:
-        def make_catching_handler(handler: Callable) -> Callable:
-            async def catching_handler(request) -> aiohttp.web.Response:
-                """Catch all exceptions and return them to the client.
-                   Without this, the client would get an 'Internal server error' message
-                   without any details. Thanks to this the test log shows the actual error.
-                """
-                try:
-                    ret = await handler(request)
-                    if ret is not None:
-                        return aiohttp.web.json_response(ret)
-                    return aiohttp.web.Response()
-                except Exception as e:
-                    tb = traceback.format_exc()
-                    self.logger.error(f'Exception when executing {handler.__name__}: {e}\n{tb}')
-                    return aiohttp.web.Response(status=500, text=str(e))
-            return catching_handler
-
-        def route_history_wrapper(blockable = False)-> Callable:
-            def outer_wrapper(handler: Callable)-> Callable:
-                @wraps(handler)
-                async def inner_wrapper(request):
-                    if blockable and self.server_broken_event.is_set():
-                        raise Exception(f"ScyllaClusterManager BROKEN, Previous test broke ScyllaClusterManager server, server_broken_reason: {self.server_broken_reason}")
-                    self.logger.info("[ScyllaClusterManager][%s] %s", asyncio.current_task().get_name(), request.url)
-                    self.tasks_history[asyncio.current_task()] = request
-                    return await handler(request)
-                return inner_wrapper
-            return outer_wrapper
-
-        def add_get(route: str, handler: Callable):
-            app.router.add_get(route, make_catching_handler(route_history_wrapper()(handler)))
-
-        def add_put(route: str, handler: Callable):
-            app.router.add_put(route, make_catching_handler(route_history_wrapper(True)(handler)))
-
-        add_get('/cluster/is-dirty', self._is_dirty)
-        add_get('/cluster/running-servers', self._cluster_running_servers)
-        add_get('/cluster/all-servers', self._cluster_all_servers)
-        add_get('/cluster/starting-servers', self._cluster_starting_servers)
-        add_get('/cluster/host-ip/{server_id}', self._cluster_server_ip_addr)
-        add_get('/cluster/host-id/{server_id}', self._cluster_host_id)
-        add_put('/cluster/before-test/{test_case_name}', self._before_test_req)
-        add_put('/cluster/after-test/{success}', self._after_test_req)
-        add_put('/cluster/mark-dirty', self._mark_dirty)
-        add_put('/cluster/mark-clean', self._mark_clean)
-        add_put('/cluster/server/{server_id}/stop', self._cluster_server_stop)
-        add_put('/cluster/server/{server_id}/stop_gracefully', self._cluster_server_stop_gracefully)
-        add_put('/cluster/server/{server_id}/start', self._cluster_server_start)
-        add_put('/cluster/server/{server_id}/pause', self._cluster_server_pause)
-        add_put('/cluster/server/{server_id}/unpause', self._cluster_server_unpause)
-        add_put('/cluster/addserver', self._cluster_server_add)
-        add_put('/cluster/addservers', self._cluster_servers_add)
-        add_put('/cluster/remove-node/{initiator}', self._cluster_remove_node)
-        add_put('/cluster/decommission-node/{server_id}', self._cluster_decommission_node)
-        add_put('/cluster/rebuild-node/{server_id}', self._cluster_rebuild_node)
-        add_get('/cluster/server/{server_id}/get_config', self._server_get_config)
-        add_put('/cluster/server/{server_id}/update_config', self._server_update_config)
-        add_put('/cluster/server/{server_id}/remove_config_option', self._server_remove_config_option)
-        add_put('/cluster/server/{server_id}/update_cmdline', self._server_update_cmdline)
-        add_put('/cluster/server/{server_id}/switch_executable', self._server_switch_executable)
-        add_put('/cluster/server/{server_id}/change_ip', self._server_change_ip)
-        add_put('/cluster/server/{server_id}/change_rpc_address', self._server_change_rpc_address)
-        add_get('/cluster/server/{server_id}/get_log_filename', self._server_get_log_filename)
-        add_get('/cluster/server/{server_id}/workdir', self._server_get_workdir)
-        add_get('/cluster/server/{server_id}/maintenance_socket_path', self._server_get_maintenance_socket_path)
-        add_get('/cluster/server/{server_id}/exe', self._server_get_exe)
-        add_put('/cluster/server/{server_id}/wipe_sstables', self._cluster_server_wipe_sstables)
-        add_get('/cluster/server/{server_id}/sstables_disk_usage', self._server_get_sstables_disk_usage)
-        add_get('/cluster/server/{server_id}/process_status', self._server_get_process_status)
-        add_get('/cluster/server/{server_id}/returncode', self._server_get_returncode)
-
-    async def _is_dirty(self, _request) -> bool:
-        return await self.is_dirty()
-
-    async def _cluster_running_servers(self, _request) -> list[ServerInfo]:
-        return await self.running_servers()
-
-    async def _cluster_all_servers(self, _request) -> list[ServerInfo]:
-        return await self.all_servers()
-
-    async def _cluster_starting_servers(self, _request) -> list[ServerInfo]:
-        return await self.starting_servers()
-
-    async def _cluster_server_ip_addr(self, request) -> IPAddress:
-        return await self.get_host_ip(ServerNum(int(request.match_info["server_id"])))
-
-    async def _cluster_host_id(self, request) -> HostID:
-        return await self.get_host_id(ServerNum(int(request.match_info["server_id"])))
-
-    async def _before_test_req(self, request) -> str:
-        return await self.before_test(request.match_info['test_case_name'])
-
-    async def _after_test_req(self, request) -> dict[str, Any]:
-        return await self.after_test(request.match_info["success"] == "True")
-
-    async def _mark_dirty(self, _request) -> None:
-        await self.mark_dirty()
-
-    async def _mark_clean(self, _request) -> None:
-        await self.mark_clean()
-
-    async def _cluster_server_stop(self, request) -> None:
-        await self.server_stop(ServerNum(int(request.match_info["server_id"])))
-
-    async def _cluster_server_stop_gracefully(self, request) -> None:
-        await self.server_stop_gracefully(ServerNum(int(request.match_info["server_id"])))
-
-    async def _cluster_server_start(self, request) -> None:
-        data = await request.json()
-        await self.server_start(
-            ServerNum(int(request.match_info["server_id"])),
-            expected_error=data.get("expected_error"),
-            seeds=data.get("seeds"),
-            expected_server_up_state=getattr(ServerUpState, data.get("expected_server_up_state", "SERVING")),
-            cmdline_options_override=data.get("cmdline_options_override"),
-            append_env_override=data.get("append_env_override"),
-            auth_provider=data.get("auth_provider"),
-        )
-
-    async def _cluster_server_pause(self, request) -> None:
-        await self.server_pause(ServerNum(int(request.match_info["server_id"])))
-
-    async def _cluster_server_unpause(self, request) -> None:
-        await self.server_unpause(ServerNum(int(request.match_info["server_id"])))
-
-    async def _cluster_server_add(self, request) -> dict[str, object]:
-        data = await request.json()
-        s_info = await self.server_add(
-            replace_cfg=ReplaceConfig(**data["replace_cfg"]) if "replace_cfg" in data else None,
-            cmdline=data.get("cmdline"),
-            config=data.get("config"),
-            version=ScyllaVersionDescription(**data["version"]) if "version" in data else None,
-            property_file=data.get("property_file"),
-            start=data.get("start", True),
-            seeds=data.get("seeds"),
-            server_encryption=data.get("server_encryption", "none"),
-            expected_error=data.get("expected_error"),
-            expected_server_up_state=getattr(ServerUpState, data.get("expected_server_up_state", "SERVING")),
-        )
-        return s_info.as_dict()
-
-    async def _cluster_servers_add(self, request) -> list[dict[str, object]]:
-        data = await request.json()
-        s_infos = await self.servers_add(
-            servers_num=data.get('servers_num'),
-            cmdline=data.get('cmdline'),
-            config=data.get('config'),
-            version=ScyllaVersionDescription(**data["version"]) if "version" in data else None,
-            property_file=data.get('property_file'),
-            start=data.get('start', True),
-            seeds=data.get('seeds', None),
-            server_encryption=data.get('server_encryption'),
-            expected_error=data.get('expected_error', None),
-        )
-        return [s_info.as_dict() for s_info in s_infos]
-
-    async def _cluster_remove_node(self, request: aiohttp.web.Request) -> None:
-        data = await request.json()
-        assert isinstance(data["ignore_dead"], list), "Invalid list of dead IP addresses"
-        await self.remove_node(
-            initiator_id=ServerNum(int(request.match_info["initiator"])),
-            server_id=ServerNum(int(data["server_id"])),
-            ignore_dead=[IPAddress(ip_addr) for ip_addr in data["ignore_dead"]],
-            expected_error=data["expected_error"],
-        )
-
-    async def _cluster_decommission_node(self, request) -> None:
-        data = await request.json()
-        await self.decommission_node(
-            server_id=ServerNum(int(request.match_info["server_id"])),
-            expected_error=data["expected_error"],
-        )
-
-    async def _cluster_rebuild_node(self, request) -> None:
-        data = await request.json()
-        await self.rebuild_node(
-            server_id=ServerNum(int(request.match_info["server_id"])),
-            expected_error=data["expected_error"],
-        )
-
-    async def _server_get_config(self, request: aiohttp.web.Request) -> dict[str, object]:
-        return await self.server_get_config(ServerNum(int(request.match_info["server_id"])))
-
-    async def _server_update_config(self, request: aiohttp.web.Request) -> None:
-        data = await request.json()
-        await self.server_update_config(ServerNum(int(request.match_info["server_id"])),
-                                        data["config_options"])
-
-    async def _server_remove_config_option(self, request: aiohttp.web.Request) -> None:
-        data = await request.json()
-        await self.server_remove_config_option(ServerNum(int(request.match_info["server_id"])),
-                                               data["key"])
-
-    async def _server_update_cmdline(self, request: aiohttp.web.Request) -> None:
-        data = await request.json()
-        await self.server_update_cmdline(ServerNum(int(request.match_info["server_id"])),
-                                         data['cmdline_options'])
-
-    async def _server_switch_executable(self, request: aiohttp.web.Request) -> None:
-        path = (await request.json())["path"]
-        await self.server_switch_executable(ServerNum(int(request.match_info["server_id"])), path)
-
-    async def _server_change_ip(self, request: aiohttp.web.Request) -> dict[str, object]:
-        ip_addr = await self.server_change_ip(ServerNum(int(request.match_info["server_id"])))
-        return {"ip_addr": ip_addr}
-
-    async def _server_change_rpc_address(self, request: aiohttp.web.Request) -> dict[str, object]:
-        rpc_address = await self.server_change_rpc_address(ServerNum(int(request.match_info["server_id"])))
-        return {"rpc_address": rpc_address}
-
-    async def _server_get_log_filename(self, request: aiohttp.web.Request) -> str:
-        return await self.server_get_log_filename(ServerNum(int(request.match_info["server_id"])))
-
-    async def _server_get_workdir(self, request: aiohttp.web.Request) -> str:
-        return await self.server_get_workdir(ServerNum(int(request.match_info["server_id"])))
-
-    async def _server_get_maintenance_socket_path(self, request: aiohttp.web.Request) -> str:
-        return await self.server_get_maintenance_socket_path(ServerNum(int(request.match_info["server_id"])))
-
-    async def _server_get_exe(self, request: aiohttp.web.Request) -> str:
-        return await self.server_get_exe(ServerNum(int(request.match_info["server_id"])))
-
-    async def _server_get_returncode(self, request: aiohttp.web.Request) -> str | int:
-        return await self.server_get_returncode(ServerNum(int(request.match_info["server_id"])))
-
-    async def _cluster_server_wipe_sstables(self, request: aiohttp.web.Request):
-        data = await request.json()
-        return await self.server_wipe_sstables(ServerNum(int(request.match_info["server_id"])),
-                                               data["keyspace"], data["table"])
-
-    async def _server_get_sstables_disk_usage(self, request: aiohttp.web.Request) -> int:
-        data = request.query
-        return await self.server_get_sstables_disk_usage(ServerNum(int(request.match_info["server_id"])),
-                                                         data["keyspace"], data["table"])
-
-    async def _server_get_process_status(self, request: aiohttp.web.Request) -> Optional[str]:
-        return await self.server_get_process_status(ServerNum(int(request.match_info["server_id"])))

--- a/test/pylib_test/test_manager_client_call.py
+++ b/test/pylib_test/test_manager_client_call.py
@@ -1,0 +1,210 @@
+#
+# Copyright (C) 2026-present ScyllaDB
+#
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
+#
+"""Tests for how ManagerClient reaches ScyllaClusterManager.
+
+The manager runs on its own event loop and owns state that belongs to it: the
+Scylla subprocess transports and the per-server asyncio locks.  Its coroutines
+therefore have to run on that loop, whichever loop -- or thread -- the caller
+happens to be on.  ManagerClient._call is what guarantees that.
+
+The exercise here uses a real ScyllaClusterManager and a real ManagerClient
+with a stub cluster, so the decorator and the bridge under test are the
+production ones.
+"""
+
+import asyncio
+import concurrent.futures
+import logging
+import threading
+from collections.abc import Iterator
+
+import pytest
+
+from test.pylib.internal_types import ServerNum
+from test.pylib.manager_client import ManagerClient
+from test.pylib.scylla_cluster import ScyllaClusterManager
+
+
+SERVER_ID = ServerNum(1)
+TIMEOUT = 30
+
+
+class StubCluster:
+    """Stands in for ScyllaCluster, with one genuinely loop-bound object.
+
+    ScyllaServer.stop() awaits its subprocess transport, and that transport
+    suspends on a future belonging to the loop that spawned Scylla (see
+    _UnixSubprocessTransport._wait).  `_release` plays that part.  Awaiting it
+    from another loop is what raises "got Future attached to a different loop",
+    so an operation has to actually suspend on it for these tests to mean
+    anything -- hence the callers below release it only after the operation has
+    entered.
+    """
+
+    def __init__(self, loop: asyncio.AbstractEventLoop) -> None:
+        self._loop = loop
+        self._release = loop.create_future()
+        self.entered = threading.Event()      # readable from any thread
+        self.stopped: list[ServerNum] = []
+        self.is_dirty = False
+
+    async def server_stop(self, server_id: ServerNum, gracefully: bool) -> None:
+        self.entered.set()
+        await self._release
+        self.stopped.append(server_id)
+
+    def release(self) -> None:
+        """Let a suspended server_stop() finish; callable from any thread."""
+        self._loop.call_soon_threadsafe(
+            lambda: None if self._release.done() else self._release.set_result(None))
+
+
+@pytest.fixture
+def manager_client() -> Iterator[tuple[ManagerClient, StubCluster, asyncio.AbstractEventLoop]]:
+    """A ManagerClient wired to a manager running on its own thread and loop.
+
+    Mirrors the manager_server fixture in test/cluster/conftest.py: the loop
+    stays alive but idle until teardown, so callers on other loops and threads
+    have something to hand work to.
+    """
+    ready: concurrent.futures.Future = concurrent.futures.Future()
+    stop_event = threading.Event()
+
+    async def run_manager() -> None:
+        manager = ScyllaClusterManager(
+            test_uname="test_manager_client_call",
+            create_cluster=None,
+            base_dir="",
+        )
+        manager.logger = logging.getLogger("test_manager_client_call")
+        manager.cluster = StubCluster(asyncio.get_running_loop())
+        ready.set_result((manager, asyncio.get_running_loop()))
+        await asyncio.get_running_loop().run_in_executor(None, stop_event.wait)
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
+        future = executor.submit(asyncio.run, run_manager())
+        future.add_done_callback(
+            lambda f: None if ready.done() else ready.set_exception(
+                f.exception() or RuntimeError("manager exited before signaling readiness")))
+        manager, loop = ready.result(timeout=TIMEOUT)
+        client = ManagerClient(
+            cluster_manager=manager,
+            manager_loop=loop,
+            port=9042,
+            use_ssl=False,
+            auth_provider=None,
+            con_gen=lambda *args, **kwargs: None,
+        )
+        try:
+            yield client, manager.cluster, loop
+        finally:
+            manager.cluster.release()   # don't strand an operation on shutdown
+            stop_event.set()
+            future.result(timeout=TIMEOUT)
+
+
+async def test_operation_runs_on_the_managers_loop(manager_client) -> None:
+    """An async caller on its own loop still gets the manager's loop."""
+    client, cluster, manager_loop = manager_client
+    assert asyncio.get_running_loop() is not manager_loop
+
+    stopping = asyncio.ensure_future(client.server_stop(SERVER_ID, convict=False))
+    assert await asyncio.to_thread(cluster.entered.wait, TIMEOUT), "operation never started"
+    cluster.release()
+    await asyncio.wait_for(stopping, TIMEOUT)
+
+    assert cluster.stopped == [SERVER_ID]
+
+
+def test_operation_from_a_worker_thread(manager_client) -> None:
+    """A synchronous caller on a worker thread reaches loop-bound state.
+
+    This is the dtest pattern -- `executor.submit(node.stop, ...)` -- and the
+    reason _call cannot simply await the manager's coroutine: universalasync
+    creates a fresh event loop per thread, and the manager's state does not
+    belong to it.
+    """
+    client, cluster, _ = manager_client
+    errors: list[BaseException] = []
+
+    def worker() -> None:
+        try:
+            # No running loop here, so universalasync drives the call itself.
+            client.server_stop(SERVER_ID, convict=False)
+        except BaseException as exc:  # pylint: disable=broad-except
+            errors.append(exc)
+
+    thread = threading.Thread(target=worker)
+    thread.start()
+    assert cluster.entered.wait(TIMEOUT), "operation never started"
+    cluster.release()
+    thread.join(timeout=TIMEOUT)
+
+    assert not thread.is_alive(), "call from a worker thread hung"
+    assert not errors, f"call from a worker thread failed: {errors[0]!r}"
+    assert cluster.stopped == [SERVER_ID]
+
+
+async def test_caller_timeout_leaves_the_operation_running(manager_client) -> None:
+    """A timed-out caller orphans the operation instead of aborting it.
+
+    The HTTP server never cancelled a handler when its client went away, and
+    after_test() relies on that: it drains whatever a test left running.
+    """
+    client, cluster, manager_loop = manager_client
+
+    with pytest.raises(asyncio.TimeoutError):
+        await client._call(client._manager.server_stop(SERVER_ID), timeout=0.2)
+
+    assert cluster.entered.is_set(), "operation never started"
+    assert len(client._manager.tasks_history) == 1, "operation was not left for the drain"
+    op, descr = next(iter(client._manager.tasks_history.items()))
+    assert not op.done()
+    assert descr.startswith("server_stop")
+
+    # Once it completes it removes itself, which is what leaves after_test()'s
+    # drain looking only at genuinely in-flight work.  _op_finished is
+    # registered before gather's own done callback, so by the time the wait
+    # below returns the entry is already gone.
+    cluster.release()
+
+    async def wait_operations_done() -> None:
+        await asyncio.gather(*client._manager.tasks_history)
+
+    await asyncio.wrap_future(
+        asyncio.run_coroutine_threadsafe(wait_operations_done(), manager_loop))
+    assert not client._manager.tasks_history
+    assert cluster.stopped == [SERVER_ID]
+
+
+async def test_exception_keeps_its_type(manager_client) -> None:
+    """Failures arrive as themselves, not as an HTTP status turned into a string."""
+    client, cluster, _ = manager_client
+
+    async def fail(server_id: ServerNum, gracefully: bool) -> None:
+        raise ValueError("stop failed")
+
+    cluster.server_stop = fail
+
+    with pytest.raises(ValueError, match="stop failed"):
+        await client.server_stop(SERVER_ID, convict=False)
+
+
+async def test_broken_manager_refuses_mutations(manager_client) -> None:
+    """A manager fenced off by a previous test rejects further changes."""
+    client, cluster, manager_loop = manager_client
+    async def do_break() -> None:
+        client._manager.break_manager("leaked task", "some_test")
+
+    await asyncio.wrap_future(
+        asyncio.run_coroutine_threadsafe(do_break(), manager_loop))
+
+    with pytest.raises(RuntimeError, match="BROKEN"):
+        await client.server_stop(SERVER_ID, convict=False)
+    assert not cluster.entered.is_set(), "a broken manager still ran the operation"
+
+    # Reads stay available so that after-test bookkeeping can still run.
+    assert await client.is_dirty() is False


### PR DESCRIPTION
## What

`ScyllaClusterManager` owns the Scylla cluster under test and used to expose it
to tests as an aiohttp HTTP server on a unix socket, with `ManagerClient`
issuing `get_json`/`put_json` requests against it. That transport is a leftover
from when the manager ran in a separate process; since it moved onto a thread
in the same process, the socket only bridged two event loops.

This series removes the transport: `ManagerClient` now calls the manager's
methods directly as Python objects. No aiohttp application, no unix socket, no
JSON serialization, no `UnixRESTClient`.

The manager keeps its dedicated thread with an always-running event loop —
its coroutines must run on the loop that owns the Scylla subprocess transports
and per-server asyncio locks, while callers live on pytest's event loops and,
in dtest, on plain worker threads (`executor.submit(node.stop, ...)`).
`ManagerClient._call()` bridges with `run_coroutine_threadsafe()` +
`wrap_future()`, which is the job the HTTP request used to do, minus the
socket.

## Why

- **Exceptions survive.** The HTTP server turned every manager-side failure
  into `500 <str(e)>`, so tests saw an `HTTPError` carrying a string instead of
  the original exception with its type, cause chain and traceback. Failures now
  propagate intact. (The one test matching on the laundered type switches from
  `HTTPError` to the `RuntimeError` the manager actually raises.)
- **Real objects instead of wire formats.** `ServerInfo`, `ReplaceConfig`,
  `ScyllaVersionDescription` and `ServerUpState` cross as themselves; the
  `as_dict()`/tuple/enum-name round trips are gone.
- **Less machinery.** The route table, request-parsing adapters,
  `make_catching_handler`, `route_history_wrapper`, the per-loop client cache
  and the `test_finished_event` dance are all gone or collapsed into one
  `manager_op` decorator and a plain flag.

## Preserved behavior

- Leaked-operation detection: each manager call still runs as its own task on
  the manager's loop and registers in `tasks_history`; `after_test()` drains
  what a test left running and `break_manager` still fences a wedged manager.
- Cancellation semantics: `manager_op` awaits through `asyncio.shield`, so a
  timed-out or cancelled caller orphans the operation instead of aborting it
  mid-flight — matching aiohttp's `handler_cancellation=False` default.
- Timeouts: the HTTP client's implicit 300 s per-request cap is preserved by
  `_call()` (600 s for before-test, `TOPOLOGY_TIMEOUT` for topology ops).
- `test/pytest.ini` and `test/cqlpy` are untouched; suites that don't use the
  manager are unaffected. Scylla's own REST/metrics clients and the external
  service mocks (S3, Azure Vault, GCP KMS, nodetool's REST mock) stay HTTP —
  Scylla is their client, not pytest.

Out of scope (follow-ups): merging `ManagerClient` into `ScyllaClusterManager`;
dropping the `RUNNING`/`NO_SUCH_PROCESS` sentinels (needs `NoSuchProcess` moved
to break an import cycle).

## Performance

Same dev build, both sides, in dbuild; median µs/call over 5×400 calls:

| Operation | HTTP | direct | speedup |
|---|---|---|---|
| `running_servers` | 879 | 353 | 2.5× |
| `server_get_workdir` | 815 | 352 | 2.3× |
| `is_dirty` | 833 | 357 | 2.3× |
| `is_dirty` (worker thread) | 877 | 360 | 2.4× |

Suite wall time is unchanged: a topology test makes ~45 manager calls, so the
transport is worth ~20 ms against 50–150 s runs dominated by node boot and
topology barriers. The win is diagnosability, not throughput.

## Testing

- Every commit compiles, collects `test/cluster` (1352 tests) and passes
  `test/pylib_test` — the series bisects.
- New `test/pylib_test/test_manager_client_call.py` (no cluster needed, ~1 s)
  pins the bridge: operation runs on the manager's loop, a synchronous caller
  on a worker thread reaches loop-bound state, a timed-out caller leaves the
  operation for the drain, exceptions keep their type, a broken manager
  refuses mutations. 3 of 5 fail if `_call()` regresses to a plain await.
- dev mode, in dbuild: `test/cluster/dtest/schema_management_test.py` (all 16,
  including the worker-thread node-kill tests), `dtest/cfid_test.py`,
  `test_topology_ops.py`, `test_alternator.py -k localnodes` (tasks_history
  canary), `test_tablets.py -k cannot_decommision`, the leaked-`create_task`
  set (`test_long_join.py`, `test_gossiper_empty_self_id_on_shadow_round.py`,
  `test_bootstrap_with_quick_group0_join.py`) — all green.
- Full CI across modes and architectures run manually.

Fixes SCYLLADB-520