### PR TITLE
test: fix memtable_test to run with shard count != 2

### DIFF
--- a/test/boost/memtable_test.cc
+++ b/test/boost/memtable_test.cc
@@ -1214,12 +1214,16 @@ SEASTAR_TEST_CASE(flushing_rate_is_reduced_if_compaction_doesnt_keep_up) {
     // correctness tests, which do run in debug mode.
     return make_ready_future<>();
 #else
-    BOOST_ASSERT(this_smp_shard_count() == 2);
+    if (this_smp_shard_count() < 2) {
+        std::cerr << "Cannot run test flushing_rate_is_reduced_if_compaction_doesnt_keep_up with this_smp_shard_count() < 2" << std::endl;
+        return make_ready_future<>();
+    }
     // The test simulates a situation where 2 threads issue flushes to 2
     // tables. Both issue small flushes, but one has injected reactor stalls.
     // This can lead to a situation where lots of small sstables accumulate on
     // disk, and, if compaction never has a chance to keep up, resources can be
-    // exhausted.
+    // exhausted. Only shards 0 and 1 participate; any additional shards are
+    // simply idle bystanders.
     return do_with_cql_env([](cql_test_env& env) -> future<> {
         struct flusher {
             cql_test_env& env;


### PR DESCRIPTION
## Motivation

`memtable_test/flushing_rate_is_reduced_if_compaction_doesnt_keep_up` aborts the whole test process with a hard `BOOST_ASSERT(this_smp_shard_count() == 2)` whenever the binary runs with a shard count other than 2 (e.g. a multi-shard sweep, or a developer running it directly without `--smp`).

## Change

The test only ever drives work on shards 0 and 1 explicitly via `smp::submit_to(0, ...)` / `smp::submit_to(1, ...)`, so any additional shards are just idle bystanders - the hard assert wasn't protecting real test logic. Replaced it with a graceful skip-below-2 check, the same pattern already used elsewhere in the codebase (`address_map_test.cc`, `multishard_combining_reader_as_mutation_source_test.cc`) for tests with a minimum shard-count requirement.

## Tests

`memtable_test/flushing_rate_is_reduced_if_compaction_doesnt_keep_up`, run directly against `combined_tests`:
- `--smp=2 -m2G`: passes, unchanged behavior.
- `--smp=3 -m3G`: previously aborted the process; now runs its real logic and passes.
- `--smp=8 -m8G`: passes.

## Results

Confirmed the fix is real, not just a skip: at `--smp=3`/`--smp=8` the test actually executes (shards 0/1 do the work, extra shards idle), rather than silently no-oping.

Fixes https://scylladb.atlassian.net/browse/SCYLLADB-3777

Backport: no, test improvement

Signed-off-by: Yaniv Kaul <yaniv.kaul@scylladb.com>