### PR TITLE
[DON'T REVIEW] PR for CI debug run

### DIFF
--- a/test/cluster/conftest.py
+++ b/test/cluster/conftest.py
@@ -55,7 +55,7 @@ Session.run_async = run_async     # patch Session for convenience
 
 logger = logging.getLogger(__name__)
 
-print(f"Driver name {DRIVER_NAME}, version {DRIVER_VERSION}")
+logger.info("Driver name %s, version %s", DRIVER_NAME, DRIVER_VERSION)
 
 
 async def decode_backtrace(build_mode: str, input: str):

--- a/test/cluster/test_tablets.py
+++ b/test/cluster/test_tablets.py
@@ -73,7 +73,7 @@ async def test_tablet_scaling_option_is_respected(manager: ManagerClient):
     assert len(tablets) == 64
 
 
-async def test_tablet_cannot_decommision_below_replication_factor(manager: ManagerClient):
+async def test_tablet_cannot_decommission_below_replication_factor(manager: ManagerClient):
     logger.info("Bootstrapping cluster")
     cfg = {'enable_user_defined_functions': False, 'tablets_mode_for_new_keyspaces': 'enabled'}
     servers = await manager.servers_add(4, config=cfg, property_file=[


### PR DESCRIPTION
The driver name/version banner was printed at conftest import time, which puts it on stdout outside the logging setup; use the module logger instead.

Also fix the misspelled test name
test_tablet_cannot_decommision_below_replication_factor.

Ref RELENG-809
