### PR TITLE
vector_store: ask the Vector Store to highlight a batch of documents

### DIFF
--- a/test/vector_search/utils.hh
+++ b/test/vector_search/utils.hh
@@ -137,6 +137,12 @@ constexpr auto CORRECT_BM25_RESPONSE_FOR_TEST_TABLE = R"({
     "scores": [0.1, 0.2]
 })";
 
+// A sample correct highlight response for the two documents the tests send.
+// A null entry marks a document the index found nothing to highlight in.
+constexpr auto CORRECT_HIGHLIGHT_RESPONSE = R"({
+    "highlights": ["a <b>fox</b> jumped", null]
+})";
+
 inline schema_ptr make_test_schema(const seastar::sstring& ks = "ks", const seastar::sstring& cf = "idx") {
     return schema_builder(this_smp_shard_count(), ks, cf)
             .with_column("pk1", byte_type, column_kind::partition_key)

--- a/test/vector_search/vector_store_client_test.cc
+++ b/test/vector_search/vector_store_client_test.cc
@@ -1194,6 +1194,12 @@ SEASTAR_TEST_CASE(vector_store_client_test_bm25_request) {
     BOOST_CHECK_EQUAL(err->status, status_type::not_found);
     BOOST_CHECK_EQUAL(err->message, "idx2 not found");
 
+    // the reply is not an object - service should return format error
+    server->next_search_response({status_type::ok, R"([])"});
+    keys = co_await vs.bm25("ks", "idx", schema, "hello world", 2, as.reset());
+    BOOST_REQUIRE(!keys);
+    BOOST_CHECK(std::holds_alternative<vector_store_client::service_reply_format_error>(keys.error()));
+
     // missing primary_keys in the reply - service should return format error
     server->next_search_response({status_type::ok, R"({"primary_keys1":{"pk1":[5,6],"pk2":[7,8],"ck1":[9,1],"ck2":[2,3]},"scores":[0.1,0.2]})"});
     keys = co_await vs.bm25("ks", "idx", schema, "hello world", 2, as.reset());
@@ -1245,6 +1251,120 @@ SEASTAR_TEST_CASE(vector_store_client_test_bm25_request) {
     BOOST_CHECK_EQUAL(seastar::format("{}", keys->at(0).clustering.explode()), "[09, 02]");
     BOOST_CHECK_EQUAL(seastar::format("{}", keys->at(1).partition.key().explode()), "[06, 08]");
     BOOST_CHECK_EQUAL(seastar::format("{}", keys->at(1).clustering.explode()), "[01, 03]");
+
+    co_await vs.stop();
+    co_await server->stop();
+}
+
+SEASTAR_TEST_CASE(vector_store_client_test_highlight_aborted) {
+    auto server = co_await make_unavailable_server();
+    auto cfg = config();
+    cfg.vector_store_primary_uri.set(format("http://good.authority.here:{}", server->port()));
+    auto vs = vector_store_client{cfg};
+    auto as = abort_source_timeout();
+    configure(vs).with_dns_refresh_interval(milliseconds(10)).with_dns_resolver([&server](auto const& host) -> future<std::optional<inet_address>> {
+        BOOST_CHECK_EQUAL(host, "good.authority.here");
+        co_await sleep(milliseconds(100));
+        co_return inet_address(server->host());
+    });
+
+    vs.start_background_tasks();
+
+    auto fragments = co_await vs.highlight("ks", "idx", "hello world", {"hello there", "world at large"}, as.reset(milliseconds(10)));
+    BOOST_REQUIRE(!fragments);
+    BOOST_CHECK(std::holds_alternative<vector_store_client::aborted>(fragments.error()));
+
+    co_await vs.stop();
+    co_await server->stop();
+}
+
+SEASTAR_TEST_CASE(vector_store_client_test_highlight_request) {
+    auto server = co_await make_vs_mock_server(vs_mock_server::mode::highlight);
+    auto cfg = config();
+    cfg.vector_store_primary_uri.set(format("http://good.authority.here:{}", server->port()));
+    auto vs = vector_store_client{cfg};
+    auto as = abort_source_timeout();
+    configure(vs).with_dns_refresh_interval(seconds(1)).with_dns({{"good.authority.here", "127.0.0.1"}});
+
+    vs.start_background_tasks();
+
+    // the query and every document must reach the request JSON-escaped - the C++ literals below
+    // hold real quote, backslash and newline characters
+    auto fragments = co_await vs.highlight("ks", "idx", "quote\"back\\slash\nnewline", {"a \"quoted\" doc", "second"}, as.reset());
+    BOOST_REQUIRE(!server->search_requests().empty());
+    BOOST_REQUIRE_EQUAL(server->search_requests().back().body,
+            R"({"query":"quote\"back\\slash\nnewline","documents":["a \"quoted\" doc","second"]})");
+    BOOST_REQUIRE(fragments);
+
+    // server responds with 404 - client should return service_error
+    server->next_search_response({status_type::not_found, "idx2 not found"});
+    fragments = co_await vs.highlight("ks", "idx2", "fox", {"a fox jumped", "second"}, as.reset());
+    BOOST_REQUIRE_EQUAL(server->search_requests().back().path, "/api/v1/indexes/ks/idx2/highlight");
+    BOOST_REQUIRE(!fragments);
+    auto* err = std::get_if<vector_store_client::service_error>(&fragments.error());
+    BOOST_CHECK(err != nullptr);
+    BOOST_CHECK_EQUAL(err->status, status_type::not_found);
+    BOOST_CHECK_EQUAL(err->message, "idx2 not found");
+
+    // a reply that is not JSON at all - service should return format error
+    server->next_search_response({status_type::ok, "not json"});
+    fragments = co_await vs.highlight("ks", "idx", "fox", {"a fox jumped", "second"}, as.reset());
+    BOOST_REQUIRE(!fragments);
+    BOOST_CHECK(std::holds_alternative<vector_store_client::service_reply_format_error>(fragments.error()));
+
+    // the reply is not an object - service should return format error
+    server->next_search_response({status_type::ok, R"([])"});
+    fragments = co_await vs.highlight("ks", "idx", "fox", {"a fox jumped", "second"}, as.reset());
+    BOOST_REQUIRE(!fragments);
+    BOOST_CHECK(std::holds_alternative<vector_store_client::service_reply_format_error>(fragments.error()));
+
+    // no 'highlights' member in the reply - service should return format error
+    server->next_search_response({status_type::ok, R"({"highlights1":["a <b>fox</b> jumped",null]})"});
+    fragments = co_await vs.highlight("ks", "idx", "fox", {"a fox jumped", "second"}, as.reset());
+    BOOST_REQUIRE(!fragments);
+    BOOST_CHECK(std::holds_alternative<vector_store_client::service_reply_format_error>(fragments.error()));
+
+    // highlights is not an array - service should return format error
+    server->next_search_response({status_type::ok, R"({"highlights":"a <b>fox</b> jumped"})"});
+    fragments = co_await vs.highlight("ks", "idx", "fox", {"a fox jumped", "second"}, as.reset());
+    BOOST_REQUIRE(!fragments);
+    BOOST_CHECK(std::holds_alternative<vector_store_client::service_reply_format_error>(fragments.error()));
+
+    // fewer fragments than documents sent - the two are matched by position and by nothing else,
+    // so a reply of a different length says nothing about which document each one came from
+    server->next_search_response({status_type::ok, R"({"highlights":["a <b>fox</b> jumped"]})"});
+    fragments = co_await vs.highlight("ks", "idx", "fox", {"a fox jumped", "second"}, as.reset());
+    BOOST_REQUIRE(!fragments);
+    BOOST_CHECK(std::holds_alternative<vector_store_client::service_reply_format_error>(fragments.error()));
+
+    // more fragments than documents sent - likewise
+    server->next_search_response({status_type::ok, R"({"highlights":["a <b>fox</b> jumped",null,null]})"});
+    fragments = co_await vs.highlight("ks", "idx", "fox", {"a fox jumped", "second"}, as.reset());
+    BOOST_REQUIRE(!fragments);
+    BOOST_CHECK(std::holds_alternative<vector_store_client::service_reply_format_error>(fragments.error()));
+
+    // a fragment that is neither a string nor null - service should return format error
+    server->next_search_response({status_type::ok, R"({"highlights":["a <b>fox</b> jumped",7]})"});
+    fragments = co_await vs.highlight("ks", "idx", "fox", {"a fox jumped", "second"}, as.reset());
+    BOOST_REQUIRE(!fragments);
+    BOOST_CHECK(std::holds_alternative<vector_store_client::service_reply_format_error>(fragments.error()));
+
+    // correct reply - a fragment for the document that matched, and an absent one for the document
+    // the index found nothing worth marking in
+    server->next_search_response({status_type::ok, CORRECT_HIGHLIGHT_RESPONSE});
+    fragments = co_await vs.highlight("ks", "idx", "fox", {"a fox jumped", "second"}, as.reset());
+    BOOST_REQUIRE(fragments);
+    BOOST_REQUIRE_EQUAL(fragments->size(), 2);
+    BOOST_REQUIRE(fragments->at(0).has_value());
+    BOOST_CHECK_EQUAL(*fragments->at(0), "a <b>fox</b> jumped");
+    BOOST_CHECK(!fragments->at(1).has_value());
+
+    // an empty document list is still a well-formed request, answered with no fragments
+    server->next_search_response({status_type::ok, R"({"highlights":[]})"});
+    fragments = co_await vs.highlight("ks", "idx", "fox", {}, as.reset());
+    BOOST_REQUIRE(fragments);
+    BOOST_CHECK(fragments->empty());
+    BOOST_CHECK_EQUAL(server->search_requests().back().body, R"({"query":"fox","documents":[]})");
 
     co_await vs.stop();
     co_await server->stop();

--- a/test/vector_search/vs_mock_server.hh
+++ b/test/vector_search/vs_mock_server.hh
@@ -27,7 +27,7 @@ namespace test::vector_search {
 
 class vs_mock_server {
 public:
-    enum class mode { ann, bm25 };
+    enum class mode { ann, bm25, highlight };
 
     struct request {
         seastar::sstring path;
@@ -127,11 +127,20 @@ private:
         if (m == mode::bm25) {
             return {seastar::http::reply::status_type::ok, CORRECT_BM25_RESPONSE_FOR_TEST_TABLE};
         }
+        if (m == mode::highlight) {
+            return {seastar::http::reply::status_type::ok, CORRECT_HIGHLIGHT_RESPONSE};
+        }
         return {seastar::http::reply::status_type::ok, CORRECT_RESPONSE_FOR_TEST_TABLE};
     }
 
-    static seastar::sstring mode_suffix(mode m) {
-        return m == mode::bm25 ? "/bm25" : "/ann";
+    static seastar::sstring endpoint_suffix(mode m) {
+        if (m == mode::bm25) {
+            return "/bm25";
+        }
+        if (m == mode::highlight) {
+            return "/highlight";
+        }
+        return "/ann";
     }
 
     seastar::future<> listen() {
@@ -151,7 +160,7 @@ private:
             std::unique_ptr<seastar::http::request> req, std::unique_ptr<seastar::http::reply> rep) {
         auto full_path = req->get_path_param("path");
         // Only handle requests matching our configured mode suffix; return 404 for others.
-        if (!full_path.ends_with(mode_suffix(_mode))) {
+        if (!full_path.ends_with(endpoint_suffix(_mode))) {
             rep->set_status(seastar::http::reply::status_type::not_found);
             rep->write_body("json", R"("not found")");
             co_return rep;

--- a/vector_search/vector_store_client.cc
+++ b/vector_search/vector_store_client.cc
@@ -56,6 +56,7 @@ using operation_type = httpd::operation_type;
 using port_number = vector_search::vector_store_client::port_number;
 using primary_key = vector_search::primary_key;
 using primary_keys = vector_search::vector_store_client::primary_keys;
+using reply_content = std::vector<seastar::temporary_buffer<char>>;
 using documents = vector_search::vector_store_client::documents;
 using highlights = vector_search::vector_store_client::highlights;
 using service_reply_format_error = vector_search::vector_store_client::service_reply_format_error;
@@ -422,15 +423,11 @@ struct vector_store_client::impl {
         }
     }
 
-    auto ann(keyspace_name keyspace, index_name name, schema_ptr schema, vs_vector vs_vector, limit limit, const rjson::value& filter, abort_source& as)
-            -> future<std::expected<primary_keys, ann_error>> {
+    auto post_to_index(std::string_view op, http_path path, json_content content, abort_source& as) -> future<std::expected<reply_content, ann_error>> {
         if (is_disabled()) {
-            vslogger.error("Disabled Vector Store while calling ann");
+            vslogger.error("Disabled Vector Store while calling {}", op);
             co_return std::unexpected{disabled{}};
         }
-
-        auto path = format("/api/v1/indexes/{}/{}/ann", keyspace, name);
-        auto content = write_ann_json(std::move(vs_vector), limit, filter);
 
         auto resp = co_await request(operation_type::POST, std::move(path), std::move(content), as);
         if (!resp) {
@@ -447,8 +444,19 @@ struct vector_store_client::impl {
             co_return std::unexpected{service_error{resp->status, std::move(error_content)}};
         }
 
+        co_return std::move(resp->content);
+    }
+
+    auto ann(keyspace_name keyspace, index_name name, schema_ptr schema, vs_vector vs_vector, limit limit, const rjson::value& filter, abort_source& as)
+            -> future<std::expected<primary_keys, ann_error>> {
+        auto content =
+                co_await post_to_index("ann", format("/api/v1/indexes/{}/{}/ann", keyspace, name), write_ann_json(std::move(vs_vector), limit, filter), as);
+        if (!content) {
+            co_return std::unexpected{content.error()};
+        }
+
         try {
-            co_return read_ann_json(rjson::parse(std::move(resp->content)), schema);
+            co_return read_ann_json(rjson::parse(std::move(*content)), schema);
         } catch (const rjson::error& e) {
             vslogger.error("Vector Store returned invalid JSON: {}", e.what());
             co_return std::unexpected{service_reply_format_error{}};
@@ -457,31 +465,13 @@ struct vector_store_client::impl {
 
     auto bm25(keyspace_name keyspace, index_name name, schema_ptr schema, query_string fts_query, limit limit, abort_source& as)
             -> future<std::expected<primary_keys, fts_error>> {
-        if (is_disabled()) {
-            vslogger.error("Disabled Vector Store while calling bm25");
-            co_return std::unexpected{disabled{}};
-        }
-
-        auto path = format("/api/v1/indexes/{}/{}/bm25", keyspace, name);
-        auto content = write_bm25_json(std::move(fts_query), limit);
-
-        auto resp = co_await request(operation_type::POST, std::move(path), std::move(content), as);
-        if (!resp) {
-            co_return std::unexpected{std::visit(
-                    [](auto&& err) {
-                        return fts_error{err};
-                    },
-                    resp.error())};
-        }
-
-        if (resp->status != status_type::ok) {
-            auto error_content = decode_error_message(resp->content);
-            vslogger.error("Vector Store returned error: HTTP status {}: {}", resp->status, error_content);
-            co_return std::unexpected{service_error{resp->status, std::move(error_content)}};
+        auto content = co_await post_to_index("bm25", format("/api/v1/indexes/{}/{}/bm25", keyspace, name), write_bm25_json(std::move(fts_query), limit), as);
+        if (!content) {
+            co_return std::unexpected{content.error()};
         }
 
         try {
-            co_return read_bm25_json(rjson::parse(std::move(resp->content)), schema);
+            co_return read_bm25_json(rjson::parse(std::move(*content)), schema);
         } catch (const rjson::error& e) {
             vslogger.error("Vector Store returned invalid JSON: {}", e.what());
             co_return std::unexpected{service_reply_format_error{}};
@@ -490,32 +480,15 @@ struct vector_store_client::impl {
 
     auto highlight(keyspace_name keyspace, index_name name, query_string fts_query, documents docs, abort_source& as)
             -> future<std::expected<highlights, fts_error>> {
-        if (is_disabled()) {
-            vslogger.error("Disabled Vector Store while calling highlight");
-            co_return std::unexpected{disabled{}};
-        }
-
-        auto path = format("/api/v1/indexes/{}/{}/highlight", keyspace, name);
         auto documents_sent = docs.size();
-        auto content = write_highlight_json(std::move(fts_query), std::move(docs));
-
-        auto resp = co_await request(operation_type::POST, std::move(path), std::move(content), as);
-        if (!resp) {
-            co_return std::unexpected{std::visit(
-                    [](auto&& err) {
-                        return fts_error{err};
-                    },
-                    resp.error())};
-        }
-
-        if (resp->status != status_type::ok) {
-            auto error_content = decode_error_message(resp->content);
-            vslogger.error("Vector Store returned error: HTTP status {}: {}", resp->status, error_content);
-            co_return std::unexpected{service_error{resp->status, std::move(error_content)}};
+        auto content = co_await post_to_index("highlight", format("/api/v1/indexes/{}/{}/highlight", keyspace, name),
+                write_highlight_json(std::move(fts_query), std::move(docs)), as);
+        if (!content) {
+            co_return std::unexpected{content.error()};
         }
 
         try {
-            co_return read_highlight_json(rjson::parse(std::move(resp->content)), documents_sent);
+            co_return read_highlight_json(rjson::parse(std::move(*content)), documents_sent);
         } catch (const rjson::error& e) {
             vslogger.error("Vector Store returned invalid JSON: {}", e.what());
             co_return std::unexpected{service_reply_format_error{}};

--- a/vector_search/vector_store_client.cc
+++ b/vector_search/vector_store_client.cc
@@ -22,6 +22,7 @@
 #include <charconv>
 #include <exception>
 #include <fmt/ranges.h>
+#include <ranges>
 #include <regex>
 #include <seastar/core/sstring.hh>
 #include <seastar/core/metrics.hh>
@@ -55,6 +56,8 @@ using operation_type = httpd::operation_type;
 using port_number = vector_search::vector_store_client::port_number;
 using primary_key = vector_search::primary_key;
 using primary_keys = vector_search::vector_store_client::primary_keys;
+using documents = vector_search::vector_store_client::documents;
+using highlights = vector_search::vector_store_client::highlights;
 using service_reply_format_error = vector_search::vector_store_client::service_reply_format_error;
 using uri = vector_search::uri;
 
@@ -160,6 +163,10 @@ auto write_ann_json(vs_vector vs_vector, limit limit, const rjson::value& filter
 
 auto read_scored_primary_keys_json(rjson::value const& json, schema_ptr const& schema, std::string_view score_field_name)
         -> std::expected<primary_keys, ann_error> {
+    if (!json.IsObject()) {
+        vslogger.error("Vector Store returned invalid JSON: the reply is not an object");
+        return std::unexpected{service_reply_format_error{}};
+    }
     if (!json.HasMember("primary_keys")) {
         vslogger.error("Vector Store returned invalid JSON: missing 'primary_keys'");
         return std::unexpected{service_reply_format_error{}};
@@ -220,6 +227,51 @@ auto write_bm25_json(query_string query, limit limit) -> json_content {
 
 auto read_bm25_json(rjson::value const& json, schema_ptr const& schema) -> std::expected<primary_keys, fts_error> {
     return read_scored_primary_keys_json(json, schema, "scores");
+}
+
+auto write_highlight_json(query_string query, documents docs) -> json_content {
+    auto quoted_docs = docs | std::views::transform([](auto const& doc) {
+        return rjson::quote_json_string(doc);
+    });
+    return seastar::format(R"({{"query":{},"documents":[{}]}})", rjson::from_string(query), fmt::join(quoted_docs, ","));
+}
+
+auto read_highlight_json(rjson::value const& json, std::size_t documents_sent) -> std::expected<highlights, fts_error> {
+    if (!json.IsObject()) {
+        vslogger.error("Vector Store returned invalid JSON: the reply is not an object");
+        return std::unexpected{service_reply_format_error{}};
+    }
+    auto const* fragments_json = rjson::find(json, "highlights");
+    if (fragments_json == nullptr) {
+        vslogger.error("Vector Store returned invalid JSON: missing 'highlights'");
+        return std::unexpected{service_reply_format_error{}};
+    }
+    if (!fragments_json->IsArray()) {
+        vslogger.error("Vector Store returned invalid JSON: 'highlights' is not an array");
+        return std::unexpected{service_reply_format_error{}};
+    }
+    auto const& fragments_arr = fragments_json->GetArray();
+
+    // The fragments are matched to the documents by position and by nothing else, so a reply of a
+    // different length says nothing about which document each one came from.
+    if (fragments_arr.Size() != documents_sent) {
+        vslogger.error("Vector Store returned invalid JSON: 'highlights' has {} entries for {} documents", fragments_arr.Size(), documents_sent);
+        return std::unexpected{service_reply_format_error{}};
+    }
+
+    auto fragments = highlights{};
+    fragments.reserve(fragments_arr.Size());
+    for (auto const& fragment : fragments_arr) {
+        if (fragment.IsNull()) {
+            fragments.emplace_back(std::nullopt);
+        } else if (fragment.IsString()) {
+            fragments.emplace_back(sstring(rjson::to_string_view(fragment)));
+        } else {
+            vslogger.error("Vector Store returned invalid JSON: 'highlights[{}]'={} is neither a string nor null", fragments.size(), rjson::print(fragment));
+            return std::unexpected{service_reply_format_error{}};
+        }
+    }
+    return std::move(fragments);
 }
 
 bool should_vector_store_service_be_disabled(std::vector<sstring> const& uris) {
@@ -436,6 +488,39 @@ struct vector_store_client::impl {
         }
     }
 
+    auto highlight(keyspace_name keyspace, index_name name, query_string fts_query, documents docs, abort_source& as)
+            -> future<std::expected<highlights, fts_error>> {
+        if (is_disabled()) {
+            vslogger.error("Disabled Vector Store while calling highlight");
+            co_return std::unexpected{disabled{}};
+        }
+
+        auto path = format("/api/v1/indexes/{}/{}/highlight", keyspace, name);
+        auto documents_sent = docs.size();
+        auto content = write_highlight_json(std::move(fts_query), std::move(docs));
+
+        auto resp = co_await request(operation_type::POST, std::move(path), std::move(content), as);
+        if (!resp) {
+            co_return std::unexpected{std::visit(
+                    [](auto&& err) {
+                        return fts_error{err};
+                    },
+                    resp.error())};
+        }
+
+        if (resp->status != status_type::ok) {
+            auto error_content = decode_error_message(resp->content);
+            vslogger.error("Vector Store returned error: HTTP status {}: {}", resp->status, error_content);
+            co_return std::unexpected{service_error{resp->status, std::move(error_content)}};
+        }
+
+        try {
+            co_return read_highlight_json(rjson::parse(std::move(resp->content)), documents_sent);
+        } catch (const rjson::error& e) {
+            vslogger.error("Vector Store returned invalid JSON: {}", e.what());
+            co_return std::unexpected{service_reply_format_error{}};
+        }
+    }
 
     future<clients::request_result> request(
             seastar::httpd::operation_type method, seastar::sstring path, std::optional<seastar::sstring> content, seastar::abort_source& as) {
@@ -495,6 +580,11 @@ auto vector_store_client::ann(keyspace_name keyspace, index_name name, schema_pt
 auto vector_store_client::bm25(keyspace_name keyspace, index_name name, schema_ptr schema, query_string fts_query, limit limit, abort_source& as)
         -> future<std::expected<primary_keys, fts_error>> {
     return _impl->bm25(std::move(keyspace), std::move(name), schema, std::move(fts_query), limit, as);
+}
+
+auto vector_store_client::highlight(keyspace_name keyspace, index_name name, query_string fts_query, documents documents, abort_source& as)
+        -> future<std::expected<highlights, fts_error>> {
+    return _impl->highlight(std::move(keyspace), std::move(name), std::move(fts_query), std::move(documents), as);
 }
 
 void vector_store_client_tester::set_dns_refresh_interval(vector_store_client& vsc, std::chrono::milliseconds interval) {

--- a/vector_search/vector_store_client.hh
+++ b/vector_search/vector_store_client.hh
@@ -16,6 +16,7 @@
 #include <chrono>
 #include <expected>
 #include <functional>
+#include <optional>
 #include <variant>
 #include <vector>
 #include <seastar/core/abort_source.hh>
@@ -54,6 +55,9 @@ public:
     using config = db::config;
     using vs_vector = std::vector<float>;
     using query_string = std::string;
+    using document = sstring;
+    using documents = std::vector<document>;
+    using highlights = std::vector<std::optional<sstring>>;
     using host_name = sstring;
     using index_name = sstring;
     using keyspace_name = sstring;
@@ -117,6 +121,19 @@ public:
     /// more relevant).
     auto bm25(keyspace_name keyspace, index_name name, schema_ptr schema, query_string fts_query, limit limit, abort_source& as)
             -> future<std::expected<primary_keys, fts_error>>;
+
+    /// Request a fragment of each of the given documents, with the terms of `fts_query` marked.
+    ///
+    /// The index is asked because choosing which of a document's terms matter needs the corpus
+    /// statistics and the analyzer that only it has - not because it can look the documents up.
+    /// It stores none of their text, which is why the caller has to send it.
+    ///
+    /// The answer is positional: entry i belongs to documents[i], std::nullopt where the reply
+    /// carried no fragment for it. Nothing in the reply pairs a fragment with its document -
+    /// hence no schema - so we expect the index to answer in the order it was asked, and pass
+    /// the reply through unchanged.
+    auto highlight(keyspace_name keyspace, index_name name, query_string fts_query, documents documents, abort_source& as)
+            -> future<std::expected<highlights, fts_error>>;
 
 private:
     friend struct vector_store_client_tester;


### PR DESCRIPTION
A full-text search can report, besides a row's relevance score, a fragment of the row's text with the matched terms marked. Choosing which terms matter needs the corpus statistics and the analyzer that only the index has, so the fragment is generated there - but the index stores none of the text, so the caller has to send it. It has it in hand: these are the rows it has just read from the base table for the keys the search returned.

So this is a second request, made after those rows are read, and it carries no primary keys in either direction: the caller supplied the documents and correlates the answer to them by position. Which is why the reply's length is checked before it is handed back - a reply of a different length says nothing about which document each fragment came from - and why an absent fragment is kept distinct from an empty one: it means the index found nothing worth marking in that document, and the caller must not turn that into a fragment.

The mock server answers /highlight under a mode of its own, as it does for the other two endpoints. It only drives the C++ client unit tests, and no test there needs one server answering two endpoints: the client issues bm25() and highlight() as independent calls through the same request().

Nothing calls this yet; HIGHLIGHT() in the SELECT clause will.

Ref: https://github.com/scylladb/vector-store/pull/559
Ref: https://scylladb.atlassian.net/browse/SCYLLADB-3573

New feature - no backport.