### PR TITLE
test/boost/bloom_filter_test: fix smp-dependent pkeys and injection leak

### DIFF
--- a/test/boost/bloom_filter_test.cc
+++ b/test/boost/bloom_filter_test.cc
@@ -265,7 +265,8 @@ SEASTAR_TEST_CASE(test_bloom_filter_reload_after_unlink) {
         simple_schema ss;
         auto schema = ss.schema();
 
-        auto mut = mutation(schema, ss.make_pkey(1));
+        // make_pkey() picks a key owned by this shard, unlike make_pkey(n).
+        auto mut = mutation(schema, ss.make_pkey());
         mut.partition().apply_insert(*schema, ss.make_ckey(1), ss.new_timestamp());
 
         // bloom filter will be reclaimed automatically due to low memory
@@ -317,9 +318,10 @@ SEASTAR_TEST_CASE(test_bloom_filter_reclaim_after_unlink) {
         simple_schema ss;
         auto schema = ss.schema();
 
+        // make_pkeys() picks keys owned by this shard, unlike make_pkey(n).
         utils::chunked_vector<mutation> mutations;
-        for (int i = 0; i < 10; i++) {
-            auto mut = mutation(schema, ss.make_pkey(i));
+        for (auto& pk : ss.make_pkeys(10)) {
+            auto mut = mutation(schema, pk);
             mut.partition().apply_insert(*schema, ss.make_ckey(1), ss.new_timestamp());
             mutations.push_back(std::move(mut));
         }
@@ -332,10 +334,10 @@ SEASTAR_TEST_CASE(test_bloom_filter_reclaim_after_unlink) {
         BOOST_REQUIRE_EQUAL(sst_mgr.get_total_memory_reclaimed(), 0);
 
         // hold a copy of shared sst object in async thread to test reclaim after unlink
-        utils::get_local_injector().enable("test_bloom_filter_reload_after_unlink");
+        utils::get_local_injector().enable("test_bloom_filter_reclaim_after_unlink");
         auto async_sst_holder = seastar::async([sst1] {
             // do nothing just hold a copy of sst and wait for message signalling test completion
-            utils::get_local_injector().inject("test_bloom_filter_reload_after_unlink", [] (auto& handler) {
+            utils::get_local_injector().inject("test_bloom_filter_reclaim_after_unlink", [] (auto& handler) {
                 auto ret = handler.wait_for_message(std::chrono::steady_clock::now() + std::chrono::seconds{5});
                 return ret;
             }).get();
@@ -363,7 +365,7 @@ SEASTAR_TEST_CASE(test_bloom_filter_reclaim_after_unlink) {
         sst2.release();
 
         // message async thread to complete waiting and thus release its copy of sst, triggering deactivation
-        utils::get_local_injector().receive_message("test_bloom_filter_reload_after_unlink");
+        utils::get_local_injector().receive_message("test_bloom_filter_reclaim_after_unlink");
         async_sst_holder.get();
 
         REQUIRE_EVENTUALLY_EQUAL<size_t>([&] { return active_list.size(); }, 0);


### PR DESCRIPTION
## Motivation

`test_bloom_filter_reload_after_unlink` and `test_bloom_filter_reclaim_after_unlink` only pass because `test_config.yaml` pins `bloom_filter_test: -c1` and test.py runs each case in its own process.
Running the binary directly with default smp fails, and the full suite (no `-c1`) ends in a SIGSEGV cascade.

## Change

- Both tests used `simple_schema::make_pkey(n)`, a deterministic key regardless of which shard owns it;
with smp > 1 the sstable's token range can miss the local shard and `sstable::unlink()` fails to generate sharding metadata.
Switched to `make_pkey()`/`make_pkeys(n)` (no explicit index), which pick keys owned by the local shard - the same idiom `test_rebuild_from_temporary_hashes` already uses in this file.
- The two tests also shared one error-injection name. `enable()` is a no-op on an already-enabled name, so the reload test's leftover received-message count let the reclaim test's 
`wait_for_message()` resolve immediately when run right after it in the same process, releasing its sstable holder too early. Gave the reclaim test its own injection name.

## Tests

`bloom_filter_test` full suite passes cleanly at both default smp (16 shards, previously SIGSEGV'd) and `-c1`, repeated 3x each with no failures.

## Results

`bloom_filter_test` no longer depends on `test_config.yaml`'s `-c1` pin or process-per-case isolation for correctness.

Fixes https://scylladb.atlassian.net/browse/SCYLLADB-3775 

Backport: No, test correction