### PR TITLE
mutation: avoid partition clone in mutation_partition::apply(schema&&, mutation_partition&&, schema&, stats&)

### DIFF
--- a/mutation/mutation_partition.cc
+++ b/mutation/mutation_partition.cc
@@ -374,6 +374,18 @@ stop_iteration mutation_partition::apply_monotonically(const schema& s, mutation
     return stop_iteration::yes;
 }
 
+void mutation_partition::finish_apply(const schema& s, mutation_partition&& p, mutation_application_stats& app_stats) {
+    apply_resume res;
+    apply_monotonically(s, std::move(p), no_cache_tracker, app_stats, is_preemptible::no, res);
+}
+
+void mutation_partition::do_apply(const schema& s, mutation_partition&& p, const schema& p_schema, mutation_application_stats& app_stats) {
+    if (s.version() != p_schema.version()) {
+        p.upgrade(p_schema, s);
+    }
+    finish_apply(s, std::move(p), app_stats);
+}
+
 void
 mutation_partition::apply(const schema& s, mutation_partition_view p,
         const schema& p_schema, mutation_application_stats& app_stats) {
@@ -381,27 +393,22 @@ mutation_partition::apply(const schema& s, mutation_partition_view p,
     mutation_partition p2(*this, copy_comparators_only{});
     partition_builder b(p_schema, p2);
     p.accept(p_schema, b);
-    if (s.version() != p_schema.version()) {
-        p2.upgrade(p_schema, s);
-    }
-    apply_resume res;
-    apply_monotonically(s, std::move(p2), no_cache_tracker, app_stats, is_preemptible::no, res);
+    do_apply(s, std::move(p2), p_schema, app_stats);
 }
 
 void mutation_partition::apply(const schema& s, const mutation_partition& p,
         const schema& p_schema, mutation_application_stats& app_stats) {
     // FIXME: Optimize
     mutation_partition p2(p_schema, p);
-    if (s.version() != p_schema.version()) {
-        p2.upgrade(p_schema, s);
-    }
-    apply_resume res;
-    apply_monotonically(s, std::move(p2), no_cache_tracker, app_stats, is_preemptible::no, res);
+    do_apply(s, std::move(p2), p_schema, app_stats);
 }
 
 void mutation_partition::apply(const schema& s, mutation_partition&& p, mutation_application_stats& app_stats) {
-    apply_resume res;
-    apply_monotonically(s, std::move(p), no_cache_tracker, app_stats, is_preemptible::no, res);
+    finish_apply(s, std::move(p), app_stats);
+}
+
+void mutation_partition::apply(const schema& s, mutation_partition&& p, const schema& p_schema, mutation_application_stats& app_stats) {
+    do_apply(s, std::move(p), p_schema, app_stats);
 }
 
 tombstone

--- a/mutation/mutation_partition.hh
+++ b/mutation/mutation_partition.hh
@@ -1350,6 +1350,8 @@ public:
     // Use in case this instance and p share the same schema.
     // Same guarantees and constraints as for other variants of apply().
     void apply(const schema& s, mutation_partition&& p, mutation_application_stats& app_stats);
+    // Like the const& overload above, but avoids cloning p: p is moved-from and upgraded in place if schemas differ.
+    void apply(const schema& this_schema, mutation_partition&& p, const schema& p_schema, mutation_application_stats& app_stats);
 
     // Applies p to this instance.
     //
@@ -1384,6 +1386,11 @@ public:
     // Strong exception guarantees.
     void upgrade(const schema& old_schema, const schema& new_schema);
 private:
+    // Common tail of the apply() overloads: applies p (already governed by this_schema) via
+    // apply_monotonically(is_preemptible::no), discarding the (irrelevant in that mode) apply_resume.
+    void finish_apply(const schema& this_schema, mutation_partition&& p, mutation_application_stats& app_stats);
+    // Upgrades p to this_schema if p_schema differs, then finish_apply()'s it.
+    void do_apply(const schema& this_schema, mutation_partition&& p, const schema& p_schema, mutation_application_stats& app_stats);
     void insert_row(const schema& s, const clustering_key& key, deletable_row&& row);
     void insert_row(const schema& s, const clustering_key& key, const deletable_row& row);
 


### PR DESCRIPTION
## Motivation

Mutation read/write is CPU-heavy in ScyllaDB. This is part of a series trying to improve it. Probably only slightly.

`mutation::apply(mutation&& m)` calls `partition().apply(*schema(), std::move(m.partition()), *m.schema(), app_stats)` - a 4-arg call with an rvalue partition. 
Before this change, the only 4-arg overload of `mutation_partition::apply()` took `const mutation_partition&`, so the call always bound to the copying overload regardless of the `std::move` - cloning the whole partition even on this supposedly-efficient move path.

## Change

- Added a new `mutation_partition::apply(const schema&, mutation_partition&&, const schema&, stats&)` overload that upgrades the moved-from partition in place (`p.upgrade(p_schema, s)`, only when schema versions differ) instead of cloning it.
This overload is preferred by C++ overload resolution for the existing call in `mutation::apply(mutation&&)`, so no call-site changes were needed - the fix takes effect automatically.
- Collapsed some redundant code into shared functions.

## Tests

`mutation_test`, `mutation_query_test`, and the `memtable_test` suite (within `combined_tests`), all pass with 0 errors.

## Results

Independently reviewed by another model for correctness: verified the overload-resolution claim by checking every 4-arg `apply()` call site (only this one passes an rvalue), audited every caller of `mutation::apply(mutation&&)` to confirm none reuses the moved-from partition afterward, and confirmed `mutation_partition::upgrade()`'s exception safety (move-assign from a temporary leaves the target unchanged on throw) preserves the existing weak exception guarantee.

**Benchmarked** using #31132's `perf_mutation --merge-mode` (merges two same-schema mutations via `mutation::apply(mutation&&)` - the path this fixes; other write paths bind `memtable::apply(const mutation&)` and never hit it).
Release build, `--smp 1`, pinned core, both arms sharing an identical base commit differing only by this PR's diff:

| cells (rows × cols) | baseline insns/op | with this PR | Δ |
|---|---|---|---|
| 16 (4×4) | 44,032.1 | 39,837.1 | **−9.53%** |
| 64 (8×8) | 201,240.1 | 189,097.1 | **−6.04%** |
| 256 (16×16) | 1,069,325.5 | 1,028,126.5 | **−3.85%** |
| 512 (32×16) | 2,484,464.7 | 2,401,775.3 | **−3.33%** |
| 1000 (100×10) | 5,971,621.9 | 5,776,072.4 | **−3.27%** |

`insns/op` was exactly reproducible run-to-run at every shape.
The absolute instruction savings grow with partition size (the percentage shrinks only because the harness's own per-op cost grows faster than linearly) - consistent with eliminating an O(partition-size) clone, confirming the mechanism claimed above.

Fixes https://scylladb.atlassian.net/browse/SCYLLADB-3781

backport: no, improvement

Signed-off-by: Yaniv Kaul <yaniv.kaul@scylladb.com>
