### PR TITLE
Add tests to restore materialized views

### DIFF
--- a/test/cluster/object_store/test_backup.py
+++ b/test/cluster/object_store/test_backup.py
@@ -255,9 +255,12 @@ async def test_backup_is_abortable_in_s3_client(manager: ScyllaClusterManager, o
     await do_test_backup_abort(manager, object_storage, breakpoint_name="backup_task_pre_upload", min_files=0, max_files=1)
 
 
-@pytest.mark.parametrize(("do_encrypt", "do_abort"), [(False, False), (False, True), (True, False)])
-async def test_simple_backup_and_restore(manager: ScyllaClusterManager, object_storage, tmpdir, do_encrypt, do_abort):
+@pytest.mark.parametrize("flavor", ['plain', 'abort', 'encrypt'])
+async def test_simple_backup_and_restore(manager: ScyllaClusterManager, object_storage, tmpdir, flavor):
     '''check that restoring from backed up snapshot for a keyspace:table works'''
+
+    do_abort = flavor == 'abort'
+    do_encrypt = flavor == 'encrypt'
 
     objconf = object_storage.create_endpoint_conf()
     cfg = {'enable_user_defined_functions': False,

--- a/test/cluster/object_store/test_backup.py
+++ b/test/cluster/object_store/test_backup.py
@@ -21,7 +21,7 @@ from test.pylib.scylla_cluster_manager import ScyllaClusterManager
 from test.pylib.internal_types import ServerInfo
 from test.cluster.util import wait_for_cql_and_get_hosts, get_replication, new_test_keyspace, new_test_table
 from test.pylib.rest_client import read_barrier, HTTPError
-from test.pylib.util import unique_name, wait_all
+from test.pylib.util import unique_name, wait_all, wait_for_view
 from test.pylib.tablets import get_tablet_replica, get_all_tablet_replicas
 from cassandra import ReadFailure
 from cassandra.cluster import ConsistencyLevel
@@ -255,12 +255,13 @@ async def test_backup_is_abortable_in_s3_client(manager: ScyllaClusterManager, o
     await do_test_backup_abort(manager, object_storage, breakpoint_name="backup_task_pre_upload", min_files=0, max_files=1)
 
 
-@pytest.mark.parametrize("flavor", ['plain', 'abort', 'encrypt'])
+@pytest.mark.parametrize("flavor", ['plain', 'abort', 'encrypt', 'view'])
 async def test_simple_backup_and_restore(manager: ScyllaClusterManager, object_storage, tmpdir, flavor):
     '''check that restoring from backed up snapshot for a keyspace:table works'''
 
     do_abort = flavor == 'abort'
     do_encrypt = flavor == 'encrypt'
+    with_view = flavor == 'view'
 
     objconf = object_storage.create_endpoint_conf()
     cfg = {'enable_user_defined_functions': False,
@@ -286,9 +287,22 @@ async def test_simple_backup_and_restore(manager: ScyllaClusterManager, object_s
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': '1'}") as ks:
         await cql.run_async(f"CREATE TABLE {ks}.{cf} ( name text primary key, value text );")
         await asyncio.gather(*(cql.run_async(f"INSERT INTO {ks}.{cf} ( name, value ) VALUES ('{name}', '{value}');") for name, value in [('0', 'zero'), ('1', 'one'), ('2', 'two')]))
+
         snap_name, toc_names = await take_snapshot_on_one_server(ks, server, manager, logger)
 
         cf_dir = os.listdir(f'{workdir}/data/{ks}')[0]
+
+        # A backup only ever captures the base table's sstables -- a view has no sstables
+        # of its own worth backing up, since it can always be rebuilt from the base table.
+        # So restoring the base table alone must eventually repopulate the view too.
+        # The view is created only after the snapshot/cf_dir are captured above, since
+        # otherwise it would create a second column-family directory under data/{ks} and
+        # make the os.listdir(...)[0] picks above racy/ambiguous.
+        view = 'test_cf_by_value'
+        if with_view:
+            await cql.run_async(f"CREATE MATERIALIZED VIEW {ks}.{view} AS SELECT * FROM {ks}.{cf} "
+                            "WHERE value IS NOT NULL AND name IS NOT NULL PRIMARY KEY (value, name)")
+            await wait_for_view(cql, view, 1)
 
         def list_sstables():
             return [f for f in os.scandir(f'{workdir}/data/{ks}/{cf_dir}') if f.is_file()]
@@ -366,6 +380,14 @@ async def test_simple_backup_and_restore(manager: ScyllaClusterManager, object_s
             res = cql.execute(f"SELECT * FROM {ks}.{cf};")
             rows = { x.name: x.value for x in res }
             assert rows == orig_rows, "Unexpected table contents after restore"
+
+            if with_view:
+                print('Check that the view eventually gets repopulated from the restored base table')
+                async def view_repopulated():
+                    res = await cql.run_async(f"SELECT * FROM {ks}.{view};")
+                    got = {x.name: x.value for x in res}
+                    return got == orig_rows or None
+                await wait_for(view_repopulated, time.time() + 60)
 
         print('Check that backup files are still there')  # regression test for #20938
         post_objects = set(o.key for o in object_storage.get_resource().Bucket(object_storage.bucket_name).objects.filter(Prefix=prefix))

--- a/test/cluster/object_store/test_backup.py
+++ b/test/cluster/object_store/test_backup.py
@@ -804,7 +804,10 @@ async def do_test_streaming_scopes(build_mode: str, manager: ScyllaClusterManage
     ])
 async def test_restore_tablets(build_mode: str, manager: ScyllaClusterManager, object_storage, topology, num_tables, num_restore_nodes):
     '''Check that tablet-aware restore works for multiple tables backed up from multiple nodes'''
+    await do_test_restore_tablets(build_mode, manager, object_storage, topology, num_tables, num_restore_nodes)
 
+
+async def do_test_restore_tablets(build_mode: str, manager: ScyllaClusterManager, object_storage, topology, num_tables, num_restore_nodes):
     servers, host_ids = await create_cluster(topology, manager, logger, object_storage)
 
     cql = manager.get_cql()

--- a/test/cluster/object_store/test_backup.py
+++ b/test/cluster/object_store/test_backup.py
@@ -807,7 +807,7 @@ async def test_restore_tablets(build_mode: str, manager: ScyllaClusterManager, o
     await do_test_restore_tablets(build_mode, manager, object_storage, topology, num_tables, num_restore_nodes)
 
 
-async def do_test_restore_tablets(build_mode: str, manager: ScyllaClusterManager, object_storage, topology, num_tables, num_restore_nodes):
+async def do_test_restore_tablets(build_mode: str, manager: ScyllaClusterManager, object_storage, topology, num_tables, num_restore_nodes, with_views=False):
     servers, host_ids = await create_cluster(topology, manager, logger, object_storage)
 
     cql = manager.get_cql()
@@ -815,6 +815,9 @@ async def do_test_restore_tablets(build_mode: str, manager: ScyllaClusterManager
     num_keys = 10
     tablet_count=5
     tables = [f'test{i}' for i in range(num_tables)]
+    # A view over the first table only -- one is enough to prove the point, and it
+    # keeps this helper's cost down when with_views isn't what the caller is after.
+    view = 'test0_by_value'
 
     # Create the keyspace, populate multiple tables, and back them all up
     async with new_test_keyspace(manager, f"WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor': {topology.rf}}}") as src_ks:
@@ -825,6 +828,13 @@ async def do_test_restore_tablets(build_mode: str, manager: ScyllaClusterManager
             await asyncio.gather(*(cql.run_async(insert_stmt, (str(i), i)) for i in range(num_keys)))
 
         await asyncio.gather(*(create_table(cf) for cf in tables))
+
+        # A backup only ever captures the base table's sstables -- a view has no sstables
+        # of its own worth backing up, since it can always be rebuilt from the base table.
+        if with_views:
+            await cql.run_async(f"CREATE MATERIALIZED VIEW {src_ks}.{view} AS SELECT * FROM {src_ks}.{tables[0]} "
+                            "WHERE value IS NOT NULL AND pk IS NOT NULL PRIMARY KEY (value, pk)")
+            await wait_for_view(cql, view, len(servers))
 
         snap_name, _ = await take_snapshot(src_ks, servers, manager, logger)
 
@@ -848,6 +858,14 @@ async def do_test_restore_tablets(build_mode: str, manager: ScyllaClusterManager
             await asyncio.gather(*(create_dst_table(i, cf) for i, cf in enumerate(tables)))
             for cf in tables:
                 assert not await cql.run_async(f"SELECT pk FROM {dst_ks}.{cf}_restored;"), f'{dst_ks}.{cf}_restored is not empty before the restore'
+
+            # The view is re-created here too, before any data exists, so its initial build
+            # is trivially over an empty table -- this is what distinguishes checking for
+            # eventual repopulation from merely checking the view's initial build succeeds.
+            if with_views:
+                await cql.run_async(f"CREATE MATERIALIZED VIEW {dst_ks}.{view} AS SELECT * FROM {dst_ks}.{tables[0]} "
+                                "WHERE value IS NOT NULL AND pk IS NOT NULL PRIMARY KEY (value, pk)")
+                await wait_for_view(cql, view, len(servers))
 
             restore_nodes = servers[:num_restore_nodes]
 
@@ -877,6 +895,27 @@ async def do_test_restore_tablets(build_mode: str, manager: ScyllaClusterManager
 
                 kept = {x.pk: x.value for x in await cql.run_async(f"SELECT pk, value FROM {src_ks}.{cf};")}
                 assert kept == expected, f'Restore into {dst_ks} modified the source table {src_ks}.{cf}: {len(kept)} rows'
+
+            if with_views:
+                print('Check that the view eventually gets repopulated from the restored base table')
+                async def view_repopulated():
+                    res = await cql.run_async(f"SELECT COUNT(*) FROM {dst_ks}.{view}")
+                    return (res[0][0] == num_keys) or None
+                await wait_for(view_repopulated, time.time() + 60)
+
+
+@pytest.mark.xfail(reason="download_tablet_sstables()'s attach_sstable() hardcodes "
+                           "sstables::sstable_state::normal for restored sstables, so neither "
+                           "the view update generator nor view_building_worker is ever told "
+                           "about the newly-restored data")
+async def test_restore_tablets_repopulates_view(build_mode: str, manager: ScyllaClusterManager, object_storage):
+    '''Check that tablet-aware restore repopulates a view over the restored base table.
+
+    A backup only ever captures the base table's sstables -- a view has no sstables of
+    its own worth backing up, since it can always be rebuilt from the base table.'''
+    await do_test_restore_tablets(build_mode, manager, object_storage,
+                                   topo(rf=1, nodes=2, racks=1, dcs=1), num_tables=1, num_restore_nodes=1,
+                                   with_views=True)
 
 
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')

--- a/test/cluster/test_refresh.py
+++ b/test/cluster/test_refresh.py
@@ -7,6 +7,7 @@
 #!/usr/bin/env python3
 
 import os
+import glob
 import logging
 import asyncio
 import pytest
@@ -17,13 +18,14 @@ import uuid
 from collections import defaultdict
 
 from cassandra.cluster import ConsistencyLevel
+from cassandra.query import SimpleStatement
 from test.pylib.minio_server import MinioServer
 from test.pylib.scylla_cluster_manager import ScyllaClusterManager
 from test.pylib.object_storage import format_tuples
 from test.cluster.object_store.test_backup import topo, take_snapshot, do_test_streaming_scopes
 from test.cluster.util import new_test_keyspace
 from test.pylib.rest_client import read_barrier
-from test.pylib.util import unique_name, wait_for
+from test.pylib.util import unique_name, wait_for, wait_for_view
 
 logger = logging.getLogger(__name__)
 
@@ -172,3 +174,97 @@ async def test_refresh_deletes_uploaded_sstables(manager: ScyllaClusterManager):
             await wait_for_upload_dir_empty(upload_dir)
 
         shutil.rmtree(tmpbackup)
+
+
+async def wait_for_row_count_on_host(cql, host, ks, table, expected, timeout=120):
+    '''Wait until `table` reports `expected` rows when read through `host`.
+
+    View updates are generated asynchronously, off the staging sstables, so the
+    count has to be polled rather than read once.
+    '''
+    stmt = SimpleStatement(f"SELECT COUNT(*) FROM {ks}.{table}", consistency_level=ConsistencyLevel.LOCAL_ONE)
+    last = None
+    async def has_all_rows():
+        nonlocal last
+        last = (await cql.run_async(stmt, host=host))[0][0]
+        return True if last == expected else None
+    try:
+        await wait_for(has_all_rows, time.time() + timeout, period=1.0, label=f"row_count_{table}")
+    except AssertionError:
+        pytest.fail(f"Expected {expected} rows in {ks}.{table} on {host}, got {last}")
+
+
+@pytest.mark.parametrize("tablets", [False, True])
+async def test_refresh_generates_view_updates(manager: ScyllaClusterManager, tablets):
+    '''
+    Check that load-and-stream generates view updates for the data it brings in.
+
+    The mutations carried by the loaded sstables have never been seen by any replica,
+    so the receiving node must put them in the staging directory and let the view
+    update generator populate the views. The interesting case is a view that is
+    already fully built: there is nothing left for the view builder to pick up, so if
+    the sstable goes to the normal directory instead, the view stays empty forever.
+    '''
+    node_count = 2
+    expected_rows = 64
+    cf = 'cf'
+    mv = 'mv'
+    idx = 'value_idx'
+    schema = "(pk text primary key, value int)"
+
+    cmdline = ['--logger-log-level', 'view_update_generator=debug',
+               '--logger-log-level', 'view_building_worker=debug']
+    servers = await manager.servers_add(node_count, auto_rack_dc="dc1", cmdline=cmdline)
+    cql, hosts = await manager.get_ready_cql(servers)
+    await manager.disable_tablet_balancing()
+
+    ks_opts = "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 2}" \
+              f" AND tablets = {{'enabled': {str(tablets).lower()}}}"
+
+    async def table_dir(server, ks):
+        workdir = await manager.server_get_workdir(server.server_id)
+        return glob.glob(os.path.join(workdir, 'data', ks, f'{cf}-*'))[0]
+
+    # The data is produced in a separate keyspace and its sstables are then loaded into
+    # the keyspace under test. That way the table under test never held the rows, so
+    # nothing but the load-and-stream can account for them showing up in its views.
+    async with new_test_keyspace(manager, ks_opts) as src_ks, new_test_keyspace(manager, ks_opts) as ks:
+        await cql.run_async(f"CREATE TABLE {src_ks}.{cf} {schema}")
+
+        insert_stmt = cql.prepare(f"INSERT INTO {src_ks}.{cf} (pk, value) VALUES (?, ?)")
+        insert_stmt.consistency_level = ConsistencyLevel.ALL
+        await asyncio.gather(*(cql.run_async(insert_stmt, (str(k), k)) for k in range(expected_rows)))
+
+        # servers[0] holds every partition (RF == node count), so its sstables alone
+        # carry the whole table.
+        logger.info('Flush and snapshot the source table')
+        snap_name = unique_name('refresh_')
+        await manager.api.flush_keyspace(servers[0].ip_addr, src_ks)
+        await manager.api.take_snapshot(servers[0].ip_addr, src_ks, snap_name)
+        snapshot_dir = os.path.join(await table_dir(servers[0], src_ks), 'snapshots', snap_name)
+
+        # The views are created on an empty table, so they are fully built - and no build
+        # is in progress - by the time load-and-stream runs. This is what makes the view
+        # updates the only way for the loaded data to reach them.
+        logger.info('Create the table under test with its views, and wait for them to be built')
+        await cql.run_async(f"CREATE TABLE {ks}.{cf} {schema}")
+        await cql.run_async(f"CREATE MATERIALIZED VIEW {ks}.{mv} AS SELECT * FROM {ks}.{cf} "
+                            "WHERE pk IS NOT NULL AND value IS NOT NULL PRIMARY KEY (value, pk)")
+        await cql.run_async(f"CREATE INDEX {idx} ON {ks}.{cf} (value)")
+        await wait_for_view(cql, mv, node_count, timeout=300)
+        await wait_for_view(cql, f'{idx}_index', node_count, timeout=300)
+
+        logger.info('Copy the sstables to the upload dir and refresh')
+        upload_dir = os.path.join(await table_dir(servers[0], ks), 'upload')
+        os.makedirs(upload_dir, exist_ok=True)
+        for item in os.listdir(snapshot_dir):
+            if item not in ('manifest.json', 'schema.cql'):
+                shutil.copy2(os.path.join(snapshot_dir, item), os.path.join(upload_dir, item))
+        await manager.api.load_new_sstables(servers[0].ip_addr, ks, cf, scope='all', load_and_stream=True)
+
+        # The base table getting the rows proves the load itself worked; the views are
+        # what the regression broke.
+        for host in hosts:
+            await wait_for_row_count_on_host(cql, host, ks, cf, expected_rows)
+            await wait_for_row_count_on_host(cql, host, ks, mv, expected_rows)
+            await wait_for_row_count_on_host(cql, host, ks, f'{idx}_index', expected_rows)


### PR DESCRIPTION
There are three ways to restore a table now -- nodetool refresh, nodetool restore and tablet-aware restore. All three can be run to restore a table with views, but none had been tested so far, this gap in validation is hereby closed.

The tablet-aware-restore currently fails and needs a design, whether it should be same self-protecting as the legacy ones, or views are to be handled somehow else for tablet-aware restore (see e.g. [this](https://github.com/scylladb/scylladb/pull/31075#issuecomment-5294933964) concern)

Adding more tests, not backporting