### PR TITLE
test: fix commitlog_cleanup_test to clean up tablets on their owning shard

### DIFF
--- a/test/boost/commitlog_cleanup_test.cc
+++ b/test/boost/commitlog_cleanup_test.cc
@@ -176,6 +176,14 @@ SEASTAR_TEST_CASE(test_commitlog_cleanups) {
     }, cfg);
 }
 
+BOOST_AUTO_TEST_SUITE_END()
+
+// This test is in its own suite, pinned to a single shard in test_config.yaml:
+// it relies on cf1 and cf2 sharing one commitlog (so that a live mutation in
+// cf1 pins the segment holding cf2's stale cleanup records), which only holds
+// when both tables' tablets land on the same shard.
+BOOST_AUTO_TEST_SUITE(commitlog_cleanup_record_gc_test)
+
 // Test that commitlog cleanup records are deleted when they become irrelevant.
 SEASTAR_TEST_CASE(test_commitlog_cleanup_record_gc) {
     BOOST_REQUIRE_EQUAL(this_smp_shard_count(), 1);

--- a/test/boost/commitlog_cleanup_test.cc
+++ b/test/boost/commitlog_cleanup_test.cc
@@ -138,9 +138,18 @@ SEASTAR_TEST_CASE(test_commitlog_cleanups) {
         e.execute_cql("insert into ks.cf (pk,ck) values (0, 0)").get();
         BOOST_REQUIRE_EQUAL(get_num_rows(), 1);
 
-        // Cleanup the tablet.
+        // Cleanup the tablet on its replica shard; other shards have no
+        // storage for it.
         e.db().invoke_on_all([&] (replica::database& db) {
-            return db.find_column_family("ks", "cf").cleanup_tablet_without_deallocation(db, e.get_system_keyspace().local(), locator::tablet_id(0));
+            auto& cf = db.find_column_family("ks", "cf");
+            auto erm = cf.get_effective_replication_map();
+            auto tablet_shard = erm->get_token_metadata().tablets()
+                    .get_tablet_map(cf.schema()->id())
+                    .get_tablet_info(locator::tablet_id(0)).replicas.front().shard;
+            if (tablet_shard != this_shard_id()) {
+                return make_ready_future<>();
+            }
+            return cf.cleanup_tablet_without_deallocation(db, e.get_system_keyspace().local(), locator::tablet_id(0));
         }).get();
         BOOST_REQUIRE_EQUAL(get_num_rows(), 0);
 

--- a/test/boost/test_config.yaml
+++ b/test/boost/test_config.yaml
@@ -45,7 +45,10 @@ custom_args:
         - '-c2 -m3G'
     cache_algorithm_test:
         - '-c1 -m256M'
-    commitlog_cleanup_test:
+    # commitlog_cleanup_record_gc_test relies on two tables sharing one
+    # commitlog, which only holds on a single shard; commitlog_cleanup_test
+    # has no such constraint and runs with the default shard count.
+    commitlog_cleanup_record_gc_test:
         - '-c1 -m2G'
     bloom_filter_test:
         - '-c1'


### PR DESCRIPTION
## Context
A series of bug fixes to tests while running tests with more shards.

## Change

`test_commitlog_cleanups` called `cleanup_tablet_without_deallocation` via `invoke_on_all` instead of on the tablet's actual owning shard, so under multishard (`-c2`/`-c4`) it threw
`std::out_of_range: Storage wasn't found for tablet 0 of table ks.cf` on every shard that didn't happen to own the tablet.
Fixed by computing the real owning shard from the tablet map and using `invoke_on(tablet_shard, ...)`.

Follow-up commit: `test_commitlog_cleanup_record_gc` has an unrelated, genuine single-shard requirement - it relies on two tables (cf1, cf2) sharing one commitlog:
a live mutation in one pins the segment holding the other's stale cleanup records, which only holds when both tables' tablets land on the same shard.
That's not a proxy for the bug above, so it's split into its  own suite (`commitlog_cleanup_record_gc_test`) that keeps the `-c1` pin, 
while the remaining `commitlog_cleanup_test` suite (now genuinely multishard-safe) is unpinned in `test/boost/test_config.yaml` so CI actually exercises the fixed path.

## Test

`test/boost/commitlog_cleanup_test.cc::test_commitlog_cleanups`, run at `-c2`/`-c4` instead of only `-c1`.

## Results

Falsified by reverting just the `invoke_on_all` → `invoke_on(tablet_shard, ...)` change: the described `std::out_of_range` reproduces exactly at `-c2`. 
Restored, rebuilt clean.

Confirmed commitlog is genuinely per-shard and shared across all column families on that shard (`replica::database::commitlog_for`), so the suite split's rationale holds - `test_commitlog_cleanup_record_gc` could not have been made multishard-safe without restructuring the test itself.

Verified the split is lossless: `commitlog_cleanup_test` reports "Running 3 test cases" (was 4 before the split, 1 moved out), all pass at `-c2`;
`commitlog_cleanup_record_gc_test` reports "Running 1 test case", passes at `-c1`.

`test_commitlog_cleanups`: 100/100 passes at `-c2`.
`test_commitlog_cleanup_record_gc`: 20/20 passes at `-c1`.

Fixes: SCYLLADB-3744
Backport: no, it's an improvement to tests, makes them more complete and accurate.