### PR TITLE
test/cluster: accept the ban notification when a join is rolled back

### DIFF
--- a/test/cluster/test_crash_coordinator_before_streaming.py
+++ b/test/cluster/test_crash_coordinator_before_streaming.py
@@ -10,8 +10,9 @@ import pytest
 
 from test.pylib.scylla_cluster_manager import ScyllaClusterManager
 from test.pylib.scylla_cluster import ReplaceConfig
-from test.cluster.util import (check_token_ring_and_group0_consistency, wait_for_token_ring_and_group0_consistency,
-                               get_coordinator_host, get_coordinator_host_ids, wait_new_coordinator_elected,
+from test.cluster.util import (BANNED_NOTIFICATION, check_token_ring_and_group0_consistency,
+                               wait_for_token_ring_and_group0_consistency, get_coordinator_host,
+                               get_coordinator_host_ids, wait_new_coordinator_elected,
                                wait_for_no_pending_topology_transition)
 
 
@@ -105,8 +106,7 @@ async def test_kill_coordinator_during_op(manager: ScyllaClusterManager, failure
     new_node = await manager.server_add(start=False, config=config, cmdline=cmdline)
     num_elections = len(await get_coordinator_host_ids(manager))
     await manager.api.enable_injection(coordinator_host.ip_addr, "crash_coordinator_before_stream", one_shot=True)
-    await manager.server_start(new_node.server_id,
-                               expected_error="Startup failed: std::runtime_error")
+    await manager.server_start(new_node.server_id, expected_error=f"Startup failed: std::runtime_error|{BANNED_NOTIFICATION}")
     await wait_new_coordinator_elected(manager, num_elections + 1, time.time() + scale_timeout(60))
     await wait_for_no_pending_topology_transition(manager, time.time() + scale_timeout(60))
     await manager.server_restart(coordinator_host.server_id, wait_others=1)
@@ -124,7 +124,7 @@ async def test_kill_coordinator_during_op(manager: ScyllaClusterManager, failure
     await manager.api.enable_injection(coordinator_host.ip_addr, "crash_coordinator_before_stream", one_shot=True)
     replace_cfg = ReplaceConfig(replaced_id = node_to_replace_srv_id, reuse_ip_addr = False, use_host_id = True)
     new_node = await manager.server_add(start=False, config=config, replace_cfg=replace_cfg, cmdline=cmdline)
-    await manager.server_start(new_node.server_id, expected_error="Replace failed. See earlier errors")
+    await manager.server_start(new_node.server_id, expected_error=f"Replace failed. See earlier errors|{BANNED_NOTIFICATION}")
     await wait_new_coordinator_elected(manager, num_elections + 1, time.time() + scale_timeout(60))
     await wait_for_no_pending_topology_transition(manager, time.time() + scale_timeout(60))
     logger.debug("Start old coordinator node")

--- a/test/cluster/test_initial_token.py
+++ b/test/cluster/test_initial_token.py
@@ -9,6 +9,7 @@ import logging
 
 from test.pylib.scylla_cluster_manager import ScyllaClusterManager
 from cassandra.policies import WhiteListRoundRobinPolicy
+from test.cluster.util import BANNED_NOTIFICATION
 
 logger = logging.getLogger(__name__)
 
@@ -24,4 +25,4 @@ async def test_initial_token(manager: ScyllaClusterManager) -> None:
     res2 = cql2.execute("SELECT tokens From system.local").one()
     assert all([i in res1.tokens for i in tokens[:2]]) and all([i in res2.tokens for i in tokens[-2:]])
     # Try to boot a node with conflicting tokens. It should fail.
-    s2 = await manager.server_add(config=cfg2, expected_error="Bootstrap failed. See earlier errors")
+    s2 = await manager.server_add(config=cfg2, expected_error=f"Bootstrap failed. See earlier errors|{BANNED_NOTIFICATION}")

--- a/test/cluster/test_topology_failure_recovery.py
+++ b/test/cluster/test_topology_failure_recovery.py
@@ -7,7 +7,7 @@ from test.pylib.scylla_cluster_manager import ScyllaClusterManager
 from test.pylib.internal_types import ServerInfo
 from test.pylib.rest_client import read_barrier
 from test.pylib.scylla_cluster import ReplaceConfig
-from test.cluster.util import new_test_keyspace
+from test.cluster.util import BANNED_NOTIFICATION, new_test_keyspace
 import pytest
 import logging
 import asyncio
@@ -95,7 +95,7 @@ async def test_topology_streaming_failure(request, manager: ScyllaClusterManager
     s = await manager.server_add(start=False, config={
         'error_injections_at_startup': ['stream_ranges_fail']
     })
-    await manager.server_start(s.server_id, expected_error="Bootstrap failed. See earlier errors")
+    await manager.server_start(s.server_id, expected_error=f"Bootstrap failed. See earlier errors|{BANNED_NOTIFICATION}")
     servers = await get_running_servers(manager)
     assert s not in servers
     matches = [await log.grep("raft_topology - rollback.*after bootstrapping failure, moving transition state to left token ring",
@@ -107,7 +107,7 @@ async def test_topology_streaming_failure(request, manager: ScyllaClusterManager
     s = await manager.server_add(start=False)
     await inject_error_on(manager, "raft_topology_barrier_fail", servers)
     try:
-        await manager.server_start(s.server_id, expected_error="Bootstrap failed. See earlier errors")
+        await manager.server_start(s.server_id, expected_error=f"Bootstrap failed. See earlier errors|{BANNED_NOTIFICATION}")
         servers = await get_running_servers(manager)
         assert s not in servers
         matches = [await log.grep("raft_topology - rollback.*after bootstrapping failure, moving transition state to left token ring",
@@ -131,7 +131,7 @@ async def test_topology_streaming_failure(request, manager: ScyllaClusterManager
     s = await manager.server_add(start=False, replace_cfg=replace_cfg, config={
         'error_injections_at_startup': ['stream_ranges_fail']
     })
-    await manager.server_start(s.server_id, expected_error="Replace failed. See earlier errors")
+    await manager.server_start(s.server_id, expected_error=f"Replace failed. See earlier errors|{BANNED_NOTIFICATION}")
     servers = await get_running_servers(manager)
     assert s not in servers
     matches = [await log.grep("raft_topology - rollback.*after replacing failure, moving transition state to left token ring",

--- a/test/cluster/util.py
+++ b/test/cluster/util.py
@@ -30,6 +30,10 @@ logger = logging.getLogger(__name__)
 
 UUID_REGEX = re.compile(r"([0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12})")
 
+# A node that is rolled back out of a join may terminate on the ban notification instead of
+# on its own failed request, so tests that expect a join to fail must accept either message.
+BANNED_NOTIFICATION = "received notification of being banned from the cluster from"
+
 
 @dataclass(frozen=True)
 class FeatureConfig:


### PR DESCRIPTION
A node whose bootstrap or replace fails is rolled back by the topology coordinator through left_token_ring, and finish_left_token_ring_transition removes it from group0 and bans it. The joining node is racing that: it either observes its own failed request and aborts startup with the message the test expects, or receives the ban notification first and terminates on that instead. Both are legitimate outcomes of the same rollback, but the tests only accepted the first, so the second showed up as a flaky failure.

Accept either message. The rollback path is shared, so the same race exists wherever a join is expected to fail: the killed-coordinator bootstrap and replace in test_kill_coordinator_during_op, the three streaming-failure cases in test_topology_streaming_failure, and the conflicting-token add in test_initial_token. expected_error is matched with re.search, so the alternation works as-is; test_cluster_features.py and test_coordinator_queue_management.py already use the same idiom with this string.

Fixes: SCYLLADB-3811

Backport to 2026.x, which have the notify_banned RPC (39cec4ae45b) that makes the second outcome reachable; 2025.x does not.