### PR TITLE
view_building_worker: Fix lost wakeup in staging sstables registrator

### DIFF
--- a/db/view/view_building_worker.cc
+++ b/db/view/view_building_worker.cc
@@ -218,7 +218,18 @@ future<> view_building_worker::run_staging_sstables_registrator() {
         try {
             co_await create_staging_sstable_tasks();
             _as.check();
-            co_await _sstables_to_register_event.when();
+            // create_staging_sstable_tasks() releases _staging_sstables_mutex just before
+            // returning here. Releasing a semaphore's units may run a waiter's continuation
+            // right there, and reaching this line after that is itself a deferred/preempted
+            // continuation -- so there is a real scheduling gap, between the mutex being
+            // released and this fiber becoming a waiter on the condition variable, during
+            // which register_staging_sstable_tasks() can grab the mutex, queue an entry and
+            // broadcast() with nobody waiting yet. broadcast() (unlike signal()) does not
+            // remember such a notification, so a bare when() here could sleep forever with
+            // work already queued. Using a predicate closes that gap: it is checked before
+            // suspending, so any entry queued during the gap above is picked up immediately
+            // instead of relying on a broadcast() that may never have had a waiter to wake.
+            co_await _sstables_to_register_event.when([this] { return !_sstables_to_register.empty(); });
         } catch (semaphore_aborted&) {
             vbw_logger.warn("Got semaphore_aborted while creating staging sstable tasks");
         } catch (broken_condition_variable&) {


### PR DESCRIPTION
register_staging_sstable_tasks() appends an entry to _sstables_to_register and notifies run_staging_sstables_registrator() with _sstables_to_register_event.broadcast(). Unlike signal(), broadcast() only wakes waiters present at that exact moment and does not remember a notification issued while nobody is waiting.

The registrator's loop is:

    co_await create_staging_sstable_tasks();
    _as.check();
    co_await _sstables_to_register_event.when();

create_staging_sstable_tasks() releases _staging_sstables_mutex just before returning. That release can hand off to a waiter's continuation immediately, and reaching the when() above is itself a continuation that may be deferred or preempted -- so there is a real scheduling gap between the mutex being released and this fiber becoming a waiter on the condition variable. If register_staging_sstable_tasks() runs in that gap, it queues its entry and calls broadcast() with no one waiting yet; the notification is dropped, and the queued sstable is never looked at again. No view building task is created for it, no view updates are generated from it, and it is never moved out of the staging/ directory -- silently, with nothing logged.

Fix: use the predicate form of when(). The predicate is evaluated before suspending, so if an entry was queued during the gap above, it is picked up immediately regardless of whether the broadcast() had a waiter to wake.

This is a tiny, classic scheduling race between releasing a semaphore and becoming a condition-variable waiter, not a complex functional bug, so no regression test is added for it here -- see below for why and what it would take.

Fixes SCYLLADB-3772
Same code in 2026.* branches, so worth backporting there too

--------------------------------------------------------------------------

Not included: a deterministic reproducer was written and run successfully against this fix (and confirmed to fail without it) as test_worker_misses_cv_broadcast_on_staging_registration in test/cluster/test_view_building_coordinator.py. It is not being committed: pinning a multi-node, multi-step, tablet-migration-based test as the permanent regression guard for a two-line scheduling race between a semaphore and a condition variable is disproportionate, and the test can only be made deterministic (rather than a ~1%-probability flake) by adding a dedicated error injection point in view_building_worker.cc, which itself is more test-scaffolding baggage than this fix should carry permanently.

For reference, reproducing it deterministically requires re-adding an injection point in run_staging_sstables_registrator(), right after create_staging_sstable_tasks() and before the when() above, e.g.:

    co_await utils::get_local_injector().inject(
        "view_building_worker_pause_before_awaiting_sstables_to_register",
        utils::wait_for_message(std::chrono::minutes(5)));

which parks the registrator exactly in the gap described above, so that a subsequent registration's broadcast() is guaranteed to find no waiter. The test that exercised it, kept here for the record:

```python
@pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode') async def test_worker_misses_cv_broadcast_on_staging_registration(manager: ManagerClient):
    node_count = 2
    smp = 2
    servers = await manager.servers_add(node_count, cmdline=cmdline_loggers + [f'--smp={smp}'], property_file=[
        {"dc": "dc1", "rack": "r1"},
        {"dc": "dc1", "rack": "r2"},
    ])
    cql, hosts = await manager.get_ready_cql(servers)
    await manager.disable_tablet_balancing()

    async with new_test_keyspace(manager, f"WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor': 2}} AND tablets = {{'initial': 1}}") as ks:
        await cql.run_async(f"CREATE TABLE {ks}.tab (key int, c int, v int, PRIMARY KEY (key))")

        rows = 1000
        for i in range(rows):
            await cql.run_async(f"INSERT INTO {ks}.tab (key, c, v) VALUES ({i}, {i}, 1)")

        await cql.run_async(f"CREATE MATERIALIZED VIEW {ks}.mv AS SELECT * FROM {ks}.tab "
                        "WHERE key IS NOT NULL AND c IS NOT NULL PRIMARY KEY (c, key) ")
        await wait_for_view(cql, 'mv', node_count)

        # Step 2: delete node0's sstables on disk and restart it empty, so that it has
        # nothing for tab/mv and a subsequent repair must stream all the rows back in.
        await manager.api.keyspace_flush(servers[0].ip_addr, ks, "tab")
        await manager.api.keyspace_flush(servers[0].ip_addr, ks, "mv")
        await delete_table_sstables(manager, servers[0], ks, "tab")
        await delete_table_sstables(manager, servers[0], ks, "mv")
        await manager.server_stop_gracefully(servers[0].server_id)
        await manager.server_start(servers[0].server_id)
        hosts = await wait_for_cql_and_get_hosts(cql, [servers[0]], time.time() + 30)

        # Step 3: block node0's view_update_generator from ever consuming a staging
        # sstable. Not part of the race -- this only keeps the sstable repair is about to
        # create sitting in staging/ long enough to survive to the migration in step 6,
        # instead of being consumed and relocated out of staging/ right away.
        s0_log = await manager.server_open_log(servers[0].server_id)
        s0_mark = await s0_log.mark()
        await manager.api.enable_injection(servers[0].ip_addr, "view_update_generator_consume_staging_sstable", one_shot=False)
        # Step 4: repair streams the missing rows into node0 via streaming/consumer.cc.
        # reason=repair with no view build in progress means check_needs_view_update_path()
        # returns staging_directly_to_generator, so this lands as one real sstable in
        # staging/, handed to the generator, which immediately fails on the step-3
        # injection. State: exactly one genuine sstable in staging/, untouched by
        # view_building_worker.
        await manager.api.repair(servers[0].ip_addr, ks, "tab")
        await s0_log.wait_for(f"Processing {ks} failed for table tab", from_mark=s0_mark, timeout=60)
        await s0_log.wait_for(f"Finished user-requested repair for tablet keyspace={ks}", from_mark=s0_mark, timeout=60)

        # Step 5: add a third node with its registrator parked right after its first
        # (empty) pass -- in the exact gap between finishing
        # create_staging_sstable_tasks() and calling when(), holding no mutex and not yet
        # a waiter on the condition variable. It has to be a separate node from node0
        # because the registration this test targets (stream_blob.cc's ungated,
        # file-streaming path) only fires on the node *receiving* a streamed-in sstable,
        # never on the node repairing/originating it.
        pause_registrator = "view_building_worker_pause_before_awaiting_sstables_to_register"
        new_server = await manager.server_add(cmdline=cmdline_loggers, property_file={"dc": "dc1", "rack": "r1"}, config={
            'error_injections_at_startup': [{'name': pause_registrator, 'one_shot': True}]
        })
        await manager.api.wait_for_injection_enter(new_server.ip_addr, pause_registrator)
        new_log = await manager.server_open_log(new_server.server_id)
        new_mark = await new_log.mark()

        # Step 6 *** the race trigger ***: move the tablet (and its one staging sstable)
        # to the new node. This goes through the ungated file-streaming path, which calls
        # register_staging_sstable_tasks() unconditionally because the sstable's state is
        # staging. The entry is queued and broadcast() is called -- but the registrator is
        # already parked, not waiting on the condition variable, so the notification is
        # dropped right here. State: the sstable file has physically moved to the new
        # node's staging/ dir; its queue entry is stranded; no notification is pending.
        s0_host_id = await manager.get_host_id(servers[0].server_id)
        new_host_id = await manager.get_host_id(new_server.server_id)
        tablet_token = 0 # Doesn't matter since there is one tablet
        replicas = await get_tablet_replicas(manager, servers[0], ks, "tab", tablet_token)
        src_replica = next((r for r in replicas if r[0] == s0_host_id), None)
        assert src_replica is not None, "node0 is not a replica of the tablet"

        await manager.api.move_tablet(servers[0].ip_addr, ks, "tab", src_replica[0], src_replica[1], new_host_id, 0, tablet_token)
        await new_log.wait_for("Saving 1 sstables for table .* to create view building tasks", from_mark=new_mark, timeout=60)

        # Step 7: release the registrator. It immediately calls the now-useless when() --
        # the broadcast() from step 6 is already lost, so without the fix (predicate-based
        # when()) this sleeps forever and "Creating process staging task" never appears,
        # which is how this test fails pre-fix. With the fix, the registrator re-checks
        # the now-nonempty queue immediately instead of relying on the dropped
        # notification, and proceeds.
        await manager.api.message_injection(new_server.ip_addr, pause_registrator)
        await new_log.wait_for("Creating process staging task", from_mark=new_mark, timeout=60)
        await new_log.wait_for(f"Processed {ks}.tab:", from_mark=new_mark, timeout=60)

        # Step 8: view updates generated by staging sstables aren't awaited in the
        # consumer, so the view building task may be finished before all the view updates
        # were written. Wait for the backlog on the node that generated them to drop to 0,
        # then verify both tab and mv show the full row count on the new node -- proving
        # the previously-stranded sstable's rows made it into the base table and the view.
        async def view_updates_drained():
            local_metrics = await manager.metrics.query(new_server.ip_addr)
            for shard in range(smp):
                backlog = local_metrics.get("scylla_database_view_update_backlog", {'shard':str(shard)})
                if backlog > 0:
                    return None
            return True
        await wait_for(view_updates_drained, deadline=time.time() + 30)

        new_hosts = await wait_for_cql_and_get_hosts(cql, [new_server], time.time() + 30)
        await asyncio.gather(*(manager.server_stop_gracefully(s.server_id) for s in servers))
        await assert_row_count_on_host(cql, new_hosts[0], ks, "tab", rows)
        # Start node0 here because the view replica might not be migrated to the new node,
        # since they are not colocated
        await manager.server_start(servers[0].server_id)
        await assert_row_count_on_host(cql, new_hosts[0], ks, "mv", rows)
        await manager.server_start(servers[1].server_id)
```