### PR TITLE
test: use a shard-owned key in test_sstable_clone_preserves_staging_state

### DIFF
--- a/test/boost/sstable_move_test.cc
+++ b/test/boost/sstable_move_test.cc
@@ -15,6 +15,7 @@
 #include "test/lib/sstable_test_env.hh"
 #include "test/lib/sstable_utils.hh"
 #include "test/lib/simple_schema.hh"
+#include "test/lib/key_utils.hh"
 #include "sstable_test.hh"
 #include "sstables/exceptions.hh"
 
@@ -158,8 +159,10 @@ SEASTAR_THREAD_TEST_CASE(test_sstable_clone_preserves_staging_state) {
     simple_schema ss;
     auto schema = ss.schema();
 
-    // Create an sstable in normal state.
-    auto sst = make_sstable_containing(env.make_sst_factory(schema), {ss.new_mutation("key1")}).get();
+    // Create an sstable in normal state. The key must be owned by this shard, or
+    // sstable::write_scylla_metadata() fails to generate sharding metadata once smp > 1.
+    auto pkey = tests::generate_partition_key(schema);
+    auto sst = make_sstable_containing(env.make_sst_factory(schema), {mutation(schema, std::move(pkey))}).get();
 
     // Move it to staging state.
     sst->change_state(sstable_state::staging).get();

--- a/test/boost/sstable_move_test.cc
+++ b/test/boost/sstable_move_test.cc
@@ -162,7 +162,9 @@ SEASTAR_THREAD_TEST_CASE(test_sstable_clone_preserves_staging_state) {
     // Create an sstable in normal state. The key must be owned by this shard, or
     // sstable::write_scylla_metadata() fails to generate sharding metadata once smp > 1.
     auto pkey = tests::generate_partition_key(schema);
-    auto sst = make_sstable_containing(env.make_sst_factory(schema), {mutation(schema, std::move(pkey))}).get();
+    mutation mut(schema, std::move(pkey));
+    ss.add_row(mut, ss.make_ckey(0), "value");
+    auto sst = make_sstable_containing(env.make_sst_factory(schema), {std::move(mut)}).get();
 
     // Move it to staging state.
     sst->change_state(sstable_state::staging).get();


### PR DESCRIPTION
## Motivation

`test_sstable_clone_preserves_staging_state` fails with `Failed to generate sharding metadata` whenever the writing shard doesn't happen to own the test's key, once smp > 1.

## Change

The test built its sstable via `simple_schema::new_mutation("key1")` - a fixed key, not one generated for (or verified to be owned by) the writing shard. Once smp > 1 the key's token can land on a different shard than the one writing the sstable, and `sstable::write_scylla_metadata()` finds no intersection between the writing shard and the sstable's token range, throwing. Same root-cause family as SCYLLADB-3742 (`make_sstable_containing` writing from `this_shard_id()` regardless of token ownership) hitting a different test. Switched to `tests::generate_partition_key()`, which defaults to a key owned by the current shard - the same fix proposed for other sstable tests hitting this class of failure in PR #30550 (not yet merged).

## Tests

`sstable_move_test/test_sstable_clone_preserves_staging_state`:
- `-c2 -m2G`: passes, unchanged behavior.
- `-c3 -m3G`: previously failed with "Failed to generate sharding metadata"; now passes.
- `-c8 -m8G`: passes.

Also ran the full `sstable_move_test` binary (all cases) at `-c2` to confirm no other regressions.

## Results

All shard counts tested pass cleanly with no errors.

Fixes https://scylladb.atlassian.net/browse/SCYLLADB-3778

Backport: no, test improvement

Signed-off-by: Yaniv Kaul <yaniv.kaul@scylladb.com>