### PR TITLE
config: default sstable_format to `mt` with Trie indexes

### DIFF
--- a/db/config.cc
+++ b/db/config.cc
@@ -1001,7 +1001,7 @@ db::config::config(std::shared_ptr<db::extensions> exts)
     /**
     * @Group Cache and index settings
     */
-    , column_index_size_in_kb(this, "column_index_size_in_kb", value_status::Used, 64,
+    , column_index_size_in_kb(this, "column_index_size_in_kb", value_status::Used, 1,
         "Granularity of the index of rows within a partition. For huge rows, decrease this setting to improve seek time. If you use key cache, be careful not to make this setting too large because key cache will be overwhelmed. If you're unsure of the size of the rows, it's best to use the default setting.")
     , column_index_auto_scale_threshold_in_kb(this, "column_index_auto_scale_threshold_in_kb", liveness::LiveUpdate, value_status::Used, 10240,
         "Auto-reduce the promoted index granularity by half when reaching this threshold, to prevent promoted index bloating due to partitions with too many rows. Set to 0 to disable this feature.")
@@ -1488,7 +1488,7 @@ db::config::config(std::shared_ptr<db::extensions> exts)
     , view_building(this, "view_building", value_status::Used, true, "Enable view building; should only be set to false when the node is experience issues due to view building.")
     , enable_sstables_mc_format(this, "enable_sstables_mc_format", value_status::Unused, true, "Enable SSTables 'mc' format to be used as the default file format.  Deprecated, please use \"sstable_format\" instead.")
     , enable_sstables_md_format(this, "enable_sstables_md_format", value_status::Unused, true, "Enable SSTables 'md' format to be used as the default file format.  Deprecated, please use \"sstable_format\" instead.")
-    , sstable_format(this, "sstable_format", liveness::LiveUpdate, value_status::Used, "me", "Default sstable file format", {"md", "me", "ms", "mt"})
+    , sstable_format(this, "sstable_format", liveness::LiveUpdate, value_status::Used, "mt", "Default sstable file format", {"md", "me", "ms", "mt"})
     , sstable_compression_user_table_options(this, "sstable_compression_user_table_options", value_status::Used, compression_parameters{compression_parameters::algorithm::lz4_with_dicts},
         "Server-global user table compression options. If enabled, all user tables"
         "will be compressed using the provided options, unless overridden"

--- a/test/boost/file_stream_test.cc
+++ b/test/boost/file_stream_test.cc
@@ -198,6 +198,20 @@ static std::function<future<>(shared_sstable)> corrupt_component_fn(component_ty
     };
 }
 
+// The component holding the sstable's index. Formats with a summary keep it in
+// Index.db, the trie-index formats (ms, mt) keep it in Partitions.db.
+static component_type index_component_of(const shared_sstable& sst) {
+    return sstables::has_summary_and_index(sst->get_version()) ? component_type::Index : component_type::Partitions;
+}
+
+static std::function<future<>(shared_sstable)> corrupt_index_component_fn() {
+    return [](shared_sstable sst) {
+        return seastar::async([sst] {
+            slightly_corrupt_sstable(sst, index_component_of(sst));
+        });
+    };
+}
+
 using compress_sstable = bool_class<struct compress_sstable_tag>;
 static future<>
 do_test_sstable_stream(cql_test_env& env, compress_sstable compress, std::function<future<>(shared_sstable)> corruption_fn = nullptr, const sstring& expected_error_msg = "", sstring storage_clause = "") {
@@ -575,7 +589,7 @@ SEASTAR_THREAD_TEST_CASE(test_sstable_stream_digest_mismatched_uncompressed) {
 }
 
 SEASTAR_THREAD_TEST_CASE(test_sstable_stream_index_digest_mismatched) {
-    test_sstable_stream(compress_sstable::no, corrupt_component_fn(component_type::Index), "digest mismatch");
+    test_sstable_stream(compress_sstable::no, corrupt_index_component_fn(), "digest mismatch");
 }
 
 SEASTAR_THREAD_TEST_CASE(test_sstable_stream_scylla_digest_mismatched) {
@@ -882,6 +896,12 @@ do_test_sstable_stream_receiver_corruption(cql_test_env& env, std::optional<comp
 
             auto sst_snapshot = sstables.front();
             auto sources = co_await sstables::create_stream_sources(sst_snapshot, permit);
+
+            // The index lives in a different component depending on the sstable
+            // format, so resolve it now that we have the sstable at hand.
+            if (corrupted_component == component_type::Index) {
+                corrupted_component = index_component_of(sst_snapshot.sst);
+            }
 
             for (auto& source : sources) {
                 auto& info = files.emplace_back();


### PR DESCRIPTION
In 949fc85217f099a ("db/config: enable `ms` sstable format by default", 2026.2) we changed the default sstable format for new clusters to `ms`, with Trie indexes as the new feature. Later we changed it to `mt` to correct a serialization bug.

Now that many clusters in production use `mt`, we make it the default format for both new clusters and upgrades, by marking it as the default in db/config.cc. We make column_index_size_in_kb have the default 1 for both new and upgraded clusters, compared to just new clusters previously.

A test that purposefully corrupts an sstable is adjusted, since corrupting the Index.db component does not work on mt format sstables; instead we corrupt the Partitions.db component.

Enabling a new feature, so certainly not backporting. `mt` will continue to mature on 2026.[123].