### PR TITLE
logstor: repair for logstor tables

### DIFF
--- a/docs/dev/row_level_repair.md
+++ b/docs/dev/row_level_repair.md
@@ -281,3 +281,86 @@ rows repair master sent.
 
 - repair_stream_cmd::error
 Notifies an error has happened on the follower.
+
+## Repair of logstor tables
+
+Logstor tables (see `docs/dev/logstor.md`) are repaired with the same wire
+protocol and the same row level repair algorithm, with a few adjustments to the
+algorithm.
+
+### Why logstor is different
+
+- A logstor record holds a whole partition. Logstor tables have a partition key
+only, so a partition is one row at the empty clustering key, or a partition
+tombstone, or both.
+
+- A logstor write *replaces* the partition. The index keeps the record with the
+highest record timestamp, and two records of the same key are never merged.
+
+The LSM storage engine works the other way: a write only adds a new mutation, and
+the engine merges all the mutations of a partition at cell level, on every read
+and during compaction. Normal row level repair relies on this LSM merge. It sends
+only the differing rows, and the LSM merge combines them with the version already
+stored on the receiving node.
+
+Logstor has no such merge, so writing only the differing rows would replace the
+whole partition and lose the cells that exist only in the other version.
+
+So repair of a logstor table has to reconcile whole partitions before it writes
+or sends anything. This is the reason for all the adjustments below.
+
+### Sync boundaries are partition aligned
+
+Whole-partition reconciliation only works if all fragments of a partition land in
+the same sync window. A logstor partition can produce two repair rows: a
+`partition_start` carrying a partition tombstone, plus the row. A sync boundary
+between them would make the master merge a partial partition and drop the
+tombstone or the row, which can resurrect deleted data. Logstor sessions
+therefore align the sync windows to partitions.
+
+### Whole-partition convergence on the master
+
+After Step B the master's working row buffer holds every distinct version of
+every row from all replicas. For logstor tables the master then converges that
+buffer (`converge_working_row_buf_for_logstor()`):
+
+1. group the buffered rows by partition key (rows of a partition are contiguous)
+2. for every partition that repair touched, that is, one that has a row pulled
+from a follower and more than one version to merge, merge all its versions into a
+single `mutation`
+3. expand the merged mutation back into repair rows, mark them dirty so the
+master flushes and sends them, and recompute the combined hash
+
+This is the same cell level reconciliation the LSM merge does, with the same row
+marker, cell and tombstone rules. Repair does not rely on logstor's index level
+replacement
+rule, which compares record timestamps only: it computes the reconciled partition
+first and writes it as a single record.
+
+The rest of the pipeline is unchanged. The master flush writes the converged
+partition to the local logstor, replacing the stale version, and Step C computes
+`master - peer` over the converged rows.
+
+Step C has one adjustment. Instead of selecting the rows whose hash is in the set
+diff, `put_row_diff` uses
+`copy_partitions_from_working_row_buf_within_set_diff()`, which sends every row
+of a partition that has at least one row in the set diff. A follower must receive
+the complete converged partition; a partial partition would replace its record
+and lose data. The `needs_all_rows` case sends the whole row buffer as before, so
+it is whole-partition already.
+
+### Applying rows
+
+`make_repair_writer()` picks the writer by storage backend. Normal tables write
+streaming SSTables, which logstor does not have. Logstor tables get
+`logstor_repair_writer_impl`, which rebuilds logical mutations and applies them
+directly. The `repair_writer` interface and the repair protocol are unchanged,
+only the sink differs. The master's local flush uses the same writer.
+
+The sink consumes the fragment stream and, per partition:
+
+1. rebuilds one `mutation`
+2. computes the destination shards with `sharder.shard_for_writes(token)`
+3. sends the frozen mutation to every destination shard
+4. on the destination shard,  calls `table::apply()`, which routes to
+`logstor::write()`

--- a/repair/row_level.cc
+++ b/repair/row_level.cc
@@ -59,6 +59,7 @@
 #include "readers/queue.hh"
 #include "readers/filtering.hh"
 #include "readers/mutation_fragment_v1_stream.hh"
+#include "readers/from_mutations.hh"
 #include "repair/hash.hh"
 #include "repair/decorated_key_with_hash.hh"
 #include "repair/row.hh"
@@ -971,6 +972,7 @@ private:
     repair_hasher _repair_hasher;
     gc_clock::time_point _compaction_time;
     bool _is_tablet;
+    bool _uses_logstor;
     reader_concurrency_semaphore::inactive_read_handle _fake_inactive_read_handle;
     std::unique_ptr<const locator::token_metadata> _small_table_optimization_tm;
     seastar::semaphore _small_table_optimization_tm_sem{1};
@@ -1104,6 +1106,7 @@ public:
             , _repair_hasher(_seed, _schema)
             , _compaction_time(compaction_time)
             , _is_tablet(cf.uses_tablets())
+            , _uses_logstor(cf.uses_logstor())
             , _frozen_topology_guard(topo_guard)
             , _topology_guard(_frozen_topology_guard)
             , _is_eligible_to_repair_rejection(cf.is_eligible_to_write_rejection_on_critical_disk_utilization())
@@ -1630,6 +1633,42 @@ private:
         co_return rows;
     }
 
+    // Copy every row of each partition that has at least one row in set_diff.
+    // Used when sending to logstor followers: logstor replaces whole partitions
+    // on write, so a follower must receive the complete converged partition
+    // rather than only the rows it is missing. Otherwise a partial partition
+    // could overwrite (or be overwritten relative to) the follower's version and
+    // lose data.
+    //
+    // The selection is by partition, not by hash, which also makes it immune to
+    // repair_hash collisions: a collision can only pull in an extra whole
+    // partition, which is harmless, and can never truncate a partition the way
+    // filtering rows by hash membership could. _working_row_buf is ordered by
+    // (partition, position), so rows of a partition are contiguous.
+    future<std::list<repair_row>>
+    copy_partitions_from_working_row_buf_within_set_diff(const repair_hash_set& set_diff) {
+        std::list<repair_row> rows;
+        auto it = _working_row_buf.begin();
+        while (it != _working_row_buf.end()) {
+            const dht::decorated_key& dk = it->get_dk_with_hash()->dk;
+            auto group_end = it;
+            bool touched = false;
+            while (group_end != _working_row_buf.end() && group_end->get_dk_with_hash()->dk.equal(*_schema, dk)) {
+                touched = touched || set_diff.contains(group_end->hash());
+                ++group_end;
+            }
+            if (touched) {
+                for (auto r = it; r != group_end; ++r) {
+                    rows.push_back(*r);
+                    co_await coroutine::maybe_yield();
+                }
+            }
+            it = group_end;
+            co_await coroutine::maybe_yield();
+        }
+        co_return rows;
+    }
+
     // Return rows in the _working_row_buf with hash within the given sef_diff
     // Give a set of row hashes, return the corresponding rows
     // If needs_all_rows is set, return all the rows in _working_row_buf, ignore the set_diff
@@ -1699,7 +1738,161 @@ private:
         // Clear gently to avoid stalls
         utils::clear_gently(row_diff).get();
     }
+
+private:
+    // Merge all versions/fragments of a single partition (the master's own rows
+    // plus the rows pulled from the followers) into one logical mutation using
+    // cell-level last-writer-wins semantics.
+    future<mutation> merge_partition_versions_for_logstor(const dht::decorated_key& dk, std::list<repair_row>& group) {
+        mutation_rebuilder rb(_schema);
+        rb.consume_new_partition(dk);
+        for (repair_row& r : group) {
+            mutation_fragment mf = r.get_frozen_mutation().unfreeze(*_schema, _permit);
+            if (mf.is_partition_start()) {
+                rb.consume(std::move(mf).as_partition_start().partition_tombstone());
+            } else if (mf.is_static_row()) {
+                rb.consume(std::move(mf).as_static_row());
+            } else if (mf.is_clustering_row()) {
+                rb.consume(std::move(mf).as_clustering_row());
+            } else if (mf.is_range_tombstone()) {
+                rb.consume(std::move(mf).as_range_tombstone());
+            } else {
+                // handle_mutation_fragment() and to_repair_rows_list() never put
+                // any other fragment kind in the row buffers. Silently dropping
+                // one here would lose data, so report it instead.
+                on_internal_error(rlogger, format("Logstor repair converge: unexpected fragment kind={} table={}.{} key={}",
+                        mf.mutation_fragment_kind(), _schema->ks_name(), _schema->cf_name(), dk));
+            }
+            co_await coroutine::maybe_yield();
+        }
+        rb.consume_end_of_partition();
+        mutation_opt m = rb.consume_end_of_stream();
+        if (!m) {
+            throw std::runtime_error(format("Logstor repair converge: failed to rebuild partition table={}.{} key={}",
+                    _schema->ks_name(), _schema->cf_name(), dk));
+        }
+        co_return std::move(*m);
+    }
+
+    // Split a converged partition mutation back into repair rows, following the
+    // same fragment selection as read_rows_from_disk (skip empty partition_start
+    // and partition_end). The resulting rows are marked dirty so the master flush
+    // rewrites the whole converged partition and Step C sends it to the followers.
+    future<std::list<repair_row>> refragment_partition_for_logstor(const dht::decorated_key& dk, mutation m) {
+        auto dk_with_hash = make_lw_shared<const decorated_key_with_hash>(*_schema, dk, _seed);
+        std::list<repair_row> rows;
+        auto rd = mutation_fragment_v1_stream(make_mutation_reader_from_mutations(_schema, _permit, std::move(m)));
+        std::exception_ptr ex;
+        try {
+            while (mutation_fragment_opt mfopt = co_await rd()) {
+                mutation_fragment& mf = *mfopt;
+                if (mf.is_partition_start()) {
+                    if (!mf.as_partition_start().partition_tombstone()) {
+                        continue;
+                    }
+                } else if (mf.is_end_of_partition()) {
+                    continue;
+                }
+                auto hash = _repair_hasher.do_hash_for_mf(*dk_with_hash, mf);
+                auto fm = freeze(*_schema, mf);
+                auto pos = position_in_partition(mf.position());
+                auto mf_ptr = make_lw_shared<mutation_fragment>(std::move(mf));
+                rows.push_back(repair_row(std::move(fm), std::move(pos), dk_with_hash, std::move(hash),
+                        is_dirty_on_master::yes, std::move(mf_ptr)));
+                co_await coroutine::maybe_yield();
+            }
+        } catch (...) {
+            ex = std::current_exception();
+        }
+        co_await rd.close();
+        if (ex) {
+            std::rethrow_exception(ex);
+        }
+        co_return std::move(rows);
+    }
+
 public:
+    // For logstor tables, reconcile _working_row_buf so that every partition
+    // touched by repair is represented by its complete, converged value.
+    //
+    // Row-level repair reconciles at row-hash granularity and normally relies on
+    // the storage engine to merge overlapping rows at read time (cell-level LWW).
+    // Logstor has no such merge: a write replaces the whole partition, keeping the
+    // record with the highest record timestamp. Sending or flushing only the
+    // differing rows would therefore drop the cells that live in the other
+    // versions. To avoid that, merge all versions of each touched partition into a
+    // single mutation and re-expand it into repair rows. The master flush then
+    // stores the converged partition locally, and Step C sends the converged
+    // partition to the followers.
+    //
+    // Must run inside a seastar thread.
+    void converge_working_row_buf_for_logstor() {
+        if (!_uses_logstor || _working_row_buf.empty()) {
+            return;
+        }
+        std::list<repair_row> converged;
+        // The rows of a partition are moved out of _working_row_buf while they
+        // are merged, so a merge that throws would leave them, and every
+        // partition converged so far, owned by locals that the unwind destroys.
+        // Hand the rows back unconditionally instead: a throw fails the repair
+        // round and the range is retried, but _working_row_buf stays complete
+        // for clear_gently() in stop().
+        auto restore = defer([&] noexcept {
+            converged.splice(converged.end(), _working_row_buf);
+            _working_row_buf = std::move(converged);
+        });
+        bool converged_any = false;
+        auto it = _working_row_buf.begin();
+        while (it != _working_row_buf.end()) {
+            const dht::decorated_key& dk = it->get_dk_with_hash()->dk;
+            auto group_end = it;
+            bool any_dirty = false;
+            while (group_end != _working_row_buf.end() && group_end->get_dk_with_hash()->dk.equal(*_schema, dk)) {
+                any_dirty = any_dirty || bool(group_end->dirty_on_master());
+                ++group_end;
+            }
+            std::list<repair_row> group;
+            group.splice(group.end(), _working_row_buf, it, group_end);
+            it = group_end;
+
+            // A partition is only at risk when repair pulled a differing version
+            // into it (any_dirty) and there is more than one version to merge.
+            // Otherwise the single row already is the complete partition value.
+            if (!any_dirty || group.size() < 2) {
+                converged.splice(converged.end(), group);
+                thread::maybe_yield();
+                continue;
+            }
+
+            try {
+                auto merged = merge_partition_versions_for_logstor(dk, group).get();
+                thread::maybe_yield();
+                auto rebuilt = refragment_partition_for_logstor(dk, std::move(merged)).get();
+                converged.splice(converged.end(), rebuilt);
+            } catch (...) {
+                // Put the unconverged rows back where they came from, so that
+                // the restore above reassembles the buffer without losing them.
+                _working_row_buf.splice(_working_row_buf.begin(), group);
+                throw;
+            }
+            converged_any = true;
+            thread::maybe_yield();
+        }
+        restore.cancel();
+        _working_row_buf = std::move(converged);
+        if (!converged_any) {
+            // Nothing was merged, so the rows and their hashes are unchanged.
+            return;
+        }
+        // The merge changed the rows, so recompute the combined hash to keep it
+        // consistent with the converged working row buffer.
+        _working_row_buf_combined_hash.clear();
+        for (const repair_row& r : _working_row_buf) {
+            _working_row_buf_combined_hash.add(r.hash());
+            thread::maybe_yield();
+        }
+    }
+
     future<const locator::token_metadata*> get_tm_for_small_table_optimization_check(const locator::token_metadata* tm) {
         auto sem_units = co_await get_units(_small_table_optimization_tm_sem, 1);
         if (!tm) {
@@ -2211,11 +2404,18 @@ public:
             if (remote_node == myhostid()) {
                 co_return;
             }
-            size_t sz = set_diff.size();
-            std::list<repair_row> row_diff = co_await get_row_diff(std::move(set_diff), needs_all_rows);
-            if (row_diff.size() != sz) {
-                rlogger.warn("Hash conflict detected, keyspace={}, table={}, range={}, row_diff.size={}, set_diff.size={}. It is recommended to compact the table and rerun repair for the range.",
-                        _schema->ks_name(), _schema->cf_name(), _range, row_diff.size(), sz);
+            std::list<repair_row> row_diff;
+            if (_uses_logstor && !needs_all_rows) {
+                // Logstor replaces whole partitions, so send the complete converged
+                // partition for every partition that differs, not only the delta rows.
+                row_diff = co_await copy_partitions_from_working_row_buf_within_set_diff(set_diff);
+            } else {
+                size_t sz = set_diff.size();
+                row_diff = co_await get_row_diff(std::move(set_diff), needs_all_rows);
+                if (row_diff.size() != sz) {
+                    rlogger.warn("Hash conflict detected, keyspace={}, table={}, range={}, row_diff.size={}, set_diff.size={}. It is recommended to compact the table and rerun repair for the range.",
+                            _schema->ks_name(), _schema->cf_name(), _range, row_diff.size(), sz);
+                }
             }
             size_t row_bytes = co_await get_repair_rows_size(row_diff);
             stats().tx_row_nr += row_diff.size();
@@ -2283,12 +2483,18 @@ public:
         if (remote_node == myhostid()) {
             co_return;
         }
-        size_t sz = set_diff.size();
-
-        std::list<repair_row> row_diff = co_await get_row_diff(std::move(set_diff), needs_all_rows);
-        if (row_diff.size() != sz) {
-            rlogger.warn("Hash conflict detected, keyspace={}, table={}, range={}, row_diff.size={}, set_diff.size={}. It is recommended to compact the table and rerun repair for the range.",
-                    _schema->ks_name(), _schema->cf_name(), _range, row_diff.size(), sz);
+        std::list<repair_row> row_diff;
+        if (_uses_logstor && !needs_all_rows) {
+            // Logstor replaces whole partitions, so send the complete converged
+            // partition for every partition that differs, not only the delta rows.
+            row_diff = co_await copy_partitions_from_working_row_buf_within_set_diff(set_diff);
+        } else {
+            size_t sz = set_diff.size();
+            row_diff = co_await get_row_diff(std::move(set_diff), needs_all_rows);
+            if (row_diff.size() != sz) {
+                rlogger.warn("Hash conflict detected, keyspace={}, table={}, range={}, row_diff.size={}, set_diff.size={}. It is recommended to compact the table and rerun repair for the range.",
+                        _schema->ks_name(), _schema->cf_name(), _range, row_diff.size(), sz);
+            }
         }
         if (small_table_optimization) {
             auto& strat = small_table_optimization->erm->get_replication_strategy();
@@ -3535,6 +3741,10 @@ private:
             throw;
           }
         }
+        // For logstor tables, merge every touched partition into its complete
+        // converged value before flushing it locally and sending it to followers,
+        // because logstor replaces whole partitions instead of merging rows.
+        master.converge_working_row_buf_for_logstor();
         master.flush_rows_in_working_row_buf(_small_table_optimization ? std::make_optional(small_table_optimization_params{ .erm = get_erm() }) : std::nullopt);
         return op_status::next_step;
     }

--- a/repair/row_level.cc
+++ b/repair/row_level.cc
@@ -1499,7 +1499,13 @@ private:
                 bool(_rs.get_config().repair_multishard_reader_enable_read_ahead()));
         }
         try {
-            while (cur_size < _max_row_buf_size) {
+            // Logstor replaces whole partitions on write, so the whole-partition
+            // convergence in repair requires that a sync window never splits a
+            // partition. Keep reading past the byte budget until the current
+            // partition is complete (its partition_end clears the current dk).
+            // Logstor partitions are small (at most a partition tombstone plus
+            // one row), so the overrun is bounded.
+            while (cur_size < _max_row_buf_size || (_uses_logstor && _repair_reader->get_current_dk())) {
                 _gate.check();
                 mutation_fragment_opt mfopt = co_await _repair_reader->read_mutation_fragment();
                 if (!mfopt) {
@@ -1551,6 +1557,19 @@ private:
         std::optional<repair_sync_boundary> sb_max;
         if (!_row_buf.empty()) {
             sb_max = _row_buf.back().boundary();
+            if (_uses_logstor) {
+                if (_repair_reader->get_current_dk()) {
+                    on_internal_error(rlogger, format("Repair row buffer ends inside a partition, table={}.{} range={}",
+                            _schema->ks_name(), _schema->cf_name(), _range));
+                }
+                // The buffer ends at a partition boundary (see read_rows_from_disk),
+                // but the last row's own position may lie inside the partition (e.g.
+                // a partition tombstone at the partition-start position). Report the
+                // boundary at the end of the partition instead, so the common sync
+                // boundary chosen by the master never cuts inside a partition on any
+                // replica.
+                sb_max->position = position_in_partition::after_all_clustered_rows();
+            }
         }
         rlogger.debug("get_sync_boundary: Got nr={} rows, sb_max={}, row_buf_size={}, repair_hash={}, skipped_sync_boundary={}",
                       new_rows_nr, sb_max, row_buf_bytes, row_buf_combined_hash, skipped_sync_boundary);

--- a/repair/row_level.cc
+++ b/repair/row_level.cc
@@ -3551,6 +3551,10 @@ private:
             // For small table optimization, we reduce the buffer size to reduce memory consumption.
             size /= _all_live_peer_nodes.size();
         }
+        utils::get_local_injector().inject("repair_tiny_max_row_buf_size", [&size] {
+            // Force many small sync windows to exercise window-boundary handling.
+            size = 100;
+        });
         return size;
     }
 

--- a/repair/row_level.cc
+++ b/repair/row_level.cc
@@ -3558,7 +3558,8 @@ public:
             bool enable_incremental_repair = _shard_task.db.local().features().tablet_incremental_repair && _is_tablet &&
                                               _shard_task.sched_info.incremental_mode != locator::tablet_repair_incremental_mode::disabled &&
                                              _shard_task.sched_info.sched_by_scheduler &&
-                                             !_shard_task.sched_info.for_tablet_rebuild;
+                                             !_shard_task.sched_info.for_tablet_rebuild &&
+                                             !s->logstor_enabled();
             if (enable_incremental_repair) {
                 auto& table = _shard_task.db.local().find_column_family(_table_id);
                 auto erm = table.get_effective_replication_map();

--- a/repair/row_level.cc
+++ b/repair/row_level.cc
@@ -19,6 +19,9 @@
 #include "sstables/sstables.hh"
 #include "sstables/sstables_manager.hh"
 #include "mutation/mutation_fragment.hh"
+#include "mutation/mutation_fragment_v2.hh"
+#include "mutation/mutation_rebuilder.hh"
+#include "schema/schema_registry.hh"
 #include "mutation_writer/multishard_writer.hh"
 #include "dht/i_partitioner.hh"
 #include "dht/sharder.hh"
@@ -548,6 +551,152 @@ sharder_helper get_sharder_helper(replica::table& t, const schema& s, service::f
     }
 }
 
+class logstor_direct_writer_queue_impl : public mutation_fragment_queue::impl {
+    schema_ptr _schema;
+    sharded<replica::database>& _db;
+    service::frozen_topology_guard _topo_guard;
+    sharder_helper _sharder;
+    db::timeout_clock::time_point _timeout;
+    std::optional<mutation_rebuilder_v2> _rebuilder;
+    std::exception_ptr _aborted;
+
+private:
+    future<> apply_rebuilt_partition(mutation m) {
+        auto shards = _sharder.sharder.shard_for_writes(m.token());
+        if (shards.empty()) {
+            return make_exception_future<>(std::runtime_error(format("No local shards for token {} of {}.{}",
+                    m.token(), _schema->ks_name(), _schema->cf_name())));
+        }
+
+        rlogger.debug("logstor repair writer: applying rebuilt partition table={}.{} token={} shards={} clustered_rows_empty={}",
+                _schema->ks_name(), _schema->cf_name(), m.token(), shards,
+                m.partition().clustered_rows().empty());
+
+        return parallel_for_each(shards, [&db = _db, fm = freeze(m), gs = global_schema_ptr(_schema), topo_guard = _topo_guard, timeout = _timeout] (shard_id shard) mutable {
+            return db.invoke_on(shard, [fm, gs, topo_guard, timeout] (replica::database& db) mutable -> future<> {
+                service::topology_guard guard(topo_guard);
+                guard.check();
+                schema_ptr schema = gs.get();
+                auto& table = db.find_column_family(schema->id());
+                auto stream_op = table.stream_in_progress();
+                rlogger.debug("logstor repair writer: applying rebuilt partition on shard={} table={}.{}",
+                        this_shard_id(), schema->ks_name(), schema->cf_name());
+                co_await table.apply(fm, schema, db::rp_handle(), timeout, db::noop_large_data_guardrail::instance());
+            });
+        });
+    }
+
+    future<> rebuild(mutation_fragment_v2 mf) {
+        if (mf.is_partition_start()) {
+            if (_rebuilder) {
+                // The same lost partition_end that push_end_of_stream() reports,
+                // just detected earlier. Starting a new rebuilder here would
+                // silently drop the partition opened by the previous one.
+                on_internal_error(rlogger, format("Logstor repair writer: partition start with an open partition, table={}.{}",
+                        _schema->ks_name(), _schema->cf_name()));
+            }
+            auto ps = std::move(mf).as_partition_start();
+            rlogger.debug("logstor repair writer: start partition table={}.{} key={}",
+                    _schema->ks_name(), _schema->cf_name(), ps.key());
+            _rebuilder.emplace(_schema);
+            (void)_rebuilder->consume(std::move(ps));
+            return make_ready_future<>();
+        }
+
+        if (!_rebuilder) {
+            return make_exception_future<>(std::runtime_error("Logstor repair writer got non-partition-start fragment without an active rebuilder"));
+        }
+
+        if (mf.is_end_of_partition()) {
+            (void)_rebuilder->consume(std::move(mf));
+            auto mut = _rebuilder->consume_end_of_stream();
+            _rebuilder.reset();
+            if (!mut) {
+                return make_exception_future<>(std::runtime_error("Logstor repair writer ended a partition without a rebuilt mutation"));
+            }
+            rlogger.debug("logstor repair writer: finished rebuilding partition table={}.{} token={}",
+                    _schema->ks_name(), _schema->cf_name(), mut->token());
+            return apply_rebuilt_partition(std::move(*mut));
+        }
+
+        (void)_rebuilder->consume(std::move(mf));
+        return make_ready_future<>();
+    }
+
+public:
+    logstor_direct_writer_queue_impl(schema_ptr schema, sharded<replica::database>& db, service::frozen_topology_guard topo_guard,
+            db::timeout_clock::time_point timeout)
+        : _schema(std::move(schema))
+        , _db(db)
+        , _topo_guard(topo_guard)
+        , _sharder(get_sharder_helper(_db.local().find_column_family(_schema->id()), *_schema, _topo_guard))
+        , _timeout(timeout) {
+    }
+
+    virtual future<> push(mutation_fragment_v2 mf) override {
+        if (_aborted) {
+            co_await coroutine::return_exception_ptr(_aborted);
+        }
+        std::exception_ptr ep;
+        try {
+            co_await rebuild(std::move(mf));
+            co_return;
+        } catch (...) {
+            ep = std::current_exception();
+        }
+        // The partition being rebuilt is incomplete now, and a logstor write
+        // replaces the whole partition, so it must never be applied. Drop it and
+        // fail every later push, which also keeps push_end_of_stream() from
+        // reporting the dropped partition as an error of its own and masking
+        // the failure that repair actually propagates.
+        this->abort(ep);
+        co_await coroutine::return_exception_ptr(std::move(ep));
+    }
+
+    virtual void abort(std::exception_ptr ep) override {
+        _aborted = std::move(ep);
+        // Drop any partially rebuilt partition so it can never be applied.
+        _rebuilder.reset();
+    }
+
+    virtual void push_end_of_stream() override {
+        // repair_writer closes the open partition before signaling end of
+        // stream, so a live rebuilder here means a partition_end was lost. A
+        // failed push cannot land here: it aborts the queue, which drops the
+        // rebuilder, so this never masks an earlier failure.
+        if (_rebuilder) {
+            on_internal_error(rlogger, format("Logstor repair writer: end of stream with an open partition, table={}.{}",
+                    _schema->ks_name(), _schema->cf_name()));
+        }
+    }
+};
+
+class logstor_repair_writer_impl : public repair_writer::impl {
+    mutation_fragment_queue _mq;
+
+    static mutation_fragment_queue make_queue(schema_ptr schema, reader_permit permit, sharded<replica::database>& db,
+            service::frozen_topology_guard topo_guard) {
+        auto timeout = permit.timeout();
+        return mutation_fragment_queue(schema, std::move(permit), seastar::shared_ptr<mutation_fragment_queue::impl>(
+                seastar::make_shared<logstor_direct_writer_queue_impl>(schema, db, topo_guard, timeout)));
+    }
+public:
+    logstor_repair_writer_impl(schema_ptr schema, reader_permit permit, sharded<replica::database>& db, service::frozen_topology_guard topo_guard)
+        : _mq(make_queue(schema, std::move(permit), db, topo_guard)) {
+    }
+
+    virtual mutation_fragment_queue& queue() override {
+        return _mq;
+    }
+
+    virtual future<> wait_for_writer_done() override {
+        return make_ready_future<>();
+    }
+
+    virtual void create_writer(lw_shared_ptr<repair_writer>) override {
+    }
+};
+
 void repair_writer_impl::create_writer(lw_shared_ptr<repair_writer> w) {
     if (_writer_done) {
         return;
@@ -596,9 +745,14 @@ lw_shared_ptr<repair_writer> make_repair_writer(
             db::view::view_builder& view_builder,
             sharded<db::view::view_building_worker>& view_building_worker,
             service::frozen_topology_guard topo_guard) {
-    auto [queue_reader, queue_handle] = make_queue_reader(schema, permit);
-    auto queue = make_mutation_fragment_queue(schema, permit, std::move(queue_handle));
-    auto i = std::make_unique<repair_writer_impl>(schema, repaired_at, permit, db, view_builder, view_building_worker, reason, std::move(queue), std::move(queue_reader), topo_guard);
+    std::unique_ptr<repair_writer::impl> i;
+    if (schema->logstor_enabled()) {
+        i = std::make_unique<logstor_repair_writer_impl>(schema, permit, db, topo_guard);
+    } else {
+        auto [queue_reader, queue_handle] = make_queue_reader(schema, permit);
+        auto queue = make_mutation_fragment_queue(schema, permit, std::move(queue_handle));
+        i = std::make_unique<repair_writer_impl>(schema, repaired_at, permit, db, view_builder, view_building_worker, reason, std::move(queue), std::move(queue_reader), topo_guard);
+    }
     return make_lw_shared<repair_writer>(schema, permit, std::move(i));
 }
 

--- a/repair/writer.hh
+++ b/repair/writer.hh
@@ -16,6 +16,8 @@ namespace db {
     class system_distributed_keyspace;
     namespace view {
         class view_update_generator;
+        class view_builder;
+        class view_building_worker;
     }
 }
 
@@ -154,10 +156,10 @@ private:
 
 lw_shared_ptr<repair_writer> make_repair_writer(
             schema_ptr schema,
+            std::optional<int64_t> repaired_at,
             reader_permit permit,
             streaming::stream_reason reason,
             sharded<replica::database>& db,
-            sharded<db::system_distributed_keyspace>& sys_dist_ks,
-            sharded<db::view::view_update_generator>& view_update_generator,
+            db::view::view_builder& view_builder,
+            sharded<db::view::view_building_worker>& view_building_worker,
             service::frozen_topology_guard topo_guard);
-

--- a/replica/logstor/index.hh
+++ b/replica/logstor/index.hh
@@ -330,6 +330,43 @@ public:
         return _partitions.upper_bound(key, dht::ring_position_comparator(*_schema));
     }
 
+    future<uint64_t> count_keys_in_token_range(dht::token_range tr) const {
+        static constexpr size_t chunk_size = 1024;
+        dht::ring_position_comparator cmp(*_schema);
+
+        std::optional<dht::ring_position> start_pos;
+        if (tr.start()) {
+            start_pos = tr.start()->is_inclusive()
+                    ? dht::ring_position::starting_at(tr.start()->value())
+                    : dht::ring_position::ending_at(tr.start()->value());
+        }
+        std::optional<dht::ring_position> end_pos;
+        if (tr.end()) {
+            end_pos = tr.end()->is_inclusive()
+                    ? dht::ring_position::ending_at(tr.end()->value())
+                    : dht::ring_position::starting_at(tr.end()->value());
+        }
+
+        uint64_t count = 0;
+        auto it = start_pos ? _partitions.lower_bound(*start_pos, cmp) : _partitions.begin();
+        while (true) {
+            auto end = end_pos ? _partitions.lower_bound(*end_pos, cmp) : _partitions.end();
+            for (size_t i = 0; i < chunk_size; ++i) {
+                if (it == end) {
+                    co_return count;
+                }
+                ++it;
+                ++count;
+            }
+            if (it == end) {
+                co_return count;
+            }
+            auto next_key = it->key();
+            co_await coroutine::maybe_yield();
+            it = _partitions.lower_bound(next_key, cmp);
+        }
+    }
+
 };
 
 }

--- a/replica/logstor/logstor.cc
+++ b/replica/logstor/logstor.cc
@@ -26,20 +26,29 @@ seastar::logger logstor_logger("logstor");
 static api::timestamp_type extract_logstor_record_timestamp(const mutation& m) {
     const auto& partition = m.partition();
 
+    api::timestamp_type ts = api::missing_timestamp;
+
     for (const auto& row_entry : partition.clustered_rows()) {
         if (row_entry.dummy()) {
             continue;
         }
         if (!row_entry.row().marker().is_missing()) {
-            return row_entry.row().marker().timestamp();
+            ts = std::max(ts, row_entry.row().marker().timestamp());
         }
     }
 
     if (const auto partition_tombstone = partition.partition_tombstone(); partition_tombstone) {
-        return partition_tombstone.timestamp;
+        ts = std::max(ts, partition_tombstone.timestamp);
     }
 
-    throw std::runtime_error("logstor mutation has no row marker or partition tombstone timestamp");
+    if (ts == api::missing_timestamp) {
+        throw std::runtime_error("logstor mutation has no row marker or partition tombstone timestamp");
+    }
+
+    // A converged partition produced by repair may carry both a live row marker
+    // and a newer partition tombstone. Use the maximum timestamp so the record
+    // wins against, and is not later resurrected by, the versions it supersedes.
+    return ts;
 }
 
 logstor::logstor(logstor_config config, ::cache_tracker& shared_cache_tracker)

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -5810,6 +5810,10 @@ dht::shard_replica_set table::shard_for_writes(dht::token t) const {
 }
 
 future<uint64_t> table::estimated_partitions_in_range(dht::token_range tr) const {
+    if (_logstor) {
+        co_return co_await logstor_index().count_keys_in_token_range(std::move(tr));
+    }
+
     // FIXME: use a better estimation for the set than a simple sum of individual estimations for each sstable.
     //
     // If sstables can be grouped by token range,

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -318,6 +318,15 @@ table::make_streaming_reader(schema_ptr s, reader_permit permit,
                            gc_clock::time_point compaction_time) const {
     auto& slice = s->full_slice();
 
+    if (_logstor) {
+        auto source = mutation_source([this] (schema_ptr s, reader_permit permit, const dht::partition_range& range, const query::partition_slice& slice,
+                                          tracing::trace_state_ptr trace_state, streamed_mutation::forwarding, mutation_reader::forwarding) {
+            return _logstor->make_reader(std::move(s), logstor_index(), std::move(permit), range, slice, std::move(trace_state));
+        });
+
+        return make_multi_range_reader(s, std::move(permit), std::move(source), ranges, slice, nullptr, mutation_reader::forwarding::no);
+    }
+
     auto source = mutation_source([this] (schema_ptr s, reader_permit permit, const dht::partition_range& range, const query::partition_slice& slice,
                                       tracing::trace_state_ptr trace_state, streamed_mutation::forwarding fwd, mutation_reader::forwarding fwd_mr) {
         std::vector<mutation_reader> readers;
@@ -341,6 +350,10 @@ mutation_reader table::make_streaming_reader(schema_ptr schema, reader_permit pe
         const query::partition_slice& slice, mutation_reader::forwarding fwd_mr, gc_clock::time_point compaction_time) const {
     auto trace_state = tracing::trace_state_ptr();
     const auto fwd = streamed_mutation::forwarding::no;
+
+    if (_logstor) {
+        return _logstor->make_reader(std::move(schema), logstor_index(), std::move(permit), range, slice, std::move(trace_state));
+    }
 
     std::vector<mutation_reader> readers;
     add_memtables_to_reader_list(readers, schema, permit, range, slice, trace_state, fwd, fwd_mr, [&] (size_t memtable_count) {

--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -5557,17 +5557,58 @@ public:
 
         bool has_diff = false;
 
+        // A logstor write replaces the replica's whole partition record, so the repair of a
+        // logstor table sends whole partitions instead of cell-level diffs.
+        const bool whole_partition_repair = schema.logstor_enabled();
+
+        // Per replica, whether it reported a partition higher than the one being processed.
+        // Partitions come in descending key order, so this is set as the loop descends, once
+        // the replica reports its first (= highest) partition. Indexed like the version
+        // vectors, which hold one entry per target in the same order for every partition.
+        utils::small_vector<bool, 3> reported_higher_partition;
+        if (whole_partition_repair && !versions.empty()) {
+            reported_higher_partition.resize(versions.front().size());
+        }
+
         // Сalculate differences: iterate over the versions from all the nodes and calculate the difference with the reconciled result.
         for (auto z : std::views::zip(versions, reconciled_partitions)) {
             const mutation& m = std::get<1>(z).mut;
+            size_t replica = 0;
             for (const version& v : std::get<0>(z)) {
+                const auto replica_index = replica++;
                 auto diff = v.par
                           ? m.partition().difference(schema, (co_await unfreeze_gently(v.par->mut(), _schema)).partition())
                           : mutation_partition(schema, m.partition());
                 std::optional<mutation> mdiff;
                 if (!diff.empty()) {
                     has_diff = true;
-                    mdiff = mutation(_schema, m.decorated_key(), std::move(diff));
+                    if (whole_partition_repair) {
+                        // The replica's result covers this partition when the replica returned
+                        // everything it has for the range, or when it reported a higher
+                        // partition - a result is truncated at its high end, never in the
+                        // middle. Only then does a missing version mean a missing record.
+                        const bool covered_by_result = v.reached_end || reported_higher_partition[replica_index];
+
+                        // Send the full reconciled partition. It replaces the stored record
+                        // on every divergent replica, converging them on the reconciled value.
+                        //
+                        // Not, however, to a replica whose result stops before this partition:
+                        // it can hold a version this reconciliation never saw, and replacing
+                        // its record would drop the cells only it has. Such a partition is
+                        // always outside the reconciled result the client gets, which
+                        // got_incomplete_information() keeps within what every replica
+                        // reported, so skipping it does not weaken the read.
+                        if (v.par || covered_by_result) {
+                            mdiff = m;
+                        }
+                    } else {
+                        mdiff = mutation(_schema, m.decorated_key(), std::move(diff));
+                    }
+                }
+                // The next partitions are lower than this one, so from now on this replica
+                // has reported a higher partition.
+                if (whole_partition_repair && v.par) {
+                    reported_higher_partition[replica_index] = true;
                 }
                 if (auto [it, added] = _diffs[m.key()].try_emplace(v.from, std::move(mdiff)); !added) {
                     // A collision could happen only in 2 cases:

--- a/test/cluster/test_logstor_repair.py
+++ b/test/cluster/test_logstor_repair.py
@@ -1,0 +1,1421 @@
+#
+# Copyright (C) 2026-present ScyllaDB
+#
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
+#
+
+import asyncio
+import json
+import re
+import time
+from contextlib import AsyncExitStack, asynccontextmanager
+from dataclasses import dataclass, field, replace
+from typing import Any, cast
+
+import pytest
+
+from cassandra import WriteFailure, WriteTimeout
+from cassandra.cluster import ConsistencyLevel
+from cassandra.query import SimpleStatement
+
+from test.cluster.util import new_test_keyspace
+from test.pylib.async_cql import _wrap_future
+from test.pylib.scylla_cluster_manager import ScyllaClusterManager
+from test.pylib.rest_client import inject_error
+from test.pylib.util import wait_for
+
+# Counts the writes a node refused, which under the database_apply injection is
+# exactly the writes it was made to suppress.
+FAILED_WRITES = 'scylla_database_total_writes_failed'
+
+
+async def create_logstor_cluster(manager: ScyllaClusterManager, *, nodes: int = 2, smp: int = 1) -> tuple[list[Any], Any, list[Any]]:
+    """Start a logstor cluster and return its servers, a cql session and its hosts.
+
+    Hinted handoff is disabled so that a write suppressed on a replica by
+    writes_suppressed_on() is never delivered to it later, which would converge
+    the replicas before repair gets to run. Read balancing is disabled so that a
+    host-pinned CL=ONE read is answered by the node it is sent to.
+    """
+    cmdline = ['--logger-log-level', 'logstor=debug', '--hinted-handoff-enabled', '0',
+               '--cache-hit-rate-read-balancing', '0']
+    if smp != 1:
+        cmdline.append(f'--smp={smp}')
+    cfg = {'experimental_features': ['logstor']}
+    servers = await manager.servers_add(nodes, cmdline=cmdline, config=cfg, auto_rack_dc="dc1")
+    cql, hosts = await manager.get_ready_cql(servers)
+    # get_ready_cql() returns the driver's host list, which is not ordered like
+    # `servers`. Order it so that hosts[i] is always the host of servers[i].
+    by_address = {host.address: host for host in hosts}
+    return servers, cast(Any, cql), [by_address[str(server.rpc_address)] for server in servers]
+
+
+@asynccontextmanager
+async def writes_suppressed_on(manager: ScyllaClusterManager, servers: list[Any], ks: str, table: str):
+    """Make writes to `ks`.`table` fail on `servers` for the duration of the block.
+
+    A CL=ONE write issued inside the block is stored only by the replicas that
+    are not suppressed, which is how every test here diverges the replicas. This
+    replaces stopping a node for the write: it needs no restart, and it leaves
+    every node up so per-node state can be read with MUTATION_FRAGMENTS()
+    throughout.
+    """
+    for server in servers:
+        await manager.api.enable_injection(server.ip_addr, "database_apply", one_shot=False,
+                parameters={"ks_name": ks, "cf_name": table, "what": "throw"})
+    try:
+        yield
+    finally:
+        for server in servers:
+            await manager.api.disable_injection(server.ip_addr, "database_apply")
+
+
+async def write_only_on(manager: ScyllaClusterManager, servers: list[Any], cql: Any, hosts: list[Any],
+                        ks: str, table: str, index: int, statements: list[str]) -> None:
+    """Run `statements` so that only the replica `index` ends up storing them.
+
+    The writes go out at CL=ALL and each one is expected to fail, but that alone
+    does not mean the suppressed replicas are done with it: the coordinator
+    answers as soon as the consistency level becomes unreachable, which the first
+    refusal already decides, so another suppressed replica can still be holding
+    the mutation. Applied after the injection is lifted, it would silently undo
+    the divergence. So wait until every suppressed replica has refused every
+    statement before letting writes through again.
+    """
+    others = [server for i, server in enumerate(servers) if i != index]
+    async with writes_suppressed_on(manager, others, ks, table):
+        before = [await manager.metrics.query(server.ip_addr) for server in others]
+        for statement in statements:
+            try:
+                await cql.run_async(SimpleStatement(statement, consistency_level=ConsistencyLevel.ALL), host=hosts[index])
+            except (WriteFailure, WriteTimeout):
+                pass  # Expected: the suppressed replicas refused the write.
+            else:
+                pytest.fail(f"the write was not suppressed on {[server.ip_addr for server in others]}: {statement}")
+        # The injection is the only thing failing writes in these tests, so the
+        # counter grows by exactly one per statement per suppressed replica.
+        for server, metrics_before in zip(others, before):
+            async def refused_every_statement(server=server, metrics_before=metrics_before):
+                metrics = await manager.metrics.query(server.ip_addr)
+                return metric_delta(metrics_before, metrics, FAILED_WRITES) >= len(statements) or None
+            await wait_for(refused_every_statement, time.time() + 60)
+
+
+async def token_order(cql: Any, ks: str, keys: list[int]) -> list[int]:
+    """Return `keys` in ring order, which is the order a scan visits them in.
+
+    The token of a partition key does not depend on the table it is written to,
+    so the order is determined with a throwaway table. That lets a test know
+    which key is where in the ring before it writes anything to the table under
+    test, which is what a test that sets up a scan page boundary needs.
+    """
+    probe = f"{ks}.token_probe"
+    await cql.run_async(f"CREATE TABLE {probe} (pk int PRIMARY KEY)")
+    try:
+        for key in keys:
+            await cql.run_async(f"INSERT INTO {probe} (pk) VALUES ({key})")
+        rows = await cql.run_async(f"SELECT pk, token(pk) AS tok FROM {probe}")
+        return [row.pk for row in sorted(rows, key=lambda row: row.tok)]
+    finally:
+        await cql.run_async(f"DROP TABLE {probe}")
+
+
+# Two bigint partition keys whose murmur3 hashes collide on the token
+# 6874760189787677834 (the same pair test_conflicting_keys_read_repair.py uses).
+# The keys of a logstor table are ordered by token first, so these two keys are
+# adjacent in every scan, and only the full decorated key distinguishes them.
+COLLIDING_PK1 = -4818441857111425024
+COLLIDING_PK2 = -8686612841249112064
+
+
+async def assert_colliding_tokens(cql: Any, ks: str) -> None:
+    """Assert the two colliding keys really share one token.
+
+    The same-token tests are built entirely on this property, and would silently
+    degenerate into ordinary multi-key tests if the partitioner setup ever
+    changed, so it is asserted rather than assumed.
+    """
+    probe = f"{ks}.collision_probe"
+    await cql.run_async(f"CREATE TABLE {probe} (pk bigint PRIMARY KEY)")
+    try:
+        for key in (COLLIDING_PK1, COLLIDING_PK2):
+            await cql.run_async(f"INSERT INTO {probe} (pk) VALUES ({key})")
+        rows = await cql.run_async(f"SELECT pk, token(pk) AS tok FROM {probe}")
+        tokens = {row.pk: row.tok for row in rows}
+        assert tokens[COLLIDING_PK1] == tokens[COLLIDING_PK2], \
+            f"the keys no longer share a token: {tokens}"
+    finally:
+        await cql.run_async(f"DROP TABLE {probe}")
+
+
+#############################################################################
+# Reading stored logstor records with SELECT ... FROM MUTATION_FRAGMENTS().
+#
+# A MUTATION_FRAGMENTS() query is answered from the coordinator's own storage
+# and never goes through the storage proxy, so sending it to a specific host
+# shows what that replica really stores, regardless of consistency level and of
+# which other nodes are up. That is what makes the assertions below possible: a
+# plain CQL read reflects a reconciling read of whichever replica answered it,
+# while these helpers compare the records themselves - fragment kinds,
+# tombstone, row marker and per-cell timestamps - across replicas.
+#
+# The helpers assume the table's partition key is a single column named `pk`,
+# which is true for every table in this file.
+#############################################################################
+
+# Fragment kinds, as reported in the mutation_fragment_kind column.
+PARTITION_START = 'partition start'
+CLUSTERING_ROW = 'clustering row'
+PARTITION_END = 'partition end'
+
+# The source holding the log record is named
+# "logstor-log:<file path>:<segment>", so it identifies the segment the record
+# is stored in, and changes when a rewrite moves the record to another segment.
+LOG_SOURCE_PREFIX = 'logstor-log:'
+CACHE_SOURCE = 'logstor-cache'
+
+
+@dataclass(frozen=True)
+class Record:
+    """The logstor record of one partition, as stored on one node.
+
+    Two replicas are converged when their records compare equal, so the fields
+    that are node-local by nature - where the record lives and whether it
+    happens to be cached - are excluded from comparison.
+    """
+    kinds: tuple[str, ...]
+    # (timestamp, deletion_time) of the partition tombstone, None if there is none.
+    partition_tombstone: tuple[int, str] | None
+    # Row marker timestamp, None if the record has no live row.
+    marker_timestamp: int | None
+    # (column, value, timestamp) per cell, sorted by column. value is None for a dead cell.
+    cells: tuple[tuple[str, Any, int], ...]
+    # The name of the mutation source the record was read from. For a log source
+    # it names the segment holding the record, see log_segments().
+    source: str = field(compare=False)
+    # The same partition as currently held in the logstor cache, if it is cached.
+    cached: 'Record | None' = field(compare=False, default=None)
+
+    def cell_values(self) -> dict[str, Any]:
+        return {name: value for name, value, _ in self.cells}
+
+    def cell_timestamps(self) -> dict[str, int]:
+        return {name: timestamp for name, _, timestamp in self.cells}
+
+    def tombstone_timestamp(self) -> int | None:
+        return self.partition_tombstone[0] if self.partition_tombstone else None
+
+
+def _parse_source(rows: list[Any], source: str) -> Record:
+    """Build a Record out of the fragments of a single mutation source.
+
+    Rows arrive in clustering order, which for the MUTATION_FRAGMENTS() schema
+    is mutation source, then partition region, so they are in fragment order.
+    """
+    tombstone = None
+    marker_timestamp = None
+    cells: dict[str, tuple[Any, int]] = {}
+    for row in rows:
+        if row.mutation_fragment_kind == PARTITION_START:
+            metadata = json.loads(row.metadata)['tombstone']
+            if metadata:
+                tombstone = (metadata['timestamp'], metadata['deletion_time'])
+        elif row.mutation_fragment_kind == CLUSTERING_ROW:
+            metadata = json.loads(row.metadata)
+            marker_timestamp = metadata.get('marker', {}).get('timestamp')
+            values = json.loads(row.value)
+            for name, cell in metadata['columns'].items():
+                cells[name] = (values.get(name), cell['timestamp'])
+    return Record(
+        kinds=tuple(row.mutation_fragment_kind for row in rows),
+        partition_tombstone=tombstone,
+        marker_timestamp=marker_timestamp,
+        cells=tuple(sorted((name, value, timestamp) for name, (value, timestamp) in cells.items())),
+        source=source,
+    )
+
+
+def _record_from_rows(rows: list[Any]) -> Record:
+    by_source: dict[str, list[Any]] = {}
+    for row in rows:
+        by_source.setdefault(row.mutation_source, []).append(row)
+    log_sources = [source for source in by_source if source.startswith(LOG_SOURCE_PREFIX)]
+    assert len(log_sources) == 1, f"expected exactly one log record source, got {sorted(by_source)}"
+    record = _parse_source(by_source[log_sources[0]], log_sources[0])
+    if CACHE_SOURCE in by_source:
+        record = replace(record, cached=_parse_source(by_source[CACHE_SOURCE], CACHE_SOURCE))
+    return record
+
+
+async def read_record(cql: Any, host: Any, table: str, pk: int) -> Record | None:
+    """Read the record of one partition as stored on `host`, None if the node has no record for it."""
+    rows = await cql.run_async(f"SELECT * FROM MUTATION_FRAGMENTS({table}) WHERE pk = {pk}", host=host)
+    return _record_from_rows(rows) if rows else None
+
+
+async def read_records(cql: Any, host: Any, table: str) -> dict[int, Record]:
+    """Read every record stored on `host`, keyed by partition key.
+
+    The key set is the one `host` holds locally, so a partition missing from a
+    node is missing from its result.
+    """
+    rows = await cql.run_async(f"SELECT * FROM MUTATION_FRAGMENTS({table})", host=host)
+    by_pk: dict[int, list[Any]] = {}
+    for row in rows:
+        by_pk.setdefault(row.pk, []).append(row)
+    return {pk: _record_from_rows(pk_rows) for pk, pk_rows in by_pk.items()}
+
+
+async def read_all_records(cql: Any, hosts: list[Any], table: str) -> list[dict[int, Record]]:
+    """Read the records stored on every host, one dict per host, in `hosts` order."""
+    return [await read_records(cql, host, table) for host in hosts]
+
+
+async def read_locally(cql: Any, host: Any, query: str) -> list[Any]:
+    """Run `query` on `host` and assert `host` answered it out of its own storage.
+
+    Read balancing is disabled in create_logstor_cluster() and the read is pinned
+    with CL=LOCAL_ONE, but only the query trace proves the coordinator did not
+    forward the read to the other replica - which matters when the point of the
+    read is the side effect it has on the local node, such as populating the
+    logstor cache.
+    """
+    result = cql.execute_async(SimpleStatement(query, consistency_level=ConsistencyLevel.LOCAL_ONE), host=host, trace=True)
+    rows = await _wrap_future(result)
+    traces = await asyncio.to_thread(result.get_all_query_traces, max_wait_per=60)
+    for trace in traces:
+        for event in trace.events:
+            assert event.source == host.address, \
+                f"the read was served by {event.source}, not by {host.address}"
+    return rows
+
+
+def check_record(record: Record) -> None:
+    """Assert the invariants that must hold for any stored logstor record.
+
+    A logstor partition is a partition start, at most one clustering row (at the
+    empty clustering key), and a partition end. A static row, a range tombstone
+    change or several rows would mean the repair apply path produced a partition
+    logstor is not supposed to store.
+
+    Also checks that a cached copy of the partition, if there is one, agrees with
+    the stored record: logstor evicts the cached mutation when a record is
+    overwritten, and repair writes through the same path, so a disagreement means
+    a node would keep serving its pre-repair value.
+    """
+    assert record.kinds[0] == PARTITION_START, f"unexpected first fragment: {record.kinds}"
+    assert record.kinds[-1] == PARTITION_END, f"unexpected last fragment: {record.kinds}"
+    rows = record.kinds[1:-1]
+    assert all(kind == CLUSTERING_ROW for kind in rows), f"unexpected fragments: {record.kinds}"
+    assert len(rows) <= 1, f"more than one row in a logstor partition: {record.kinds}"
+    assert record.cached is None or record.cached == record, \
+        f"stale logstor cache: cached {record.cached}, stored {record}"
+
+
+def check_deleted_record(record: Record, timestamp: int) -> None:
+    """Assert `record` is a partition deleted at `timestamp`.
+
+    A converged record may still physically contain the row the tombstone
+    deletes, because merging applies the tombstone but does not purge the data it
+    shadows. So what has to hold is that the tombstone is stored, and that
+    nothing in the record is newer than it - at equal timestamps the tombstone
+    wins.
+    """
+    assert record.tombstone_timestamp() == timestamp, f"expected a tombstone at {timestamp}: {record}"
+    assert (record.marker_timestamp or 0) <= timestamp, f"row marker survived the tombstone: {record}"
+    for name, cell_timestamp in record.cell_timestamps().items():
+        assert cell_timestamp <= timestamp, f"cell {name} survived the tombstone: {record}"
+
+
+@dataclass(frozen=True)
+class Deleted:
+    """The expected state of a partition that converged to a deletion at `timestamp`."""
+    timestamp: int
+
+
+class _Live:
+    """The expected state of a live partition whose cells the caller checks itself."""
+
+    def __repr__(self) -> str:
+        return 'LIVE'
+
+
+LIVE = _Live()
+
+# What a partition is expected to hold after the tested operation: the exact cell
+# values of its converged record, Deleted(timestamp), or LIVE.
+Expected = dict[int, dict[str, Any] | Deleted | _Live]
+
+
+async def check_converged(cql: Any, hosts: list[Any], table: str, expected: Expected) -> dict[int, Record]:
+    """Assert every replica stores identical records holding exactly `expected`, and return them.
+
+    This is the verification step of every test in this file. It reads what each
+    node stores rather than running a plain SELECT because a SELECT is answered
+    by the storage proxy coordinator, which is free to serve it from either
+    replica and may itself read-repair the very divergence the test is about. It
+    is also strictly stronger than comparing query results: it sees the partition
+    tombstone, the row marker and the per-cell timestamps, so a replica that ends
+    up with the right values but a different timestamp, or that received only the
+    cells it was missing instead of the whole converged partition, is caught.
+
+    `expected` must name every partition key the replicas hold, so a record that
+    should have been deleted, or one that should never have been created, is
+    caught by the key set alone.
+    """
+    records = check_records_converged(hosts, await read_all_records(cql, hosts, table))
+    assert set(records) == set(expected), \
+        f"the replicas hold keys {sorted(records)}, expected {sorted(expected)}"
+    for pk, want in expected.items():
+        if isinstance(want, Deleted):
+            check_deleted_record(records[pk], want.timestamp)
+        elif want is not LIVE:
+            assert records[pk].cell_values() == want, f"pk {pk}: expected {want}, got {records[pk]}"
+    return records
+
+
+def check_records_converged(hosts: list[Any], per_host: list[dict[int, Record]]) -> dict[int, Record]:
+    """Assert every replica stores identical records, and return them.
+
+    Stricter than comparing query results: it compares the stored records
+    including tombstone, row marker and per-cell timestamps, so a replica that
+    ends up with the right values but a different timestamp, or that received
+    only the rows it was missing instead of the whole converged partition, is
+    caught.
+    """
+    for records in per_host:
+        for record in records.values():
+            check_record(record)
+    reference = per_host[0]
+    for host, records in zip(hosts[1:], per_host[1:]):
+        assert set(records) == set(reference), \
+            f"host {host} holds keys {sorted(records)}, host {hosts[0]} holds {sorted(reference)}"
+        for pk, record in records.items():
+            assert record == reference[pk], \
+                f"pk {pk} differs: host {hosts[0]} has {reference[pk]}, host {host} has {record}"
+    return reference
+
+
+def log_segments(records: dict[int, Record]) -> dict[int, str]:
+    """The segment each record is stored in, taken from its log source name.
+
+    Comparing this across two reads tells whether a record was rewritten, as long
+    as a rewrite is bound to land in another segment - see
+    flush_records_to_segments().
+    """
+    return {pk: record.source for pk, record in records.items()}
+
+
+async def flush_records_to_segments(manager: ScyllaClusterManager, servers: list[Any]) -> None:
+    """Move every record written so far out of the segment the next write goes to.
+
+    Writes append to one active segment per node, and the small records these
+    tests write all fit in one, so a rewritten record would land in the very
+    segment it is already in and log_segments() would not show it moving.
+    Flushing the separator moves the records written so far into their compaction
+    group's own segments, so that whatever is written afterwards - a repair
+    applying a partition, for one - lands in a segment of its own.
+    """
+    await asyncio.gather(*(manager.api.logstor_flush(server.ip_addr) for server in servers))
+
+
+# Scalar counters of the row level algorithm, as logged by the repair master when
+# it finishes a repair. The two fast path counters count sync windows that were
+# found to be in sync - the first when the replicas reported the same sync
+# boundary and the same combined hash, the second when the combined hashes of the
+# negotiated window matched - and the slow path counter counts the windows that
+# needed full row hashes and row transfers.
+REPAIR_STATS_FIELDS = (
+    'round_nr',
+    'round_nr_fast_path_already_synced',
+    'round_nr_fast_path_same_combined_hashes',
+    'round_nr_slow_path',
+    'tx_row_nr',
+    'rx_row_nr',
+)
+
+REPAIR_STATS_LINE = r'repair\[.*\]: stats: '
+
+
+async def read_repair_stats(log: Any, from_mark: int) -> dict[str, int]:
+    """Sum the repair stats logged since `from_mark`.
+
+    One line is logged per repair task, so a repair of a tablet keyspace logs one
+    per tablet, on the shard that owns it. They all have to be summed to describe
+    the whole repair.
+    """
+    await log.wait_for(REPAIR_STATS_LINE, from_mark=from_mark, timeout=60)
+    matches = await log.grep(REPAIR_STATS_LINE, from_mark=from_mark)
+    stats = dict.fromkeys(REPAIR_STATS_FIELDS, 0)
+    for line, _ in matches:
+        for name in REPAIR_STATS_FIELDS:
+            # The names are matched with a trailing '=' so that, for example,
+            # tx_row_nr does not match the tx_row_nr_peer map on the same line.
+            match = re.search(rf'\b{name}=(\d+)', line)
+            assert match, f"{name} missing from the repair stats line: {line}"
+            stats[name] += int(match.group(1))
+    return stats
+
+
+def metric_delta(before: Any, after: Any, name: str) -> int:
+    """Growth of a repair counter. The counters are absent until the first repair runs."""
+    return int((after.get(name) or 0) - (before.get(name) or 0))
+
+
+@pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
+async def test_repair_missing_partition(manager: ScyllaClusterManager):
+    """Test that repair syncs a partition that exists on one node but is missing from another node.
+
+    The write to node2 is suppressed, so node1 stores the row and node2 does not.
+    After repair, node2 should have the row with the correct value.
+    """
+    servers, cql, hosts = await create_logstor_cluster(manager)
+
+    async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 2}") as ks:
+        await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, v text) WITH storage_engine = 'logstor'")
+
+        await write_only_on(manager, servers, cql, hosts, ks, "test", 0,
+                            [f"INSERT INTO {ks}.test (pk, v) VALUES (1, 'a')"])
+
+        # The record is missing from node2's own storage, which a reconciling
+        # read could not show while both nodes are up.
+        assert await read_record(cql, hosts[1], f"{ks}.test", 1) is None
+
+        await manager.api.repair(servers[0].ip_addr, ks, "test")
+
+        records = await check_converged(cql, hosts, f"{ks}.test", {1: {'v': 'a'}})
+        assert records[1].partition_tombstone is None
+
+
+@pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
+async def test_repair_same_timestamp_conflict(manager: ScyllaClusterManager):
+    """Test that repair reconciles two rows with the same primary key, same timestamp, but different values.
+
+    Node1 has value 'a', node2 has value 'b', both at timestamp 1000.
+    After repair, both nodes converge to the same value (the one that wins the
+    cell-level tiebreaker — largest value wins at equal timestamp).
+    """
+    servers, cql, hosts = await create_logstor_cluster(manager)
+
+    async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 2}") as ks:
+        await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, v text) WITH storage_engine = 'logstor'")
+
+        await write_only_on(manager, servers, cql, hosts, ks, "test", 0,
+                            [f"INSERT INTO {ks}.test (pk, v) VALUES (1, 'a') USING TIMESTAMP 1000"])
+        await write_only_on(manager, servers, cql, hosts, ks, "test", 1,
+                            [f"INSERT INTO {ks}.test (pk, v) VALUES (1, 'b') USING TIMESTAMP 1000"])
+
+        # The stored records show the divergence the test set up, which a
+        # reconciling read cannot show.
+        before = await read_all_records(cql, hosts, f"{ks}.test")
+        assert before[0][1].cell_values() == {'v': 'a'}
+        assert before[1][1].cell_values() == {'v': 'b'}
+
+        await manager.api.repair(servers[0].ip_addr, ks, "test")
+
+        # At equal timestamps the lexicographically larger cell value wins. Both
+        # nodes must store the same record, with the original timestamp: the merge
+        # picks a winning cell, it does not rewrite timestamps.
+        records = await check_converged(cql, hosts, f"{ks}.test", {1: {'v': 'b'}})
+        assert records[1].cell_timestamps() == {'v': 1000}
+        assert records[1].marker_timestamp == 1000
+
+
+@pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
+async def test_repair_same_timestamp_tombstone_wins(manager: ScyllaClusterManager):
+    """Test that a tombstone beats a live cell when both have the same timestamp.
+
+    Node1 has a live row (v=100), node2 has a tombstone deleting pk=1, both at timestamp 1000.
+    After repair, both nodes converge to the tombstone (row deleted).
+    """
+    servers, cql, hosts = await create_logstor_cluster(manager)
+
+    async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 2}") as ks:
+        await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, v int) WITH storage_engine = 'logstor'")
+
+        await write_only_on(manager, servers, cql, hosts, ks, "test", 0,
+                            [f"INSERT INTO {ks}.test (pk, v) VALUES (1, 100) USING TIMESTAMP 1000"])
+        await write_only_on(manager, servers, cql, hosts, ks, "test", 1,
+                            [f"DELETE FROM {ks}.test USING TIMESTAMP 1000 WHERE pk = 1"])
+
+        before = await read_all_records(cql, hosts, f"{ks}.test")
+        assert before[0][1].cell_values() == {'v': '100'}
+        assert before[1][1].tombstone_timestamp() == 1000
+
+        await manager.api.repair(servers[0].ip_addr, ks, "test")
+
+        # The converged record must store the deletion itself, and the live row it
+        # shadows must not survive it.
+        await check_converged(cql, hosts, f"{ks}.test", {1: Deleted(1000)})
+
+
+@pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
+async def test_repair_multishard_routing(manager: ScyllaClusterManager):
+    """Test that repair works correctly with multiple shards and tablets.
+
+    Use smp=2 and 2 tablets. Insert disjoint partition sets on each node
+    (pk 0-15 on node1, pk 16-31 on node2). After repair, both nodes should
+    have all 32 rows.
+    """
+    servers, cql, hosts = await create_logstor_cluster(manager, smp=2)
+
+    async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 2} AND tablets = {'initial': 2}") as ks:
+        await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, v int) WITH storage_engine = 'logstor'")
+
+        await write_only_on(manager, servers, cql, hosts, ks, "test", 0,
+                            [f"INSERT INTO {ks}.test (pk, v) VALUES ({pk}, {pk + 100})" for pk in range(16)])
+        await write_only_on(manager, servers, cql, hosts, ks, "test", 1,
+                            [f"INSERT INTO {ks}.test (pk, v) VALUES ({pk}, {pk + 100})" for pk in range(16, 32)])
+
+        await manager.api.repair(servers[0].ip_addr, ks, "test")
+
+        # Every record must be present in each node's own storage: a scan would go
+        # through the read path, where a range can be served by the other replica,
+        # so it would not prove the rows were applied on the right node.
+        await check_converged(cql, hosts, f"{ks}.test", {pk: {'v': str(pk + 100)} for pk in range(32)})
+
+
+@pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
+async def test_repair_mixed_outcomes(manager: ScyllaClusterManager):
+    """Test repair with a mix of conflict types in a single repair run.
+
+    Scenarios covered on pk 1-6:
+      pk=1: identical on both nodes — no-op.
+      pk=2: same timestamp, different values — tiebreaker picks larger.
+      pk=3: live row vs tombstone (same timestamp) — tombstone wins.
+      pk=4: different timestamps — newer wins.
+      pk=5: only on node1 — synced to node2.
+      pk=6: only on node2 — synced to node1.
+    After repair, both nodes have identical data matching the expected outcome for each case.
+    """
+    servers, cql, hosts = await create_logstor_cluster(manager)
+
+    async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 2}") as ks:
+        await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, v text) WITH storage_engine = 'logstor'")
+
+        await write_only_on(manager, servers, cql, hosts, ks, "test", 0, [
+            f"INSERT INTO {ks}.test (pk, v) VALUES ({pk}, '{v}') USING TIMESTAMP 1000"
+            for pk, v in [(1, 'a'), (2, 'b'), (3, 'd'), (4, 'e'), (5, 'g')]])
+        await write_only_on(manager, servers, cql, hosts, ks, "test", 1, [
+            f"INSERT INTO {ks}.test (pk, v) VALUES (2, 'c') USING TIMESTAMP 1000",
+            f"DELETE FROM {ks}.test USING TIMESTAMP 1000 WHERE pk = 3",
+            f"INSERT INTO {ks}.test (pk, v) VALUES (4, 'f') USING TIMESTAMP 900",
+            f"INSERT INTO {ks}.test (pk, v) VALUES (6, 'h') USING TIMESTAMP 1000"])
+
+        await manager.api.repair(servers[0].ip_addr, ks, "test")
+
+        # Both nodes must store the same record for every key, each with the
+        # expected shape: a live row, or the tombstone record for the deleted pk=3.
+        # check_converged() also checks the record shape invariants, so a repair
+        # apply that produced, say, a static row is caught here.
+        await check_converged(cql, hosts, f"{ks}.test", {
+            1: {'v': 'a'},
+            2: {'v': 'c'},
+            3: Deleted(1000),
+            4: {'v': 'e'},
+            5: {'v': 'g'},
+            6: {'v': 'h'},
+        })
+
+
+@pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
+async def test_repair_mutation_merge_conflicting_rows_with_same_timestamp_multicell(manager: ScyllaClusterManager):
+    """Test that repair correctly merges multi-column rows with same-timestamp column-level conflicts.
+
+    Node1 has (a='a', b='b'), node2 has (a='b', b='a'), both at timestamp 1000.
+    After repair, each column is reconciled independently: the larger value wins
+    per-column, so the result is (a='b', b='b').
+    """
+    servers, cql, hosts = await create_logstor_cluster(manager)
+
+    async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 2}") as ks:
+        await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, a text, b text) WITH storage_engine = 'logstor'")
+
+        await write_only_on(manager, servers, cql, hosts, ks, "test", 0,
+                            [f"INSERT INTO {ks}.test (pk, a, b) VALUES (1, 'a', 'b') USING TIMESTAMP 1000"])
+        await write_only_on(manager, servers, cql, hosts, ks, "test", 1,
+                            [f"INSERT INTO {ks}.test (pk, a, b) VALUES (1, 'b', 'a') USING TIMESTAMP 1000"])
+
+        before = await read_all_records(cql, hosts, f"{ks}.test")
+        assert before[0][1].cell_values() == {'a': 'a', 'b': 'b'}
+        assert before[1][1].cell_values() == {'a': 'b', 'b': 'a'}
+
+        await manager.api.repair(servers[0].ip_addr, ks, "test")
+
+        # Each column is reconciled independently but keeps its own timestamp.
+        records = await check_converged(cql, hosts, f"{ks}.test", {1: {'a': 'b', 'b': 'b'}})
+        assert records[1].cell_timestamps() == {'a': 1000, 'b': 1000}
+
+
+@pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
+async def test_repair_three_replica_multicell_merge(manager: ScyllaClusterManager):
+    """Test that repair converges a partition whose columns are split across three replicas.
+
+    Each replica holds a disjoint column of pk=1 at the same timestamp (node1 a='x',
+    node2 b='y', node3 c='z'), because the other replicas were down when each write
+    happened and hinted handoff is disabled. Repair must gather all versions on the
+    master and push the fully merged partition to every replica, so each node ends up
+    with a='x', b='y', c='z'. This exercises the logstor whole-partition convergence:
+    sending only the differing rows would drop the columns held by other replicas.
+    """
+    servers, cql, hosts = await create_logstor_cluster(manager, nodes=3)
+
+    async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 3}") as ks:
+        await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, a text, b text, c text) WITH storage_engine = 'logstor'")
+
+        # Write a disjoint column on each node, suppressed on the other two.
+        for idx, col, val in [(0, 'a', 'x'), (1, 'b', 'y'), (2, 'c', 'z')]:
+            await write_only_on(manager, servers, cql, hosts, ks, "test", idx,
+                                [f"INSERT INTO {ks}.test (pk, {col}) VALUES (1, '{val}') USING TIMESTAMP 1000"])
+
+        await manager.api.repair(servers[0].ip_addr, ks, "test")
+
+        # All three replicas must store the same merged record, with each column
+        # keeping the timestamp it was written with. A replica that received only
+        # the rows it was missing would store a partial partition here.
+        records = await check_converged(cql, hosts, f"{ks}.test", {1: {'a': 'x', 'b': 'y', 'c': 'z'}})
+        assert records[1].cell_timestamps() == {'a': 1000, 'b': 1000, 'c': 1000}
+        assert records[1].marker_timestamp == 1000
+
+
+@pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
+async def test_repair_three_replica_conflicting_versions(manager: ScyllaClusterManager):
+    """Test that repair converges three replicas that hold conflicting versions.
+
+    In test_repair_three_replica_multicell_merge the three versions are disjoint,
+    so merging them cannot lose anything. Here every replica holds a genuinely
+    conflicting version of the same partition, and one of them is a delete:
+
+      pk=1: node1 v='a', node2 v='b', node3 v='c', all at ts=1000
+            - the cell tiebreaker picks the largest value, 'c'.
+      pk=2: node1 v='old' ts=1000, node2 v='new' ts=3000, node3 delete ts=2000
+            - v='new' wins, over a tombstone that is newer than node1's version.
+      pk=3: only on node3 - synced to the other two.
+
+    With three replicas the master merges versions pulled from two different
+    followers into one partition before flushing it and sending it on, and it
+    copies the working row buffer instead of moving it (the _nr_peer_nodes == 1
+    shortcut in get_row_diff()). A two node cluster exercises neither.
+    """
+    servers, cql, hosts = await create_logstor_cluster(manager, nodes=3)
+
+    async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 3}") as ks:
+        await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, v text) WITH storage_engine = 'logstor'")
+        table = f"{ks}.test"
+
+        await write_only_on(manager, servers, cql, hosts, ks, "test", 0, [
+            f"INSERT INTO {table} (pk, v) VALUES (1, 'a') USING TIMESTAMP 1000",
+            f"INSERT INTO {table} (pk, v) VALUES (2, 'old') USING TIMESTAMP 1000"])
+        await write_only_on(manager, servers, cql, hosts, ks, "test", 1, [
+            f"INSERT INTO {table} (pk, v) VALUES (1, 'b') USING TIMESTAMP 1000",
+            f"INSERT INTO {table} (pk, v) VALUES (2, 'new') USING TIMESTAMP 3000"])
+        await write_only_on(manager, servers, cql, hosts, ks, "test", 2, [
+            f"INSERT INTO {table} (pk, v) VALUES (1, 'c') USING TIMESTAMP 1000",
+            f"DELETE FROM {table} USING TIMESTAMP 2000 WHERE pk = 2",
+            f"INSERT INTO {table} (pk, v) VALUES (3, 'only') USING TIMESTAMP 1000"])
+
+        before = await read_all_records(cql, hosts, table)
+        assert [sorted(records) for records in before] == [[1, 2], [1, 2], [1, 2, 3]]
+        assert [records[1].cell_values()['v'] for records in before] == ['a', 'b', 'c']
+        assert before[0][2].cell_timestamps() == {'v': 1000}, f"node1 pk=2: {before[0][2]}"
+        assert before[1][2].cell_timestamps() == {'v': 3000}, f"node2 pk=2: {before[1][2]}"
+        assert before[2][2].tombstone_timestamp() == 2000, f"node3 pk=2: {before[2][2]}"
+
+        await manager.api.repair(servers[0].ip_addr, ks, "test")
+
+        records = await check_converged(cql, hosts, table,
+                                       {1: {'v': 'c'}, 2: {'v': 'new'}, 3: {'v': 'only'}})
+        assert records[1].cell_timestamps() == {'v': 1000}
+        assert records[2].cell_timestamps() == {'v': 3000}
+        # The winning version is newer than the tombstone, so the partition stays
+        # live, but the converged record must still carry the tombstone: dropping
+        # it would let node1's older version resurrect on a later repair.
+        assert records[2].tombstone_timestamp() == 2000
+
+
+@pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
+async def test_repair_delete_newer_than_live_no_resurrection(manager: ScyllaClusterManager):
+    """Test that a delete newer than a live row converges to deleted and cannot be resurrected.
+
+    Node1 has a live row (v=100) at timestamp 1000, node2 deletes pk=1 at timestamp 2000.
+    After repair both nodes must be deleted, and the converged record must carry the
+    tombstone timestamp (2000). A subsequent write at an older timestamp (1500) must
+    therefore be rejected on every node, leaving the partition deleted. Without deriving
+    the record timestamp from the max of the row marker and partition tombstone, the
+    converged record would keep timestamp 1000 and the older write would resurrect it.
+    """
+    servers, cql, hosts = await create_logstor_cluster(manager)
+
+    async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 2}") as ks:
+        await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, v int) WITH storage_engine = 'logstor'")
+
+        await write_only_on(manager, servers, cql, hosts, ks, "test", 0,
+                            [f"INSERT INTO {ks}.test (pk, v) VALUES (1, 100) USING TIMESTAMP 1000"])
+        await write_only_on(manager, servers, cql, hosts, ks, "test", 1,
+                            [f"DELETE FROM {ks}.test USING TIMESTAMP 2000 WHERE pk = 1"])
+
+        await manager.api.repair(servers[0].ip_addr, ks, "test")
+
+        # The converged record must carry the deletion timestamp, and nothing in it
+        # may be newer than the tombstone. A record that kept only the row marker's
+        # older timestamp is what would let the older write below resurrect it.
+        await check_converged(cql, hosts, f"{ks}.test", {1: Deleted(2000)})
+
+        # A write older than the tombstone must not resurrect the partition. It
+        # goes out at CL=ALL so that both replicas are known to have seen it and
+        # rejected it by the time the records are read.
+        await cql.run_async(SimpleStatement(f"INSERT INTO {ks}.test (pk, v) VALUES (1, 200) USING TIMESTAMP 1500",
+                                            consistency_level=ConsistencyLevel.ALL))
+
+        await check_converged(cql, hosts, f"{ks}.test", {1: Deleted(2000)})
+
+
+@pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
+async def test_repair_window_never_splits_partition(manager: ScyllaClusterManager):
+    """Test that a repair sync window never splits a logstor partition.
+
+    Logstor repair converges whole partitions, so all fragments of a partition
+    must land in the same sync window. The repair_tiny_max_row_buf_size injection
+    shrinks the repair row buffer below a single fragment, which is what makes
+    the window boundaries observable at all. Keeping windows partition-aligned
+    then takes two things, and the two key groups below cover one each:
+
+    - read_rows_from_disk() reads past the byte budget until the open partition
+      is complete, so the row buffer never ends inside one. The two_fragment
+      keys need this: a record written by a batch that combines a partition
+      delete with a newer insert carries a partition tombstone and a row, and a
+      buffer that stopped between them would converge half a partition.
+
+    - get_sync_boundary() reports the boundary at after_all_clustered_rows()
+      rather than at the last row's own position. The tombstone_only keys need
+      this: on node1 the partition is a partition tombstone and nothing else, so
+      its only repair row sits at the partition-start position. Reported as-is,
+      that boundary is the minimum across the replicas and cuts node2's row for
+      the same partition into the next window.
+
+    Both groups end up with the tombstone lost from the converged record and the
+    cells it deleted resurrected, which is what the assertions below catch.
+
+    Both groups converge to the same value, and differ only in which replica
+    holds the tombstone and in the fragment shape that produces the boundary:
+
+      two_fragment keys   node1: batch DELETE ts=2000 + INSERT v='new' ts=3000
+                          node2: INSERT v='old', w='stale' ts=1000
+      tombstone_only keys node1: DELETE ts=2000, nothing else
+                          node2: batch INSERT w='stale' ts=1000 + v='new' ts=3000
+
+      converged, both:    live, v='new', w killed by the tombstone at 2000
+
+    Note the second group needs node2's surviving cell to be *newer* than the
+    tombstone. With an older one a split does no visible damage: logstor keeps
+    the record with the highest timestamp, so the older row could never replace
+    the tombstone that was converged without it.
+    """
+    servers, cql, hosts = await create_logstor_cluster(manager)
+
+    two_fragment_keys = range(10)
+    tombstone_only_keys = range(10, 20)
+    keys = list(two_fragment_keys) + list(tombstone_only_keys)
+
+    async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 2}") as ks:
+        await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, v text, w text) WITH storage_engine = 'logstor'")
+
+        await write_only_on(manager, servers, cql, hosts, ks, "test", 0, [
+            f"BEGIN UNLOGGED BATCH "
+            f"DELETE FROM {ks}.test USING TIMESTAMP 2000 WHERE pk = {pk}; "
+            f"INSERT INTO {ks}.test (pk, v) VALUES ({pk}, 'new') USING TIMESTAMP 3000; "
+            f"APPLY BATCH" for pk in two_fragment_keys] + [
+            f"DELETE FROM {ks}.test USING TIMESTAMP 2000 WHERE pk = {pk}" for pk in tombstone_only_keys])
+        await write_only_on(manager, servers, cql, hosts, ks, "test", 1, [
+            f"INSERT INTO {ks}.test (pk, v, w) VALUES ({pk}, 'old', 'stale') USING TIMESTAMP 1000"
+            for pk in two_fragment_keys] + [
+            f"BEGIN UNLOGGED BATCH "
+            f"INSERT INTO {ks}.test (pk, w) VALUES ({pk}, 'stale') USING TIMESTAMP 1000; "
+            f"INSERT INTO {ks}.test (pk, v) VALUES ({pk}, 'new') USING TIMESTAMP 3000; "
+            f"APPLY BATCH" for pk in tombstone_only_keys])
+
+        async with AsyncExitStack() as stack:
+            for server in servers:
+                await stack.enter_async_context(inject_error(manager.api, server.ip_addr, "repair_tiny_max_row_buf_size"))
+            await manager.api.repair(servers[0].ip_addr, ks, "test")
+
+        # The cells are checked below rather than through `expected`: w may
+        # legitimately still be present in the record, shadowed by the tombstone,
+        # so the converged cell set is not fixed.
+        records = await check_converged(cql, hosts, f"{ks}.test", {pk: LIVE for pk in keys})
+        # The converged record must still carry the partition tombstone next to
+        # the newer row. A record that only kept the row reads the same to a
+        # client, but has lost the deletion: a later write of w at a timestamp
+        # between 1000 and 2000 would then resurrect it.
+        for pk, record in records.items():
+            assert record.kinds == (PARTITION_START, CLUSTERING_ROW, PARTITION_END), f"pk {pk}: {record}"
+            assert record.tombstone_timestamp() == 2000, f"pk {pk}: tombstone lost from the converged record: {record}"
+            assert record.cell_values()['v'] == 'new', f"pk {pk}: {record}"
+            # w may still be present in the record, shadowed by the tombstone,
+            # but it must never be newer than the tombstone that deleted it.
+            assert record.cell_timestamps().get('w', 0) < 2000, f"pk {pk}: w survived the tombstone: {record}"
+
+
+@pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
+async def test_repair_same_token_missing_keys(manager: ScyllaClusterManager):
+    """Test that repair syncs two partitions whose keys share one token.
+
+    The logstor primary index and range reader order same-token keys by the full
+    decorated key, and repair compares sync boundaries and groups its convergence
+    work by the full key as well. A token-only comparison anywhere in that chain
+    would order the two keys differently on different replicas, sync the wrong
+    record, or treat the two partitions as one. So the colliding keys diverge in
+    opposite directions - each replica misses one of them - and repair must end
+    with both replicas holding both records, next to plain keys that make the
+    colliding run part of a larger scan.
+
+    The second repair, run from the other node as master, asserts the repaired
+    range hashes clean: converged same-token records must compare equal on the
+    next run, with no rows transferred and no records rewritten. Replicas that
+    emitted or hashed the same-token run inconsistently would show up here as
+    spurious diffs on every repair.
+    """
+    servers, cql, hosts = await create_logstor_cluster(manager)
+
+    plain_keys = range(4)
+
+    async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 2}") as ks:
+        await cql.run_async(f"CREATE TABLE {ks}.test (pk bigint PRIMARY KEY, v text) WITH storage_engine = 'logstor'")
+        table = f"{ks}.test"
+        await assert_colliding_tokens(cql, ks)
+
+        await write_only_on(manager, servers, cql, hosts, ks, "test", 0,
+                            [f"INSERT INTO {table} (pk, v) VALUES ({COLLIDING_PK1}, 'a') USING TIMESTAMP 1000"] +
+                            [f"INSERT INTO {table} (pk, v) VALUES ({pk}, 'v{pk}') USING TIMESTAMP 1000"
+                             for pk in plain_keys[:2]])
+        await write_only_on(manager, servers, cql, hosts, ks, "test", 1,
+                            [f"INSERT INTO {table} (pk, v) VALUES ({COLLIDING_PK2}, 'b') USING TIMESTAMP 1000"] +
+                            [f"INSERT INTO {table} (pk, v) VALUES ({pk}, 'v{pk}') USING TIMESTAMP 1000"
+                             for pk in plain_keys[2:]])
+
+        # Each node misses the colliding key written to the other one.
+        assert await read_record(cql, hosts[1], table, COLLIDING_PK1) is None
+        assert await read_record(cql, hosts[0], table, COLLIDING_PK2) is None
+
+        await manager.api.repair(servers[0].ip_addr, ks, "test")
+
+        expected = {COLLIDING_PK1: {'v': 'a'}, COLLIDING_PK2: {'v': 'b'}}
+        expected |= {pk: {'v': f'v{pk}'} for pk in plain_keys}
+        records = await check_converged(cql, hosts, table, expected)
+        assert records[COLLIDING_PK1].marker_timestamp == 1000
+        assert records[COLLIDING_PK2].marker_timestamp == 1000
+
+        # A second repair, from the other node as master, must find everything in
+        # sync: no slow-path windows, no rows moved, no records rewritten.
+        await flush_records_to_segments(manager, servers)
+        before = await read_all_records(cql, hosts, table)
+        log = await manager.server_open_log(servers[1].server_id)
+        mark = await log.mark()
+
+        await manager.api.repair(servers[1].ip_addr, ks, "test")
+
+        stats = await read_repair_stats(log, mark)
+        assert stats['round_nr_slow_path'] == 0, \
+            f"the converged same-token records did not hash equal across the replicas: {stats}"
+        assert stats['tx_row_nr'] == 0 and stats['rx_row_nr'] == 0, f"repair transferred rows: {stats}"
+
+        after = await read_all_records(cql, hosts, table)
+        for host, old, new in zip(hosts, before, after):
+            assert log_segments(new) == log_segments(old), f"host {host} rewrote records that were already in sync"
+
+
+@pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
+async def test_repair_same_token_window_boundary(manager: ScyllaClusterManager):
+    """Test repair sync windows that cut between two keys sharing one token.
+
+    The repair_tiny_max_row_buf_size injection shrinks the repair row buffer
+    below a single fragment, so every sync window holds exactly one partition and
+    a window boundary necessarily falls between the two colliding keys. Unlike a
+    split inside a partition, a cut between two keys at an equal token is legal -
+    but only if every step uses the full decorated key: the boundary each replica
+    reports (with its position forced to after_all_clustered_rows), the common
+    boundary the master picks as the minimum across the replicas, and the split
+    of the row buffer at that boundary. Comparing by token alone would put the
+    second key on different sides of the boundary on different replicas, or
+    converge the two partitions as one.
+
+    Both colliding keys carry a conflict that makes such a mixup visible:
+
+      COLLIDING_PK1  node1: INSERT v='a...' ts=1000  node2: INSERT v='b...' ts=1000
+                     -> converges by the equal-timestamp cell tiebreak to 'b...',
+                        and must not pick up the other key's tombstone
+
+      COLLIDING_PK2  node1: DELETE ts=2000, nothing else
+                     node2: batch INSERT w='stale' ts=1000 + v='new...' ts=3000
+                     -> converges to a live row v='new...' still carrying the
+                        tombstone that kills w; on node1 its only repair row
+                        sits at the partition-start position, the shape that
+                        makes the reported boundary position matter
+
+    Every live value is padded above the injected byte budget, so a window that
+    read a live row is full once the partition completes. On node2 both colliding
+    partitions are live, so each fills a window by itself and node2 reports a
+    boundary exactly between the two keys - the common boundary the master picks
+    is the minimum across the replicas and windows only advance, so that cut is
+    reached whatever node1's windows look like. A run of plain keys diverges
+    alongside them so the repair processes many windows; the round count checks
+    the padding really kept the windows at one live partition each (only node1's
+    tombstone-only record, which no padding can reach, may share a window with
+    its ring-order successor).
+    """
+    servers, cql, hosts = await create_logstor_cluster(manager)
+
+    plain_keys = range(8)
+    # repair_tiny_max_row_buf_size caps the row buffer at 100 bytes; a 128-byte
+    # value keeps every live row fragment alone above the cap.
+    pad = 'x' * 128
+
+    async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 2}") as ks:
+        await cql.run_async(f"CREATE TABLE {ks}.test (pk bigint PRIMARY KEY, v text, w text) WITH storage_engine = 'logstor'")
+        table = f"{ks}.test"
+        await assert_colliding_tokens(cql, ks)
+
+        await write_only_on(manager, servers, cql, hosts, ks, "test", 0,
+                            [f"INSERT INTO {table} (pk, v) VALUES ({COLLIDING_PK1}, 'a{pad}') USING TIMESTAMP 1000",
+                             f"DELETE FROM {table} USING TIMESTAMP 2000 WHERE pk = {COLLIDING_PK2}"] +
+                            [f"INSERT INTO {table} (pk, v) VALUES ({pk}, 'v{pk}{pad}') USING TIMESTAMP 1000"
+                             for pk in plain_keys])
+        await write_only_on(manager, servers, cql, hosts, ks, "test", 1,
+                            [f"INSERT INTO {table} (pk, v) VALUES ({COLLIDING_PK1}, 'b{pad}') USING TIMESTAMP 1000",
+                             f"BEGIN UNLOGGED BATCH "
+                             f"INSERT INTO {table} (pk, w) VALUES ({COLLIDING_PK2}, 'stale') USING TIMESTAMP 1000; "
+                             f"INSERT INTO {table} (pk, v) VALUES ({COLLIDING_PK2}, 'new{pad}') USING TIMESTAMP 3000; "
+                             f"APPLY BATCH"])
+
+        log = await manager.server_open_log(servers[0].server_id)
+        mark = await log.mark()
+
+        async with AsyncExitStack() as stack:
+            for server in servers:
+                await stack.enter_async_context(inject_error(manager.api, server.ip_addr, "repair_tiny_max_row_buf_size"))
+            await manager.api.repair(servers[0].ip_addr, ks, "test")
+
+        # The master holds one live padded partition per plain key plus
+        # COLLIDING_PK1, each needing a window of its own; only its tombstone-only
+        # COLLIDING_PK2 record may share a window. A common boundary can cut a
+        # window shorter but never merge two, so this lower bound is exact enough
+        # to catch the padding failing to keep windows at one partition.
+        stats = await read_repair_stats(log, mark)
+        assert stats['round_nr'] >= len(plain_keys) + 1, f"a sync window held more than one live partition: {stats}"
+
+        expected = {COLLIDING_PK1: {'v': f'b{pad}'}, COLLIDING_PK2: LIVE}
+        expected |= {pk: {'v': f'v{pk}{pad}'} for pk in plain_keys}
+        records = await check_converged(cql, hosts, table, expected)
+
+        # The equal-timestamp conflict converges by the cell tiebreak (largest
+        # value wins) with the original timestamp, and must not have picked up
+        # the tombstone of the other key at the same token.
+        assert records[COLLIDING_PK1].cell_timestamps() == {'v': 1000}
+        assert records[COLLIDING_PK1].partition_tombstone is None, \
+            f"the tombstone of the key sharing the token leaked into this record: {records[COLLIDING_PK1]}"
+
+        # The deleted-then-rewritten key must keep the newer row and the
+        # tombstone next to it, and w must not have survived the deletion.
+        record = records[COLLIDING_PK2]
+        assert record.tombstone_timestamp() == 2000, f"tombstone lost from the converged record: {record}"
+        assert record.cell_values()['v'] == f'new{pad}', f"{record}"
+        assert record.cell_timestamps().get('w', 0) < 2000, f"w survived the tombstone: {record}"
+
+
+async def test_repair_consistent_nodes_transfers_nothing(manager: ScyllaClusterManager):
+    """Test that repair of already consistent replicas finds them equal and applies nothing.
+
+    This is the case every periodic repair of a healthy cluster hits, and for
+    logstor it is the case that has to stay cheap: a repair that failed to see two
+    identical partitions as identical would converge and rewrite every record in
+    the range, and one that skipped the comparison altogether would silently stop
+    repairing.
+
+    So the test asserts all three properties, from three independent angles:
+
+      - repair really compared the data and found it equal: every sync window took
+        one of the two fast paths and none took the slow path that fetches full row
+        hashes and rows;
+      - nothing moved between the nodes: no rows were sent or received, while rows
+        were in fact read from disk and hashed, which is what makes the previous
+        assertion meaningful;
+      - nothing was applied: every record is still in the segment it was in
+        before the repair.
+    """
+    servers, cql, hosts = await create_logstor_cluster(manager)
+
+    keys = range(32)
+
+    async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 2}") as ks:
+        await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, v text) WITH storage_engine = 'logstor'")
+        table = f"{ks}.test"
+
+        # No write is suppressed, so both replicas store the same records.
+        for pk in keys:
+            await cql.run_async(f"INSERT INTO {table} (pk, v) VALUES ({pk}, 'v{pk}') USING TIMESTAMP 1000")
+
+        await flush_records_to_segments(manager, servers)
+        before = await read_all_records(cql, hosts, table)
+        reference = check_records_converged(hosts, before)
+        assert set(reference) == set(keys)
+
+        metrics_before = [await manager.metrics.query(server.ip_addr) for server in servers]
+        log = await manager.server_open_log(servers[0].server_id)
+        mark = await log.mark()
+
+        await manager.api.repair(servers[0].ip_addr, ks, "test")
+
+        stats = await read_repair_stats(log, mark)
+        assert stats['round_nr'] > 0, f"repair did no rounds at all: {stats}"
+        assert stats['round_nr_slow_path'] == 0, \
+            f"repair failed to see the identical replicas as in sync and took the slow path: {stats}"
+        assert stats['round_nr_fast_path_already_synced'] + stats['round_nr_fast_path_same_combined_hashes'] > 0, \
+            f"no sync window was resolved by comparing hashes: {stats}"
+        assert stats['tx_row_nr'] == 0 and stats['rx_row_nr'] == 0, f"repair transferred rows: {stats}"
+
+        metrics_after = [await manager.metrics.query(server.ip_addr) for server in servers]
+        for server, m_before, m_after in zip(servers, metrics_before, metrics_after):
+            assert metric_delta(m_before, m_after, 'scylla_repair_tx_row_nr') == 0, f"{server.ip_addr} sent rows"
+            assert metric_delta(m_before, m_after, 'scylla_repair_rx_row_nr') == 0, f"{server.ip_addr} received rows"
+            # Both replicas read and hashed their own copy of every partition, so
+            # the comparison above was made on the real data.
+            assert metric_delta(m_before, m_after, 'scylla_repair_row_from_disk_nr') >= len(keys), \
+                f"{server.ip_addr} did not read the rows it compared"
+
+        after = await read_all_records(cql, hosts, table)
+        for host, old, new in zip(hosts, before, after):
+            assert log_segments(new) == log_segments(old), f"host {host} rewrote records that were already in sync"
+        assert check_records_converged(hosts, after) == reference
+
+
+@pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
+async def test_repair_does_not_rewrite_clean_partitions(manager: ScyllaClusterManager):
+    """Test that repair rewrites only the logstor records of partitions that differ.
+
+    Logstor repair converges and flushes whole partitions, but only the ones a
+    peer disagreed about: flush_rows() skips rows that are not dirty, and a
+    follower only applies what it was sent. A repair that rewrote clean
+    partitions would be correct but would turn every repair into a full rewrite
+    of the range.
+
+    The segment holding the record, visible in the MUTATION_FRAGMENTS() source
+    name, changes when a rewrite moves the record to another segment, which makes
+    this observable: repair a synced range and no record may move, diverge one key
+    and only that key's record may move. flush_records_to_segments() is what makes
+    a rewrite land in another segment in the first place.
+    """
+    servers, cql, hosts = await create_logstor_cluster(manager)
+
+    keys = range(8)
+    diverged = 0
+
+    async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 2}") as ks:
+        await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, v text) WITH storage_engine = 'logstor'")
+        table = f"{ks}.test"
+
+        # No write is suppressed, so both replicas store the identical record.
+        for pk in keys:
+            await cql.run_async(f"INSERT INTO {table} (pk, v) VALUES ({pk}, 'v{pk}') USING TIMESTAMP 1000")
+
+        await flush_records_to_segments(manager, servers)
+        before = await read_all_records(cql, hosts, table)
+        for records in before:
+            assert set(records) == set(keys)
+
+        await manager.api.repair(servers[0].ip_addr, ks, "test")
+
+        after = await read_all_records(cql, hosts, table)
+        for host, old, new in zip(hosts, before, after):
+            assert log_segments(new) == log_segments(old), f"host {host} rewrote records while everything was in sync"
+
+        # Diverge a single key on the repair master.
+        await write_only_on(manager, servers, cql, hosts, ks, "test", 0,
+                            [f"INSERT INTO {table} (pk, v) VALUES ({diverged}, 'new') USING TIMESTAMP 2000"])
+
+        before = await read_all_records(cql, hosts, table)
+        await manager.api.repair(servers[0].ip_addr, ks, "test")
+        after = await read_all_records(cql, hosts, table)
+
+        for host, old, new in zip(hosts, before, after):
+            for pk in keys:
+                if pk == diverged:
+                    continue
+                assert new[pk].source == old[pk].source, f"host {host} rewrote clean pk {pk}"
+
+        # The follower had the stale version, so its record must have been replaced.
+        # Nothing is asserted about the master's own record: it holds the winning
+        # version, but it also merges and reflushes the partition it pulled a
+        # differing version for.
+        assert after[1][diverged].source != before[1][diverged].source, \
+            "the follower's stale record was not replaced"
+
+        await check_converged(cql, hosts, table,
+                              {pk: {'v': 'new' if pk == diverged else f'v{pk}'} for pk in keys})
+
+        # Everything is in sync again, so a second repair rewrites nothing. The
+        # records the repair just wrote are in the active segment, so they have to
+        # be flushed out of it again for a rewrite to be visible.
+        await flush_records_to_segments(manager, servers)
+        before = await read_all_records(cql, hosts, table)
+        await manager.api.repair(servers[0].ip_addr, ks, "test")
+        after = await read_all_records(cql, hosts, table)
+        for host, old, new in zip(hosts, before, after):
+            assert log_segments(new) == log_segments(old), f"host {host} rewrote records in a repair with nothing to do"
+
+
+@pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
+async def test_repair_overwrites_stale_cached_partition(manager: ScyllaClusterManager):
+    """Test that repair does not leave a node serving a stale cached partition.
+
+    Logstor answers reads from a cache keyed by primary index entry, and
+    overwriting a record evicts the cached mutation (primary_index::insert).
+    Repair applies through the same table write path, so the same eviction has to
+    happen there: otherwise a node whose partition was read (and thus cached)
+    before repair keeps serving the pre-repair value even though its record on
+    disk was replaced.
+
+    Node2 holds v=100 and has it cached, node1 holds the newer v=200. After
+    repair, node2's record and its cached copy must both be the new value.
+    """
+    servers, cql, hosts = await create_logstor_cluster(manager)
+
+    async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 2}") as ks:
+        await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, v int)"
+                            " WITH storage_engine = 'logstor' AND speculative_retry = 'NONE'")
+        table = f"{ks}.test"
+
+        await cql.run_async(f"INSERT INTO {table} (pk, v) VALUES (1, 100) USING TIMESTAMP 1000")
+
+        # Write the newer value on node1 only.
+        await write_only_on(manager, servers, cql, hosts, ks, "test", 0,
+                            [f"INSERT INTO {table} (pk, v) VALUES (1, 200) USING TIMESTAMP 2000"])
+
+        # Populate node2's logstor cache with its stale version. read_locally()
+        # checks the read really was answered by node2: served from node1 it
+        # would leave node2's cache empty and the test would prove nothing.
+        rows = await read_locally(cql, hosts[1], f"SELECT v FROM {table} WHERE pk = 1")
+        assert rows[0].v == 100
+        record = await read_record(cql, hosts[1], table, 1)
+        assert record is not None and record.cached is not None, \
+            f"the read did not populate the logstor cache: {record}"
+
+        await manager.api.repair(servers[0].ip_addr, ks, "test")
+
+        # check_converged() asserts that a cached copy, if the overwrite left one
+        # behind, agrees with the stored record.
+        records = await check_converged(cql, hosts, table, {1: {'v': '200'}})
+        assert records[1].cell_timestamps() == {'v': 2000}
+
+        # And node2 must serve the new value out of its own storage.
+        rows = await read_locally(cql, hosts[1], f"SELECT v FROM {table} WHERE pk = 1")
+        assert rows[0].v == 200, "node2 served a stale cached value after repair"
+
+
+#############################################################################
+# Read repair on logstor tables.
+#
+# Read repair is the coordinator-side reconciliation that runs when a digest read
+# detects that the replicas disagree: the coordinator reads the full data from all
+# the replicas, merges the versions, and writes back to each divergent replica
+# before returning the reconciled result to the client.
+#
+# For logstor tables the write-back must carry the full reconciled partition
+# rather than the usual cell-level diff, because a logstor write replaces the
+# replica's whole partition record. See the "Master-side whole-partition
+# convergence" section of docs/dev/row_level_repair.md for the same reasoning
+# applied to background repair.
+#
+# These tests trigger read repair with a CL=ALL read of divergent replicas and
+# then assert, with MUTATION_FRAGMENTS() reads of each node's storage, that the
+# replicas converged on the reconciled records.
+#############################################################################
+
+FOREGROUND_READ_REPAIRS = 'scylla_storage_proxy_coordinator_foreground_read_repairs'
+
+
+@pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
+async def test_read_repair_converges_divergent_replicas(manager: ScyllaClusterManager):
+    """Test that a reconciling read converges divergent logstor replicas.
+
+    Node2 misses three writes: a new partition, a newer value for an existing
+    partition, and a partition delete. A CL=ALL read of each partition detects
+    the digest mismatch and read-repairs it, so afterwards both nodes must store
+    the reconciled record.
+    """
+    servers, cql, hosts = await create_logstor_cluster(manager)
+
+    async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 2}") as ks:
+        await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, v text) WITH storage_engine = 'logstor'")
+        table = f"{ks}.test"
+
+        # No write is suppressed, so both replicas store pk 2 and pk 3.
+        await cql.run_async(SimpleStatement(f"INSERT INTO {table} (pk, v) VALUES (2, 'old') USING TIMESTAMP 1000", consistency_level=ConsistencyLevel.ALL))
+        await cql.run_async(SimpleStatement(f"INSERT INTO {table} (pk, v) VALUES (3, 'c') USING TIMESTAMP 1000", consistency_level=ConsistencyLevel.ALL))
+
+        await write_only_on(manager, servers, cql, hosts, ks, "test", 0, [
+            f"INSERT INTO {table} (pk, v) VALUES (1, 'a') USING TIMESTAMP 2000",
+            f"INSERT INTO {table} (pk, v) VALUES (2, 'new') USING TIMESTAMP 2000",
+            f"DELETE FROM {table} USING TIMESTAMP 2000 WHERE pk = 3"])
+
+        # The stored records still show the divergence the test set up.
+        await flush_records_to_segments(manager, servers)
+        before = await read_all_records(cql, hosts, table)
+        assert set(before[0]) == {1, 2, 3} and set(before[1]) == {2, 3}
+        assert before[0][2].cell_values() == {'v': 'new'}
+        assert before[1][2].cell_values() == {'v': 'old'}
+        assert before[0][3].tombstone_timestamp() is not None
+        assert before[1][3].tombstone_timestamp() is None
+
+        metrics_before = await manager.metrics.query(servers[0].ip_addr)
+
+        # Each read goes to both replicas, sees the mismatch and repairs it
+        # before returning the reconciled result.
+        rows = await cql.run_async(SimpleStatement(f"SELECT pk, v FROM {table} WHERE pk = 1", consistency_level=ConsistencyLevel.ALL), host=hosts[0])
+        assert [(row.pk, row.v) for row in rows] == [(1, 'a')]
+        rows = await cql.run_async(SimpleStatement(f"SELECT pk, v FROM {table} WHERE pk = 2", consistency_level=ConsistencyLevel.ALL), host=hosts[0])
+        assert [(row.pk, row.v) for row in rows] == [(2, 'new')]
+        rows = await cql.run_async(SimpleStatement(f"SELECT pk, v FROM {table} WHERE pk = 3", consistency_level=ConsistencyLevel.ALL), host=hosts[0])
+        assert rows == []
+
+        metrics_after = await manager.metrics.query(servers[0].ip_addr)
+        assert metric_delta(metrics_before, metrics_after, FOREGROUND_READ_REPAIRS) >= 3, \
+            "the reads did not go through foreground read repair"
+
+        records = await check_converged(cql, hosts, table,
+                                       {1: {'v': 'a'}, 2: {'v': 'new'}, 3: Deleted(2000)})
+        assert records[1].marker_timestamp == 2000
+        assert records[2].marker_timestamp == 2000
+
+        # For pk 1 and pk 2 the reconciled partition equals what node1 already
+        # stores, so read repair must not have written to node1 at all.
+        after_node1 = await read_records(cql, hosts[0], table)
+        for pk in (1, 2):
+            assert log_segments(after_node1)[pk] == log_segments(before[0])[pk], \
+                f"read repair rewrote node1's already-reconciled record for pk {pk}"
+
+
+@pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
+async def test_read_repair_same_timestamp_conflict(manager: ScyllaClusterManager):
+    """Test read repair of two values with the same timestamp on a logstor table.
+
+    Node1 has value 'a', node2 has value 'b', both at timestamp 1000. The
+    reconciled value is 'b' (largest value wins the cell tiebreaker at equal
+    timestamp), and the coordinator's diff for node1 is that cell alone -
+    without a row marker, since the markers tie. A logstor replica cannot apply
+    such a partial diff: its write path replaces the whole partition record and
+    rejects a mutation with no row marker and no partition tombstone. Read
+    repair therefore has to send the full reconciled partition, and this test
+    fails with a read error if it does not.
+    """
+    servers, cql, hosts = await create_logstor_cluster(manager)
+
+    async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 2}") as ks:
+        await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, v text) WITH storage_engine = 'logstor'")
+        table = f"{ks}.test"
+
+        await write_only_on(manager, servers, cql, hosts, ks, "test", 0,
+                            [f"INSERT INTO {table} (pk, v) VALUES (1, 'a') USING TIMESTAMP 1000"])
+        await write_only_on(manager, servers, cql, hosts, ks, "test", 1,
+                            [f"INSERT INTO {table} (pk, v) VALUES (1, 'b') USING TIMESTAMP 1000"])
+
+        await flush_records_to_segments(manager, servers)
+        before = await read_all_records(cql, hosts, table)
+        assert before[0][1].cell_values() == {'v': 'a'}
+        assert before[1][1].cell_values() == {'v': 'b'}
+
+        rows = await cql.run_async(SimpleStatement(f"SELECT pk, v FROM {table} WHERE pk = 1", consistency_level=ConsistencyLevel.ALL), host=hosts[0])
+        assert [(row.pk, row.v) for row in rows] == [(1, 'b')]
+
+        records = await check_converged(cql, hosts, table, {1: {'v': 'b'}})
+        assert records[1].marker_timestamp == 1000
+        assert records[1].partition_tombstone is None
+
+        # Node2 already stored the winning value, so read repair must have
+        # written only to node1, leaving node2's record where it was.
+        after_node2 = await read_records(cql, hosts[1], table)
+        assert log_segments(after_node2)[1] == log_segments(before[1])[1], \
+            "read repair rewrote node2's record although it already held the reconciled value"
+
+
+@pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
+async def test_read_repair_scan_leaves_partitions_beyond_the_page(manager: ScyllaClusterManager):
+    """Test that a scan does not read-repair a partition its page did not reach.
+
+    Every replica fills a scan page up to the row limit on its own, so a replica
+    that holds more live partitions than the others stops at a lower key. The
+    reconciliation still sees the partitions the other replicas reported past
+    that key, and the replica that stopped short reports no version for them -
+    which at the coordinator is indistinguishable from not holding them.
+
+    Sending such a replica the whole reconciled partition would replace a record
+    the reconciliation never saw. Here node1's page ends at `mid`, which only
+    node1 holds, so it reports nothing for `high` although its own record for
+    `high` carries the only copy of that partition's v2 cell.
+    """
+    servers, cql, hosts = await create_logstor_cluster(manager)
+
+    # A single tablet, so the whole ring is scanned as one range read whose row
+    # limit is shared by the three partitions.
+    async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 2} "
+                                          "AND tablets = {'initial': 1}") as ks:
+        low, mid, high = await token_order(cql, ks, [1, 2, 3])
+
+        await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, v1 text, v2 text) WITH storage_engine = 'logstor'")
+        table = f"{ks}.test"
+
+        # Both replicas store `low` and the first version of `high`.
+        await cql.run_async(SimpleStatement(f"INSERT INTO {table} (pk, v1, v2) VALUES ({low}, 'x', 'x2') USING TIMESTAMP 1000",
+                                            consistency_level=ConsistencyLevel.ALL))
+        await cql.run_async(SimpleStatement(f"INSERT INTO {table} (pk, v1, v2) VALUES ({high}, 'old', 'keep') USING TIMESTAMP 1000",
+                                            consistency_level=ConsistencyLevel.ALL))
+        # Only node2 gets the newer version of `high`. A logstor write replaces
+        # the whole record, so node2's copy has no v2 at all and node1's older
+        # record is the only place v2 is stored.
+        await write_only_on(manager, servers, cql, hosts, ks, "test", 1,
+                            [f"INSERT INTO {table} (pk, v1) VALUES ({high}, 'new') USING TIMESTAMP 2000"])
+        # Only node1 gets `mid`, so below `high` node1 has one live partition
+        # more than node2.
+        await write_only_on(manager, servers, cql, hosts, ks, "test", 0,
+                            [f"INSERT INTO {table} (pk, v1) VALUES ({mid}, 'm') USING TIMESTAMP 1000"])
+
+        await flush_records_to_segments(manager, servers)
+        before = await read_all_records(cql, hosts, table)
+        assert set(before[0]) == {low, mid, high} and set(before[1]) == {low, high}
+        assert before[0][high].cell_values() == {'v1': 'old', 'v2': 'keep'}
+        assert before[1][high].cell_values() == {'v1': 'new'}
+
+        metrics_before = await manager.metrics.query(servers[0].ip_addr)
+
+        # A page of two rows: node1 fills it with `low` and `mid` and stops
+        # before `high`, node2 fills it with `low` and `high`. The digests
+        # differ, so the page is read-repaired before it is returned.
+        statement = SimpleStatement(f"SELECT pk, v1, v2 FROM {table}", consistency_level=ConsistencyLevel.ALL, fetch_size=2)
+        page = await cql.run_async(statement, all_pages=False, host=hosts[0])
+        assert [row.pk for row in page] == [low, mid]
+
+        metrics_after = await manager.metrics.query(servers[0].ip_addr)
+        assert metric_delta(metrics_before, metrics_after, FOREGROUND_READ_REPAIRS) >= 1, \
+            "the page did not go through foreground read repair"
+
+        after = await read_all_records(cql, hosts, table)
+        # `mid` is the partition node2 really is missing, and repairing it is
+        # what the page is supposed to do.
+        assert after[1][mid].cell_values() == {'v1': 'm'}
+        # `high` is past node1's part of the page, so node1's record for it must
+        # be left alone: replacing it drops the only copy of v2.
+        assert after[0][high].cell_values() == {'v1': 'old', 'v2': 'keep'}, \
+            "read repair overwrote node1's record for a partition its page never reached"
+        assert log_segments(after[0])[high] == log_segments(before[0])[high], \
+            "read repair rewrote node1's record for a partition its page never reached"
+
+        # The rest of the scan does reach `high`, where both replicas report
+        # their version, and converges them on the merged record.
+        rows = await cql.run_async(statement, all_pages=True, host=hosts[0])
+        assert [(row.pk, row.v1, row.v2) for row in rows] == [(low, 'x', 'x2'), (mid, 'm', None), (high, 'new', 'keep')]
+
+        records = await check_converged(cql, hosts, table, {
+            low: {'v1': 'x', 'v2': 'x2'},
+            mid: {'v1': 'm'},
+            high: {'v1': 'new', 'v2': 'keep'},
+        })
+        assert records[high].marker_timestamp == 2000


### PR DESCRIPTION
Implement initial full tablet repair and read-repair for logstor tables by extending the existing row-level repair and read-repair, with no wire changes.

Logstor tables are key-value tables with no clustering columns. For each key we have a partition that has a single row (possibly with multiple cells) or a tombstone, and is stored as a single frozen mutation.
It supports only overwriting the partition by writing the full partition mutation. Unlike LSM tables, it doesn't support writing the "difference" for a row as a partial mutation that gets merged. Therefore the user (repair in this case) needs to reconcile and build the full partition mutation first and then apply it to the table.

The main repair flow for logstor and changes are therefore:
1. Read rows in a token range and calculate common sync boundary: we use the existing logstor range reader to read the rows. the sync boundary is forced to be on partition boundary, which is fine since partitions have at most a single row.
2. New step for logstor tables: when repair master receives all the mutation fragments, for each dirty partition, it merges all the fragments into a single mutation, and expands the merged mutation back into fragments that represent the merged row.
3. For each peer, for each row in the difference set, send all fragments of that partition.
4. A node applies the received rows by rebuilding the full partition mutation from the fragments and then applying it to the table.

We also extend the read-repair to work with logstor tables by sending the full reconciled partition mutation instead of the diff mutation.

known limitations:
* no incremental repair. we will consider this as a follow up optimization.
* no staging sstables and no view update generation from repair path. we will consider MV support including repair in a separate task.

Fixes https://scylladb.atlassian.net/browse/SCYLLADB-2722
Fixes https://scylladb.atlassian.net/browse/SCYLLADB-3493

no backport - new feature