### PR TITLE
docs: address review follow-ups for Full-Text Search docs

### DIFF
--- a/docs/cql/cql-extensions.md
+++ b/docs/cql/cql-extensions.md
@@ -491,6 +491,7 @@ statement: `DESCRIBE SCHEMA WITH INTERNALS AND PASSWORDS`, which also includes t
 
 For more details, see [the article on DESCRIBE SCHEMA](./describe-schema.rst).
 
+(cql-per-row-ttl)=
 ## Per-row TTL
 
 CQL's traditional time-to-live (TTL) feature attaches an expiration time to

--- a/docs/cql/dml/select.rst
+++ b/docs/cql/dml/select.rst
@@ -434,14 +434,13 @@ have a :ref:`full-text index <create-fulltext-index-statement>` created with
 and scores rows using the BM25 ranking algorithm.
 
 A full-text search query must contain **both** of the following clauses,
-referencing the **same** column:
+referencing the **same** column and the **same** search term:
 
 * A ``WHERE`` filter of the exact form ``BM25(column, 'term') > 0``.
 * An ``ORDER BY BM25(column, 'term')`` clause that ranks the matching rows.
 
 Neither clause is accepted on its own. A query that has only ``WHERE BM25()`` or
-only ``ORDER BY BM25()`` is rejected, and the two clauses must reference the same
-column.
+only ``ORDER BY BM25()`` is rejected.
 
 **Syntax:**
 
@@ -460,6 +459,9 @@ not a partition-key column.
 ``ORDER BY BM25()`` must be the only ordering in the query - it cannot be combined
 with another ``ORDER BY`` column, a second ``BM25()`` ordering, or an ``ANN``
 ordering.
+
+A ``LIMIT`` clause is mandatory; queries without ``LIMIT`` are rejected. The
+specified value must not exceed 1000.
 
 **Examples:**
 

--- a/docs/cql/secondary-indexes.rst
+++ b/docs/cql/secondary-indexes.rst
@@ -371,11 +371,32 @@ The following options are supported for full-text indexes:
 | ``analyzer``   | Text analyzer for tokenization. Determines how text is split into terms.                  | ``standard``      |
 |                | Supported values (case-insensitive): ``standard``, ``english``, ``german``,               |                   |
 |                | ``french``, ``spanish``, ``italian``, ``portuguese``, ``russian``, ``simple``,            |                   |
-|                | ``whitespace``. CJK analyzers (``chinese``, ``japanese``, ``korean``) are not supported.  |                   |
+|                | ``whitespace``. No other values are supported.                                            |                   |
 +----------------+-------------------------------------------------------------------------------------------+-------------------+
 | ``positions``  | Whether token positions are stored. Required for phrase queries.                          | ``true``          |
 |                | Supported values: ``true``, ``false`` (case-insensitive).                                 |                   |
 +----------------+-------------------------------------------------------------------------------------------+-------------------+
+
+The analyzers differ in how they tokenize and normalize text:
+
+* ``standard`` splits text into terms on whitespace and punctuation, lowercases
+  them, and applies a generic set of English stop words. It does not apply any
+  language-specific stemming.
+* The language analyzers (``english``, ``german``, ``french``, ``spanish``,
+  ``italian``, ``portuguese``, ``russian``) tokenize and lowercase like
+  ``standard``, but additionally apply stemming and stop-word removal specific
+  to that language, so that related word forms (e.g., ``running`` and ``run``)
+  match the same term.
+* ``simple`` lowercases text and splits on any non-alphanumeric character
+  (including punctuation); digits and letters adjacent to each other stay in
+  the same term (e.g., ``abc123`` is one term), while punctuation is dropped
+  rather than kept as part of a term or as a term of its own (e.g., ``don't``
+  becomes the terms ``don`` and ``t``). It does not apply stemming or
+  stop-word removal.
+* ``whitespace`` splits only on whitespace characters; punctuation attached to
+  a word is kept as part of that term (e.g., ``Hello, World!`` becomes the terms
+  ``Hello,`` and ``World!``). It does not apply lowercasing, stemming,
+  or stop-word removal.
 
 .. _drop-index-statement:
 

--- a/docs/features/fulltext-search.rst
+++ b/docs/features/fulltext-search.rst
@@ -25,7 +25,11 @@ target column::
 
     CREATE CUSTOM INDEX ON ks.t (v) USING 'fulltext_index';
 
-You can specify an analyzer to control how text is tokenized::
+You can specify an analyzer to control how text is tokenized. The default is
+``standard``; for a description of each supported analyzer, see
+:ref:`Full-text Index <create-fulltext-index-statement>`.
+
+::
 
     CREATE CUSTOM INDEX ON ks.t (v) USING 'fulltext_index'
         WITH OPTIONS = {'analyzer': 'english'};
@@ -42,6 +46,13 @@ You can specify an analyzer to control how text is tokenized::
   CDC is enabled automatically when creating a fulltext index, so you do not
   need to configure it manually.
 
+Cell-level TTL, set with the standard ``USING TTL`` syntax on ``INSERT`` or
+``UPDATE``, makes the value unreadable at its expiration deadline but does
+not generate a CDC event, so the fulltext index is not updated and keeps a
+stale entry for that value. If the index must reflect expiration, use the
+:ref:`Per-row TTL <cql-per-row-ttl>` feature instead: it deletes expired rows
+explicitly and does generate a CDC event.
+
 Querying with BM25
 -------------------
 
@@ -49,7 +60,7 @@ FTS queries use the ``BM25()`` function to score rows against a search term.
 ``BM25()`` takes two arguments: a column name and a query string.
 
 A full-text search query must use ``BM25()`` in **both** of these clauses, on
-the **same** column:
+the **same** column and with the **same** search term:
 
 * A ``WHERE`` clause of the exact form ``BM25(column, 'term') > 0`` to **filter**
   the rows that match the search term.
@@ -93,23 +104,16 @@ The query term can be supplied with a bind marker in prepared statements::
         ORDER BY BM25(v, ?)
         LIMIT 10;
 
+Both bind markers are checked at execution time and must be given the same
+value; binding different values for the ``WHERE`` and ``ORDER BY`` markers
+causes the query to be rejected.
+
 Disambiguating from a user-defined function
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 ``BM25`` is not a reserved word. If a keyspace defines a user-defined function
 named ``bm25``, an unqualified ``BM25()`` call becomes ambiguous; qualify the
 built-in operator as ``system.bm25(...)`` to select it explicitly.
-
-Unsupported ScyllaDB Features
-------------------------------
-
-Full-text indexes do not support all ScyllaDB features. The following features
-are not supported when using Full-Text Search:
-
-* Tracing
-* TTL (Time To Live)
-* Paging
-* Grouping (``GROUP BY``)
 
 Query Constraints
 ------------------
@@ -135,8 +139,9 @@ FTS queries enforce the following rules:
        restriction (e.g., a partition key equality) is rejected. Combined filtering
        is planned for a future release.
    * - ``LIMIT`` is required
-     - Every FTS query must include a ``LIMIT`` clause. Queries without
-       ``LIMIT`` are rejected.
+     - Every FTS query must include a ``LIMIT`` clause of at most 1000.
+       Queries without ``LIMIT``, or with a ``LIMIT`` greater than 1000,
+       are rejected.
    * - ``PER PARTITION LIMIT`` not supported
      - ``PER PARTITION LIMIT`` cannot be used with FTS queries.
    * - Aggregation not supported
@@ -148,10 +153,11 @@ FTS queries enforce the following rules:
    * - ``BM25()`` cannot appear in ``SELECT``
      - ``BM25()`` is only valid in ``WHERE`` and ``ORDER BY`` clauses, not
        as a selector.
-   * - Partition key columns excluded
-     - A ``fulltext_index`` cannot be created on a partition key column, so
-       ``BM25()`` cannot target one. Regular and clustering-key text columns
-       are supported.
    * - Single ordering only
      - ``ORDER BY BM25()`` cannot be combined with other ``ORDER BY`` columns,
        a second ``BM25()`` ordering, or with ``ANN`` ordering.
+   * - Paging not supported
+     - FTS queries do not support paging; all matching rows up to ``LIMIT``
+       are returned in a single page.
+   * - Grouping not supported
+     - FTS queries cannot include a ``GROUP BY`` clause.


### PR DESCRIPTION
Resolve remaining review comments from PR #30014.

Clarify that WHERE/ORDER BY BM25() must share the same term (not just column). Document the mandatory LIMIT <= 1000.
Explain how the analyzer values differ instead of singling out CJK as unsupported. Correct the inaccurate TTL restriction claim, and move paging/grouping/partition-key constraints into the Query Constraints table where they belong.

Fixes: SCYLLADB-3126

Backport to 2026.3 as it was the version FTS support was introduced.