### PR TITLE
large_bitset: batch yields during construction, construct whole chunks in resize()

### DIFF
--- a/test/boost/chunked_vector_test.cc
+++ b/test/boost/chunked_vector_test.cc
@@ -582,3 +582,123 @@ BOOST_AUTO_TEST_CASE(test_swap) {
     BOOST_REQUIRE(std::ranges::equal(v1, std::array{2, 4}));
     BOOST_REQUIRE(std::ranges::equal(v2, std::array{1}));
 }
+
+// resize() value-initializes its elements, so unlike exception_safe_class the
+// element type has to be default-constructible and can't be handed a checker.
+static exception_safety_checker* resize_checker = nullptr;
+
+class default_constructible_exception_safe_class {
+public:
+    default_constructible_exception_safe_class() {
+        resize_checker->add_live_object();
+    }
+    default_constructible_exception_safe_class(const default_constructible_exception_safe_class&) {
+        resize_checker->add_live_object();
+    }
+    default_constructible_exception_safe_class(default_constructible_exception_safe_class&&) noexcept {
+        resize_checker->add_live_object_noexcept();
+    }
+    ~default_constructible_exception_safe_class() {
+        resize_checker->del_live_object();
+    }
+};
+
+// resize() constructs a whole chunk at a time, so cover growth that crosses
+// chunk boundaries and growth starting mid-chunk, for a type that is neither
+// trivially constructible nor trivially destructible.
+BOOST_AUTO_TEST_CASE(test_resize_across_chunk_boundary) {
+    constexpr size_t chunk_size = 512;
+    using chunked_vector = utils::chunked_vector<std::string, chunk_size>;
+    constexpr size_t max_chunk_capacity = chunked_vector::max_chunk_capacity();
+    static_assert(max_chunk_capacity > 1);
+
+    // Grow from empty, across several chunks, ending mid-chunk.
+    chunked_vector v;
+    v.resize(3 * max_chunk_capacity + max_chunk_capacity / 2);
+    BOOST_REQUIRE_EQUAL(v.size(), 3 * max_chunk_capacity + max_chunk_capacity / 2);
+    for (auto& s : v) {
+        BOOST_REQUIRE(s.empty());
+    }
+
+    // Grow from a partial last chunk left by shrink_to_fit(), preserving the
+    // existing elements.
+    chunked_vector w;
+    for (size_t i = 0; i < max_chunk_capacity + max_chunk_capacity / 2; ++i) {
+        w.push_back(fmt::to_string(i));
+    }
+    w.shrink_to_fit();
+    BOOST_REQUIRE_EQUAL(w.capacity(), w.size());
+    const auto old_size = w.size();
+    w.resize(4 * max_chunk_capacity);
+    BOOST_REQUIRE_EQUAL(w.size(), 4 * max_chunk_capacity);
+    for (size_t i = 0; i < old_size; ++i) {
+        BOOST_REQUIRE_EQUAL(w[i], fmt::to_string(i));
+    }
+    for (size_t i = old_size; i < w.size(); ++i) {
+        BOOST_REQUIRE(w[i].empty());
+    }
+
+    // Growing to the current size is a no-op, and growing to an exact chunk
+    // multiple keeps the elements intact.
+    w.resize(4 * max_chunk_capacity);
+    BOOST_REQUIRE_EQUAL(w.size(), 4 * max_chunk_capacity);
+    w.resize(5 * max_chunk_capacity);
+    BOOST_REQUIRE_EQUAL(w.size(), 5 * max_chunk_capacity);
+    for (size_t i = 0; i < old_size; ++i) {
+        BOOST_REQUIRE_EQUAL(w[i], fmt::to_string(i));
+    }
+}
+
+// The batched construction must value-initialize (not default-initialize) the
+// new elements, including when the batch is memset-able.
+BOOST_AUTO_TEST_CASE(test_resize_value_initializes) {
+    constexpr size_t chunk_size = 1024;
+    using chunked_vector = utils::chunked_vector<uint64_t, chunk_size>;
+    constexpr size_t max_chunk_capacity = chunked_vector::max_chunk_capacity();
+
+    chunked_vector v;
+    // Dirty a chunk's worth of memory, then release it, so that a freshly
+    // allocated chunk is likely to be served from the same non-zero memory.
+    v.resize(max_chunk_capacity);
+    for (auto& x : v) {
+        x = ~uint64_t(0);
+    }
+    v.clear();
+
+    v.push_back(~uint64_t(0));
+    v.resize(2 * max_chunk_capacity + 1);
+    BOOST_REQUIRE_EQUAL(v.size(), 2 * max_chunk_capacity + 1);
+    BOOST_REQUIRE_EQUAL(v[0], ~uint64_t(0));
+    for (size_t i = 1; i < v.size(); ++i) {
+        BOOST_REQUIRE_EQUAL(v[i], uint64_t(0));
+    }
+}
+
+BOOST_AUTO_TEST_CASE(tests_resize_exception_safety) {
+    constexpr size_t chunk_size = 512;
+    using chunked_vector = utils::chunked_vector<default_constructible_exception_safe_class, chunk_size>;
+    constexpr size_t max_chunk_capacity = chunked_vector::max_chunk_capacity();
+    static_assert(max_chunk_capacity > 1);
+
+    auto checker = exception_safety_checker();
+    resize_checker = &checker;
+    {
+        chunked_vector v;
+        v.resize(max_chunk_capacity / 2);
+        BOOST_REQUIRE_EQUAL(size_t(checker.live_objects()), v.size());
+
+        // Throw while constructing the batch that fills the second chunk.
+        checker.set_countdown(max_chunk_capacity);
+        try {
+            v.resize(4 * max_chunk_capacity);
+            BOOST_REQUIRE(false);
+        } catch (...) {
+        }
+        // The partially constructed batch is rolled back, so size() still
+        // accounts for every live element.
+        BOOST_REQUIRE_EQUAL(size_t(checker.live_objects()), v.size());
+        BOOST_REQUIRE_LT(v.size(), 4 * max_chunk_capacity);
+    }
+    BOOST_REQUIRE(checker.ok());
+    resize_checker = nullptr;
+}

--- a/utils/bloom_filter.hh
+++ b/utils/bloom_filter.hh
@@ -44,10 +44,6 @@ public:
 
     virtual bool is_present(hashed_key key) override;
 
-    virtual void clear() override {
-        _bitset.clear();
-    }
-
     virtual void close() override { }
 
     virtual size_t memory_size() override {
@@ -78,8 +74,6 @@ struct always_present_filter: public i_filter {
 
     virtual void add(const bytes_view& key) override { }
     virtual void add(const hashed_key& key) override { }
-
-    virtual void clear() override { }
 
     virtual void close() override { }
 

--- a/utils/chunked_vector.hh
+++ b/utils/chunked_vector.hh
@@ -574,9 +574,11 @@ chunked_vector<T, max_contiguous_allocation>::resize(size_t n) {
         return;
     }
     reserve(n);
-    // FIXME: construct whole chunks at once
     while (_size < n) {
-        push_back(T{});
+        // Construct up to a whole chunk at once.
+        auto now = std::min(n - _size, max_chunk_capacity() - _size % max_chunk_capacity());
+        std::uninitialized_value_construct_n(addr(_size), now);
+        _size += now;
     }
 }
 

--- a/utils/i_filter.hh
+++ b/utils/i_filter.hh
@@ -41,7 +41,6 @@ struct i_filter {
     virtual void add(const hashed_key& key) = 0;
     virtual bool is_present(const bytes_view& key) = 0;
     virtual bool is_present(hashed_key) = 0;
-    virtual void clear() = 0;
     virtual void close() = 0;
 
     virtual size_t memory_size() = 0;

--- a/utils/large_bitset.cc
+++ b/utils/large_bitset.cc
@@ -13,16 +13,21 @@
 #include <seastar/core/align.hh>
 #include <seastar/core/thread.hh>
 
+#include <algorithm>
+
 using namespace seastar;
+
+// Bound the preemption-check granularity to one chunk of the storage.
+static constexpr size_t words_per_yield = large_bitset::storage_type::max_chunk_capacity();
 
 large_bitset::large_bitset(size_t nr_bits) : _nr_bits(nr_bits) {
     SCYLLA_ASSERT(thread::running_in_thread());
 
     size_t nr_ints = align_up(nr_bits, bits_per_int()) / bits_per_int();
     utils::reserve_gently(_storage, nr_ints).get();
-    while (nr_ints) {
-        _storage.push_back(0);
-        --nr_ints;
+    // Fill one chunk per yield; capacity is already reserved.
+    while (_storage.size() < nr_ints) {
+        _storage.resize(std::min(nr_ints, _storage.size() + words_per_yield));
         thread::maybe_yield();
     }
 }

--- a/utils/large_bitset.cc
+++ b/utils/large_bitset.cc
@@ -31,12 +31,3 @@ large_bitset::large_bitset(size_t nr_bits) : _nr_bits(nr_bits) {
         thread::maybe_yield();
     }
 }
-
-void
-large_bitset::clear() {
-    SCYLLA_ASSERT(thread::running_in_thread());
-    for (auto&& pos: _storage) {
-        pos = 0;
-        thread::maybe_yield();
-    }
-}

--- a/utils/large_bitset.hh
+++ b/utils/large_bitset.hh
@@ -16,14 +16,17 @@
 
 class large_bitset {
     using int_type = uint64_t;
+public:
+    using storage_type = utils::chunked_vector<int_type>;
+private:
     static constexpr size_t bits_per_int() {
         return std::numeric_limits<int_type>::digits;
     }
     size_t _nr_bits = 0;
-    utils::chunked_vector<int_type> _storage;
+    storage_type _storage;
 public:
     explicit large_bitset(size_t nr_bits);
-    explicit large_bitset(size_t nr_bits, utils::chunked_vector<int_type> storage) : _nr_bits(nr_bits), _storage(std::move(storage)) {}
+    explicit large_bitset(size_t nr_bits, storage_type storage) : _nr_bits(nr_bits), _storage(std::move(storage)) {}
     large_bitset(large_bitset&&) = default;
     large_bitset(const large_bitset&) = delete;
     large_bitset& operator=(const large_bitset&) = delete;
@@ -55,7 +58,7 @@ public:
     }
     void clear();
 
-    const utils::chunked_vector<int_type>& get_storage() const {
+    const storage_type& get_storage() const {
         return _storage;
     }
 };

--- a/utils/large_bitset.hh
+++ b/utils/large_bitset.hh
@@ -56,7 +56,6 @@ public:
         auto idx2 = idx;
         _storage[idx1] &= ~(int_type(1) << idx2);
     }
-    void clear();
 
     const storage_type& get_storage() const {
         return _storage;


### PR DESCRIPTION
## Motivation

`large_bitset` construction and `clear()` yielded (via `reserve_gently` and per-word checks) once per 64-bit word, and `chunked_vector::resize()` grew one element at a time via `push_back(T{})` 
- excessive scheduling-point overhead for large bitsets (e.g. bloom filters built during compaction).

## Change

- `chunked_vector::resize()`: construct up to a whole chunk per iteration with `std::uninitialized_value_construct_n` (lowers to `memset` for trivial `T`), resolving the FIXME left in the code.
- `large_bitset`: fill one chunk per iteration during construction, checking for preemption once per chunk instead of once per word.
- Remove `i_filter::clear()`, its two implementations and `large_bitset::clear()` - nothing calls it, and nothing ever has. (It was optimized first; measurement showed checking for preemption once per chunk bought nothing on its own, since the per-word store loop is the bottleneck, not the check. Removing it is better than tuning it.)

No on-disk format change; behavior is unchanged, only the granularity of yielding/construction.

## Tests

Built from scratch (dev mode) and run:

- `chunked_vector_test`: passes. Added coverage for `resize()` growth across chunk boundaries, growth from the partial last chunk left by `shrink_to_fit()`, value-initialization, and exception safety when an element constructor throws mid-batch. The existing random walk draws resize sizes from a geometric distribution with mean well below one chunk, so it never crossed a chunk boundary - it passes even with the chunk-remainder clamp removed, while the new cases fail without it. Also fuzzed out-of-tree against a `std::deque` reference, 300 seeds x 20k ops x 4 configs (incl. the production 128KB chunk size and a throwing element type), clean under ASan/UBSan.
- `bloom_filter_test`: passes with `-c1`, except the pre-existing `test_bloom_filter_reclaim_after_unlink` failure, which reproduces identically on an unpatched binary; see #31119.

## Results

Measured on the real path - `i_filter::get_filter()`, fp chance 0.01, Ryzen 7 8845HS, dev build:

| partitions | filter size | before | after |
| --- | --- | --- | --- |
| 1M | 1.2MB | 0.66ms | 0.015ms |
| 10M | 11.9MB | 6.65ms | 0.17ms |
| 100M | 119MB | 67.3ms | 4.5ms |

~39x on filter creation. In proportion, creation drops from ~0.75% to ~0.03% of the cost of building a filter (creating it plus adding all keys), so this is a small constant saving per sstable write rather than a throughput change.

Backport: No, improvement
