### PR TITLE
tablets: don't block migration streaming on compaction-group split

### DIFF
--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -5527,21 +5527,14 @@ future<> storage_service::stream_tablet(locator::global_tablet_id tablet) {
             }
         }
 
-        // If new pending tablet replica needs splitting, streaming waits for it to complete.
-        // That's to provide a guarantee that once migration is over, the coordinator can finalize
-        // splitting under the promise that compaction groups of tablets are all split, ready
-        // for the subsequent topology change.
-        //
-        // FIXME:
-        //  We could do the splitting not in the streaming stage, but in a later stage, so that
-        //  from the tablet scheduler's perspective migrations blocked on compaction are not
-        //  participating in streaming anymore (which is true), so it could schedule more
-        //  migrations. This way compaction would run in parallel with streaming which can
-        //  reduce the delay.
-        co_await _db.invoke_on(pending_replica->shard, [tablet] (replica::database& db) {
-            auto& table = db.find_column_family(tablet.table);
-            return table.maybe_split_compaction_group_of(tablet.tablet);
-        });
+        // Split of the pending replica's compaction group is handled by the
+        // split monitor (process_tablet_split_candidate) and by split-on-attach
+        // (maybe_split_new_sstable in add_new_sstable_and_update_cache) which
+        // splits every incoming sstable before it is loaded into the compaction
+        // group.  There is no need to block the streaming stage on a full
+        // compaction-group split here — doing so would hold a streaming slot on
+        // the coordinator while the split compaction runs, preventing it from
+        // scheduling further migrations.
         co_await utils::get_local_injector().inject("pause_after_streaming_tablet", utils::wait_for_message{std::chrono::minutes(1)});
         co_return tablet_operation_result();
     });


### PR DESCRIPTION
maybe_split_compaction_group_of() in stream_tablet() was introduced to ensure the pending replica's compaction group is fully split before the streaming stage advances, so that split finalization can proceed.

This is no longer necessary because:

1. split-on-attach (maybe_split_new_sstable in add_new_sstable_and_update_cache) already splits every incoming sstable before it is loaded, so streamed data lands directly in split-ready compaction groups.

2. set_split_mode() is called both when a new storage group is allocated for a migrating-in tablet (allocate_storage_group) and when a split decision is emitted for existing groups (update_effective_replication_map), so writes during migration also go to the correct split-ready groups.

3. The split monitor (process_tablet_split_candidate) independently handles splitting all storage groups and only acks readiness when all groups are fully split.

Blocking here is harmful: split compaction is serialized per shard, so if many tablets are migrating to the same node, each maybe_split_compaction_group_of() call queues behind all other pending splits.  Meanwhile the migration remains in stage=streaming from the coordinator's perspective, holding a streaming slot and preventing further migrations from being scheduled.

Fixes https://scylladb.atlassian.net/browse/SCYLLADB-3774

We have to backport to all vulnerable branches.