### PR TITLE
build: disable LTTng

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -115,6 +115,7 @@ else()
     set(Seastar_SCHEDULING_GROUPS_COUNT 24 CACHE STRING "" FORCE)
     set(Seastar_UNUSED_RESULT_ERROR ON CACHE BOOL "" FORCE)
     set(Seastar_OPENSSL OFF CACHE BOOL "" FORCE)
+    set(Seastar_LTTNG OFF CACHE BOOL "" FORCE)
     # Match configure.py's build_seastar_shared_libs: Debug and Dev
     # build Seastar as a shared library, others build it static.
     if(CMAKE_BUILD_TYPE STREQUAL "Debug" OR CMAKE_BUILD_TYPE STREQUAL "Dev")

--- a/configure.py
+++ b/configure.py
@@ -2221,6 +2221,7 @@ def configure_seastar(build_dir, mode, mode_config, compiler_cache=None):
         '-DSeastar_SCHEDULING_GROUPS_COUNT=24',
         '-DSeastar_IO_URING=ON',
         '-DSeastar_OPENSSL=OFF',
+        '-DSeastar_LTTNG=OFF', # https://scylladb.atlassian.net/browse/SCYLLADB-3797, https://bugs.lttng.org/issues/1438
     ]
 
     if compiler_cache:

--- a/scripts/compare_build_systems.py
+++ b/scripts/compare_build_systems.py
@@ -131,7 +131,6 @@ _KNOWN_LIB_ASYMMETRIES = {
     "protobuf": "conf",
     "jsoncpp": "conf",
     "fmt": "conf",
-    "lttng-ust": "conf",
     # CMake resolves these transitively through Boost imported targets
     "boost_atomic": "cmake",
     # CMake links ssl explicitly for encryption targets


### PR DESCRIPTION
LTTng-ust, had a bug [1] that causes large memory allocations with raised RLIMIT_NOFILE (as we do). This not only consumes a lot of memory, it also interacts badly with our pre-start memory allocation.

The bug was fixed, but in version 2.16, while we have 2.14 in the frozen toolchain.

Disable LTTng until we receive the bug fix.

[1] https://bugs.lttng.org/issues/1438

Fixes https://scylladb.atlassian.net/browse/SCYLLADB-3797

lttng is not in any release branch, so not backporting.