### PR TITLE
test/cluster/object_store: wait for sealed registry entries before verifying

### DIFF
--- a/test/cluster/object_store/test_scaling.py
+++ b/test/cluster/object_store/test_scaling.py
@@ -15,7 +15,7 @@ import pytest
 from test.pylib.manager_client import ManagerClient
 from test.pylib.object_storage import keyspace_options
 from test.cluster.util import new_test_keyspace, wait_for_no_pending_topology_transition, wait_for_no_running_compactions
-from test.pylib.util import wait_for_cql_and_get_hosts
+from test.pylib.util import wait_for, wait_for_cql_and_get_hosts
 from test.pylib.tablets import get_all_tablet_replicas
 from cassandra.query import SimpleStatement, ConsistencyLevel
 
@@ -120,6 +120,28 @@ async def test_scaling(manager: ManagerClient, object_storage):
             table_id = str(await manager.get_table_id(ks, "test"))
 
             live_hosts = await wait_for_cql_and_get_hosts(cql, live_servers, time.time() + 30)
+
+            # An sstable's registry entry is non-sealed for the whole interval in
+            # which its object-storage state may change: wipe() marks it "removing"
+            # before any object is touched, and destroy() deletes the entry only
+            # after the last one is gone (garbage_collect() uses the same order).
+            # A "creating" entry likewise covers the interval in which the objects
+            # are being written.  So once every entry is sealed, the bucket is
+            # quiescent and the checks below observe a consistent snapshot rather
+            # than an sstable caught mid-creation or mid-deletion.
+            async def all_entries_sealed():
+                per_host = await asyncio.gather(*(cql.run_async(
+                    "SELECT table_id, node_owner, generation, status FROM system.sstables", host=host)
+                    for host in live_hosts))
+                unsealed = [(str(row.node_owner), str(row.generation), row.status)
+                            for rows in per_host for row in rows
+                            if str(row.table_id) == table_id and row.status != "sealed"]
+                if unsealed:
+                    logger.info("Waiting for %d unsealed registry entries: %s", len(unsealed), unsealed)
+                    return None
+                return True
+
+            await wait_for(all_entries_sealed, time.time() + 120)
 
             async def get_object_storage_refs():
                 sstables = await manager.api.client.get_json("/storage_service/object_storage/sstables", host=server.ip_addr, params=params)


### PR DESCRIPTION
verify_object_storage_namespace() asserts that every sstable listed in the bucket has at least one object under refs/. That is not an invariant: object_storage_base::destroy() deletes this node's reference object first, re-lists the references to learn whether it was the last owner, and only then deletes the components. Between those two steps the sstable's prefix holds components but nothing under refs/, and the listing endpoint derives the sstable set from any key under sstables/, so it reports the sstable with num_references == 0 and the test fails with "SSTable <uuid> has no object-storage references".

The order cannot be reversed: deleting the reference is the decrement of a refcount whose only storage is the bucket, so the check has to follow it. Two nodes sharing an sstable id - which tablet migration creates via reference sharing - releasing it concurrently would otherwise both see two references, both skip deleting the components, and leave the objects orphaned with no "removing" registry entry for garbage_collect() to act on.

Nothing the test can wait on covers destroy() either. It runs fire-and-forget from the shared_sstable deleter once the last in-memory reference drops, and wipe() performs no bucket operation at all for object storage, only marking the registry entry "removing". So when wait_for_no_running_compactions() returns, the deletion of that compaction's inputs has not started yet.

Wait for the registry instead. A non-sealed entry exists for the whole interval in which an sstable's object-storage state can change, on both ends: wipe() and atomic_deletion_impl::commit() mark it "removing" before any object is touched, destroy() deletes the entry only after the last object is gone, and garbage_collect() uses the same order; on the creation side the entry is "creating" until the objects are written. Polling every live node until all entries for the table are sealed therefore makes the bucket quiescent, which is the precondition both assertions need. It also covers the "removing" variant of the bucket-versus-registry key comparison, whose "creating" variant was addressed for SCYLLADB-3284 by draining migrations and compactions.

Fixes: SCYLLADB-3625

**No backport required. Fixes test flakiness on master**