### PR TITLE
replica: share sstable references in intra-node tablet migration

### DIFF
--- a/replica/table.cc
+++ b/replica/table.cc
@@ -1663,8 +1663,9 @@ table::clone_tablet_storage(locator::tablet_id tid, bool leave_unsealed) {
     // otherwise components of sstables in the set might be unlinked from the filesystem
     // by compaction while we are waiting for the lock.
     auto deletion_guard = co_await get_sstable_list_permit();
+    const bool may_use_reference_sharing = _sstables_manager.get_features().sstable_reference_sharing;
     co_await sg.make_sstable_set()->for_each_sstable_gently([&] (const sstables::shared_sstable& sst) -> future<> {
-        ret.push_back(co_await sst->clone(calculate_generation_for_new_table(), leave_unsealed));
+        ret.push_back(co_await sst->clone(calculate_generation_for_new_table(), leave_unsealed, may_use_reference_sharing));
     });
     co_return ret;
 }

--- a/sstables/sstables_manager.hh
+++ b/sstables/sstables_manager.hh
@@ -253,6 +253,7 @@ public:
     virtual sstable_writer_config configure_writer(sstring origin) const;
     const config& get_config() const noexcept { return _config; }
     cache_tracker& get_cache_tracker() { return _cache_tracker; }
+    const gms::feature_service& get_features() const noexcept { return _features; }
     const std::vector<sstables::file_io_extension*>& file_io_extensions() const { return _file_io_extensions; }
 
     // Get the highest supported sstable version, according to cluster features.


### PR DESCRIPTION
### Problem

For object-storage-backed (S3/GCS) tables, intra-node tablet migration clones the tablet's sstables with a real server-side `copy_object` per component. `replica::table::clone_tablet_storage()` calls `sstable::clone()` with two arguments, so the `may_use_reference_sharing` hint takes its default of `false` and the zero-copy path is never requested — even though the source and the destination are the same node reading the same bucket. The call site dates back to 715ae689c0 ("Implement fast streaming for intra-node migration", 2024), roughly two years before reference sharing existed, and it was not revisited when 77b955ce7c added the mechanism for the cross-node path.

### Changes

`sstables_manager` exposes its `gms::feature_service` through a `get_features()` accessor, matching the accessor `data_dictionary::database` already provides for the same type. `replica::table` holds an `sstables_manager&` and has no other route to the feature service.

`table::clone_tablet_storage()` passes `may_use_reference_sharing` to `sstable::clone()`, gated on the `SSTABLE_REFERENCE_SHARING` cluster feature — the same gate the cross-node path applies in `streaming/stream_blob.cc`. With the feature enabled, `object_storage_base::clone()` writes one small reference marker object instead of copying every component of every sstable of the migrated tablet, so the clone cost becomes O(1) per sstable instead of proportional to sstable size and component count. `filesystem_storage::clone()` ignores the hint, so tables on local storage are unaffected.


Fixes: https://scylladb.atlassian.net/browse/SCYLLADB-3803

No backport needed: this is an optimization, not a bug fix — the existing code is correct, only more expensive than it needs to be. 