### PR TITLE
compaction_group: inherit tombstone_gc_enabled on split, not default

### DIFF
--- a/replica/table.cc
+++ b/replica/table.cc
@@ -3316,7 +3316,10 @@ compaction_group::compaction_group(table& t, size_t group_id, dht::token_range t
 }
 
 compaction_group_ptr compaction_group::make_empty_group(const compaction_group& base) {
-    return make_lw_shared<compaction_group>(base._t, base._group_id, base._token_range, base._repair_sstable_classifier);
+    auto cg = make_lw_shared<compaction_group>(base._t, base._group_id, base._token_range, base._repair_sstable_classifier);
+    // Inherit rather than default: the update_effective_replication_map() sweep may not run.
+    cg->set_tombstone_gc_enabled(base.tombstone_gc_enabled());
+    return cg;
 }
 
 bool compaction_group::stopped() const noexcept {

--- a/test/boost/sstable_set_test.cc
+++ b/test/boost/sstable_set_test.cc
@@ -208,6 +208,40 @@ SEASTAR_TEST_CASE(test_tablet_sstable_set_copy_ctor) {
     }, std::move(cfg));
 }
 
+SEASTAR_TEST_CASE(test_split_compaction_group_inherits_tombstone_gc_enabled) {
+    // enable tablets, to get access to tablet_storage_group_manager
+    cql_test_config cfg;
+    cfg.db_config->tablets_mode_for_new_keyspaces(db::tablets_mode_t::mode::enabled);
+
+    return do_with_cql_env_thread([&](cql_test_env& env) {
+        env.execute_cql("CREATE KEYSPACE test_split_compaction_group_inherits_tombstone_gc_enabled"
+                " WITH REPLICATION = {'class' : 'NetworkTopologyStrategy', 'replication_factor' : 1};").get();
+        env.execute_cql("CREATE TABLE test_split_compaction_group_inherits_tombstone_gc_enabled.test (pk int PRIMARY KEY);").get();
+        for (int i = 0; i < 10; i++) {
+            env.execute_cql(fmt::format("INSERT INTO test_split_compaction_group_inherits_tombstone_gc_enabled.test (pk) VALUES ({})", i)).get();
+        }
+        auto& cf = env.local_db().find_column_family("test_split_compaction_group_inherits_tombstone_gc_enabled", "test");
+        auto& sgm = column_family_test::get_storage_group_manager(cf);
+
+        // SCYLLADB-3773: Simulate a pending replica mid-migration: tombstone GC must stay disabled so
+        // regular compaction on split-ready groups can't resurrect data still being streamed in.
+        sgm->for_each_storage_group([] (size_t, replica::storage_group& sg) {
+            sg.main_compaction_group()->set_tombstone_gc_enabled(false);
+        });
+
+        sgm->split_all_storage_groups(tasks::task_info{}).get();
+
+        bool checked_any = false;
+        sgm->for_each_storage_group([&checked_any] (size_t, replica::storage_group& sg) {
+            for (auto& cg : sg.split_ready_compaction_groups()) {
+                checked_any = true;
+                BOOST_REQUIRE(!cg->tombstone_gc_enabled());
+            }
+        });
+        BOOST_REQUIRE(checked_any);
+    }, std::move(cfg));
+}
+
 SEASTAR_TEST_CASE(test_sstable_set_fast_forward_by_cache_reader_simulation) {
     return test_env::do_with_async([] (test_env& env) {
         simple_schema ss;


### PR DESCRIPTION
Extracted from #31068 per raphaelsc's review comment: https://github.com/scylladb/scylladb/pull/31068#discussion_r3785781268

`storage_group::set_split_mode()` creates new split-ready compaction groups via `make_empty_group()`, which left `tombstone_gc_enabled` at its class default (`true`) instead of inheriting the base group's value.

The per-group flag is normally kept correct by the `update_effective_replication_map()` sweep, which disables tombstone GC on a pending replica's groups so regular compaction can't GC data that is still being streamed in during migration.
That sweep may not run between a migration reaching the streaming phase and a split being triggered, so a pending replica's split-ready groups could default back to GC-enabled and resurrect data hidden by a not-yet-integrated streamed sstable.

Added a unit test (`test_split_compaction_group_inherits_tombstone_gc_enabled` in `test/boost/sstable_set_test.cc`) that disables tombstone GC on the main compaction group, triggers a split, and asserts the split-ready groups inherit it.
Confirmed the test fails without the fix (`boost::execution_aborted` on the `BOOST_REQUIRE`) and passes with it.

Fixes: SCYLLADB-3773

Backport: Yes, fixes an important data resurrection bug
