### PR TITLE
mutation_partition: skip cell copy when incoming atomic cell loses merge

### DIFF
--- a/mutation/mutation_partition.cc
+++ b/mutation/mutation_partition.cc
@@ -1158,6 +1158,13 @@ apply_monotonically(const column_definition& def, cell_and_hash& dst,
 void
 row::apply(const column_definition& column, const atomic_cell_or_collection& value, cell_hash_opt hash,
         db::large_data_cache_tracker* tracker) {
+    if (column.is_atomic() && !column.is_counter()) {
+        const cell_and_hash* cah = find_cell_and_hash(column.id);
+        // avoid the copy when the incoming cell would just lose the merge
+        if (cah && compare_atomic_cell_for_merge(cah->cell.as_atomic_cell(column), value.as_atomic_cell(column)) >= 0) {
+            return;
+        }
+    }
     auto tmp = value.copy(*column.type);
     apply_monotonically(column, std::move(tmp), std::move(hash), tracker);
 }


### PR DESCRIPTION
## Motivation

Mutation read/write is CPU-heavy in ScyllaDB. In `row::apply(const column_definition&, const atomic_cell_or_collection&, ...)`, the incoming atomic cell was always copied into LSA before comparing it against the existing cell via `compare_atomic_cell_for_merge()` - even when the incoming cell turns out to lose the merge and the copy is immediately discarded. This is a large fraction of calls on read-modify-write / repair / streaming paths, which very often apply already-stale data.

## Change

For atomic (non-collection, non-counter) columns, peek at the existing cell and compare before copying; only copy when the incoming cell actually wins the merge (or the column is new). Removes one LSA allocation + memcpy per losing-cell merge.

## Tests

`mutation_test`, `mutation_query_test`, and the `memtable_test` suite (within `combined_tests`), all pass with 0 errors.

## Results

Independently reviewed by another model for correctness: verified the "loses merge" fast path is exactly the complement of the old copy-then-compare logic (same comparator, same argument order), confirmed counters/collections are correctly excluded and no side effects (large-data tracker, hash, stats) are skipped. No benchmark run - the CPU/allocation-count benefit is a mechanism-level hypothesis, not a measured number.

Fixes https://scylladb.atlassian.net/browse/SCYLLADB-3780

backport: no, improvement

Signed-off-by: Yaniv Kaul <yaniv.kaul@scylladb.com>