### PR TITLE
replica: don't admit new compactions while a compaction group is stopped

### DIFF
--- a/compaction/compaction_manager.hh
+++ b/compaction/compaction_manager.hh
@@ -462,6 +462,10 @@ private:
 
 public:
     // Stops ongoing compaction of a given table and/or compaction_type.
+    // Never fails: any error encountered while stopping is logged and swallowed, so
+    // callers may rely on the returned future resolving successfully. In particular it
+    // is safe to co_await it while holding a future that must still be awaited
+    // afterwards (see compaction_group::stop()).
     future<> stop_ongoing_compactions(sstring reason, compaction::compaction_group_view* t = nullptr, std::optional<compaction_type> type_opt = {}) noexcept;
 
     future<> await_ongoing_compactions(compaction_group_view* t);

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -3338,9 +3338,16 @@ compaction_group::~compaction_group() {
 }
 
 future<> compaction_group::stop(sstring reason) noexcept {
-    if (_async_gate.is_closed()) {
+    if (stopped()) {
         co_return;
     }
+    // Mark the gate closed before stopping compactions, and only wait for it to drain
+    // below. Same reasoning as in storage_group::stop(): table-wide iterations hold this
+    // gate across a *sequence* of per-view operations (see
+    // table::parallel_foreach_compaction_group_view()), so unless they can observe that
+    // this group is being stopped, aborting the currently registered task merely lets
+    // them start a new one for the next view, and the gate never drains.
+    auto closed_gate_fut = _async_gate.close();
   // FIXME: indentation
   for (auto view : all_views()) {
     co_await _t._compaction_manager.stop_ongoing_compactions(reason, view);
@@ -3348,7 +3355,9 @@ future<> compaction_group::stop(sstring reason) noexcept {
     if (_t.uses_logstor()) {
         co_await get_logstor_compaction_manager().stop_ongoing_compactions(*this);
     }
-    co_await _async_gate.close();
+    // compaction_manager::stop_ongoing_compactions swallows all encountered errors. So the closed_gate_fut
+    // future will not get abandoned.
+    co_await std::move(closed_gate_fut);
     auto flush_future = co_await seastar::coroutine::as_future(flush());
 
     co_await flush_separator();
@@ -5507,6 +5516,14 @@ compaction::compaction_group_view& table::try_get_compaction_group_view_with_sta
 future<> table::parallel_foreach_compaction_group_view(std::function<future<>(compaction::compaction_group_view&)> action) {
     return parallel_foreach_compaction_group([action = std::move(action)] (compaction_group& cg) -> future<> {
        for (auto view : cg.all_views()) {
+           // The gate holder taken by parallel_foreach_compaction_group() spans every
+           // view, so re-check it between views: once this group starts being stopped
+           // (tablet cleanup, table removal), starting work for a further view would
+           // hold the gate open and block the stop. Skipping is the intended behaviour
+           // for table-wide ops racing a migration, see parallel_foreach_storage_group().
+           if (cg.stopped()) {
+               co_return;
+           }
            co_await action(*view);
        }
     });

--- a/test/cluster/test_tablets2.py
+++ b/test/cluster/test_tablets2.py
@@ -859,6 +859,80 @@ async def test_concurrent_table_drop_and_major(manager: ManagerClient):
             logger.info("Check that major was successfully aborted on migration")
             await s1_log.wait_for(f"ongoing compactions for table {ks}.test .* due to table removal", from_mark=s1_mark)
 
+@pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
+async def test_tablet_leaves_cleanup_stage_during_major_compaction(manager: ManagerClient):
+    """Reproducer for SCYLLADB-3758: tablet migration stuck in stage=cleanup.
+
+    table::parallel_foreach_compaction_group_view() holds one
+    compaction_group::_async_gate holder across a major compaction of each of
+    compaction_group::all_views() (three of them), run sequentially. Tablet cleanup goes
+    compaction_group::stop(), which aborts the tasks registered at that instant and only
+    then waits on that gate. Since perform_major_compaction() passes
+    throw_if_stopping::no, the abort surfaces as a successful return, so the iteration
+    just advances to the next view and registers a fresh major compaction that the abort
+    loop has already walked past -- the gate never drains and the tablet never leaves
+    stage=cleanup.
+
+    In production the wait is unbounded rather than infinite: each per-view major
+    acquires the shard-wide single-unit _maintenance_ops_sem before checking
+    can_proceed(), so it queues behind every other tablet's major on the shard. The
+    injection below stands in for that queue.
+
+    Unlike test_concurrent_tablet_migration_and_major above, the injection is *not*
+    one-shot: with one_shot=True only the first view parks, views two and three finish
+    immediately and the gate holder is released, which is why that test passes even
+    without the fix.
+    """
+    src = await manager.server_add()
+    await manager.disable_tablet_balancing()
+
+    cql = manager.get_cql()
+    async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1}"
+                                          " AND tablets = {'initial': 1}") as ks:
+        # Created directly rather than with new_test_table(), whose finally-block DROPs the
+        # table unconditionally. On the failing path this test deliberately leaves a tablet
+        # stuck mid-migration, and that DROP then blocks behind it until the driver's client
+        # timeout, masking the failure with cassandra.OperationTimedOut. new_test_keyspace()
+        # is fine: it skips its DROP when the body raises.
+        await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, t text);")
+
+        await asyncio.gather(*[cql.run_async(f"INSERT INTO {ks}.test (pk, t) VALUES ({k}, '{k}');") for k in range(256)])
+        # Give the major compaction something to do, so it really reaches do_run().
+        await manager.api.flush_keyspace(src.ip_addr, ks)
+
+        dst = await manager.server_add()
+        dst_host_id = await manager.get_host_id(dst.server_id)
+
+        src_log = await manager.server_open_log(src.server_id)
+        src_mark = await src_log.mark()
+
+        await manager.api.enable_injection(src.ip_addr, "major_compaction_wait", one_shot=False)
+
+        logger.info("Starting table-wide major compaction")
+        compaction = asyncio.create_task(manager.api.keyspace_compaction(src.ip_addr, ks))
+        await manager.api.wait_for_injection_enter(src.ip_addr, "major_compaction_wait")
+
+        replicas = await get_all_tablet_replicas(manager, src, ks, 'test')
+        assert len(replicas) == 1, f"expected a single tablet, got {len(replicas)}"
+        tablet = replicas[0]
+
+        logger.info("Migrating the tablet away, which puts it into stage=cleanup")
+        migration = asyncio.create_task(manager.api.move_tablet(
+            src.ip_addr, ks, 'test',
+            *tablet.replicas[0], dst_host_id, 0, tablet.last_token))
+
+        # Confirm the source really entered tablet cleanup, so that a timeout below can
+        # only mean "stuck in cleanup" and not a stall in an earlier stage such as
+        # streaming. This line is emitted by cleanup's own abort of the parked major.
+        # Note the slash: compaction_stopped_exception formats "<ks>/<table>".
+        await src_log.wait_for(f"Compaction for {ks}/test was stopped due to: tablet cleanup",
+                               from_mark=src_mark)
+        logger.info("Tablet reached stage=cleanup on the source")
+
+        # move_tablet returns only once the migration has left stage=cleanup.
+        await asyncio.wait_for(migration, timeout=30)
+        await asyncio.wait_for(compaction, timeout=30)
+
 async def assert_tablet_count_metric_value_for_shards(manager: ManagerClient, server: ServerInfo, expected_count_per_shard: list[int]):
     tablet_count_metric_name = "scylla_tablets_count"
     metrics = await manager.metrics.query(server.ip_addr)


### PR DESCRIPTION
A tablet migration can get stuck in stage=cleanup indefinitely when a table-wide major compaction is in flight on the leaving replica, which blocks decommission until it times out, with nothing logged.

table::parallel_foreach_compaction_group_view() takes a single compaction_group::_async_gate holder and then, under that one holder, runs an operation for each of compaction_group::all_views() -- three views -- sequentially. Tablet cleanup reaches compaction_group::stop(), which aborts the compaction tasks registered at that instant, per view, and only then waits on that gate.

Since perform_major_compaction() passes throw_if_stopping::no, the abort surfaces to the caller as a successful return rather than an exception, so the iteration simply advances to the next view and registers a fresh major-compaction task that the abort loop has already walked past. Nothing stops that one: compaction_state::gate is closed later, in compaction_manager::remove(), which runs after the gate close. The gate holder therefore outlives the abort and _async_gate.close() never completes.

Fix both halves of the problem:

- compaction_group::stop() now marks the gate closed before stopping compactions and only waits for it to drain at the end. This mirrors storage_group::stop(), whose existing comment already spells out the reasoning: "start it earlier to prevent iterations from picking this group that is being stopped".

- table::parallel_foreach_compaction_group_view() re-checks the gate between views, since the holder spans all of them. Skipping is the intended behaviour here, as documented in storage_group_manager::parallel_foreach_storage_group(): "Table-wide ops, like 'nodetool compact', are inherently racy with migrations, so it's okay to skip storage of tablets being migrated away."

Fixes: https://scylladb.atlassian.net/browse/SCYLLADB-3758

**All versions starting from 2026.1 are affected and require backport. 2025.1 is not affected: compact_all_sstables() there performs a single operation per gate holder — no view loop**