### PR TITLE
replica: give split-ready compaction groups their post-split token ranges

### DIFF
--- a/replica/compaction_group.hh
+++ b/replica/compaction_group.hh
@@ -147,6 +147,9 @@ public:
 
     // Create a group with same metadata of base like range, id, but with empty data (sstable & memtable).
     static lw_shared_ptr<compaction_group> make_empty_group(const compaction_group& base);
+    // Like make_empty_group(), but with a token range of its own, for a group which
+    // will only ever hold part of base's range.
+    static lw_shared_ptr<compaction_group> make_empty_group(const compaction_group& base, dht::token_range token_range);
 
     void update_id(size_t id) {
         _group_id = id;
@@ -342,6 +345,16 @@ public:
 
 using compaction_group_ptr = lw_shared_ptr<compaction_group>;
 using const_compaction_group_ptr = lw_shared_ptr<const compaction_group>;
+
+// The two ranges `range` will be split into, or nullopt if it cannot be split:
+// either an end of it is unbounded, so there is nothing to take a midpoint between,
+// or it holds fewer than two tokens, so one side would come out empty.
+//
+// The split point is derived from the range's own bounds the same way
+// locator::tablet_map::get_split_token() derives it, so that these sub-ranges agree
+// with the sides tablet_map::get_tablet_range_side() routes writes to, and with the
+// ranges handle_tablet_split_completion() installs once the split completes.
+std::optional<std::pair<dht::token_range, dht::token_range>> split_token_range(const dht::token_range& range);
 
 // Storage group is responsible for storage that belongs to a single tablet.
 // A storage group can manage 1 or more compaction groups, each of which can be compacted independently.

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -1057,6 +1057,24 @@ bool storage_group::split_unready_groups_are_empty() const {
     return std::ranges::all_of(split_unready_groups(), std::mem_fn(&compaction_group::empty));
 }
 
+std::optional<std::pair<dht::token_range, dht::token_range>>
+split_token_range(const dht::token_range& range) {
+    if (!range.start() || !range.end()) {
+        return std::nullopt;
+    }
+    auto split_point = dht::token::midpoint(range.start()->value(), range.end()->value());
+    // A range with fewer than two tokens in it has nothing to split between. The
+    // midpoint of two adjacent tokens is the lower of them, so the left side would come
+    // out empty and the right side would be the whole range. That cannot happen for a
+    // tablet range today, but it would for a tablet holding a single token, which is
+    // how a hot partition would be isolated.
+    if (split_point.raw() <= range.start()->value().raw()) {
+        return std::nullopt;
+    }
+    return std::pair(dht::token_range::make(*range.start_copy(), {split_point, true}),
+                     dht::token_range::make({split_point, false}, *range.end_copy()));
+}
+
 bool storage_group::set_split_mode() {
     // A group being stopped (e.g. during migration cleanup) cannot satisfy split mode.
     // Also, a race can happen if new groups are added while old ones are being stopped,
@@ -1070,15 +1088,33 @@ bool storage_group::set_split_mode() {
             tlogger.debug("storage_group::set_split_mode: split ready groups not created due to compaction disabled on the main group");
             return false;
         }
-        auto create_cg = [this] () -> compaction_group_ptr {
-            // TODO: use the actual sub-ranges instead, to help incremental selection on the read path.
-            return compaction_group::make_empty_group(*_main_cg);
+        // Each split-ready group is given the sub-range it will own once the split
+        // completes, rather than the whole range of the group being split. Their
+        // sstable sets index by token range, and a set which is told it spans twice
+        // the range its sstables can cover misjudges every one of them: an sstable
+        // flushed by a split-ready group spans at most its own side, so it comes out
+        // at about half the range the set thinks it has, and
+        // partitioned_sstable_set::store_as_unleveled() then keeps it out of the
+        // vector which exists to hold range-spanning sstables (SCYLLADB-3790). The
+        // narrower range also lets the read path skip a group a query does not reach.
+        auto sub_ranges = split_token_range(_main_cg->token_range());
+        if (!sub_ranges) {
+            tlogger.warn("storage_group::set_split_mode: range {} of group {} cannot be split, either because an "
+                    "end of it is unbounded or because it holds fewer than two tokens; split ready groups will "
+                    "inherit it", _main_cg->token_range(), _main_cg->group_id());
+        }
+        auto create_cg = [this, &sub_ranges] (locator::tablet_range_side side) -> compaction_group_ptr {
+            if (!sub_ranges) {
+                return compaction_group::make_empty_group(*_main_cg);
+            }
+            return compaction_group::make_empty_group(*_main_cg,
+                    side == locator::tablet_range_side::left ? sub_ranges->first : sub_ranges->second);
         };
         tlogger.debug("storage_group::set_split_mode: Set sstables_repaired_at={} for split old_group={} old_range={}",
                 _main_cg->get_sstables_repaired_at(), _main_cg->group_id(), _main_cg->token_range());
         std::vector<compaction_group_ptr> split_ready_groups(2);
-        split_ready_groups[to_idx(locator::tablet_range_side::left)] = create_cg();
-        split_ready_groups[to_idx(locator::tablet_range_side::right)] = create_cg();
+        split_ready_groups[to_idx(locator::tablet_range_side::left)] = create_cg(locator::tablet_range_side::left);
+        split_ready_groups[to_idx(locator::tablet_range_side::right)] = create_cg(locator::tablet_range_side::right);
         _split_ready_groups = std::move(split_ready_groups);
     }
 
@@ -3317,7 +3353,11 @@ compaction_group::compaction_group(table& t, size_t group_id, dht::token_range t
 }
 
 compaction_group_ptr compaction_group::make_empty_group(const compaction_group& base) {
-    auto cg = make_lw_shared<compaction_group>(base._t, base._group_id, base._token_range, base._repair_sstable_classifier);
+    return make_empty_group(base, base._token_range);
+}
+
+compaction_group_ptr compaction_group::make_empty_group(const compaction_group& base, dht::token_range token_range) {
+    auto cg = make_lw_shared<compaction_group>(base._t, base._group_id, std::move(token_range), base._repair_sstable_classifier);
     // Inherit rather than default: the update_effective_replication_map() sweep may not run.
     cg->set_tombstone_gc_enabled(base.tombstone_gc_enabled());
     return cg;

--- a/test/boost/tablets_test.cc
+++ b/test/boost/tablets_test.cc
@@ -32,6 +32,8 @@
 #include "db/schema_tables.hh"
 #include "schema/schema_builder.hh"
 
+#include "replica/compaction_group.hh"
+#include "test/boost/sstable_test.hh"
 #include "replica/tablets.hh"
 #include "replica/tablet_mutation_builder.hh"
 #include "locator/tablets.hh"
@@ -5845,6 +5847,119 @@ SEASTAR_THREAD_TEST_CASE(test_get_split_token_is_compatible_with_old_behavior) {
 
         thread::maybe_yield();
     }
+}
+
+// The sub-ranges storage_group::set_split_mode() hands to its split-ready compaction
+// groups are derived from the group's own token range, without consulting the tablet
+// map. Check that the derivation agrees with the map, which is what routes writes to
+// those groups: the same split point, the same ranges the post-split tablets will
+// have, and each side's range holding exactly the tokens the map sends to that side.
+// A disagreement would give a group a range its own sstables fall outside of.
+SEASTAR_THREAD_TEST_CASE(test_split_token_range_agrees_with_tablet_map) {
+    for (auto tablet_count : {1ul, 2ul, 8ul, 128ul}) {
+        locator::tablet_map tmap(tablet_count);
+        locator::tablet_map tmap_after_splitting(tablet_count * 2);
+
+        for (size_t id = 0; id < tablet_count; id++) {
+            auto tid = tablet_id(id);
+            auto range = tmap.get_token_range(tid);
+            auto sub_ranges = replica::split_token_range(range);
+            BOOST_REQUIRE(sub_ranges.has_value());
+            const auto& [left, right] = *sub_ranges;
+            testlog.debug("tablet_count {}, id {}, range {}, left {}, right {}", tablet_count, id, range, left, right);
+
+            // Split at the same token the map splits at.
+            BOOST_REQUIRE(left.end()->value() == tmap.get_split_token(tid));
+            // The two halves are the ranges of the tablets the split will produce,
+            // which handle_tablet_split_completion() installs once it completes.
+            BOOST_REQUIRE(left == tmap_after_splitting.get_token_range(tablet_id(id * 2)));
+            BOOST_REQUIRE(right == tmap_after_splitting.get_token_range(tablet_id(id * 2 + 1)));
+            // Between them they cover the range being split, and no more.
+            BOOST_REQUIRE(*left.start_copy() == *range.start_copy());
+            BOOST_REQUIRE(*right.end_copy() == *range.end_copy());
+
+            // A token the map routes to one side lies in that side's range, so a
+            // split-ready group's range covers everything written to it.
+            auto check = [&] (dht::token t, tablet_range_side expected_side, const dht::token_range& expected_range) {
+                BOOST_REQUIRE_EQUAL(tmap.get_tablet_range_side(t), expected_side);
+                BOOST_REQUIRE(expected_range.contains(t, dht::token_comparator()));
+            };
+            auto lower_token = range.start()->value() == dht::minimum_token() ? dht::first_token() : range.start()->value();
+            check(next_token(lower_token), tablet_range_side::left, left);
+            check(left.end()->value(), tablet_range_side::left, left);
+            check(next_token(left.end()->value()), tablet_range_side::right, right);
+            check(range.end()->value(), tablet_range_side::right, right);
+
+            thread::maybe_yield();
+        }
+    }
+
+    // A range which cannot be split reports so rather than returning a pair with an
+    // empty side. Splitting a range holding a single token does not arise for a tablet
+    // today, but it will for a tablet isolating a hot partition.
+    auto t = dht::token::bias(uint64_t(1) << 63);   // an ordinary key token, mid-ring
+    BOOST_REQUIRE(!replica::split_token_range(dht::token_range::make({t, false}, {next_token(t), true})));
+    BOOST_REQUIRE(!replica::split_token_range(dht::token_range::make_singular(t)));
+    BOOST_REQUIRE(!replica::split_token_range(dht::token_range::make_open_ended_both_sides()));
+    BOOST_REQUIRE(!replica::split_token_range(dht::token_range::make_starting_with({t, false})));
+    BOOST_REQUIRE(!replica::split_token_range(dht::token_range::make_ending_with({t, true})));
+}
+
+// Once a table is in split mode, each of a storage group's split-ready compaction
+// groups should own the range of the tablet it will become, not the whole range of the
+// tablet being split. Checked against the tablet map rather than against the way
+// set_split_mode() derives the ranges, so that the two have to agree.
+SEASTAR_THREAD_TEST_CASE(test_split_ready_groups_own_their_post_split_range) {
+    auto cfg = tablet_cql_test_config();
+    cfg.initial_tablets = std::bit_floor(this_smp_shard_count());
+    do_with_cql_env_thread([] (cql_test_env& e) {
+        e.execute_cql(
+                "CREATE TABLE cf (pk int, ck int, v int, PRIMARY KEY (pk, ck))").get();
+
+        for (unsigned i = 0; i < this_smp_shard_count() * 20; i++) {
+            e.execute_cql(format("INSERT INTO cf (pk, ck, v) VALUES ({}, 0, 0)", i)).get();
+        }
+
+        e.db().invoke_on_all([] (replica::database& db) {
+            auto& table = db.find_column_family("ks", "cf");
+            return table.flush();
+        }).get();
+
+        e.db().invoke_on_all([] (replica::database& db) {
+            auto& table = db.find_column_family("ks", "cf");
+            return table.split_all_storage_groups(tasks::task_info{});
+        }).get();
+
+        e.db().invoke_on_all([] (replica::database& db) {
+            auto& t = db.find_column_family("ks", "cf");
+            auto& sgm = column_family_test::get_storage_group_manager(t);
+            sgm->for_each_storage_group([&] (size_t id, replica::storage_group& sg) {
+                const auto& groups = sg.split_ready_compaction_groups();
+                THREADSAFE_BOOST_REQUIRE_EQUAL(groups.size(), 2);
+
+                // A token on each side of the split point, taken from the bounds of
+                // the range being split: its start is exclusive and belongs to the
+                // preceding tablet, its end is inclusive and is the last token of
+                // this one.
+                auto range = sg.token_range();
+                auto lower_token = range.start()->value() == dht::minimum_token()
+                        ? dht::first_token() : next_token(range.start()->value());
+                auto upper_token = range.end()->value();
+
+                for (auto [side, token] : {std::pair(tablet_range_side::left, lower_token),
+                                           std::pair(tablet_range_side::right, upper_token)}) {
+                    const auto& cg = groups[size_t(side)];
+                    auto expected = t.get_token_range_after_split(token);
+                    testlog.debug("group {} side {} range {} expected {}", id, int(side), cg->token_range(), expected);
+                    THREADSAFE_BOOST_REQUIRE(cg->token_range() == expected);
+                    // The point of the narrower range: it is the range the group's
+                    // own sstables can span, not twice it.
+                    THREADSAFE_BOOST_REQUIRE(cg->token_range() != range);
+                    THREADSAFE_BOOST_REQUIRE(cg->token_range().contains(token, dht::token_comparator()));
+                }
+            });
+        }).get();
+    }, std::move(cfg)).get();
 }
 
 SEASTAR_THREAD_TEST_CASE(basic_tablet_storage_splitting_test) {


### PR DESCRIPTION
When a storage group enters split mode it creates two compaction groups, one per
side of the split point, and routes writes to them by token. Each of them was
created with make_empty_group(), which copies the range of the group being split,
so both were told they span the whole tablet range while neither can ever hold more
than half of it.

That misleads the sstable set. partitioned_sstable_set stores an sstable in a flat
vector, rather than in its interval map, only when the sstable spans at least 85% of
the range the set was given; the vector exists precisely to keep sstables which
overlap everything out of a structure whose size is the number of (sub-range,
sstable) incidences. An sstable flushed by a split-ready group covers at most its
own side of the split point, so against the whole tablet range it measures about
50%, misses the threshold, and lands in the interval map together with every other
sstable in the group. The interval map then holds N * D elements for N sstables at
overlap depth D, and a group which accumulates sstables faster than it can compact
them grows quadratically -- the memory a production node was found to be spending on
this index, 92M elements for a single compaction group (SCYLLADB-3790).

Splitting is exactly when a group is most likely to be in that state: it is
splitting because it grew large, its main group is being drained into the two new
ones, and every memtable flush lands in one of them.

So derive the two sub-ranges from the group's own range and give each split-ready
group the one it will own. The split point is the midpoint of the range's bounds,
which is how locator::tablet_map::get_split_token() derives it, so the sub-ranges
agree both with the sides tablet_map::get_tablet_range_side() routes writes to and
with the ranges handle_tablet_split_completion() installs once the split completes.
Deriving it from the range rather than asking the tablet map keeps this independent
of whether a current map is at hand, which set_split_mode() has no other reason to
need. A range which cannot be split keeps the old behaviour, with a warning, rather
than being handed a degenerate pair: one with an unbounded end, and one holding fewer
than two tokens, since the midpoint of adjacent tokens is the lower of them, so the
left side would come out empty and the right side would be the whole range. Neither
arises for a tablet range today. The narrow one will once a tablet can hold a single
token, which is how a hot partition would be isolated.

This is the TODO the code carried at that spot. It also does what the TODO said it
would for the read path: a group whose range is half as wide is a group a query can
skip.

Reported by [Raphael S. Carvalho](https://github.com/raphaelsc), who identified both the scenario and the fix.

Results
-------

Measured with test/perf/perf_sstable_set (from
https://github.com/scylladb/scylladb/pull/31140), which builds a partitioned_sstable_set
from a synthetic workload and reports its footprint. The two columns below are the same
10000 sstables, with the same run structure, inserted into a set which is told it
spans the range they cover ("own range", what this patch gives a split-ready group)
and into one told it spans twice that ("tablet range", what it got before). Only the
range the set is given differs. --random-seed 24301.

With a third of the sstables spanning the group's range, the benchmark's default mix:

                              own range    tablet range
    (sub-range, sstable) incidences
                                5824627        42782957      7.3x
    populated set              317.99 MiB       2.14 GiB     6.9x
    live allocations            6327062        46348556      7.3x
    bytes/sstable               32.56 KiB     224.09 KiB     6.9x

    insert                     167570.5 ns   1278096.3 ns    7.6x   (per sstable)
    erase                      137184.4 ns   1066699.6 ns    7.8x
    copy ctor                   14992.5 ns    135033.6 ns    9.0x

With 90% of them spanning it, which is what a group in split mode taking memtable
flushes looks like:

                              own range    tablet range
    (sub-range, sstable) incidences
                                 150381        23009933       153x
    populated set                8.93 MiB       1.04 GiB      119x
    live allocations             194085        23366046       120x
    bytes/sstable                  935 B     109.49 KiB       120x

    insert                       2744.9 ns    678317.7 ns     247x
    erase                        3096.3 ns    510218.1 ns     165x
    copy ctor                     209.4 ns     73384.8 ns     350x

The wider the sstables, the more the misclassification costs, because a wide sstable
is replicated into every sub-interval it covers -- which is the whole map. Both
figures understate the flush case a little, since the benchmark's wide sstables span
the group's range rather than the tablet's.

The gap closes as the set gets smaller, since what it removes is quadratic. At 100
sstables, 90% wide: 20.00 KiB against 100.00 KiB, and insert 246.5 ns against
5965.7 ns.

Growth rate, 90% wide, per-sstable footprint over the benchmark's --scaling sweep:

    sstables    own range    tablet range
      1250         340 B       17.41 KiB
      2500         427 B       28.15 KiB
      5000         598 B       55.86 KiB
     10000         925 B      109.31 KiB

The per-sstable cost doubles with every doubling of the count in the right-hand
column and does not in the left-hand one, which is the quadratic term this patch
takes out of a splitting group.

The benchmark's select() and selector figures are not comparable between the two
columns and are left out: its queries are spread over the range the set was given,
so with the wider range half of them fall where no sstable lives and return less.

The knob used to produce these numbers is a three-line addition to that benchmark:
the sstables are confined to the leading half of its key pool while the set is still
constructed with the whole pool's range.

For master, note that PR #31140 replaces the interval map with an index whose size
does not depend on the range the set is given, at which point this patch stops
mattering for memory. It matters for every branch which does not have that series,
and it remains correct in itself: a compaction group should know the range it owns.

Tests
-----

    ./tools/toolchain/dbuild -- ./test.py --mode dev \
        test/boost/tablets_test.cc test/boost/sstable_compaction_test.cc \
        test/boost/sstable_set_test.cc test/boost/compaction_group_test.cc

418 cases, all passing.

    ./tools/toolchain/dbuild -- ./test.py --mode dev \
        test/cluster/test_tablets2.py -k split \
        test/cluster/test_tablets.py -k split \
        test/cluster/test_tablets_merge.py test/cluster/test_sstable_set.py

25 cases, all passing, 3 skipped. test/cluster/test_sstable_set.py is the one which
asserts, through the sstable_set_insertion_verification injection, whether each
inserted sstable was placed in the interval map or in the vector; it holds.

Two tests are added. test_split_ready_groups_own_their_post_split_range puts a real
table into split mode and checks each split-ready group's range against
table::get_token_range_after_split(), i.e. against the tablet map rather than
against the way this patch derives the ranges, so the two have to agree. It fails
without this patch, which makes it a reproducer, and it fails if the two sides are
swapped.

test_split_token_range_agrees_with_tablet_map checks the derivation directly over a
range of tablet counts: the same split point the map computes, sub-ranges equal to
the ranges of the tablets the split will produce, and each side's range holding the
tokens the map routes to that side. It fails if either bound's inclusivity is
flipped, which is the way a hand-derived range goes quietly wrong. It also covers the
ranges which cannot be split -- a single-token range, a singular one, and the three
unbounded shapes -- and fails if the check for those is dropped.

Backporting
-----------

Labels: backport/2026.1, backport/2026.2, backport/2026.3

The memory this reclaims is what ends a node that falls behind on compaction while a
tablet is splitting, so every branch which can reach that state wants it. It is
small, self-contained, and does not depend on the series in PR #31140.

Earlier branches are not proposed, on the same grounds as that series: 2025.4 and
below are end of life apart from 2025.1, which is the remaining long-term-support
release and is close to retirement, so the bar there is higher than this clears.

Fixes https://scylladb.atlassian.net/browse/SCYLLADB-3790

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>


