### PR TITLE
test/alternator: add reproducer for already-fixed buffer overflow

### DIFF
--- a/test/alternator/test_compressed_response.py
+++ b/test/alternator/test_compressed_response.py
@@ -27,6 +27,8 @@
 
 import gzip
 import zlib
+import random
+import string
 import pytest
 from contextlib import contextmanager
 
@@ -134,6 +136,41 @@ def test_compressed_response_large(dynamodb, test_table_s, encoding):
                 assert response["WasCompressed"] == encoding
                 # Not very precise, but check that some compression actually happened
                 assert response["DecompressedLength"] > 1.2 * response["HTTPContentLength"]
+
+# Reproducer for CUSTOMER-623, a buffer overflow bug that used to exist in
+# compression of responses. That bug was fixed in pull request #29718, and
+# this test can be used to reproduce the failure prior to that fix.
+#
+# Note that bug is a memory overflow, which can overwrite unrelated memory
+# and often crash Scylla; However, this crash is not guaranteed and when it
+# does happen, it's often after the test already passed and Scylla is shutting
+# down. So it is recommended to run this test with ASAN (i.e., debug or
+# sanitize build) and have it detect the memory overflow when it happens
+# and fail the test deterministically and immediately.
+def test_compressed_response_overflow(dynamodb, test_table_s):
+    p = random_string()
+    with client_response_decompression(dynamodb):
+        with server_response_compression(dynamodb):
+            with request_custom_headers(dynamodb, {'Accept-Encoding': 'gzip'}):
+                # The response length must be over 4096 to trigger compression.
+                # We want to use relatively poorly compressible data, so the
+                # output will need multiple buffers.
+                # We test two response sizes - one that was shown to trigger
+                # an overflow with PR #29718 reverted, and a second random.
+                # If this test begins to fail randomly, we'll know the bug
+                # reappeared for other sizes.
+                for size in [17000, random.randint(5000, 40000)]:
+                    # Use a random number generator with a fixed seed to
+                    # generate the poorly-compressible data, to make the test
+                    # deterministic and reproducible.
+                    chars = (string.ascii_uppercase + string.digits).encode()
+                    table = bytes(chars[i % len(chars)] for i in range(256))
+                    rng = random.Random(67)
+                    data = rng.randbytes(size).translate(table).decode()
+                    test_table_s.put_item(Item={'p': p, 'x': data})
+                    response = test_table_s.get_item(Key={'p': p})
+                    assert response['Item']['x'] == data
+                    assert response['WasCompressed'] == 'gzip'
 
 # Test with a very small compressed response (which we can force only on
 # Alternator, so this is a scylla_only test). Our implementation has special


### PR DESCRIPTION
In commit #29718 we fixed a typo in the Alternator reponse compression code, where the wrong size was used for the buffer. At the time, we believed this bug was benign and could not cause real overflows, but as it turned out in CUSTOMER-623, this was wrong - it can cause real buffer overflows that cause Scylla to crash.

In this patch we introduce a short test/alternator test that reproduces this bug. On Scylla 2026.3 and above the new test passes successfully (the fix from #29718 is already in). But on 2026.2 and 2026.1 the test crashes Scylla in half the runs in release build (in my test), and fails deterministically on a debug build with ASAN.

The bug involves compression spanning multiple output buffers, so the test uses a GetItem large enough to be compressed (over 4KB), and poorly-compressible enought to require multiple output buffers. Exprimentally, size 17,000 deterministically causes the overflow before #29718, so the test tries this size. It also tries a random size (in the range between 5000 and 40000), with the idea that the bug regresses but now requires a different size to demonstrate, some of the runs will fail when they pick the new "bad" size.

You can see that 2026.1 is vulnerable to this bug by running

    test/alternator/run --release 2026.1 \
      test_compressed_response.py::test_compressed_response_overflow

You will typically see the test passing, but in roughly half the runs (in my experiments), Scylla crashes while shutting down due to the buffer overflow destroying unrelated areas in memory. As mentioned above, to see reliable failures with this test you should run it in the debug build, with ASAN.

Refs CUSTOMER-623