### PR TITLE
logstor: add missing include

### DIFF
--- a/replica/logstor/logstor.cc
+++ b/replica/logstor/logstor.cc
@@ -9,6 +9,7 @@
 #include <seastar/core/coroutine.hh>
 #include <seastar/util/log.hh>
 #include <seastar/core/future.hh>
+#include <seastar/core/metrics.hh>
 #include "query/query-request.hh"
 #include "readers/from_mutations.hh"
 #include "keys/keys.hh"


### PR DESCRIPTION
Add missing include for changes in #30721. Without this include, Scylla does not compile when configured with `--disable-precompiled-header`. The error is masked in CI because of the precompiled headers, similarly to #30934.

no backport, the PR which introduced this changes was not backported