### PR TITLE
alternator: validate parameter types before use in several requests

### DIFF
--- a/alternator/conditions.cc
+++ b/alternator/conditions.cc
@@ -364,8 +364,14 @@ static bool check_comparable_type(const rjson::value& v) {
     if (!v.IsObject() || v.MemberCount() != 1) {
         return false;
     }
-    const rjson::value& type = v.MemberBegin()->name;
-    return type == "S" || type == "N" || type == "B";
+    const auto& kv = *v.MemberBegin();
+    if (kv.name != "S" && kv.name != "N" && kv.name != "B") {
+        return false;
+    }
+    // S, N and B are all encoded as a JSON string (S and B directly, N as a
+    // string holding a decimal number) - see validate_value(). A type tag
+    // whose value isn't really a string (e.g. {"S": 123}) isn't comparable.
+    return kv.value.IsString();
 }
 
 // Check if two JSON-encoded values match with cmp.

--- a/alternator/executor.cc
+++ b/alternator/executor.cc
@@ -1160,6 +1160,9 @@ static void update_tags_map(const rjson::value& tags, std::map<sstring, sstring>
         }
     } else if (action == update_tags_action::delete_tags) {
         for (auto it = tags.Begin(); it != tags.End(); ++it) {
+            if (!it->IsString()) {
+                throw api_error::validation("TagKeys entries must be strings");
+            }
             auto tag_key = rjson::to_string_view(*it);
             if (tag_key_is_internal(tag_key)) {
                 throw api_error::validation(fmt::format("Tag key '{}' is reserved for internal use", tag_key));
@@ -2508,7 +2511,11 @@ void validate_value(const rjson::value& v, const char* caller) {
                     caller, element.GetDouble()));
             }
         }
-    } else if (type != "L" && type != "M" && type != "BOOL" && type != "NULL") {
+    } else if (type == "BOOL") {
+        if (!it->value.IsBool()) {
+            throw api_error::validation(format("{}: improperly formatted value '{}'", caller, v));
+        }
+    } else if (type != "L" && type != "M" && type != "NULL") {
         // TODO: can do more sanity checks on the content of the above types.
         throw api_error::validation(fmt::format("{}: unknown type {} for value {}", caller, type, v));
     }
@@ -3998,7 +4005,7 @@ static bool check_needs_read_before_write_attribute_updates(rjson::value *attrib
     // that _attribute_updates, when it exists, is a map
     for (auto it = attribute_updates->MemberBegin(); it != attribute_updates->MemberEnd(); ++it) {
         rjson::value* action = rjson::find(it->value, "Action");
-        if (action) {
+        if (action && action->IsString()) {
             std::string_view action_s = rjson::to_string_view(*action);
             if (action_s == "ADD") {
                 return true;
@@ -4303,7 +4310,11 @@ inline void update_item_operation::apply_attribute_updates(const std::unique_ptr
         if (cdef && cdef->is_primary_key()) {
             throw api_error::validation(format("UpdateItem cannot update key column {}", rjson::to_string_view(it->name)));
         }
-        std::string action = rjson::to_string((it->value)["Action"]);
+        const rjson::value& action_json = (it->value)["Action"];
+        if (!action_json.IsString()) {
+            throw api_error::validation("AttributeUpdates Action must be a string");
+        }
+        std::string action = rjson::to_string(action_json);
         if (action == "DELETE") {
             // The DELETE operation can do two unrelated tasks. Without a
             // "Value" option, it is used to delete an attribute. With a
@@ -4576,9 +4587,8 @@ future<executor::request_return_type> executor::list_tables(client_state& client
     co_await utils::get_local_injector().inject("alternator_list_tables", utils::wait_for_message(5min));
 
     rjson::value* exclusive_start_json = rjson::find(request, "ExclusiveStartTableName");
-    rjson::value* limit_json = rjson::find(request, "Limit");
     std::string exclusive_start = exclusive_start_json ? rjson::to_string(*exclusive_start_json) : "";
-    int limit = limit_json ? limit_json->GetInt() : 100;
+    int limit = get_int_attribute(request, "Limit").value_or(100);
     if (limit < 1 || limit > 100) {
         co_return api_error::validation("Limit must be greater than 0 and no greater than 100");
     }

--- a/alternator/executor_read.cc
+++ b/alternator/executor_read.cc
@@ -138,6 +138,9 @@ static std::optional<attrs_to_get> calculate_attrs_to_get(const rjson::value& re
         const rjson::value& attributes_to_get = req["AttributesToGet"];
         attrs_to_get ret;
         for (auto it = attributes_to_get.Begin(); it != attributes_to_get.End(); ++it) {
+            if (!it->IsString()) {
+                throw api_error::validation("AttributesToGet entries must be strings");
+            }
             attribute_path_map_add("AttributesToGet", ret, rjson::to_string(*it));
             validate_attr_name_length("AttributesToGet", it->GetStringLength(), false);
         }
@@ -189,7 +192,7 @@ get_table_or_view(service::storage_proxy& proxy, const rjson::value& request) {
             type = table_or_view_type::gsi;
         } else {
             throw api_error::validation(
-                    fmt::format("Non-string IndexName '{}'", rjson::to_string_view(*index_name)));
+                    fmt::format("Non-string IndexName '{}'", *index_name));
         }
         // If no tables for global indexes were found, the index may be local
         if (!proxy.data_dictionary().has_schema(keyspace_name, table_name)) {
@@ -787,8 +790,17 @@ future<executor::request_return_type> executor::scan(client_state& client_state,
         return make_ready_future<request_return_type>(api_error::validation(
                 "Consistent reads are not allowed on global indexes (GSI)"));
     }
+    // Unlike Query, real DynamoDB's Scan doesn't seem to actually enforce
+    // Limit's documented type (Integer) or range - despite both operations
+    // documenting Limit identically, an oversized Limit that Query rejects
+    // is silently accepted by Scan. We match this by treating a Limit that
+    // doesn't fit in 32 bits the same as an absent one (unbounded), instead
+    // of rejecting it like get_uint64_attribute() would.
     rjson::value* limit_json = rjson::find(request, "Limit");
-    uint32_t limit = limit_json ? limit_json->GetUint64() : std::numeric_limits<uint32_t>::max();
+    uint32_t limit = std::numeric_limits<uint32_t>::max();
+    if (limit_json && limit_json->IsUint64() && limit_json->GetUint64() <= std::numeric_limits<uint32_t>::max()) {
+        limit = limit_json->GetUint64();
+    }
     if (limit <= 0) {
         return make_ready_future<request_return_type>(api_error::validation("Limit must be greater than 0"));
     }
@@ -2153,8 +2165,7 @@ future<executor::request_return_type> executor::query(client_state& client_state
         return make_ready_future<request_return_type>(api_error::validation(
                 "Consistent reads are not allowed on global indexes (GSI)"));
     }
-    rjson::value* limit_json = rjson::find(request, "Limit");
-    uint32_t limit = limit_json ? limit_json->GetUint64() : std::numeric_limits<uint32_t>::max();
+    uint32_t limit = get_uint64_attribute(request, "Limit").value_or(std::numeric_limits<uint32_t>::max());
     if (limit <= 0) {
         return make_ready_future<request_return_type>(api_error::validation("Limit must be greater than 0"));
     }

--- a/alternator/executor_util.cc
+++ b/alternator/executor_util.cc
@@ -38,6 +38,17 @@ std::optional<int> get_int_attribute(const rjson::value& value, std::string_view
     return attribute_value->GetInt();
 }
 
+std::optional<uint64_t> get_uint64_attribute(const rjson::value& value, std::string_view attribute_name) {
+    const rjson::value* attribute_value = rjson::find(value, attribute_name);
+    if (!attribute_value)
+        return {};
+    if (!attribute_value->IsUint64()) {
+        throw api_error::validation(fmt::format("Expected non-negative integer value for attribute {}, got: {}",
+                attribute_name, value));
+    }
+    return attribute_value->GetUint64();
+}
+
 std::string get_string_attribute(const rjson::value& value, std::string_view attribute_name, const char* default_return) {
     const rjson::value* attribute_value = rjson::find(value, attribute_name);
     if (!attribute_value)

--- a/alternator/executor_util.hh
+++ b/alternator/executor_util.hh
@@ -55,6 +55,12 @@ using body_writer = noncopyable_function<future<>(output_stream<char>&&)>;
 /// api_error is thrown.
 std::optional<int> get_int_attribute(const rjson::value& value, std::string_view attribute_name);
 
+/// Get the value of a 64-bit non-negative integer attribute, or an empty
+/// optional if it is missing. If the attribute exists, but isn't a
+/// non-negative integer that fits in 64 bits, a descriptive api_error is
+/// thrown.
+std::optional<uint64_t> get_uint64_attribute(const rjson::value& value, std::string_view attribute_name);
+
 /// Get the value of a string attribute, or a default value if it is missing.
 /// If the attribute exists, but is not a string, a descriptive api_error is
 /// thrown.

--- a/test/alternator/test_manual_requests.py
+++ b/test/alternator/test_manual_requests.py
@@ -698,3 +698,119 @@ def test_request_limit_exceeded_connection_reuse(dynamodb, cql):
         assert 'ResourceNotFoundException' in body, body
     finally:
         conn.close()
+
+# validate_value() checks the shape of every value type it recognizes - S
+# and B must be strings, N a numeric string, sets non-empty arrays, and so
+# on - but it used to accept "BOOL" unconditionally, without checking that
+# its value is really a JSON boolean. A value like {"BOOL": "dog"} passed
+# validation and only failed later, when serialization assumed it was a
+# bool: an InternalServerError instead of a clean ValidationException.
+# Needs a manual request: boto3 rejects a non-bool BOOL value client-side.
+@pytest.mark.parametrize("op", ['PutItem', 'UpdateItem', 'BatchWriteItem'])
+def test_write_malformed_bool_value(dynamodb, test_table_s, op):
+    p = random_string()
+    payloads = {
+        'PutItem': '''{
+            "TableName": "''' + test_table_s.name + '''",
+            "Item": {"p": {"S": "''' + p + '''"}, "x": {"BOOL": "dog"}}}''',
+        'UpdateItem': '''{
+            "TableName": "''' + test_table_s.name + '''",
+            "Key": {"p": {"S": "''' + p + '''"}},
+            "UpdateExpression": "SET x = :x",
+            "ExpressionAttributeValues": {":x": {"BOOL": "dog"} }}''',
+        'BatchWriteItem': '''{
+            "RequestItems": {
+            "''' + test_table_s.name + '''": [
+                {"PutRequest":
+                    {"Item": {"p": {"S": "''' + p + '''"}, "x": {"BOOL": "dog"}}}}
+            ]}}'''
+    }
+    with pytest.raises(ManualRequestError) as err:
+        manual_request(dynamodb, op, payloads[op])
+    assert err.value.type in ('ValidationException', 'SerializationException'), \
+        f'Unexpected error type {err.value.type} for {op} with malformed {{"BOOL": "dog"}}'
+
+# The legacy Expected/ComparisonOperator checks (check_comparable_type() in
+# conditions.cc) only checked an AttributeValueList entry's type tag ("S",
+# "N" or "B"), not that its value actually has that JSON type. A malformed
+# entry like {"S": 123} passed that check and reached code that assumes a
+# string: an InternalServerError instead of a clean ValidationException.
+# Affects every comparator that reads such a value (LT, LE, GT, GE, BETWEEN,
+# BEGINS_WITH, CONTAINS); we only test LT here. Needs a manual request:
+# boto3 rejects a non-string "S" value client-side.
+def test_expected_comparison_operator_type_mismatch(dynamodb, test_table_s):
+    p = random_string()
+    # Seed the item with a normal, validly-typed string attribute "x", so
+    # the *existing* value also passes check_comparable_type() - an Expected
+    # check against a *missing* attribute short-circuits before ever
+    # reaching the buggy code.
+    manual_request(dynamodb, 'PutItem', '''{
+        "TableName": "''' + test_table_s.name + '''",
+        "Item": {"p": {"S": "''' + p + '''"}, "x": {"S": "hello"}}}''')
+    body = '''{
+        "TableName": "''' + test_table_s.name + '''",
+        "Key": {"p": {"S": "''' + p + '''"}},
+        "Expected": {"x": {"ComparisonOperator": "LT", "AttributeValueList": [{"S": 123}]}}}'''
+    with pytest.raises(ManualRequestError) as err:
+        manual_request(dynamodb, 'DeleteItem', body)
+    assert err.value.type in ('ValidationException', 'SerializationException'), \
+        f'Unexpected error type {err.value.type} (message: {err.value.message})'
+
+# GetItem's legacy "AttributesToGet" entries weren't checked to be strings
+# before use - same class of bug as above. A non-string entry like 123 got
+# an InternalServerError instead of a ValidationException. Needs a manual
+# request: boto3 rejects non-string entries client-side.
+def test_get_item_attributes_to_get_non_string(dynamodb, test_table_s):
+    p = random_string()
+    body = '''{
+        "TableName": "''' + test_table_s.name + '''",
+        "Key": {"p": {"S": "''' + p + '''"}},
+        "AttributesToGet": [123]}'''
+    with pytest.raises(ManualRequestError) as err:
+        manual_request(dynamodb, 'GetItem', body)
+    assert err.value.type in ('ValidationException', 'SerializationException'), \
+        f'Unexpected error type {err.value.type} (message: {err.value.message})'
+
+# AttributeUpdates's legacy "Action" field wasn't checked to be a string -
+# same class of bug as above, in two places: once while deciding whether the
+# update needs a read-before-write, and again while actually applying it.
+# A non-string Action like 123 got an InternalServerError instead of a
+# ValidationException. Needs a manual request: boto3 rejects a non-string
+# Action client-side.
+def test_update_item_attribute_updates_non_string_action(dynamodb, test_table_s):
+    p = random_string()
+    body = '''{
+        "TableName": "''' + test_table_s.name + '''",
+        "Key": {"p": {"S": "''' + p + '''"}},
+        "AttributeUpdates": {"y": {"Action": 123, "Value": {"S": "z"}}}}'''
+    with pytest.raises(ManualRequestError) as err:
+        manual_request(dynamodb, 'UpdateItem', body)
+    assert err.value.type in ('ValidationException', 'SerializationException'), \
+        f'Unexpected error type {err.value.type} (message: {err.value.message})'
+
+# UntagResource's "TagKeys" entries weren't checked to be strings - same
+# class of bug as above. A non-string entry like 123 got an
+# InternalServerError instead of a ValidationException. Needs a manual
+# request: boto3 rejects non-string entries client-side.
+def test_untag_resource_non_string_tag_key(dynamodb, test_table):
+    arn = test_table.meta.client.describe_table(TableName=test_table.name)['Table']['TableArn']
+    body = '{"ResourceArn": "' + arn + '", "TagKeys": [123]}'
+    with pytest.raises(ManualRequestError) as err:
+        manual_request(dynamodb, 'UntagResource', body)
+    assert err.value.type in ('ValidationException', 'SerializationException'), \
+        f'Unexpected error type {err.value.type} (message: {err.value.message})'
+
+# Query already rejects a non-string IndexName, but the error message it
+# built for that case read the value as a string too - so reporting the
+# error hit the same class of bug as above, giving an InternalServerError
+# instead of the intended ValidationException. Needs a manual request:
+# boto3 rejects a non-string IndexName client-side.
+def test_query_non_string_index_name(dynamodb, test_table):
+    body = '''{
+        "TableName": "''' + test_table.name + '''",
+        "IndexName": 123,
+        "KeyConditions": {"p": {"AttributeValueList": [{"S": "x"}], "ComparisonOperator": "EQ"}}}'''
+    with pytest.raises(ManualRequestError) as err:
+        manual_request(dynamodb, 'Query', body)
+    assert err.value.type in ('ValidationException', 'SerializationException'), \
+        f'Unexpected error type {err.value.type} (message: {err.value.message})'

--- a/test/alternator/test_query.py
+++ b/test/alternator/test_query.py
@@ -318,6 +318,18 @@ def test_query_limit(test_table_sn):
     with pytest.raises(ClientError, match='ValidationException.*[lL]imit'):
         test_table_sn.query(ConsistentRead=True, KeyConditions={'p': {'AttributeValueList': [p], 'ComparisonOperator': 'EQ'}}, Limit=0)
 
+# Query's Limit used to be read directly with GetUint64() with no preceding
+# IsUint64() check, so a Limit too large to fit (boto3 enforces a minimum of
+# 1 but no maximum, so e.g. 2**64 reaches the server unmodified) got an
+# internal, non-communicative error instead of a clean ValidationException.
+def test_query_invalid_limit_type(test_table):
+    with pytest.raises(ClientError) as err:
+        test_table.query(Limit=2**64)
+    code = err.value.response['Error']['Code']
+    message = err.value.response['Error'].get('Message', '')
+    assert code in ('ValidationException', 'SerializationException'), \
+        f'Unexpected error code {code} for oversized Limit: {message}'
+
 # In test_query_limit we tested just that Limit allows to stop the result
 # after right right number of items. Here we test that such a stopped result
 # can be resumed, via the LastEvaluatedKey/ExclusiveStartKey paging mechanism.

--- a/test/alternator/test_scan.py
+++ b/test/alternator/test_scan.py
@@ -300,6 +300,17 @@ def test_scan_parallel_with_exclusive_start_key(filled_test_table):
     with pytest.raises(ClientError, match='ValidationException.*Exclusive'):
         full_scan(test_table, TotalSegments=1000000, Segment=0, ExclusiveStartKey={'p': '0', 'c': '0'})
 
+# Scan's Limit used to be read directly with GetUint64() with no preceding
+# IsUint64() check, so a Limit too large to fit (e.g. 2**64) got an
+# InternalServerError. Unlike Query and ListTables, real DynamoDB doesn't
+# actually reject an oversized Limit here, despite documenting it
+# identically: it's simply treated as infinite. Alternator now matches
+# that for compatibility - though as with a missing Limit, a page is still
+# capped at around 1MB, so it's not really infinite in practice (see
+# test_scan_paging_missing_limit()).
+def test_scan_invalid_limit_type(test_table):
+    test_table.scan(Limit=2**64)
+
 # We used to have a bug with formatting of LastEvaluatedKey in the response
 # of Query and Scan with bytes keys (issue #7768). In test_query_paging_byte()
 # (test_query.py) we tested the case of bytes *sort* keys. In the following

--- a/test/alternator/test_table.py
+++ b/test/alternator/test_table.py
@@ -440,6 +440,20 @@ def test_list_tables_wrong_limit(dynamodb):
     with pytest.raises(ClientError, match='ValidationException'):
         dynamodb.meta.client.list_tables(Limit=101)
 
+# ListTables's Limit used to be read directly with GetInt() with no
+# preceding IsInt() check, so a Limit too large to fit in 32 bits (boto3
+# enforces a minimum of 1 but no maximum) got an InternalServerError
+# instead of the clean ValidationException that test_list_tables_wrong_limit()
+# above already expects for a Limit that's merely out of the documented
+# 1..100 range.
+def test_list_tables_invalid_limit_type(dynamodb):
+    with pytest.raises(ClientError) as err:
+        dynamodb.meta.client.list_tables(Limit=2**64)
+    code = err.value.response['Error']['Code']
+    message = err.value.response['Error'].get('Message', '')
+    assert code in ('ValidationException', 'SerializationException'), \
+        f'Unexpected error code {code} for oversized Limit: {message}'
+
 # Even before Alternator gains support for configuring server-side encryption
 # ("encryption at rest") with CreateTable's SSESpecification option, we should
 # support the option "Enabled=false" which is the default, and means the server


### PR DESCRIPTION
    
    Several request parameters were read assuming a specific JSON type,
    without checking it first. None of this was a security hole - input was
    still fully validated in the end - but a request with the wrong type for
    one of these parameters got either the wrong kind of error, or (in one
    case) had a nonsensical value silently ignored instead of rejected:
    
    * A "BOOL" attribute value wasn't checked to actually hold a JSON boolean,
      so a malformed value like {"BOOL": "dog"} was only caught later, by
      code that assumed a boolean and reported an InternalServerError instead
      of a ValidationException.
    * The legacy Expected/ComparisonOperator checks (LT, LE, GT, GE, BETWEEN,
      BEGINS_WITH, CONTAINS) checked an AttributeValueList entry's type tag
      ("S", "N" or "B") but not that its value actually had that type, e.g.
      {"S": 123}, again turning into an InternalServerError.
    * GetItem's legacy AttributesToGet, UpdateItem's legacy AttributeUpdates
      Action, and UntagResource's TagKeys entries weren't checked to be
      strings before use, with the same InternalServerError result.
    * Query's error message for a non-string IndexName itself assumed
      IndexName was a string, so reporting the error failed the same way.
    * Query, Scan and ListTables read their "Limit" parameter without
      checking it fit in the expected integer type, so an out-of-range value
      (reachable via plain boto3, which doesn't validate upper bounds on
      plain integers) hit the same bug. Scan is a special case: real
      DynamoDB doesn't actually reject an oversized Limit there, unlike Query
      and ListTables, even though all three document Limit identically - it
      just treats it as unbounded, which we now match.
    
    Adds a regression test for each of these in test_manual_requests.py,
    test_query.py, test_scan.py and test_table.py. All these new tests
    pass on DynamoDB, failed on Alternator before this patch - and pass
    after this patch.
