### PR TITLE
utils/gcp: drain in-flight requests before closing the http client

### DIFF
--- a/test/cluster/object_store/test_basic.py
+++ b/test/cluster/object_store/test_basic.py
@@ -21,7 +21,6 @@ from test.cqlpy.rest_api import scylla_inject_error
 from test.cluster.test_config import wait_for_config
 from test.cluster.util import new_test_keyspace, wait_for_token_ring_and_group0_consistency
 from test.pylib.tablets import get_all_tablet_replicas
-from test.pylib.skip_types import skip_bug
 from test.pylib.util import wait_for
 
 logger = logging.getLogger(__name__)
@@ -388,10 +387,6 @@ async def test_create_keyspace_after_config_update(manager: ManagerClient, objec
     else:
         updated_ep['credentials_file'] = ''
         updated_expected_conf = f'{{ "type": "gs", "credentials_file": "{updated_ep["credentials_file"]}" }}'
-        skip_bug(
-            link="https://scylladb.atlassian.net/browse/SCYLLADB-1559",
-            reason="Flaky test due to race condition closing the GCS object storage client while operations are in flight",
-        )
 
     await manager.server_update_config(server.server_id, 'object_storage_endpoints', updated_objconf)
     await wait_for_config(manager, server, 'object_storage_endpoints', {updated_ep['name']: updated_expected_conf})

--- a/utils/gcp/object_storage.cc
+++ b/utils/gcp/object_storage.cc
@@ -299,6 +299,7 @@ class utils::gcp::storage::client::impl {
     seastar::semaphore& _limits;
     seastar::http::client _client;
     shared_ptr<seastar::tls::certificate_credentials> _certs;
+    seastar::gate _gate;
     future<> authorize(request_wrapper& req, const std::string& scope);
 public:
     impl(const utils::http::url_info&, std::optional<google_credentials>, seastar::semaphore*, shared_ptr<seastar::tls::certificate_credentials> creds);
@@ -541,6 +542,9 @@ using namespace std::chrono_literals;
  */
 future<>
 utils::gcp::storage::client::impl::send_with_retry(const std::string& path, const std::string& scope, body_variant body, std::string_view content_type, handler_func_ex handler, httpclient::method_type op, key_values headers, seastar::abort_source* as) {
+    // Held for the whole request. close() waits for the gate before closing
+    // _client, so no http connection can outlive it.
+    auto holder = _gate.hold();
     rest::request_wrapper req(_endpoint);
     req.target(path);
     req.method(op);
@@ -651,6 +655,7 @@ utils::gcp::storage::client::impl::send_with_retry(const std::string& path, cons
 }
 
 future<> utils::gcp::storage::client::impl::close() {
+    co_await _gate.close();
     co_await _client.close();
 }
 


### PR DESCRIPTION
`seastar::http::client::close()` drains only the connection pool. A connection checked out for an in-flight request is not in the pool, so `close()` returns while that connection is still alive, and `http::client` has no destructor that waits for it. The GCS client hands a `shared_ptr<impl>` to every `readable_file`, data source and data sink, so `impl` outlives the `client` object that created it — and `gs_client_wrapper::update_config_sync()` swaps in a new client and closes the old one in the background while sstable files are still open on it. When the last holder drops, `~impl` destroys the embedded `http::client` with a connection still live, and that connection's `client_ref` destructor then dereferences freed memory.

### Changes

`impl` gets a gate that every request holds for its duration, and `impl::close()` closes the gate before closing the http client. After `close()` returns there is no request in flight and every connection is back in the pool, so the pool drain is complete and destroying `impl` later has nothing left to dangle. All three `send_with_retry()` overloads funnel through one of them, and `rest::simple_send()` there is the only use of `_client`, so a single hold covers every request.

The `gs` flavor of `test_create_keyspace_after_config_update` is re-enabled. It was stopping at a `skip_bug()` call placed immediately before the config update that reconfigures a live client, which is the path that reproduces the fault.

### Verification

Reproduced on the first debug run with the skip removed — ASan `heap-use-after-free` in `seastar::http::internal::client_ref::~client_ref()`, the region freed by the last `shared_ptr<client::readable_file>` and allocated by the `gs_client_wrapper` constructor. With the fix, a repeat run covering roughly 110 config-update cycles produced no ASan report in any of the 100 server logs.

### Follow-ups

This fixes the caller, not the contract. Two tickets track the rest:

- https://scylladb.atlassian.net/browse/SCYLLADB-3845 — `seastar::http::client::close()` should be a real barrier and wait for connections outside the pool. `~client_ref` already broadcasts `_wait_con` on every decrement, so the wakeup path exists. Fixing it there covers every user instead of one caller at a time, and removes the need for gates like this one.
- https://scylladb.atlassian.net/browse/SCYLLADB-3844 — `utils/s3` has the same ownership shape (`readable_file` holds `shared_ptr<client>`, and `client::close()` closes each `_https` entry's http client pool-first), but `s3_client_wrapper::update_config_sync()` reconfigures the live client in place instead of swapping it, so there is no equivalent trigger today and S3 only closes at shutdown. Left alone here.

Fixes: https://scylladb.atlassian.net/browse/SCYLLADB-1559

Backport to 2026.2 and 2026.3, which both carry the `update_config_sync()` swap-and-close path that opens the window. 2026.1 has `gs_client_wrapper` but no `update_config_sync()` override, so it is not affected.