### PR TITLE
Track the compaction group each sstable belongs to

### DIFF
--- a/replica/compaction_group.hh
+++ b/replica/compaction_group.hh
@@ -9,6 +9,7 @@
 #include <seastar/core/condition-variable.hh>
 #include <seastar/core/gate.hh>
 #include <seastar/core/rwlock.hh>
+#include <seastar/core/weak_ptr.hh>
 
 #include "database_fwd.hh"
 #include "compaction/compaction_descriptor.hh"
@@ -56,7 +57,7 @@ using repair_classifier_func = std::function<repair_sstable_classification(const
 //      - Also, a group will be owned by a single table. Different tables own different groups.
 //      - Each group can be thought of an isolated LSM tree, where Memtable(s) and SSTable(s) are
 //          isolated from other groups.
-class compaction_group {
+class compaction_group : public seastar::weakly_referencable<compaction_group> {
     table& _t;
     // The compaction group views are the logical compaction groups, each having its own logical
     // set of sstables. Even though they share the same instance of sstable_set, compaction will
@@ -111,6 +112,27 @@ class compaction_group {
 private:
     std::unique_ptr<compaction_group_view> make_compacting_view();
     std::unique_ptr<compaction_group_view> make_non_compacting_view();
+
+    // Records in the sstable that it now belongs to this group. Idempotent.
+    // Calls on_internal_error() if the sstable belongs to another group already,
+    // as an sstable can be owned by at most one group at a time.
+    void link_sstable(const sstables::shared_sstable& sst);
+    // Records in the sstable that it no longer belongs to this group.
+    // Tolerates the sstable being linked to another group, or to none.
+    void unlink_sstable(const sstables::shared_sstable& sst) noexcept;
+    // Reconciles the sstables' back-pointers to this group after one of the group's
+    // sstable sets was replaced with a rebuilt one: `old_set` was replaced by
+    // `new_set`, while `other_set` is the group's other sstable set, as it stands
+    // once the replacement is complete.
+    // An sstable leaves the group only if it's gone from both sets, so that an
+    // sstable moved between the main and maintenance sets, e.g. by off-strategy
+    // compaction, remains linked throughout.
+    // Allocation free, as the callers can't afford to fail. Not noexcept, so that
+    // a broken invariant is still reported through on_internal_error() rather than
+    // being turned into a std::terminate().
+    // `old_set` and `other_set` must be the group's sets as they stand on entry.
+    void relink_sstables(const sstables::sstable_set& old_set, const sstables::sstable_set& new_set,
+                         const sstables::sstable_set& other_set);
 
     // Adds new sstable to the set of sstables
     // Doesn't update the cache. The cache must be synchronized in order for reads to see

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -2668,8 +2668,22 @@ compaction_group::do_update_sstable_sets_on_compaction_completion(compaction::co
                 auto& cg = _t.compaction_group_for_sstable(sst);
                 _cg_desc[&cg].desc.new_sstables.push_back(sst);
             }
-            // The group that triggered compaction is the only one to have sstables removed from it.
-            _cg_desc[&_cg].desc.old_sstables = _desc.old_sstables;
+            // Remove each input sstable from the group that actually owns it.
+            // That is usually _cg, the group the compaction runs on, but it isn't
+            // guaranteed to be: an output sstable is routed to its group through
+            // the tablet map, by compaction_group_for_sstable() above, whereas the
+            // sstable is removed in a later replacer call, and a tablet merge can
+            // swap the tablet map in between. A garbage-collected sstable added to
+            // the new main group after such a swap would then be looked up in _cg,
+            // a merging group which never held it, and fail the check below.
+            // The sstable knows which group holds it, so ask it rather than
+            // recomputing the routing. Falls back to _cg for an sstable that
+            // belongs to no group, to report it below as the input we failed to
+            // remove.
+            for (auto& sst : _desc.old_sstables) {
+                auto* owner = sst->get_compaction_group();
+                _cg_desc[owner ? owner : &_cg].desc.old_sstables.push_back(sst);
+            }
             for (auto& [cg, d] : _cg_desc) {
                 size_t removed_sstables = 0;
                 d.main_sstable_set_builder_result = co_await _builder.build_new_list(*cg->main_sstables(), cg->make_main_sstable_set(),

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -549,6 +549,62 @@ void compaction_group::backlog_tracker_adjust_charges(const std::vector<sstables
     tracker.replace_sstables(old_sstables, new_sstables);
 }
 
+void compaction_group::link_sstable(const sstables::shared_sstable& sst) {
+    const auto* cg = sst->get_compaction_group();
+    if (cg == this) {
+        return;
+    }
+    if (cg) [[unlikely]] {
+        // An sstable can belong to at most one compaction group at a time.
+        on_internal_error(tlogger, fmt::format("Attempted to add SSTable {} of {}.{}, which already belongs to compaction group {}, to compaction group {}",
+                sst->get_filename(), _t.schema()->ks_name(), _t.schema()->cf_name(), *cg, *this));
+    }
+    sst->set_compaction_group(weak_from_this());
+}
+
+void compaction_group::unlink_sstable(const sstables::shared_sstable& sst) noexcept {
+    if (sst->get_compaction_group() == this) {
+        sst->set_compaction_group(nullptr);
+    }
+}
+
+void compaction_group::relink_sstables(const sstables::sstable_set& old_set, const sstables::sstable_set& new_set,
+                                       const sstables::sstable_set& other_set) {
+    // Phrased as three plain walks rather than membership tests, so that no set has
+    // to be materialized: the setters run from the execute() step of a row cache
+    // update and from the completion of a tablet merge, neither of which tolerates
+    // an allocation failure.
+    // for_each_sstable_until() rather than for_each_sstable() for the same reason:
+    // the latter wraps the callback in a second std::function, which is too large
+    // to be stored inline and therefore allocates on every call. The lambdas below
+    // capture nothing but this, so they are stored inline.
+    auto for_each = [] (const sstables::sstable_set& set, auto&& func) {
+        set.for_each_sstable_until([&func] (const sstables::shared_sstable& sst) {
+            func(sst);
+            return stop_iteration::no;
+        });
+    };
+    // Release everything the replaced set held.
+    for_each(old_set, [this] (const sstables::shared_sstable& sst) {
+        unlink_sstable(sst);
+    });
+    // Take ownership of everything the replacement brings in.
+    for_each(new_set, [this] (const sstables::shared_sstable& sst) {
+        link_sstable(sst);
+    });
+    // Restore the link of anything still held through the group's other set, which
+    // is how an sstable moved between the main and maintenance sets, e.g. by
+    // off-strategy compaction, stays linked across the two setter calls. Only
+    // sstables the first walk left unowned are relinked: one that moved to another
+    // group in this same update belongs to that group now, and it drops out of this
+    // set once that set is replaced in turn.
+    for_each(other_set, [this] (const sstables::shared_sstable& sst) {
+        if (!sst->get_compaction_group()) {
+            link_sstable(sst);
+        }
+    });
+}
+
 lw_shared_ptr<sstables::sstable_set>
 compaction_group::do_add_sstable(lw_shared_ptr<sstables::sstable_set> sstables, sstables::shared_sstable sstable,
         enable_backlog_tracker backlog_tracker) {
@@ -562,6 +618,10 @@ compaction_group::do_add_sstable(lw_shared_ptr<sstables::sstable_set> sstables, 
     // allow in-progress reads to continue using old list
     auto new_sstables = make_lw_shared<sstables::sstable_set>(*sstables);
     new_sstables->insert(sstable);
+    // Kept ahead of the updates below, which aren't undone on failure: if the
+    // sstable turns out to belong to another group, the caller discards
+    // new_sstables and the group is left untouched.
+    link_sstable(sstable);
     if (backlog_tracker) {
         table::add_sstable_to_backlog_tracker(get_backlog_tracker(), sstable);
     }
@@ -584,6 +644,7 @@ sstables::sstable_set compaction_group::make_main_sstable_set() const {
 }
 
 void compaction_group::set_main_sstables(lw_shared_ptr<sstables::sstable_set> new_main_sstables) {
+    relink_sstables(*_main_sstables, *new_main_sstables, *_maintenance_sstables);
     _main_sstables = std::move(new_main_sstables);
 }
 
@@ -596,6 +657,7 @@ const lw_shared_ptr<sstables::sstable_set>& compaction_group::maintenance_sstabl
 }
 
 void compaction_group::set_maintenance_sstables(lw_shared_ptr<sstables::sstable_set> new_maintenance_sstables) {
+    relink_sstables(*_maintenance_sstables, *new_maintenance_sstables, *_main_sstables);
     _maintenance_sstables = std::move(new_maintenance_sstables);
 }
 
@@ -2504,10 +2566,18 @@ compaction_group::merge_sstables_from(compaction_group& group) {
     auto sstables_to_merge = group.all_sstables();
     // re-build new list for this group with sstables of the group being merged.
     auto res = co_await builder.build_new_list(*main_sstables(), make_main_sstable_set(), sstables_to_merge, {});
+    // The empty sets the merged group is left with are built here rather than by
+    // clear_sstables() below, since building them allocates and the block below
+    // must not fail.
+    auto emptied_main = make_lw_shared<sstables::sstable_set>(group.make_main_sstable_set());
+    auto emptied_maintenance = group.make_maintenance_sstable_set();
     // execute:
     std::invoke([&] noexcept {
+        // The other group has to release the sstables before this group takes them over,
+        // as an sstable can only be linked to one compaction group at a time.
+        group.set_main_sstables(std::move(emptied_main));
+        group.set_maintenance_sstables(std::move(emptied_maintenance));
         set_main_sstables(std::move(res.new_sstable_set));
-        group.clear_sstables();
         // FIXME: backlog adjustment is not exception safe.
         backlog_tracker_adjust_charges({}, sstables_to_merge);
     });
@@ -2633,6 +2703,18 @@ compaction_group::do_update_sstable_sets_on_compaction_completion(compaction::co
             }
         }
         virtual void execute() override {
+            // Release the input sstables from the groups holding them before any group
+            // takes ownership below. An sstable can be an input and an output of the
+            // same completion, which is how a split moves an sstable that didn't need
+            // splitting into a split-ready group, and how off-strategy moves an sstable
+            // that didn't need reshaping into the main set. Such an sstable changes
+            // hands within this single update, and _cg_desc is unordered, so linking it
+            // to its new group first would find it still owned by the old one.
+            for (auto& [cg, d] : _cg_desc) {
+                for (auto& sst : d.desc.old_sstables) {
+                    cg->unlink_sstable(sst);
+                }
+            }
             for (auto&& [cg, d] : _cg_desc) {
                 cg->set_main_sstables(std::move(d.main_sstable_set_builder_result.new_sstable_set));
                 if (d.new_maintenance_sstables) {
@@ -3381,8 +3463,9 @@ const schema_ptr& compaction_group::schema() const {
 }
 
 void compaction_group::clear_sstables() {
-    _main_sstables = make_lw_shared<sstables::sstable_set>(make_main_sstable_set());
-    _maintenance_sstables = make_maintenance_sstable_set();
+    // Goes through the setters, so the sstables leaving the group are unlinked from it.
+    set_main_sstables(make_lw_shared<sstables::sstable_set>(make_main_sstable_set()));
+    set_maintenance_sstables(make_maintenance_sstable_set());
 }
 
 void storage_group::clear_sstables() {

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -49,6 +49,7 @@
 #include "sstables/file_size_stats.hh"
 
 #include <seastar/util/optimized_optional.hh>
+#include <seastar/core/weak_ptr.hh>
 #include <fmt/format.h>
 
 class sstable_assertions;
@@ -64,6 +65,10 @@ class in_memory_config_type;
 namespace db {
 class large_data_handler;
 class corrupt_data_handler;
+}
+
+namespace replica {
+class compaction_group;
 }
 
 namespace sstables {
@@ -672,6 +677,15 @@ private:
     // Total memory reclaimed so far from this sstable
     size_t _total_memory_reclaimed{0};
     std::optional<db_clock::time_point> _unlinked_at;
+    // The compaction group this sstable currently belongs to, if any.
+    // Maintained by replica::compaction_group as the sstable joins and leaves
+    // its sstable sets. An sstable belongs to at most one compaction group at
+    // a time; replica::compaction_group reports an internal error if that
+    // invariant is found to be broken.
+    // Weak, since the compaction group is the one owning the sstable, and not
+    // the other way around. It is cleared automatically if the compaction group
+    // happens to be destroyed while the sstable is still linked to it.
+    seastar::weak_ptr<replica::compaction_group> _compaction_group;
     const bool _ignore_component_digest_mismatch;
 
     // The mutate semaphore is used to serialize operations like rewrite_statistics
@@ -1176,6 +1190,24 @@ public:
         return _unlinked_at;
     }
 
+    // Returns the compaction group this sstable belongs to, or nullptr if it
+    // doesn't belong to any (e.g. it was just created by compaction and wasn't
+    // attached to a table yet, or it was already compacted away).
+    replica::compaction_group* get_compaction_group() noexcept {
+        return _compaction_group.get();
+    }
+    const replica::compaction_group* get_compaction_group() const noexcept {
+        return _compaction_group.get();
+    }
+private:
+    // Records the compaction group this sstable now belongs to, or none when
+    // disengaged. Reserved for replica::compaction_group, which is responsible
+    // for keeping this in sync with its sstable sets.
+    void set_compaction_group(seastar::weak_ptr<replica::compaction_group> cg) noexcept {
+        _compaction_group = std::move(cg);
+    }
+public:
+
     // The sstable identifier identifies the sstable globally across all nodes, shards, and over time.
     // When the sstable is created, the sstable identifier is equal to the sstable generation,
     // but over time, e.g. when a sstable is migrated across shards or nodes, its identifier
@@ -1224,6 +1256,8 @@ public:
     friend class mc::writer;
     friend class index_reader;
     friend class sstables_manager;
+    // Calls set_compaction_group() as the sstable joins and leaves compaction groups.
+    friend class replica::compaction_group;
     template <typename DataConsumeRowsContext>
     friend future<std::unique_ptr<DataConsumeRowsContext>>
     data_consume_rows(const schema&, shared_sstable, typename DataConsumeRowsContext::consumer&, disk_read_range, uint64_t, integrity_check);

--- a/test/boost/compaction_group_test.cc
+++ b/test/boost/compaction_group_test.cc
@@ -272,3 +272,78 @@ SEASTAR_TEST_CASE(compactions_dont_cross_group_boundary_test) {
         }
     });
 }
+
+// An sstable records the compaction group that owns it, so the group can be
+// located from the sstable side. Verifies that the back-pointer is set when the
+// sstable joins a group and cleared when it leaves, along the paths that move
+// sstables in and out of a group's sstable sets: joining the main set, joining
+// the maintenance set, off-strategy compaction (which moves sstables from the
+// maintenance set into the main set) and major compaction (which replaces the
+// whole main set).
+SEASTAR_TEST_CASE(sstable_tracks_its_compaction_group_test) {
+    return test_env::do_with_async([] (test_env& env) {
+        auto s = schema_builder(this_smp_shard_count(), "tests", "sstable_tracks_its_compaction_group")
+                .with_column("id", utf8_type, column_kind::partition_key)
+                .with_column("cl", int32_type, column_kind::clustering_key)
+                .with_column("value", int32_type)
+                .build();
+
+        auto t = env.make_table_for_tests(s);
+        auto close_table = deferred_stop(t);
+        t->start();
+
+        // Disable auto compaction so sstable sets only change where the test says so.
+        t->disable_auto_compaction().get();
+
+        auto* cg = t->get_any_compaction_group();
+        BOOST_REQUIRE(cg != nullptr);
+
+        // An sstable belongs to the group iff the table currently owns it, and every
+        // sstable the table owns belongs to the group. `known` are the sstables the
+        // test created itself, which may or may not still be owned by the table.
+        auto verify_group_membership = [&] (const std::vector<sstables::shared_sstable>& known) {
+            auto owned = t->get_sstables();
+            for (const auto& sst : *owned) {
+                BOOST_REQUIRE(sst->get_compaction_group() == cg);
+            }
+            for (const auto& sst : known) {
+                BOOST_REQUIRE(sst->get_compaction_group() == (owned->contains(sst) ? cg : nullptr));
+            }
+        };
+
+        auto sst_factory = env.make_sst_factory(s);
+
+        // An sstable that was never attached to a table belongs to no group.
+        auto detached = sstable_that_needs_split(s, sst_factory);
+        BOOST_REQUIRE(detached->get_compaction_group() == nullptr);
+
+        // Joining the main sstable set links the sstable to the group.
+        auto main_sst = sstable_that_needs_split(s, sst_factory);
+        t->add_sstable_and_update_cache(main_sst).get();
+        BOOST_REQUIRE(main_sst->get_compaction_group() == cg);
+
+        // So does joining the maintenance sstable set.
+        auto maintenance_sst = sstable_that_needs_split(s, sst_factory);
+        t->add_sstable_and_update_cache(maintenance_sst, sstables::offstrategy::yes).get();
+        BOOST_REQUIRE(maintenance_sst->get_compaction_group() == cg);
+        verify_group_membership({detached, main_sst, maintenance_sst});
+
+        // Off-strategy compaction moves sstables from the maintenance set into the
+        // main set. An sstable that doesn't need reshaping is moved rather than
+        // rewritten, by a completion descriptor that lists it as both an input and
+        // an output, so it is released by the group and taken over by it again
+        // within a single update. It must come out of that still linked.
+        t->perform_offstrategy_compaction(tasks::task_info{}).get();
+        BOOST_REQUIRE(t->get_sstables()->contains(maintenance_sst));
+        verify_group_membership({detached, main_sst, maintenance_sst});
+
+        // Major compaction replaces the whole main set: its input sstables leave the
+        // group, its output sstables join it.
+        auto inputs = t->get_sstables();
+        BOOST_REQUIRE(!inputs->empty());
+        t->compact_all_sstables({}).get();
+        BOOST_REQUIRE(!t->get_sstables()->empty());
+        verify_group_membership(std::vector(inputs->begin(), inputs->end()));
+        BOOST_REQUIRE(detached->get_compaction_group() == nullptr);
+    });
+}

--- a/test/cluster/test_tablets_merge.py
+++ b/test/cluster/test_tablets_merge.py
@@ -652,3 +652,133 @@ async def test_background_merge_deadlock(manager: ManagerClient, feature_config:
     await wait_for(finished_merge, time.time() + 120)
 
     await manager.server_stop(servers[0].server_id, convict=False)
+
+
+@pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
+async def test_gc_sstable_release_during_tablet_merge(manager: ManagerClient):
+    """
+    Reproducer for the "Unable to remove input SSTable ... origin=garbage_collection"
+    crash during tablet merge.
+
+    The bug: sstable_list_updater::prepare() routes new sstables via the live
+    tablet map (compaction_group_for_sstable) but pins old sstables to _cg.
+    During merge the tablet map is swapped synchronously, so a GC sstable
+    produced AFTER the merge is routed to the new main CG, but on release
+    the code tries to remove it from _cg (the merging group) — crash.
+
+    Strategy:
+      1. Create multi-fragment run + tombstones (2 tablets)
+      2. Block merge_completion_fiber (prevents stopping compactions)
+      3. Trigger merge (tablet map swaps, groups become merging)
+      4. Start major compaction (runs on the merging group)
+      5. Compaction produces GC sstable → routed to new main CG
+      6. GC release → tries to remove from merging group → crash
+
+    Refs https://scylladb.atlassian.net/browse/SCYLLADB-3595.
+    """
+
+    logger.info('Bootstrapping cluster')
+    cfg = {'enable_tablets': True, 'tablet_load_stats_refresh_interval_in_seconds': 1}
+    cmdline = [
+        '--logger-log-level', 'compaction_manager=info',
+        '--logger-log-level', 'compaction=info',
+    ]
+    server = await manager.server_add(cmdline=cmdline, config=cfg)
+
+    cql = manager.get_cql()
+    await manager.disable_tablet_balancing()
+
+    initial_tablets = 2
+
+    async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1}") as ks:
+        # sstable_size_in_mb=1 forces writer rotation → multi-fragment runs.
+        # No compression so data sizes are predictable.
+        await cql.run_async(f"""CREATE TABLE {ks}.test (pk int PRIMARY KEY, c text)
+                               WITH compaction = {{'class': 'IncrementalCompactionStrategy',
+                                                   'sstable_size_in_mb': 1}}
+                               AND compression = {{}}
+                               AND tablets = {{'min_tablet_count': {initial_tablets}}}""")
+
+        # Disable auto-compaction via API (not via strategy 'enabled=false'
+        # which replaces ICS with NullCompactionStrategy).
+        await manager.api.disable_autocompaction(server.ip_addr, ks, 'test')
+
+        n_keys = 5000
+        blob_value = 'x' * 4096
+
+        # Step 1: Write live data, flush.
+        batch_size = n_keys // 10
+        for i in range(0, n_keys, batch_size):
+            await asyncio.gather(*[cql.run_async(f"INSERT INTO {ks}.test (pk, c) VALUES ({k}, '{blob_value}')")
+                                   for k in range(i, min(i + batch_size, n_keys))])
+        await manager.api.flush_keyspace(server.ip_addr, ks)
+
+        # Step 2: First major → produces multi-fragment run.
+        await manager.api.keyspace_compaction(server.ip_addr, ks)
+
+        # Step 3: Delete keys in batches (multiple tombstone sstables).
+        batch_size = n_keys // 10
+        for i in range(0, n_keys, batch_size):
+            await asyncio.gather(*[cql.run_async(f"DELETE FROM {ks}.test WHERE pk = {k}")
+                                   for k in range(i, min(i + batch_size, n_keys)) if k % 2 == 0])
+            await manager.api.flush_keyspace(server.ip_addr, ks)
+
+        # Step 4: Set gc_grace_seconds=0 + immediate mode so tombstones
+        # are purgeable (bypasses repair-time and commitlog checks).
+        await cql.run_async(f"""ALTER TABLE {ks}.test
+                               WITH gc_grace_seconds = 0
+                               AND tombstone_gc = {{'mode': 'immediate'}}""")
+        # Extra flush to advance commitlog
+        await manager.api.flush_keyspace(server.ip_addr, ks)
+
+        # Step 5: Block the merge_completion_fiber. This prevents it from
+        # stopping compactions on the merging groups after the merge fires.
+        await manager.api.enable_injection(server.ip_addr, "merge_completion_fiber", one_shot=True)
+
+        log = await manager.server_open_log(server.server_id)
+        log_mark = await log.mark()
+
+        try:
+            # Step 6: Trigger merge (2 → 1 tablet). The topology coordinator
+            # will swap the tablet map synchronously. The old groups become
+            # merging groups, but their compactions are NOT stopped (fiber is blocked).
+            target_tablets = 1
+            await cql.run_async(f"ALTER TABLE {ks}.test WITH tablets = {{'min_tablet_count': {target_tablets}}}")
+            await manager.enable_tablet_balancing()
+
+            # Wait for merge to be finalized (tablet count changes)
+            started = time.time()
+            while True:
+                tablet_count = await get_tablet_count(manager, server, ks, 'test')
+                if tablet_count == target_tablets:
+                    break
+                assert time.time() - started < 120, f'Timeout waiting for merge (current={tablet_count}, target={target_tablets})'
+                await asyncio.sleep(0.5)
+
+            logger.info("Merge done, tablet count = %s", tablet_count)
+
+            # Step 7: Now run major compaction with consider_only_existing_data=True
+            # (disables commitlog check so tombstones can actually be GC'd).
+            # The compaction will run on the merging group, produce GC sstables
+            # routed to the new main CG, and crash on GC release.
+            await manager.api.keyspace_compaction(server.ip_addr, ks, consider_only_existing_data=True)
+
+            # Assert on the log rather than relying on the node having cored: the
+            # compaction runs in the background, so a regression can fail the removal
+            # without the API call itself reporting anything.
+            failed_removals = await log.grep("Unable to remove input SSTable", from_mark=log_mark)
+            assert not failed_removals, \
+                f"Input SSTable removed from the wrong compaction group: {failed_removals[0][0]}"
+            logger.info("Compaction completed successfully (bug is fixed)")
+        finally:
+            # Unblock the merge fiber to let cleanup proceed. In a finally block
+            # since step 7 is what crashes when the bug is present, and leaving
+            # the fiber parked would hold up the keyspace drop and node teardown
+            # until its own 5 minute timeout. Best effort: when the bug is present
+            # the node is gone by now and there is nothing left to unblock, so
+            # don't let this replace the failure that got us here.
+            try:
+                await manager.api.wait_for_injection_enter(server.ip_addr, "merge_completion_fiber")
+                await manager.api.message_injection(server.ip_addr, "merge_completion_fiber")
+            except Exception:
+                logger.warning("Failed to release merge_completion_fiber", exc_info=True)


### PR DESCRIPTION
Given an sstable, there was no way to tell which compaction group owns it. Only
the opposite mapping existed, from a group to the sstables in its main and
maintenance sstable sets, so answering the question meant scanning every group
of the table.

This series adds a back-pointer to `sstables::sstable`, maintained by
`replica::compaction_group` as the sstable joins and leaves its sstable sets,
exposed as `sstable::get_compaction_group()`. It is null while the sstable
belongs to no group, e.g. right after compaction created it and before it was
attached to a table, or after it was compacted away. An sstable belongs to at
most one compaction group at a time, and `compaction_group::link_sstable()`
reports an internal error if that invariant is found to be broken.

The back-pointer is weak, since the compaction group is the one owning the
sstable and not the other way around. An owning reference would close a cycle
through the group's sstable sets, so a group dropped while still holding
sstables would leak silently, taking its open file descriptors with it, and
`~compaction_group()` would never run to report it. A weak reference clears
itself instead.

Sstables enter a group through `do_add_sstable()` and enter or leave it through
`set_main_sstables()` and `set_maintenance_sstables()`. The latter two install a
fully rebuilt set rather than a delta, so they reconcile the back-pointers by
diffing the old set against the new one. An sstable leaves the group only if
it's gone from both of its sets, otherwise an sstable promoted from the
maintenance set to the main set by off-strategy compaction would be unlinked
even though it never left the group.

The last two patches are an alternative fix for SCYLLADB-3595, replacing the one
in #31083, together with the reproducer test from that PR.

`sstable_list_updater::prepare()` routes compaction output sstables to their
group through the live tablet map, but pins the input sstables to `_cg`, the
group the compaction runs on. A garbage-collection sstable is added in one
replacer call and removed in a later one, so a tablet merge that swaps the
tablet map in between makes the two operations target different groups, and the
removal aborts with 'Unable to remove input SSTable'. The fix asks each input
sstable which group holds it, rather than recomputing the routing that went
stale in the first place.

## Tests

`compaction_group_test.cc` gains a test walking an sstable from detached, to the
main set, to the maintenance set, through off-strategy compaction and then major
compaction, asserting at each step that it belongs to the group if and only if
the table still owns it. Mutation-tested by disabling `unlink_sstable()`.

The reproducer from #31083 aborts on the parent commit and passes on the fix.

Also ran, all green: 484 boost tests (compaction_group, sstable_compaction,
tablets, incremental_compaction, database, view_build) and 114 cluster tests
(test_tablets_merge, test_tablets, test_truncate_with_tablets).

Fixes https://scylladb.atlassian.net/browse/SCYLLADB-3595

Regression was caused by 742affe1035df93225216ee8ad7c0457c8bc68ab (2026.1.11) and therefor requires backport to 2026.1 and forward.
