### PR TITLE
Revert "Merge 'Run restore-from-backup in the maintenance/backup sche…

### DIFF
--- a/debug.cc
+++ b/debug.cc
@@ -13,6 +13,5 @@ namespace debug {
 seastar::sharded<replica::database>* volatile the_database = nullptr;
 seastar::scheduling_group streaming_scheduling_group;
 seastar::scheduling_group gossip_scheduling_group;
-seastar::scheduling_group backup_scheduling_group;
 
 }

--- a/debug.hh
+++ b/debug.hh
@@ -19,7 +19,6 @@ namespace debug {
 extern seastar::sharded<replica::database>* volatile the_database;
 extern seastar::scheduling_group streaming_scheduling_group;
 extern seastar::scheduling_group gossip_scheduling_group;
-extern seastar::scheduling_group backup_scheduling_group;
 
 }
 

--- a/docs/features/backup-and-restore.rst
+++ b/docs/features/backup-and-restore.rst
@@ -41,13 +41,9 @@ Backup Process
 #. **Native Configuration**: 
 
    * For `native` backup to work without interference to users' workload, it is
-     best to limit io-scheduling. See :ref:`backup_io_throughput_mb_per_sec <confprop_backup_io_throughput_mb_per_sec>` for details.
+     best to limit io-scheduling. See :ref:`stream_io_throughput_mb_per_sec <confprop_stream_io_throughput_mb_per_sec>` for details.     
    * For `native` backup to work, ScyllaDB node must have access to the S3 bucket.
      See :ref:`Configuring Object Storage <object-storage-configuration>` for details.
-   * The restore process, as well as :doc:`nodetool refresh </operating-scylla/nodetool-commands/refresh>`
-     (with or without :ref:`--load-and-stream <nodetool-refresh-load-and-stream>`), run in the same I/O
-     scheduling group as backup and are throttled by the same
-     :ref:`backup_io_throughput_mb_per_sec <confprop_backup_io_throughput_mb_per_sec>` setting.
 
 Restore Process
 ---------------

--- a/docs/operating-scylla/nodetool-commands/refresh.rst
+++ b/docs/operating-scylla/nodetool-commands/refresh.rst
@@ -7,11 +7,6 @@ Copy the files to the table's upload directory, by default it is located under `
 
 If the table has any :doc:`Materialized Views (MV)</cql/mv/>` or :doc:`Secondary Indexes (SI)</cql/secondary-indexes/>`, content view updates will be generated from the uploaded SSTables. Uploading MV or SI SSTables is not required and will fail.
 
-.. note:: ``nodetool refresh`` (with or without ``--load-and-stream``) runs in the same I/O scheduling
-   group as backup and restore, and is therefore throttled by the
-   :ref:`backup_io_throughput_mb_per_sec <confprop_backup_io_throughput_mb_per_sec>` setting rather than
-   :ref:`stream_io_throughput_mb_per_sec <confprop_stream_io_throughput_mb_per_sec>`.
-
 .. _nodetool-refresh-local:
 
 Local refresh

--- a/idl/streaming.idl.hh
+++ b/idl/streaming.idl.hh
@@ -62,7 +62,6 @@ enum class stream_reason : uint8_t {
     rebuild,
     repair,
     replace,
-    restore,
 };
 
 enum class stream_mutation_fragments_cmd : uint8_t {

--- a/main.cc
+++ b/main.cc
@@ -1266,7 +1266,6 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
             dbcfg.commitlog_scheduling_group = create_scheduling_group("commitlog", "clog", 1000).get();
             dbcfg.schema_commitlog_scheduling_group = create_scheduling_group("schema_commitlog", "sclg", 1000).get();
             dbcfg.backup_scheduling_group = create_scheduling_group("backup", "bckp", 200, maintenance_supergroup).get(),
-            debug::backup_scheduling_group = dbcfg.backup_scheduling_group;
             dbcfg.available_memory = memory::stats().total_memory();
 
             // Make sure to initialize the scheduling group keys at a point where we are sure
@@ -1987,7 +1986,7 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
 
             debug::the_stream_manager = &stream_manager;
             checkpoint(stop_signal, "starting streaming service");
-            stream_manager.start(std::ref(*cfg), std::ref(db), std::ref(view_builder), std::ref(view_building_worker), std::ref(messaging), std::ref(mm), std::ref(gossiper), dbcfg.streaming_scheduling_group, dbcfg.backup_scheduling_group).get();
+            stream_manager.start(std::ref(*cfg), std::ref(db), std::ref(view_builder), std::ref(view_building_worker), std::ref(messaging), std::ref(mm), std::ref(gossiper), dbcfg.streaming_scheduling_group).get();
             auto stop_stream_manager = defer_verbose_shutdown("stream manager", [&stream_manager] {
                 // FIXME -- keep the instances alive, just call .stop on them
                 stream_manager.invoke_on_all(&streaming::stream_manager::stop).get();
@@ -2430,7 +2429,7 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
             });
 
             checkpoint(stop_signal, "starting sstables loader");
-            sst_loader.start(std::ref(db), std::ref(ss), std::ref(messaging), std::ref(view_builder), std::ref(view_building_worker), std::ref(task_manager), std::ref(sstm), std::ref(sys_dist_ks), dbcfg.backup_scheduling_group).get();
+            sst_loader.start(std::ref(db), std::ref(ss), std::ref(messaging), std::ref(view_builder), std::ref(view_building_worker), std::ref(task_manager), std::ref(sstm), std::ref(sys_dist_ks), dbcfg.streaming_scheduling_group).get();
             auto stop_sst_loader = defer_verbose_shutdown("sstables loader", [&sst_loader] {
                 sst_loader.stop().get();
             });

--- a/sstables_loader.cc
+++ b/sstables_loader.cc
@@ -501,7 +501,7 @@ future<> sstable_streamer::stream_sstable_mutations(streaming::plan_id ops_uuid,
     const auto token_range = pr.transform(std::mem_fn(&dht::ring_position::token));
     auto s = _table.schema();
     const auto cf_id = s->id();
-    const auto reason = streaming::stream_reason::restore;
+    const auto reason = streaming::stream_reason::repair;
 
     auto sst_set = make_lw_shared<sstables::sstable_set>(sstables::make_partitioned_sstable_set(s, std::move(token_range)));
     size_t estimated_partitions = 0;
@@ -828,8 +828,6 @@ public:
 };
 
 future<> sstables_loader::download_task_impl::run() {
-    co_await coroutine::switch_to(_loader.local()._sched_group);
-
     // Load-and-stream reads the entire content from SSTables, therefore it can afford to discard the bloom filter
     // that might otherwise consume a significant amount of memory.
     sstables::sstable_open_config cfg {
@@ -959,8 +957,6 @@ future<sstables::shared_sstable> sstables_loader::attach_sstable(table_id tid, c
 }
 
 future<> sstables_loader::download_tablet_sstables(locator::global_tablet_id tid, locator::tablet_metadata_guard& guard) {
-    co_await coroutine::switch_to(_sched_group);
-
     auto& tmap = guard.get_tablet_map();
 
     auto* trinfo = tmap.get_tablet_transition_info(tid.tablet);
@@ -1334,8 +1330,6 @@ public:
 
 protected:
     virtual future<> run() override {
-        co_await coroutine::switch_to(_loader.local()._sched_group);
-
         auto& loader = _loader.local();
 
         auto current_schema = loader.local_db().find_schema(_tid);

--- a/streaming/consumer.cc
+++ b/streaming/consumer.cc
@@ -34,10 +34,9 @@ mutation_reader_consumer make_streaming_consumer(sstring origin,
     return [&db, &vb = vb.container(), &vbw, estimated_partitions, reason, offstrategy, origin = std::move(origin), frozen_guard, on_sstable_written] (mutation_reader reader) -> future<> {
         std::exception_ptr ex;
         try {
-            auto expected_scheduling_group = reason == stream_reason::restore ? debug::backup_scheduling_group : debug::streaming_scheduling_group;
-            if (current_scheduling_group() != expected_scheduling_group) {
-                on_internal_error(sstables::sstlog, format("The stream consumer is not running in the expected scheduling group, expected={} current_scheduling_group={}",
-                        expected_scheduling_group.name(), current_scheduling_group().name()));
+            if (current_scheduling_group() != debug::streaming_scheduling_group) {
+                on_internal_error(sstables::sstlog, format("The stream consumer is not running in streaming group current_scheduling_group={}",
+                        current_scheduling_group().name()));
             }
 
             auto cf = db.local().find_column_family(reader.schema()).shared_from_this();

--- a/streaming/stream_manager.cc
+++ b/streaming/stream_manager.cc
@@ -31,7 +31,7 @@ stream_manager::stream_manager(db::config& cfg,
             sharded<db::view::view_building_worker>& view_building_worker,
             sharded<netw::messaging_service>& ms,
             sharded<service::migration_manager>& mm,
-            gms::gossiper& gossiper, scheduling_group sg, scheduling_group backup_sg)
+            gms::gossiper& gossiper, scheduling_group sg)
         : _db(db)
         , _view_builder(view_builder)
         , _view_building_worker(view_building_worker)
@@ -39,7 +39,6 @@ stream_manager::stream_manager(db::config& cfg,
         , _mm(mm)
         , _gossiper(gossiper)
         , _streaming_group(std::move(sg))
-        , _backup_scheduling_group(std::move(backup_sg))
         , _io_throughput_mbs(cfg.stream_io_throughput_mb_per_sec)
 {
     namespace sm = seastar::metrics;
@@ -50,7 +49,6 @@ stream_manager::stream_manager(db::config& cfg,
     _finished_percentage[streaming::stream_reason::rebuild] = 1;
     _finished_percentage[streaming::stream_reason::repair] = 1;
     _finished_percentage[streaming::stream_reason::replace] = 1;
-    _finished_percentage[streaming::stream_reason::restore] = 1;
 
     auto ops_label_type = sm::label("ops");
     _metrics.add_group("streaming", {
@@ -77,9 +75,6 @@ stream_manager::stream_manager(db::config& cfg,
 
         sm::make_gauge("finished_percentage", [this] { return _finished_percentage[streaming::stream_reason::replace]; },
                 sm::description("Finished percentage of node operation on this shard"), {ops_label_type("replace"), basic_level}),
-
-        sm::make_gauge("finished_percentage", [this] { return _finished_percentage[streaming::stream_reason::restore]; },
-                sm::description("Finished percentage of node operation on this shard"), {ops_label_type("restore"), basic_level}),
     });
 }
 

--- a/streaming/stream_manager.hh
+++ b/streaming/stream_manager.hh
@@ -24,9 +24,6 @@
 #include "readers/mutation_reader.hh"
 #include <seastar/core/semaphore.hh>
 #include <seastar/core/metrics_registration.hh>
-#include <seastar/rpc/rpc_types.hh>
-
-class frozen_mutation_fragment;
 
 namespace db {
 class config;
@@ -53,8 +50,6 @@ class database;
 }
 
 namespace streaming {
-
-enum class stream_mutation_fragments_cmd : uint8_t;
 
 struct stream_bytes {
     int64_t bytes_sent = 0;
@@ -105,7 +100,6 @@ private:
     std::unordered_map<streaming::stream_reason, float> _finished_percentage;
 
     scheduling_group _streaming_group;
-    scheduling_group _backup_scheduling_group;
     utils::updateable_value<uint32_t> _io_throughput_mbs;
 
 public:
@@ -114,7 +108,7 @@ public:
             sharded<db::view::view_building_worker>& view_building_worker,
             sharded<netw::messaging_service>& ms,
             sharded<service::migration_manager>& mm,
-            gms::gossiper& gossiper, scheduling_group sg, scheduling_group backup_sg);
+            gms::gossiper& gossiper, scheduling_group sg);
 
     future<> start(abort_source& as);
     future<> stop();
@@ -192,10 +186,6 @@ private:
     future<> uninit_messaging_service_handler();
     future<> update_io_throughput(uint32_t value_mbs);
 
-    future<rpc::sink<int>> handle_stream_mutation_fragments(streaming::plan_id plan_id, table_schema_version schema_id, table_id cf_id, uint64_t estimated_partitions,
-            locator::host_id from, uint32_t cpu_id, locator::host_id src, stream_reason reason, service::frozen_topology_guard topo_guard,
-            rpc::source<frozen_mutation_fragment, rpc::optional<stream_mutation_fragments_cmd>> source, abort_source& as);
-
 public:
     void update_finished_percentage(streaming::stream_reason reason, float percentage);
 
@@ -206,7 +196,6 @@ public:
     future<> fail_stream_plan(streaming::plan_id plan_id);
 
     scheduling_group get_scheduling_group() const noexcept { return _streaming_group; }
-    scheduling_group get_backup_scheduling_group() const noexcept { return _backup_scheduling_group; }
 };
 
 } // namespace streaming

--- a/streaming/stream_reason.hh
+++ b/streaming/stream_reason.hh
@@ -24,7 +24,6 @@ enum class stream_reason : uint8_t {
     replace,
     tablet_migration,
     tablet_rebuild,
-    restore,
 };
 
 }
@@ -53,8 +52,6 @@ struct fmt::formatter<streaming::stream_reason> : fmt::formatter<string_view> {
             return formatter<string_view>::format("tablet migration", ctx);
         case tablet_rebuild:
             return formatter<string_view>::format("tablet rebuild", ctx);
-        case restore:
-            return formatter<string_view>::format("restore", ctx);
         }
         std::abort();
     }

--- a/streaming/stream_session.cc
+++ b/streaming/stream_session.cc
@@ -12,7 +12,6 @@
 #include "utils/log.hh"
 #include "message/messaging_service.hh"
 #include <seastar/coroutine/maybe_yield.hh>
-#include <seastar/core/with_scheduling_group.hh>
 #include "streaming/stream_session.hh"
 #include "streaming/prepare_message.hh"
 #include "streaming/stream_result_future.hh"
@@ -50,7 +49,6 @@ static sstables::offstrategy is_offstrategy_supported(streaming::stream_reason r
         streaming::stream_reason::decommission,
         streaming::stream_reason::repair,
         streaming::stream_reason::rebuild,
-        streaming::stream_reason::restore,
     };
     return sstables::offstrategy(operations_supported.contains(reason));
 }
@@ -93,87 +91,122 @@ stream_manager::make_streaming_consumer(uint64_t estimated_partitions, stream_re
     return streaming::make_streaming_consumer("streaming", _db, _view_builder, _view_building_worker, estimated_partitions, reason, is_offstrategy_supported(reason), topo_guard);
 }
 
-future<rpc::sink<int>>
-stream_manager::handle_stream_mutation_fragments(streaming::plan_id plan_id, table_schema_version schema_id, table_id cf_id, uint64_t estimated_partitions,
-        locator::host_id from, uint32_t cpu_id, locator::host_id src, stream_reason reason, service::frozen_topology_guard topo_guard,
-        rpc::source<frozen_mutation_fragment, rpc::optional<stream_mutation_fragments_cmd>> source, abort_source& as) {
-    return _mm.local().get_schema_for_write(schema_id, src, cpu_id, _ms.local(), as).then([this, from, estimated_partitions, plan_id, cf_id, source, reason, topo_guard, &as] (schema_ptr s) mutable {
-        auto permit = _db.local().get_reader_concurrency_semaphore().make_tracking_only_permit(s, "stream-session", db::no_timeout, {});
-        struct stream_mutation_fragments_cmd_status {
-            bool got_cmd = false;
-            bool got_end_of_stream = false;
-        };
-        auto cmd_status = make_lw_shared<stream_mutation_fragments_cmd_status>();
-        auto offstrategy_update = make_lw_shared<offstrategy_trigger>(_db, cf_id, plan_id);
-        auto guard = service::topology_guard(topo_guard);
+void stream_manager::init_messaging_service_handler(abort_source& as) {
+    auto& ms = _ms.local();
 
-        // Will log a message when streaming is done. Used to synchronize tests.
-        lw_shared_ptr<std::any> log_done;
-        if (utils::get_local_injector().is_enabled("stream_mutation_fragments")) {
-            log_done = make_lw_shared<std::any>(seastar::make_shared(seastar::defer([] noexcept {
-                sslog.info("stream_mutation_fragments: done");
-            })));
-        }
+    ser::streaming_rpc_verbs::register_prepare_message(&ms, [this] (const rpc::client_info& cinfo, prepare_message msg, streaming::plan_id plan_id, sstring description, rpc::optional<stream_reason> reason_opt, rpc::optional<service::session_id> session) {
+        const auto& src_cpu_id = cinfo.retrieve_auxiliary<uint32_t>("src_cpu_id");
+        const auto& from = cinfo.retrieve_auxiliary<locator::host_id>("host_id");
+        auto dst_cpu_id = this_shard_id();
+        auto reason = reason_opt ? *reason_opt : stream_reason::unspecified;
+        auto topo_guard = service::frozen_topology_guard(session.value_or(service::default_session_id));
+        return container().invoke_on(dst_cpu_id, [msg = std::move(msg), plan_id, description = std::move(description), from, src_cpu_id, reason, topo_guard] (auto& sm) mutable {
+            auto sr = stream_result_future::init_receiving_side(sm, plan_id, description, from);
+            auto session = sm.get_session(plan_id, from, "PREPARE_MESSAGE");
+            session->init(sr);
+            session->dst_cpu_id = src_cpu_id;
+            session->set_reason(reason);
+            session->set_topo_guard(topo_guard);
+            return session->prepare(std::move(msg.requests), std::move(msg.summaries));
+        });
+    });
+    ser::streaming_rpc_verbs::register_prepare_done_message(&ms, [this] (const rpc::client_info& cinfo, streaming::plan_id plan_id, unsigned dst_cpu_id) {
+        const auto& from = cinfo.retrieve_auxiliary<locator::host_id>("host_id");
+        return container().invoke_on(dst_cpu_id, [plan_id, from] (auto& sm) mutable {
+            auto session = sm.get_session(plan_id, from, "PREPARE_DONE_MESSAGE");
+            session->follower_start_sent();
+            return make_ready_future<>();
+        });
+    });
+    ms.register_stream_mutation_fragments([this, &as] (const rpc::client_info& cinfo, streaming::plan_id plan_id, table_schema_version schema_id, table_id cf_id, uint64_t estimated_partitions,
+            rpc::optional<stream_reason> reason_opt,
+            rpc::source<frozen_mutation_fragment, rpc::optional<stream_mutation_fragments_cmd>> source,
+            rpc::optional<service::session_id> session) {
+        auto from = cinfo.retrieve_auxiliary<locator::host_id>("host_id");
+        auto cpu_id = cinfo.retrieve_auxiliary<uint32_t>("src_cpu_id");
 
-        auto get_next_mutation_fragment = [guard = std::move(guard), &as, &sm = container(), &db = _db, source, plan_id, from, s, cmd_status, offstrategy_update, permit] () mutable {
-            guard.check();
-            return source().then([&sm, &db, &guard, &as, plan_id, from, s, cmd_status, offstrategy_update, permit] (std::optional<std::tuple<frozen_mutation_fragment, rpc::optional<stream_mutation_fragments_cmd>>> opt) mutable {
-                if (opt) {
-                    auto cmd = std::get<1>(*opt);
-                    if (cmd) {
-                        cmd_status->got_cmd = true;
-                        switch (*cmd) {
-                        case stream_mutation_fragments_cmd::mutation_fragment_data:
-                            break;
-                        case stream_mutation_fragments_cmd::error:
-                            return make_exception_future<mutation_fragment_opt>(std::runtime_error("Sender failed"));
-                        case stream_mutation_fragments_cmd::abort:
-                            return make_exception_future<mutation_fragment_opt>(rpc::canceled_error());
-                        case stream_mutation_fragments_cmd::end_of_stream:
-                            cmd_status->got_end_of_stream = true;
-                            return make_ready_future<mutation_fragment_opt>();
-                        default:
-                            return make_exception_future<mutation_fragment_opt>(std::runtime_error("Sender sent wrong cmd"));
+        auto src = cinfo.retrieve_auxiliary<locator::host_id>("host_id");
+
+        auto reason = reason_opt ? *reason_opt: stream_reason::unspecified;
+        service::frozen_topology_guard topo_guard = session.value_or(service::default_session_id);
+        sslog.trace("Got stream_mutation_fragments from {} reason {}, session {}", from, int(reason), session);
+        return _mm.local().get_schema_for_write(schema_id, src, cpu_id, _ms.local(), as).then([this, from, estimated_partitions, plan_id, cf_id, source, reason, topo_guard, &as] (schema_ptr s) mutable {
+            auto permit = _db.local().get_reader_concurrency_semaphore().make_tracking_only_permit(s, "stream-session", db::no_timeout, {});
+            struct stream_mutation_fragments_cmd_status {
+                bool got_cmd = false;
+                bool got_end_of_stream = false;
+            };
+            auto cmd_status = make_lw_shared<stream_mutation_fragments_cmd_status>();
+            auto offstrategy_update = make_lw_shared<offstrategy_trigger>(_db, cf_id, plan_id);
+            auto guard = service::topology_guard(topo_guard);
+
+            // Will log a message when streaming is done. Used to synchronize tests.
+            lw_shared_ptr<std::any> log_done;
+            if (utils::get_local_injector().is_enabled("stream_mutation_fragments")) {
+                log_done = make_lw_shared<std::any>(seastar::make_shared(seastar::defer([] noexcept {
+                    sslog.info("stream_mutation_fragments: done");
+                })));
+            }
+
+            auto get_next_mutation_fragment = [guard = std::move(guard), &as, &sm = container(), &db = _db, source, plan_id, from, s, cmd_status, offstrategy_update, permit] () mutable {
+                guard.check();
+                return source().then([&sm, &db, &guard, &as, plan_id, from, s, cmd_status, offstrategy_update, permit] (std::optional<std::tuple<frozen_mutation_fragment, rpc::optional<stream_mutation_fragments_cmd>>> opt) mutable {
+                    if (opt) {
+                        auto cmd = std::get<1>(*opt);
+                        if (cmd) {
+                            cmd_status->got_cmd = true;
+                            switch (*cmd) {
+                            case stream_mutation_fragments_cmd::mutation_fragment_data:
+                                break;
+                            case stream_mutation_fragments_cmd::error:
+                                return make_exception_future<mutation_fragment_opt>(std::runtime_error("Sender failed"));
+                            case stream_mutation_fragments_cmd::abort:
+                                return make_exception_future<mutation_fragment_opt>(rpc::canceled_error());
+                            case stream_mutation_fragments_cmd::end_of_stream:
+                                cmd_status->got_end_of_stream = true;
+                                return make_ready_future<mutation_fragment_opt>();
+                            default:
+                                return make_exception_future<mutation_fragment_opt>(std::runtime_error("Sender sent wrong cmd"));
+                            }
                         }
+                        frozen_mutation_fragment& fmf = std::get<0>(*opt);
+                        auto sz = fmf.representation().size();
+                        auto mf = fmf.unfreeze(*s, permit);
+                        sm.local().update_progress(plan_id, from, progress_info::direction::IN, sz);
+                        offstrategy_update->update();
+
+                        return utils::get_local_injector().inject("stream_mutation_fragments", [&guard, &as] (auto& handler) -> future<> {
+                            auto& guard_ = guard;
+                            auto& as_ = as;
+                            sslog.info("stream_mutation_fragments: waiting");
+                            while (!handler.poll_for_message()) {
+                                guard_.check();
+                                co_await sleep_abortable(std::chrono::milliseconds(5), as_);
+                            }
+                            sslog.info("stream_mutation_fragments: released");
+                        }).then([mf = std::move(mf), &db] () mutable {
+                            if (utils::get_local_injector().is_enabled("stream_mutation_fragments_rx_error")) {
+                                sslog.info("stream_mutation_fragments_rx_error: throw");
+                                throw std::runtime_error("stream_mutation_fragments_rx_error");
+                            }
+                            if (db.local().is_in_critical_disk_utilization_mode()) {
+                                throw replica::critical_disk_utilization_exception("rejected streamed mutation fragment");
+                            }
+                            return mutation_fragment_opt(std::move(mf));
+                        });
+                    } else {
+                        // If the sender has sent stream_mutation_fragments_cmd it means it is
+                        // a node that understands the new protocol. It must send end_of_stream
+                        // before close the stream.
+                        if (cmd_status->got_cmd && !cmd_status->got_end_of_stream) {
+                            return make_exception_future<mutation_fragment_opt>(std::runtime_error("Sender did not sent end_of_stream"));
+                        }
+                        return make_ready_future<mutation_fragment_opt>();
                     }
-                    frozen_mutation_fragment& fmf = std::get<0>(*opt);
-                    auto sz = fmf.representation().size();
-                    auto mf = fmf.unfreeze(*s, permit);
-                    sm.local().update_progress(plan_id, from, progress_info::direction::IN, sz);
-                    offstrategy_update->update();
-
-                    return utils::get_local_injector().inject("stream_mutation_fragments", [&guard, &as] (auto& handler) -> future<> {
-                        auto& guard_ = guard;
-                        auto& as_ = as;
-                        sslog.info("stream_mutation_fragments: waiting");
-                        while (!handler.poll_for_message()) {
-                            guard_.check();
-                            co_await sleep_abortable(std::chrono::milliseconds(5), as_);
-                        }
-                        sslog.info("stream_mutation_fragments: released");
-                    }).then([mf = std::move(mf), &db] () mutable {
-                        if (utils::get_local_injector().is_enabled("stream_mutation_fragments_rx_error")) {
-                            sslog.info("stream_mutation_fragments_rx_error: throw");
-                            throw std::runtime_error("stream_mutation_fragments_rx_error");
-                        }
-                        if (db.local().is_in_critical_disk_utilization_mode()) {
-                            throw replica::critical_disk_utilization_exception("rejected streamed mutation fragment");
-                        }
-                        return mutation_fragment_opt(std::move(mf));
-                    });
-                } else {
-                    // If the sender has sent stream_mutation_fragments_cmd it means it is
-                    // a node that understands the new protocol. It must send end_of_stream
-                    // before close the stream.
-                    if (cmd_status->got_cmd && !cmd_status->got_end_of_stream) {
-                        return make_exception_future<mutation_fragment_opt>(std::runtime_error("Sender did not sent end_of_stream"));
-                    }
-                    return make_ready_future<mutation_fragment_opt>();
-                }
-            });
-        };
-        auto sink = _ms.local().make_sink_for_stream_mutation_fragments(source);
-        try {
+                });
+            };
+          auto sink = _ms.local().make_sink_for_stream_mutation_fragments(source);
+          try {
             // Make sure the table with cf_id is still present at this point.
             // Close the sink in case the table is dropped.
             auto& table = _db.local().find_column_family(cf_id);
@@ -245,61 +278,13 @@ stream_manager::handle_stream_mutation_fragments(streaming::plan_id plan_id, tab
                     co_await sink.close();
                 });
             });
-        } catch (...) {
+          } catch (...) {
             return sink.close().then([sink, eptr = std::current_exception()] () -> future<rpc::sink<int>> {
                 return make_exception_future<rpc::sink<int>>(eptr);
             });
-        }
-        return make_ready_future<rpc::sink<int>>(sink);
-    });
-}
-
-void stream_manager::init_messaging_service_handler(abort_source& as) {
-    auto& ms = _ms.local();
-
-    ser::streaming_rpc_verbs::register_prepare_message(&ms, [this] (const rpc::client_info& cinfo, prepare_message msg, streaming::plan_id plan_id, sstring description, rpc::optional<stream_reason> reason_opt, rpc::optional<service::session_id> session) {
-        const auto& src_cpu_id = cinfo.retrieve_auxiliary<uint32_t>("src_cpu_id");
-        const auto& from = cinfo.retrieve_auxiliary<locator::host_id>("host_id");
-        auto dst_cpu_id = this_shard_id();
-        auto reason = reason_opt ? *reason_opt : stream_reason::unspecified;
-        auto topo_guard = service::frozen_topology_guard(session.value_or(service::default_session_id));
-        return container().invoke_on(dst_cpu_id, [msg = std::move(msg), plan_id, description = std::move(description), from, src_cpu_id, reason, topo_guard] (auto& sm) mutable {
-            auto sg = reason == stream_reason::restore ? sm.get_backup_scheduling_group() : current_scheduling_group();
-            return with_scheduling_group(sg, [&sm, msg = std::move(msg), plan_id, description = std::move(description), from, src_cpu_id, reason, topo_guard] () mutable {
-                auto sr = stream_result_future::init_receiving_side(sm, plan_id, description, from);
-                auto session = sm.get_session(plan_id, from, "PREPARE_MESSAGE");
-                session->init(sr);
-                session->dst_cpu_id = src_cpu_id;
-                session->set_reason(reason);
-                session->set_topo_guard(topo_guard);
-                return session->prepare(std::move(msg.requests), std::move(msg.summaries));
-            });
-        });
-    });
-    ser::streaming_rpc_verbs::register_prepare_done_message(&ms, [this] (const rpc::client_info& cinfo, streaming::plan_id plan_id, unsigned dst_cpu_id) {
-        const auto& from = cinfo.retrieve_auxiliary<locator::host_id>("host_id");
-        return container().invoke_on(dst_cpu_id, [plan_id, from] (auto& sm) mutable {
-            auto session = sm.get_session(plan_id, from, "PREPARE_DONE_MESSAGE");
-            session->follower_start_sent();
-            return make_ready_future<>();
-        });
-    });
-    ms.register_stream_mutation_fragments([this, &as] (const rpc::client_info& cinfo, streaming::plan_id plan_id, table_schema_version schema_id, table_id cf_id, uint64_t estimated_partitions,
-            rpc::optional<stream_reason> reason_opt,
-            rpc::source<frozen_mutation_fragment, rpc::optional<stream_mutation_fragments_cmd>> source,
-            rpc::optional<service::session_id> session) {
-        auto from = cinfo.retrieve_auxiliary<locator::host_id>("host_id");
-        auto cpu_id = cinfo.retrieve_auxiliary<uint32_t>("src_cpu_id");
-
-        auto src = cinfo.retrieve_auxiliary<locator::host_id>("host_id");
-
-        auto reason = reason_opt ? *reason_opt: stream_reason::unspecified;
-        service::frozen_topology_guard topo_guard = session.value_or(service::default_session_id);
-        sslog.trace("Got stream_mutation_fragments from {} reason {}, session {}", from, int(reason), session);
-        auto sg = reason == stream_reason::restore ? get_backup_scheduling_group() : current_scheduling_group();
-        return with_scheduling_group(sg, [this, plan_id, schema_id, cf_id, estimated_partitions, from, cpu_id, src, reason, topo_guard, source, &as] () mutable {
-            return handle_stream_mutation_fragments(plan_id, schema_id, cf_id, estimated_partitions, from, cpu_id, src, reason, topo_guard, source, as);
-        });
+          }
+            return make_ready_future<rpc::sink<int>>(sink);
+      });
     });
     ser::streaming_rpc_verbs::register_stream_mutation_done(&ms, [this] (const rpc::client_info& cinfo, streaming::plan_id plan_id, dht::token_range_vector ranges, table_id cf_id, unsigned dst_cpu_id) {
         const auto& from = cinfo.retrieve_auxiliary<locator::host_id>("host_id");

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -101,7 +101,6 @@ future<scheduling_groups> get_scheduling_groups() {
         _scheduling_groups->memtable_scheduling_group = co_await create_scheduling_group("memtable", 1000);
         _scheduling_groups->memtable_to_cache_scheduling_group = co_await create_scheduling_group("memtable_to_cache", 200);
         _scheduling_groups->gossip_scheduling_group = co_await create_scheduling_group("gossip", 1000);
-        _scheduling_groups->backup_scheduling_group = co_await create_scheduling_group("backup", 200);
     }
     co_return *_scheduling_groups;
 }
@@ -600,7 +599,6 @@ private:
             auto scheduling_groups = get_scheduling_groups().get();
             debug::streaming_scheduling_group = scheduling_groups.streaming_scheduling_group;
             debug::gossip_scheduling_group = scheduling_groups.streaming_scheduling_group;
-            debug::backup_scheduling_group = scheduling_groups.backup_scheduling_group;
 
             auto notify_set = init_configurables
                 ? configurable::init_all(*cfg, init_configurables->extensions, service_set(
@@ -673,7 +671,6 @@ private:
             dbcfg.memtable_scheduling_group = scheduling_groups.memtable_scheduling_group;
             dbcfg.memtable_to_cache_scheduling_group = scheduling_groups.memtable_to_cache_scheduling_group;
             dbcfg.gossip_scheduling_group = scheduling_groups.gossip_scheduling_group;
-            dbcfg.backup_scheduling_group = scheduling_groups.backup_scheduling_group;
 
             auto get_tm_cfg = sharded_parameter([&] {
                 return tasks::task_manager::config {
@@ -991,7 +988,7 @@ private:
                 _view_builder.stop().get();
             });
 
-            _stream_manager.start(std::ref(*cfg), std::ref(_db), std::ref(_view_builder), std::ref(_view_building_worker), std::ref(_ms), std::ref(_mm), std::ref(_gossiper), scheduling_groups.streaming_scheduling_group, scheduling_groups.backup_scheduling_group).get();
+            _stream_manager.start(std::ref(*cfg), std::ref(_db), std::ref(_view_builder), std::ref(_view_building_worker), std::ref(_ms), std::ref(_mm), std::ref(_gossiper), scheduling_groups.streaming_scheduling_group).get();
             auto stop_streaming = defer_verbose_shutdown("stream manager", [this] { _stream_manager.stop().get(); });
 
             _auth_cache.start(std::ref(_qp), std::ref(abort_sources)).get();

--- a/test/lib/cql_test_env.hh
+++ b/test/lib/cql_test_env.hh
@@ -89,7 +89,6 @@ struct scheduling_groups {
     scheduling_group memtable_scheduling_group;
     scheduling_group memtable_to_cache_scheduling_group;
     scheduling_group gossip_scheduling_group;
-    scheduling_group backup_scheduling_group;
 };
 
 // Creating and destroying scheduling groups on each env setup and teardown


### PR DESCRIPTION
…duling group' from Pavel Emelyanov"

This reverts PR #30864 (commit 3e47fa05ee6d1757cce47000aec0369f613a1fd7)

This PR broke the way staging sstables are registered while streaming and applying a "quick fix" is not possible, so reverting the change for the rework.

Fixes SCYLLADB-3610

Reverting recently merged PR, not backporting