### PR TITLE
repair: abort user repairs that block topology barriers

### DIFF
--- a/repair/repair.cc
+++ b/repair/repair.cc
@@ -660,6 +660,31 @@ void repair::task_manager_module::abort_all_repairs() {
     rlogger.info0("Started to abort repair jobs={}, nr_jobs={}", _pending_repairs, _pending_repairs.size());
 }
 
+void repair::task_manager_module::abort_repairs_pinning_stale_versions(locator::token_metadata::version_t current_version) {
+    for (auto& [id, task_id] : _repairs) {
+        auto it = get_local_tasks().find(task_id);
+        if (it == get_local_tasks().end()) {
+            continue;
+        }
+        auto* impl = dynamic_cast<repair::shard_repair_task_impl*>(it->second->_impl.get());
+        if (!impl) {
+            // Cannot happen: _repairs is populated only by shard_repair_task_impl::run().
+            // This runs from a timer callback, so log instead of throwing.
+            on_internal_error_noexcept(rlogger, format("repair task {} in _repairs is not a shard_repair_task_impl", task_id));
+            continue;
+        }
+        if (impl->reason() != streaming::stream_reason::repair) {
+            continue;
+        }
+        auto pinned_version = impl->pinned_token_metadata_version();
+        if (pinned_version && *pinned_version < current_version) {
+            rlogger.warn("repair[{}]: Aborting repair job because it pins stale token metadata version {} which blocks a topology barrier for version {}, keyspace={}, tables={}",
+                    impl->global_repair_id.uuid(), *pinned_version, current_version, impl->get_keyspace(), impl->table_names());
+            it->second->abort();
+        }
+    }
+}
+
 float repair::task_manager_module::report_progress() {
     uint64_t nr_ranges_finished = 0;
     uint64_t nr_ranges_total = 0;

--- a/repair/task_manager_module.hh
+++ b/repair/task_manager_module.hh
@@ -235,6 +235,16 @@ public:
 
     locator::effective_replication_map_ptr get_erm();
 
+    // Returns the token metadata version pinned by this repair's
+    // effective_replication_map, or nullopt if it no longer holds one.
+    std::optional<locator::token_metadata::version_t> pinned_token_metadata_version() const noexcept {
+        return erm ? std::optional(erm->get_token_metadata().get_version()) : std::nullopt;
+    }
+
+    size_t get_total_rf() {
+        return get_erm()->get_replication_factor();
+    }
+
     future<> repair_range(const dht::token_range& range, table_info table);
 
     size_t ranges_size() const noexcept;
@@ -291,6 +301,11 @@ public:
     std::vector<int> get_active() const;
     size_t nr_running_repair_jobs();
     void abort_all_repairs();
+    // Aborts user-requested repair jobs whose effective_replication_map pins
+    // a token metadata version older than current_version. Such repairs block
+    // topology barriers (raft_topology_cmd::barrier_and_drain) for their whole
+    // duration, which is unbounded.
+    void abort_repairs_pinning_stale_versions(locator::token_metadata::version_t current_version);
     named_semaphore& range_parallelism_semaphore();
     future<> run(repair_uniq_id id, std::function<void ()> func);
     future<repair_status> repair_await_completion(int id, std::chrono::steady_clock::time_point timeout);

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -4816,6 +4816,53 @@ future<> storage_service::snitch_reconfigured() {
     }
 }
 
+// Decides whether a topology barrier should evict (abort) user repairs
+// which pin stale token metadata versions and thus block the barrier.
+//
+// Evict only when the barrier is part of a node operation (bootstrap,
+// decommission, removenode, replace, cleanup, rollback) or another
+// coordinator-driven transition. The tablet load balancer runs the same
+// barrier continuously (every migration stage bumps the topology version
+// and drains stale versions), so evicting there would keep killing vnode
+// repairs whenever tablets are being balanced, e.g. for the whole duration
+// of a vnodes-to-tablets migration. A balancing-only barrier instead waits
+// for the repair to finish, as before.
+//
+// A pending per-node request counts as a node operation: with parallel
+// tablet draining, decommission and removenode drain tablets through
+// ordinary migration rounds (transition_state::tablet_migration) while the
+// request is still pending, and those drain barriers must evict the repair
+// for the operation to make progress.
+static bool should_abort_repair(const topology& topo) {
+    if (!topo.requests.empty() || !topo.transition_nodes.empty()) {
+        return true;
+    }
+    if (!topo.tstate) {
+        return false;
+    }
+    switch (*topo.tstate) {
+    // Tablet-balancing-only transitions: wait for the repair instead of
+    // aborting it.
+    case topology::transition_state::tablet_migration:
+    case topology::transition_state::tablet_resize_finalization:
+    case topology::transition_state::tablet_split_finalization:
+        return false;
+    // Coordinator-driven transitions: abort user repairs blocking the
+    // barrier.
+    case topology::transition_state::join_group0:
+    case topology::transition_state::commit_cdc_generation:
+    case topology::transition_state::tablet_draining:
+    case topology::transition_state::write_both_read_old:
+    case topology::transition_state::write_both_read_new:
+    case topology::transition_state::left_token_ring:
+    case topology::transition_state::rollback_to_normal:
+    case topology::transition_state::truncate_table:
+    case topology::transition_state::lock:
+    case topology::transition_state::snapshot_tables:
+        return true;
+    }
+}
+
 future<> storage_service::local_topology_barrier() {
     if (this_shard_id() != 0) {
         co_await container().invoke_on(0, [] (storage_service& ss) {
@@ -4843,7 +4890,11 @@ future<> storage_service::local_topology_barrier() {
         }
     }
 
-    co_await container().invoke_on_all([version] (storage_service& ss) -> future<> {
+    // The topology state used by should_abort_repair() is up to date because
+    // raft_topology_cmd_handler runs a group0 read barrier first.
+    const bool evict_blocking_repairs = should_abort_repair(_topology_state_machine._topology);
+
+    co_await container().invoke_on_all([version, evict_blocking_repairs] (storage_service& ss) -> future<> {
         const auto current_version = ss._shared_token_metadata.get()->get_version();
         rtlogger.info("Got raft_topology_cmd::barrier_and_drain, version {}, "
                       "current version {}, stale versions (version: use_count): {}",
@@ -4866,10 +4917,26 @@ future<> storage_service::local_topology_barrier() {
 
         rtlogger.info("raft_topology_cmd::barrier_and_drain version {}: waiting for stale token metadata versions to be released", version);
         {
-            seastar::timer<lowres_clock> warn_timer([&ss, version] {
+            // A user-requested repair on a vnode keyspace holds its
+            // effective_replication_map, and thus pins a stale token metadata
+            // version, for the entire duration of the repair, which is
+            // unbounded. Abort such repairs instead of stalling the topology
+            // operation behind them; the operator can re-run the repair once
+            // the topology change completes. The abort is retried from the
+            // periodic timer to catch repairs which acquired their
+            // effective_replication_map before the barrier but registered
+            // their per-shard tasks only after the initial call.
+            auto abort_stale_repairs = [&ss, current_version, evict_blocking_repairs] {
+                if (evict_blocking_repairs && ss._repair.local_is_initialized()) {
+                    ss._repair.local().get_repair_module().abort_repairs_pinning_stale_versions(current_version);
+                }
+            };
+            abort_stale_repairs();
+            seastar::timer<lowres_clock> warn_timer([&ss, version, abort_stale_repairs] {
                 rtlogger.warn("raft_topology_cmd::barrier_and_drain version {}: still waiting for stale versions, "
                               "stale versions (version: use_count): {}",
                               version, ss._shared_token_metadata.describe_stale_versions());
+                abort_stale_repairs();
             });
             warn_timer.arm_periodic(std::chrono::minutes(5));
             co_await ss._shared_token_metadata.stale_versions_in_use();

--- a/test/cluster/test_repair.py
+++ b/test/cluster/test_repair.py
@@ -18,6 +18,7 @@ from cassandra.query import SimpleStatement
 from test.pylib.internal_types import ServerInfo
 from test.pylib.scylla_cluster_manager import ScyllaClusterManager
 from test.pylib.rest_client import HTTPError
+from test.pylib.tablets import get_tablet_replica
 from test.pylib.util import wait_for_cql_and_get_hosts
 from test.cluster.util import new_test_keyspace
 
@@ -726,3 +727,130 @@ async def test_data_resurrection_from_repair_range_spanning_replica_sets(manager
         rows = list(cql.execute(SimpleStatement(f"SELECT * FROM {table} WHERE pk = {pk}",
                                                 consistency_level=ConsistencyLevel.ALL)))
         assert rows == [], f"deleted row was resurrected: {rows}"
+
+
+@pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
+async def test_topology_barrier_aborts_vnode_repair_pinning_stale_versions(manager: ManagerClient):
+    """Verify that a topology barrier is not blocked behind a long-running
+    user-requested vnode repair.
+
+    Such a repair holds its effective_replication_map, and thus pins a stale
+    token metadata version, for its entire duration. The topology barrier
+    (raft_topology_cmd::barrier_and_drain) waits for stale versions to be
+    released, so before the fix a topology operation like decommission would
+    stall until the repair finished, potentially for hours.
+
+    The test pauses a repair mid-ranges with an error injection so it keeps
+    holding the effective_replication_map, then decommissions another node.
+    The barrier must abort the repair instead of waiting for it: the repair
+    ends up FAILED and the decommission completes.
+    Reproduces https://scylladb.atlassian.net/browse/SCYLLADB-93
+    """
+    injection = "repair_shard_repair_task_impl_do_repair_ranges"
+    servers = await manager.servers_add(3, auto_rack_dc="dc1")
+
+    cql = manager.get_cql()
+
+    cql.execute("CREATE KEYSPACE ks WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 2} AND TABLETS = {'enabled': false}")
+    cql.execute("CREATE TABLE ks.tbl (pk int PRIMARY KEY)")
+    for i in range(100):
+        cql.execute(f"INSERT INTO ks.tbl (pk) VALUES ({i})")
+
+    log = await manager.server_open_log(servers[0].server_id)
+    mark = await log.mark()
+
+    # Pause the repair once more than half of its ranges are done, while it
+    # still holds the effective_replication_map.
+    await manager.api.enable_injection(servers[0].ip_addr, injection, one_shot=True)
+    sequence_number = await manager.api.client.post_json("/storage_service/repair_async/ks",
+                                                         host=servers[0].ip_addr,
+                                                         params={"columnFamilies": "tbl"})
+    await log.wait_for(f"{injection}: waiting for message", from_mark=mark)
+
+    # The decommission's topology barrier must find the pinned stale version
+    # and abort the repair rather than wait for it.
+    decommission = asyncio.create_task(manager.decommission_node(servers[2].server_id))
+    await log.wait_for("Aborting repair job because it pins stale token metadata version", from_mark=mark)
+
+    # Let the paused repair resume; it observes the abort at the next range
+    # boundary and releases the effective_replication_map, unblocking the
+    # barrier.
+    await manager.api.message_injection(servers[0].ip_addr, injection)
+    await manager.api.disable_injection(servers[0].ip_addr, injection)
+
+    await decommission
+
+    status = await manager.api.client.get_json("/storage_service/repair_status",
+                                               host=servers[0].ip_addr,
+                                               params={"id": str(sequence_number)})
+    assert status == "FAILED"
+
+
+@pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
+async def test_tablet_migration_barrier_does_not_abort_vnode_repair(manager: ManagerClient):
+    """Verify that a tablet migration barrier does not abort a running
+    user-requested vnode repair.
+
+    Tablet load balancing runs the same barrier_and_drain as node operations,
+    and every migration stage bumps the topology version, so a running vnode
+    repair always pins a stale version from the barrier's point of view. Only
+    node operations may evict the repair; a balancing-only barrier must wait
+    for it instead. Otherwise continuous balancing, e.g. during a
+    vnodes-to-tablets migration, would keep killing vnode repairs until the
+    operator disables balancing via the API.
+
+    The test pauses a vnode repair mid-ranges so it keeps holding its
+    effective_replication_map, starts a tablet migration, waits until the
+    migration's barrier is waiting for the pinned stale version, then resumes
+    the repair. The repair must complete successfully, without being aborted,
+    and the migration must finish after it.
+    """
+    injection = "repair_shard_repair_task_impl_do_repair_ranges"
+    servers = await manager.servers_add(2, auto_rack_dc="dc1")
+    await manager.disable_tablet_balancing()
+
+    cql = manager.get_cql()
+
+    cql.execute("CREATE KEYSPACE ks WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 2} AND TABLETS = {'enabled': false}")
+    cql.execute("CREATE TABLE ks.tbl (pk int PRIMARY KEY)")
+    for i in range(100):
+        cql.execute(f"INSERT INTO ks.tbl (pk) VALUES ({i})")
+
+    cql.execute("CREATE KEYSPACE tablet_ks WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND TABLETS = {'initial': 1}")
+    cql.execute("CREATE TABLE tablet_ks.tbl (pk int PRIMARY KEY)")
+    cql.execute("INSERT INTO tablet_ks.tbl (pk) VALUES (0)")
+
+    tablet_token = 0  # Doesn't matter since there is one tablet
+    replica = await get_tablet_replica(manager, servers[0], "tablet_ks", "tbl", tablet_token)
+    host_ids = [await manager.get_host_id(s.server_id) for s in servers]
+    dst_host = host_ids[1] if replica[0] == host_ids[0] else host_ids[0]
+
+    log = await manager.server_open_log(servers[0].server_id)
+    mark = await log.mark()
+
+    # Pause the repair once more than half of its ranges are done, while it
+    # still holds the effective_replication_map.
+    await manager.api.enable_injection(servers[0].ip_addr, injection, one_shot=True)
+    sequence_number = await manager.api.client.post_json("/storage_service/repair_async/ks",
+                                                         host=servers[0].ip_addr,
+                                                         params={"columnFamilies": "tbl"})
+    await log.wait_for(f"{injection}: waiting for message", from_mark=mark)
+
+    # Start a tablet migration. Its barrier waits behind the token metadata
+    # version pinned by the paused repair, but must not abort the repair.
+    migration = asyncio.create_task(
+        manager.api.move_tablet(servers[0].ip_addr, "tablet_ks", "tbl",
+                                replica[0], replica[1], dst_host, 0, tablet_token))
+    await log.wait_for("waiting for stale token metadata versions to be released", from_mark=mark)
+
+    # Resume the repair; it releases the effective_replication_map when it
+    # completes, which unblocks the migration's barrier.
+    await manager.api.message_injection(servers[0].ip_addr, injection)
+    await manager.api.disable_injection(servers[0].ip_addr, injection)
+
+    await migration
+
+    status = await manager.api.client.get_json("/storage_service/repair_status",
+                                               host=servers[0].ip_addr,
+                                               params={"id": str(sequence_number)})
+    assert status == "SUCCESSFUL"


### PR DESCRIPTION
A user-requested repair on a vnode keyspace holds its effective_replication_map for the entire duration of the repair, which pins the token metadata version that was current when the repair started. When a topology operation (e.g. decommission) runs raft_topology_cmd::barrier_and_drain, the barrier waits for all stale token metadata versions to be released, so it stalls behind the repair for the repair's remaining duration, which is unbounded. Multi-hour stalls were observed in longevity runs, and the only way to unblock the topology operation was to restart the node running the repair.

The preemption mechanism for this hazard already exists: repair checks a topology guard between ranges, and the topology coordinator invalidates guards when it needs to make progress. Tablet repair uses it correctly, but user-requested vnode repair is constructed with default_session_id, whose session is never closed, so the per-range check never fires.

Reusing the session mechanism for user repair is not straightforward: sessions are coordinator-owned and closed on every token metadata change (storage_service::prepare_token_metadata_change), so a repair-local session would abort the repair on any topology or tablet transition, not just those that need the repair gone.

Instead, make the barrier evict the blocking repairs directly: when barrier_and_drain starts waiting for stale versions, abort user-requested repair tasks whose effective_replication_map pins a version older than the barrier's version. The abort is retried from the existing 5-minute warning timer to catch repairs which acquired their effective_replication_map before the barrier but registered their per-shard tasks only afterwards (e.g. while flushing hints).

With this, a user repair is aborted exactly when it actually blocks a topology barrier, and only then. The repair fails with an abort error and can be re-run by the operator once the topology change completes.

Fixes: SCYLLADB-93

Backport to all active releases. 