### PR TITLE
sstables: never fail object_storage_base::wipe

### DIFF
--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -375,6 +375,12 @@ public:
         return _marked_for_deletion == mark_for_deletion::marked;
     }
 
+    // Undo mark_for_deletion(). Used when the intent to delete could not be
+    // recorded durably, so the sstable must be left in place.
+    void unmark_for_deletion() {
+        _marked_for_deletion = mark_for_deletion::none;
+    }
+
     const std::set<generation_type>& compaction_ancestors() const {
         return _compaction_ancestors;
     }

--- a/sstables/storage.cc
+++ b/sstables/storage.cc
@@ -988,28 +988,36 @@ future<> object_storage_base::change_state(const sstable& sst, sstable_state sta
 }
 
 future<> object_storage_base::wipe(sstable& sst, const atomic_deletion* deletion) noexcept {
-    // Mark the sstable for deletion so that destroy() — called when the
-    // last shared_sstable reference is dropped — will delete the cloud
-    // objects.
-    sst.mark_for_deletion();
-    // Transition the registry entry to "removing" state to signal intent to
-    // delete.  The entry must survive the crash window so that
-    // garbage_collect() on restart can retry the S3 object deletion.
+    // Record the intent to delete in the registry before any object is removed,
+    // so the sstable is never left with its entry pointing at objects that are
+    // gone. The entry survives the crash window: garbage_collect() on restart
+    // removes every entry that is not "sealed", together with its objects.
     //
-    // Durability argument: if a crash loses the unfsynced commitlog, BOTH
-    // the status update and the S3 objects survive — the state is consistent
-    // and the sstable is loadable on restart.  If the update is committed,
-    // the entry is in "removing" and destroy() will clean up the S3 objects
-    // and delete the registry entry.  Either way, the registry is never left
-    // pointing at deleted objects, and orphaned S3 objects are always covered
-    // by a "removing" registry entry that garbage_collect() can act on.
-    //
-    // FIXME: unlike filesystem_storage::wipe, this implementation does not
-    // catch exceptions from sstables_registry calls and may return an
-    // exceptional future, breaking the contract documented on storage::wipe.
+    // The atomic deletion path already recorded the intent for the whole batch
+    // in atomic_deletion::commit(), so here it only needs the mark.
     if (!deletion) {
-        co_await sst.manager().sstables_registry().update_entry_status(owner(), sst.manager().get_local_host_id(), sst.generation(), status_removing);
+        try {
+            co_await sst.manager().sstables_registry().update_entry_status(owner(), sst.manager().get_local_host_id(), sst.generation(), status_removing);
+        } catch (...) {
+            // storage::wipe must not return an exceptional future, so the error
+            // is not propagated. It cannot be ignored either: destroy() deletes
+            // the objects of every sstable marked for deletion, and with the
+            // intent unrecorded that would leave a sealed entry pointing at
+            // objects that are gone. garbage_collect() reaps only entries that
+            // are not "sealed", so startup would then fail to load it. Clear the
+            // mark instead, including one set by a caller before unlink(), so
+            // destroy() leaves the objects and the entry alone: a sealed sstable
+            // stays valid until a later compaction reclaims it, an unsealed one
+            // is reaped by garbage_collect() on the next startup.
+            sst.unmark_for_deletion();
+            sstlog.error("Failed to mark {} as {} in the sstables registry: {}. Not deleting it.", sst.toc_filename(), status_removing, std::current_exception());
+            co_return;
+        }
     }
+
+    // destroy(), called when the last shared_sstable reference is dropped,
+    // deletes the objects only for sstables marked for deletion.
+    sst.mark_for_deletion();
 }
 
 future<> object_storage_base::destroy(const sstable& sst) {


### PR DESCRIPTION
### Problem

`storage::wipe` is documented as never returning an exceptional future, and `sstable::unlink()` — itself documented as ignoring all errors — depends on that: `unlink()` awaits the wipe future with no handler, so an error skips the remaining bookkeeping (`_stats.on_delete()` and `sstables_manager::on_unlink()`) and resolves `unlink()` exceptionally for callers that treat deletion as infallible.

`filesystem_storage::wipe` honors the contract. `object_storage_base::wipe` did not, and carried a `FIXME` saying so: its transition of the registry entry to `"removing"` can return an exceptional future.

### Changes

`object_storage_base::wipe` records the intent to delete before any object is removed, and on failure leaves the sstable alone rather than deleting it.

Ignoring the error is not an option. `destroy()` deletes the objects of every sstable marked for deletion, so with the intent unrecorded a sealed entry would be left pointing at objects that are gone. `garbage_collect()` reaps only entries that are not `"sealed"`, so nothing repairs that, and the next startup feeds the entry to `process_descriptor()` where `load_sstable()` fails.

The mark is cleared rather than merely left unset, because five other places set it before `unlink()` runs — `sstables_loader.cc`, three sites in `compaction.cc`, one in `table.cc`. `wipe()` can cover all of them because it is the choke point: `sstable::destroy()` runs `close_files()` first, and `close_files()` unlinks anything marked that has not been unlinked yet, so `wipe()` always runs before `destroy()` consults the mark.

An unplugged registry is left to the `SCYLLA_ASSERT` in `sstables_manager::sstables_registry()`, which is active in every build mode. No flow should wipe an sstable after the registry is gone.

The atomic deletion path is unchanged: it passes a non-null `atomic_deletion`, whose `commit()` already recorded `"removing"` for the whole batch before any `unlink()`, and `atomic_deletion::execute()` already wraps `unlink()` in a try-catch.

### Trade-off worth a reviewer's attention

A retained sstable reappears after a restart — as a duplicate, or as data that was never published. Reads pick the newest timestamp and a later compaction reclaims it. The paths that could bring back *purged* data, compaction inputs and unattached outputs, delete through `atomic_deletion`, where a failed `commit()` means `execute()` never runs and nothing is deleted at all.

The known gap is that this is quiet: the only signal is an error-level log line. Two ways to fix that, both deliberately left out of this patch — a counter, so the condition is alertable rather than scrolling past in a log; or moving the intent write into a caller-owned `atomic_deletion::commit()` on the paths that have a caller, where throwing is safe and the operation fails visibly and can be retried. The second is the real fix and is its own ticket.

Fixes: https://scylladb.atlassian.net/browse/SCYLLADB-1754

Backport to 2026.3: `branch-2026.3` carries the identical unguarded `update_entry_status` call and the same `FIXME`, so the bug is present there.
