### PR TITLE
topology_coordinator: poll zero-token nodes in collect_tablet_load_stats

### DIFF
--- a/service/topology_coordinator.cc
+++ b/service/topology_coordinator.cc
@@ -4742,12 +4742,26 @@ future<topology_coordinator::tablet_load_stats_collect_result> topology_coordina
     std::unordered_map<table_id, size_t> total_replicas;
     bool table_load_stats_invalid = false;
 
-    for (auto& [dc, nodes] : tm->get_datacenter_token_owners_nodes()) {
+    // Poll every normal node of each DC, not only its token owners: a node that owns no
+    // tokens (e.g. in an arbiter DC) still switches its local storage mode during a
+    // vnodes-to-tablets migration, and finalization needs to observe that.
+    for (auto& [dc, nodes] : tm->get_topology().get_datacenter_nodes()) {
         locator::load_stats dc_stats;
-        rtlogger.debug("raft topology: Refreshing table load stats for DC {} that has {} token owners", dc, nodes.size());
+        bool dc_has_token_owners = false;
+        rtlogger.debug("raft topology: Refreshing table load stats for DC {} that has {} node(s)", dc, nodes.size());
         co_await coroutine::parallel_for_each(nodes, [&] (const auto& node) -> future<> {
             auto dst = node.get().host_id();
             auto dst_server = raft::server_id(dst.uuid());
+
+            const bool is_token_owner = tm->is_normal_token_owner(dst);
+
+            // get_datacenter_nodes() also contains nodes in transient states; only normal
+            // ones take part in the migration and can be expected to report load stats.
+            if (!is_token_owner && !_topo_sm._topology.normal_nodes.contains(dst_server)) {
+                co_return;
+            }
+
+            dc_has_token_owners |= is_token_owner;
 
             _as.check();
 
@@ -4771,7 +4785,9 @@ future<topology_coordinator::tablet_load_stats_collect_result> topology_coordina
                     node_stats = _load_stats_per_node[dst];
                 } else {
                     rtlogger.debug("raft topology: Unable to refresh table load on {} because it's down.", dst);
-                    table_load_stats_invalid = true;
+                    if (is_token_owner) {
+                        table_load_stats_invalid = true;
+                    }
                     co_return;
                 }
             } else if (_feature_service.tablet_load_stats_v2) {
@@ -4788,8 +4804,19 @@ future<topology_coordinator::tablet_load_stats_collect_result> topology_coordina
             }
 
             _load_stats_per_node[dst] = node_stats;
-            dc_stats += node_stats;
+            if (is_token_owner) {
+                dc_stats += node_stats;
+            }
         });
+
+        // A DC with no token owners holds no replicas of any table, so dc_stats was never
+        // merged into and is still the identity element. `stats += dc_stats` would not be a
+        // no-op for it: load_stats::operator+= invalidates split readiness for every table
+        // the source does not report, and decides whether to do so from the destination's
+        // _aggregated flag rather than the source's. So skip such a DC entirely.
+        if (!dc_has_token_owners) {
+            continue;
+        }
 
         for (auto& [table_id, table_stats] : dc_stats.tables) {
             co_await coroutine::maybe_yield();

--- a/test/cluster/test_vnodes_to_tablets_migration.py
+++ b/test/cluster/test_vnodes_to_tablets_migration.py
@@ -1360,3 +1360,85 @@ async def test_pow2_convergence_virtual_task(manager: ScyllaClusterManager):
         convergence_tasks = [t for t in tasks if t.type == "pow2_convergence"]
         assert len(convergence_tasks) == 0, \
             f"Expected no convergence tasks after completion, got {len(convergence_tasks)}"
+
+
+async def test_migration_with_zero_token_node(manager: ScyllaClusterManager):
+    """Verify vnodes-to-tablets migration succeeds in the presence of zero-token nodes (arbiter DCs).
+
+    Reproduces SCYLLADB-3268: finalization used to fail with "No load stats available" for
+    zero-token nodes because collect_tablet_load_stats only queried token-owning nodes, but
+    the finalization check iterated all normal nodes.
+
+    The migration status API is deliberately not used to check progress here. It derives
+    current_mode from system.tablet_sizes, which is keyed by tablet replica, so a zero-token
+    node never appears in it and is always reported as using vnodes no matter what it has
+    actually done. That is a separate bug with a separate fix, so this test only checks that
+    finalization itself no longer fails.
+
+    Steps:
+    1. Start a 2-node cluster: one token-owning node in dc1 and one zero-token node in dc2 (arbiter DC).
+    2. Create a vnode keyspace with RF={'dc1': 1, 'dc2': 0}.
+    3. Start the migration.
+    4. Mark both nodes for upgrade and restart them.
+    5. Finalize the migration — this should succeed (previously it would fail).
+    6. Verify the keyspace now uses tablets and the data is intact.
+    """
+    num_keys = 100
+    tokens_per_node = 16
+
+    logger.info("Starting a token-owning node in dc1")
+    cfg = {'tablet_load_stats_refresh_interval_in_seconds': 1, 'num_tokens': tokens_per_node}
+    server_dc1 = await manager.server_add(cmdline=['--smp', '2'], config=cfg, property_file={"dc": "dc1", "rack": "rack1"})
+
+    logger.info("Starting a zero-token node in dc2 (arbiter DC)")
+    zero_token_cfg = cfg | {'join_ring': False}
+    server_dc2 = await manager.server_add(cmdline=['--smp', '2'], config=zero_token_cfg, property_file={"dc": "dc2", "rack": "rack1"})
+
+    # Only wait for the token-owning node to be CQL-ready: the zero-token node has no
+    # tokens in the ring metadata, so the driver does not treat it as a replica for any
+    # query. It does serve CQL though, and the driver may still route a query to it, so
+    # reads that must observe a specific group0 state are pinned to a host explicitly.
+    token_owning_servers = [server_dc1]
+    cql, _ = await manager.get_ready_cql(token_owning_servers)
+
+    logger.info("Creating keyspace with RF={'dc1': 1, 'dc2': 0}")
+    async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'dc1': 1, 'dc2': 0} AND tablets = {'enabled': false}") as ks:
+        await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int)")
+
+        logger.info(f"Populating table with {num_keys} rows")
+        stmt = cql.prepare(f"INSERT INTO {ks}.test (pk, c) VALUES (?, ?)")
+        await asyncio.gather(*(cql.run_async(stmt, [k, k]) for k in range(num_keys)))
+
+        logger.info("Starting vnodes-to-tablets migration")
+        await manager.api.create_vnode_tablet_migration(server_dc1.ip_addr, ks)
+
+        logger.info("Marking both nodes for tablets migration")
+        await manager.api.upgrade_node_to_tablets(server_dc1.ip_addr)
+        await manager.api.upgrade_node_to_tablets(server_dc2.ip_addr)
+
+        logger.info("Restarting token-owning node to trigger resharding")
+        await manager.server_restart(server_dc1.server_id)
+        await reconnect_driver(manager)
+        cql, _ = await manager.get_ready_cql(token_owning_servers)
+
+        logger.info("Restarting zero-token node to trigger its migration")
+        await manager.server_restart(server_dc2.server_id)
+        await reconnect_driver(manager)
+        cql, _ = await manager.get_ready_cql(token_owning_servers)
+
+        logger.info("Finalizing tablets migration (should succeed with zero-token node present)")
+        await manager.api.finalize_vnode_tablet_migration(server_dc1.ip_addr, ks)
+
+        # finalize_vnode_tablet_migration returns once the group0 command is applied on the
+        # topology coordinator; other nodes apply it asynchronously. Barrier before reading
+        # the schema so we observe the latest group0 state.
+        await read_barrier(manager.api, server_dc1.ip_addr)
+        host_dc1 = cql.cluster.metadata.get_host(server_dc1.ip_addr)
+
+        logger.info("Verifying that the keyspace schema has tablets enabled")
+        res = await cql.run_async(f"SELECT * FROM system_schema.scylla_keyspaces WHERE keyspace_name = '{ks}'", host=host_dc1)
+        assert len(res) == 1 and res[0].initial_tablets is not None, \
+            "Keyspace is still using vnodes after migration finalization"
+
+        logger.info("Verifying data integrity after finalization")
+        await verify_data_integrity(cql, ks, "test", num_keys)


### PR DESCRIPTION
Vnodes-to-tablets migration finalization iterates all normal_nodes and
checks that each has an entry in _load_stats_per_node reporting the
migrating table. However, collect_tablet_load_stats only polled
token-owning nodes (via get_datacenter_token_owners_nodes), so zero-token
nodes (e.g. in an arbiter DC) never got an entry. Finalization then failed
with 'No load stats available for node X', even though such a node had
already switched to tablets and would have reported it if asked.

Iterate topology::get_datacenter_nodes() instead, which covers all nodes of
a DC rather than only its token owners, restricted to nodes in the normal
state.

Nodes owning no tokens are polled but kept out of the DC-level aggregation,
and DCs without any token owner are skipped entirely. This matters because
the aggregation is replica-scoped: split_ready_seq_number is a minimum over
replicas, and load_stats::operator+= forces it to the minimum for any table
a source does not report. Feeding a non-replica into it would stall resize
convergence for the table.

Backport is not needed

Fixes https://scylladb.atlassian.net/browse/SCYLLADB-3268