### PR TITLE
compaction: register backlog tracker of compaction groups created after start

### DIFF
--- a/compaction/compaction_backlog_manager.hh
+++ b/compaction/compaction_backlog_manager.hh
@@ -81,11 +81,18 @@ public:
     void copy_ongoing_charges(compaction_backlog_tracker& new_bt, bool move_read_charges = true) const;
     void revert_charges(sstables::shared_sstable sst);
 
+    // Stops tracking. A disabled tracker reports the "backlog unknown" sentinel, which
+    // makes the controller fall back to maximum shares. Used when the tracker failed
+    // and its state can no longer be trusted.
     void disable() {
         _impl = {};
         _ongoing_writes = {};
         _ongoing_compactions = {};
     }
+
+    // The tracked compaction group is gone. Stops tracking and stops contributing to
+    // the manager's backlog altogether, as there is no work left to account for.
+    void retire();
 private:
     // Returns true if this SSTable can be added or removed from the tracker.
     bool sstable_belongs_to_tracker(const sstables::shared_sstable& sst);

--- a/compaction/compaction_manager.cc
+++ b/compaction/compaction_manager.cc
@@ -2602,7 +2602,7 @@ compaction_reenabler compaction_manager::add_with_compaction_disabled(compaction
 future<> compaction_manager::remove(compaction_group_view& t, sstring reason) noexcept {
     auto& c_state = get_compaction_state(&t);
     auto erase_state = defer([&t, this] () noexcept {
-       t.get_backlog_tracker().disable();
+       t.get_backlog_tracker().retire();
        _compaction_state.erase(&t);
     });
 
@@ -2711,6 +2711,14 @@ void compaction_manager::plug_system_keyspace(db::system_keyspace& sys_ks) noexc
 
 future<> compaction_manager::unplug_system_keyspace() noexcept {
     co_await _sys_ks.unplug();
+}
+
+void compaction_backlog_tracker::retire() {
+    if (_manager) {
+        _manager->remove_backlog_tracker(this);
+        _manager = nullptr;
+    }
+    disable();
 }
 
 double compaction_backlog_tracker::backlog() const {

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -3309,11 +3309,15 @@ compaction_group::compaction_group(table& t, size_t group_id, dht::token_range t
     , _main_sstables(make_lw_shared<sstables::sstable_set>(make_main_sstable_set()))
     , _maintenance_sstables(make_maintenance_sstable_set())
     , _async_gate(format("[compaction_group {}.{} {}]", t.schema()->ks_name(), t.schema()->cf_name(), group_id))
-    , _backlog_tracker(t.get_compaction_strategy().make_backlog_tracker())
     , _repair_sstable_classifier(std::move(repair_classifier))
     , _logstor_segments(make_lw_shared<logstor::segment_set>())
     , _lowest_rp(db::replay_position::max)
 {
+    // Must go through register_backlog_tracker(), otherwise this group's backlog would
+    // be tracked but never accounted by the compaction backlog manager. Groups created
+    // after the table was started (tablet split, migration or merge) are not covered by
+    // the registration done by table::set_compaction_strategy().
+    register_backlog_tracker(t.get_compaction_strategy().make_backlog_tracker());
 }
 
 compaction_group_ptr compaction_group::make_empty_group(const compaction_group& base) {

--- a/test/boost/tablets_test.cc
+++ b/test/boost/tablets_test.cc
@@ -33,6 +33,7 @@
 #include "schema/schema_builder.hh"
 
 #include "replica/tablets.hh"
+#include "compaction/compaction_manager.hh"
 #include "replica/tablet_mutation_builder.hh"
 #include "locator/tablets.hh"
 #include "service/tablet_allocator.hh"
@@ -5875,6 +5876,106 @@ SEASTAR_THREAD_TEST_CASE(basic_tablet_storage_splitting_test) {
             auto& table = db.find_column_family("ks", "cf");
             return make_ready_future<bool>(table.all_storage_groups_split());
         }, bool(false), std::logical_or<bool>()).get(), true);
+    }, std::move(cfg)).get();
+}
+
+// Compaction groups created after the table was started must contribute to the
+// compaction backlog.
+//
+// replica::compaction_group's constructor builds a backlog tracker but never
+// registers it with compaction_backlog_manager. The only registration path is
+// table::set_compaction_strategy(), which runs at table start and on schema
+// change, so it only ever covers the compaction groups that exist at that
+// moment. The groups a tablet split creates keep a live, correctly charged
+// tracker that nothing ever reads, and the shard reports no compaction backlog
+// at all while sstables pile up in them.
+//
+// The split here is driven the same way a user would drive it: ALTER TABLE
+// raising min_tablet_count, then the tablet scheduler.
+SEASTAR_THREAD_TEST_CASE(test_compaction_backlog_of_compaction_groups_created_by_tablet_split) {
+    auto cfg = tablet_cql_test_config();
+    cfg.initial_tablets = std::bit_floor(this_smp_shard_count());
+    cfg.db_config->tablets_per_shard_goal.set(10000); // Inhibit scaling-down of the count.
+    do_with_cql_env_thread([] (cql_test_env& e) {
+        e.execute_cql("CREATE TABLE cf (pk int, ck int, v text, PRIMARY KEY (pk, ck))").get();
+        auto table = e.local_db().find_column_family("ks", "cf").schema()->id();
+
+        // Auto compaction would consume the very backlog this test observes.
+        e.db().invoke_on_all([] (replica::database& db) {
+            return db.find_column_family("ks", "cf").disable_auto_compaction();
+        }).get();
+
+        auto total_backlog = [&e] {
+            return e.db().map_reduce0([] (replica::database& db) {
+                return make_ready_future<double>(db.get_compaction_manager().backlog());
+            }, double(0), std::plus<double>()).get();
+        };
+        auto total_sstables = [&e] {
+            return e.db().map_reduce0([] (replica::database& db) {
+                return make_ready_future<int64_t>(db.find_column_family("ks", "cf").sstables_count());
+            }, int64_t(0), std::plus<int64_t>()).get();
+        };
+
+        // Each round produces one sstable per compaction group holding data. More than
+        // min_compaction_threshold sstables of similar size, so the size-tiered backlog
+        // tracker finds an interesting bucket.
+        auto write_sstables = [&e] (int rounds, int key_base) {
+            for (int round = 0; round < rounds; round++) {
+                for (int i = 0; i < 256; i++) {
+                    e.execute_cql(format("INSERT INTO cf (pk, ck, v) VALUES ({}, {}, 'payload to give the sstable some size')",
+                                         key_base + round * 256 + i, round)).get();
+                }
+                e.db().invoke_on_all([] (replica::database& db) {
+                    return db.find_column_family("ks", "cf").flush();
+                }).get();
+            }
+        };
+
+        write_sstables(8, 0);
+
+        testlog.info("before split: sstables={} backlog={}", total_sstables(), total_backlog());
+        // Sanity check: the compaction group that existed when the table was started is
+        // registered, so the backlog does account for accumulated work.
+        BOOST_REQUIRE_GT(total_backlog(), 0.0);
+
+        testlog.info("Requesting a tablet split...");
+        auto new_tablet_count = 2 * std::bit_floor(this_smp_shard_count());
+        e.execute_cql(format("ALTER TABLE ks.cf WITH tablets = {{'min_tablet_count': '{}'}}", new_tablet_count)).get();
+
+        auto& stm = e.shared_token_metadata().local();
+        shared_load_stats load_stats;
+        stm.get()->get_topology().for_each_node([&] (const locator::node& node) {
+            load_stats.set_capacity(node.host_id(), service::default_target_tablet_size * node.get_shard_count());
+        });
+        load_stats.set_tablet_sizes(stm.get(), table, service::default_target_tablet_size);
+
+        // Emit the split resize decision. The replica's own split monitor notices it
+        // and splits the storage groups in the background.
+        apply_resize_decisions(e, load_stats);
+
+        // Wait for the replica to finish splitting, like the topology coordinator does.
+        auto deadline = lowres_clock::now() + std::chrono::minutes(1);
+        while (!e.db().map_reduce0([] (replica::database& db) {
+                    return make_ready_future<bool>(db.find_column_family("ks", "cf").all_storage_groups_split());
+                }, true, std::logical_and<bool>()).get()) {
+            BOOST_REQUIRE(lowres_clock::now() < deadline);
+            seastar::sleep(std::chrono::milliseconds(100)).get();
+        }
+
+        // Finalize the resize: the tablet count doubles and the groups created for the
+        // split become the storage groups of the new tablets.
+        load_stats.set_split_ready_seq_number(table, stm.get()->tablets().get_tablet_map(table).resize_decision().sequence_number);
+        rebalance_tablets(e, &load_stats);
+        BOOST_REQUIRE_EQUAL(stm.get()->tablets().get_tablet_map(table).tablet_count(), new_tablet_count);
+
+        // Fill the compaction groups that the split created.
+        write_sstables(8, 1000000);
+
+        auto sstables_after = total_sstables();
+        auto backlog_after = total_backlog();
+        testlog.info("after split: sstables={} backlog={}", sstables_after, backlog_after);
+        BOOST_REQUIRE_GT(sstables_after, 0);
+        BOOST_REQUIRE_GT(backlog_after, 0.0);
     }, std::move(cfg)).get();
 }
 


### PR DESCRIPTION

replica::compaction_group's constructor builds its backlog tracker but never registers it with compaction_backlog_manager. The only registration path is table::set_compaction_strategy(), which runs at table start and on schema change, so it only ever covers the compaction groups that exist at that moment.

Groups created later -- by tablet split, tablet migration or tablet merge -- keep a live, correctly charged tracker that nothing ever reads. Their sstables don't contribute to compaction_manager::backlog(), so the compaction controller under-provisions shares and scylla_compaction_manager_backlog under-reports. It decays over time: when a tablet splits or migrates, the old registered group is destroyed and deregisters its tracker, while the group that replaces it is unregistered, so after enough tablet churn a shard reports a zero backlog no matter how many sstables it holds. A schema change masks it temporarily, since set_schema() re-registers every group existing at that point.

Register in the compaction group constructor, going through compaction_group::register_backlog_tracker() so that there is a single registration path.

Now that every group is registered, compaction_manager::remove() must stop the tracker of the group it removes from contributing. It disables the tracker, and a disabled tracker reports the "backlog unknown" sentinel, which would put the whole shard on maximum compaction shares until the group object is freed. Add retire() for that -- deregister, then disable -- and leave disable() as it is for the replace_sstables() failure path, where reporting the sentinel is the deliberate safe fallback.

Introduced in b88acffd663 ("replica: Allow one compaction_backlog_tracker for each compaction_group"), first released in 5.2.0, which replaced the per-table strategy tracker (registered on every strategy change and shared by all groups) with per-group trackers, without adding registration at group creation. It became reachable only in 85020861fca ("replica: Remap compaction groups when tablet split is finalized"), first released in 6.0.0, the first compaction groups to be created after table::start() has run.

The test drives the split the way a user would: ALTER TABLE raising min_tablet_count, then the tablet scheduler, leaving the split itself to the replica's own split monitor. Before this patch it observes 32 sstables and a backlog of exactly 0, against 8 sstables and a backlog of ~208k before the split.

Fixes: https://scylladb.atlassian.net/browse/SCYLLADB-3793

Backporting to all live versions, as this is a critical bug and can easily cause a cluster to run out of memory and have huge read amplification.