### PR TITLE
storage_service: assign tablet shards by token range size

### DIFF
--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -4110,7 +4110,7 @@ future<> storage_service::update_tablet_metadata(const locator::tablet_metadata_
 future<locator::tablet_map> storage_service::build_tablet_map_for_migration(
         locator::token_metadata_ptr tm,
         const locator::static_effective_replication_map_ptr& erm,
-        size_t target_pow2) const {
+        size_t target_pow2) {
     const auto& sorted_tokens = tm->sorted_tokens();
 
     // Construct token boundaries: union of vnode tokens + optional pow2 boundaries.

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -4107,11 +4107,11 @@ future<> storage_service::update_tablet_metadata(const locator::tablet_metadata_
     wake_up_topology_state_machine();
 }
 
-locator::tablet_map storage_service::build_tablet_map_for_migration(
-        const locator::token_metadata& tm,
+future<locator::tablet_map> storage_service::build_tablet_map_for_migration(
+        locator::token_metadata_ptr tm,
         const locator::static_effective_replication_map_ptr& erm,
         size_t target_pow2) const {
-    const auto& sorted_tokens = tm.sorted_tokens();
+    const auto& sorted_tokens = tm->sorted_tokens();
 
     // Construct token boundaries: union of vnode tokens + optional pow2 boundaries.
     // target_pow2 == 0 means no pow2 convergence target and only wrap-around pre-split.
@@ -4159,6 +4159,7 @@ locator::tablet_map storage_service::build_tablet_map_for_migration(
         auto boundary = tablet_last.unbias();
         tablets.push_back(tablet_desc{locator::tablet_id(i), vnode_token, boundary - prev_boundary});
         prev_boundary = boundary;
+        co_await coroutine::maybe_yield();
     }
 
     // Aggregate token range assigned to each shard of a node, kept as a min-heap
@@ -4167,7 +4168,7 @@ locator::tablet_map storage_service::build_tablet_map_for_migration(
     // holds exactly.
     using shard_range = std::pair<uint64_t, shard_id>;
     std::unordered_map<locator::host_id, std::vector<shard_range>> shard_load;
-    tm.for_each_token_owner([&] (const locator::node& node) {
+    tm->for_each_token_owner([&] (const locator::node& node) {
         auto shard_count = node.get_shard_count();
         if (!shard_count) {
             throw std::runtime_error(fmt::format("Shard count not known for node {}", node.host_id()));
@@ -4194,13 +4195,14 @@ locator::tablet_map storage_service::build_tablet_map_for_migration(
             std::ranges::push_heap(shards, std::greater<>{});
         }
         tmap.set_tablet(tablet.id, locator::tablet_info(std::move(tablet_replicas)));
+        co_await coroutine::maybe_yield();
     }
 
     if (target_pow2 && tablet_count != target_pow2) {
         tmap.set_target_pow2_tablet_count(target_pow2);
     }
 
-    return tmap;
+    co_return tmap;
 }
 
 future<std::unordered_map<table_id, uint64_t>> storage_service::collect_table_sizes_for_migration(
@@ -4333,7 +4335,8 @@ future<> storage_service::prepare_for_tablets_migration(const sstring& ks_name) 
         //  min           P1            P2            P3          max
         //   |------------|-------------|-------------|------------|
 
-        const auto& tm = get_token_metadata();
+        const auto tmptr = get_token_metadata_ptr();
+        const auto& tm = *tmptr;
 
         // Estimate table sizes when pow2 convergence is enabled.
         // The estimates are used by the tablet allocator to determine the
@@ -4388,11 +4391,11 @@ future<> storage_service::prepare_for_tablets_migration(const sstring& ks_name) 
                     if (auto it = target_pow2s.find(tid); it != target_pow2s.end()) {
                         target_pow2 = it->second;
                     }
-                    auto tmap = build_tablet_map_for_migration(tm, erm, target_pow2);
+                    auto tmap = co_await build_tablet_map_for_migration(tmptr, erm, target_pow2);
                     co_await append_tablet_map_mutations(tid, cf_name, tmap, target_pow2);
                 }
             } else {
-                auto shared_tmap = build_tablet_map_for_migration(tm, erm, 0);
+                auto shared_tmap = co_await build_tablet_map_for_migration(tmptr, erm, 0);
                 for (const auto& [tid, cf_name] : tables_to_migrate) {
                     co_await append_tablet_map_mutations(tid, cf_name, shared_tmap, 0);
                 }

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -4135,31 +4135,65 @@ locator::tablet_map storage_service::build_tablet_map_for_migration(
     locator::tablet_map tmap(std::move(last_tokens));
     auto tablet_count = tmap.tablet_count();
 
-    // Stateful lambdas for round-robin shard assignment per node.
-    std::unordered_map<locator::host_id, std::function<shard_id()>> next_shard_for;
-    tm.for_each_token_owner([&] (const locator::node& node) {
-        auto host = node.host_id();
-        next_shard_for[host] = [num_shards = node.get_shard_count(), idx = 0u] () mutable {
-            return shard_id(idx++ % num_shards);
-        };
-    });
+    struct tablet_desc {
+        locator::tablet_id id;
+        dht::token vnode_token;
+        uint64_t token_range_size;
+    };
+    utils::chunked_vector<tablet_desc> tablets;
+    tablets.reserve(tablet_count);
 
     size_t vnode_idx = 0;
+    // unbias() maps tokens monotonically onto [0, 2^64), so the distance between
+    // consecutive tablet boundaries is the size of the range a tablet owns.
+    // unbias(minimum_token()) is 0, the lower bound of the first tablet.
+    uint64_t prev_boundary = dht::minimum_token().unbias();
     for (size_t i = 0; i < tablet_count; ++i) {
-        auto tablet = locator::tablet_id(i);
-        auto tablet_last = dht::raw_token(tmap.get_last_token(tablet));
-        while (vnode_idx < sorted_tokens.size() && dht::raw_token(sorted_tokens[vnode_idx]) < tablet_last) {
+        auto tablet_last = tmap.get_last_token(locator::tablet_id(i));
+        while (vnode_idx < sorted_tokens.size() && dht::raw_token(sorted_tokens[vnode_idx]) < dht::raw_token(tablet_last)) {
             ++vnode_idx;
         }
         auto vnode_token = (vnode_idx < sorted_tokens.size())
             ? sorted_tokens[vnode_idx]
             : sorted_tokens[0]; // wrap-around vnode
-        auto vnode_replica_hosts = erm->get_natural_replicas(vnode_token, true);
-        locator::tablet_replica_set tablet_replicas;
-        for (auto host : vnode_replica_hosts) {
-            tablet_replicas.push_back(locator::tablet_replica{host, next_shard_for[host]()});
+        auto boundary = tablet_last.unbias();
+        tablets.push_back(tablet_desc{locator::tablet_id(i), vnode_token, boundary - prev_boundary});
+        prev_boundary = boundary;
+    }
+
+    // Aggregate token range assigned to each shard of a node, kept as a min-heap
+    // ordered by (range, shard). A tablet is placed on at most one shard per node,
+    // so the per-shard sums add up to the size of the ring at most, which uint64_t
+    // holds exactly.
+    using shard_range = std::pair<uint64_t, shard_id>;
+    std::unordered_map<locator::host_id, std::vector<shard_range>> shard_load;
+    tm.for_each_token_owner([&] (const locator::node& node) {
+        auto shard_count = node.get_shard_count();
+        if (!shard_count) {
+            throw std::runtime_error(fmt::format("Shard count not known for node {}", node.host_id()));
         }
-        tmap.set_tablet(tablet, locator::tablet_info(std::move(tablet_replicas)));
+        std::vector<shard_range> shards;
+        shards.reserve(shard_count);
+        for (shard_id shard = 0; shard < shard_count; ++shard) {
+            shards.emplace_back(0, shard);
+        }
+        std::ranges::make_heap(shards, std::greater<>{});
+        shard_load.emplace(node.host_id(), std::move(shards));
+    });
+
+    std::ranges::sort(tablets, std::ranges::greater(), &tablet_desc::token_range_size);
+
+    for (const auto& tablet : tablets) {
+        locator::tablet_replica_set tablet_replicas;
+        for (auto host : erm->get_natural_replicas(tablet.vnode_token, true)) {
+            auto& shards = shard_load.at(host);
+            std::ranges::pop_heap(shards, std::greater<>{});
+            auto& [range, shard] = shards.back();
+            range += tablet.token_range_size;
+            tablet_replicas.push_back(locator::tablet_replica{host, shard});
+            std::ranges::push_heap(shards, std::greater<>{});
+        }
+        tmap.set_tablet(tablet.id, locator::tablet_info(std::move(tablet_replicas)));
     }
 
     if (target_pow2 && tablet_count != target_pow2) {
@@ -4260,9 +4294,10 @@ future<> storage_service::prepare_for_tablets_migration(const sstring& ks_name) 
         // vnode range. If the last vnode token is not MAX_TOKEN, an additional
         // tablet is created to cover the wrap-around range
         // (last_vnode_token, MAX_TOKEN].
-        // Tablets inherit their replica hosts from their corresponding vnode
-        // and shards are assigned in round-robin fashion per node so that
-        // tablets are evenly distributed within each node.
+        // Tablets inherit their replica hosts from their corresponding vnode.
+        // Shards are picked per node so that the aggregate token range owned by
+        // each shard is as even as possible, since vnode-derived tablets differ
+        // widely in size and counting them alone would misrepresent the load.
         //
         // However, this direct 1:1 mapping is not sufficient in terms of
         // performance because vnode token ranges vary in size, producing

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -379,7 +379,7 @@ private:
     void register_metrics();
     future<> snitch_reconfigured();
 
-    locator::tablet_map build_tablet_map_for_migration(const locator::token_metadata& tm,
+    future<locator::tablet_map> build_tablet_map_for_migration(locator::token_metadata_ptr tm,
             const locator::static_effective_replication_map_ptr& erm,
             size_t target_pow2 = 0) const;
     future<std::unordered_map<table_id, uint64_t>> collect_table_sizes_for_migration(

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -379,9 +379,14 @@ private:
     void register_metrics();
     future<> snitch_reconfigured();
 
-    future<locator::tablet_map> build_tablet_map_for_migration(locator::token_metadata_ptr tm,
+public:
+    // Builds the initial tablet map for a vnodes-to-tablets migration. Depends on
+    // nothing but its arguments, so it is static and can be driven directly with a
+    // synthetic topology.
+    static future<locator::tablet_map> build_tablet_map_for_migration(locator::token_metadata_ptr tm,
             const locator::static_effective_replication_map_ptr& erm,
-            size_t target_pow2 = 0) const;
+            size_t target_pow2 = 0);
+private:
     future<std::unordered_map<table_id, uint64_t>> collect_table_sizes_for_migration(
         const locator::token_metadata& tm,
         const locator::tablet_aware_replication_strategy* trs,

--- a/test/boost/vnodes_to_tablets_migration_test.cc
+++ b/test/boost/vnodes_to_tablets_migration_test.cc
@@ -13,6 +13,15 @@
 #include "test/lib/cql_test_env.hh"
 #include "locator/tablets.hh"
 #include "service/storage_service.hh"
+#include "locator/abstract_replication_strategy.hh"
+#include "locator/network_topology_strategy.hh"
+#include "locator/token_metadata.hh"
+#include "db/schema_tables.hh"
+#include "dht/token.hh"
+#include "utils/UUID_gen.hh"
+
+#include <seastar/testing/thread_test_case.hh>
+#include <seastar/util/defer.hh>
 
 BOOST_AUTO_TEST_SUITE(vnodes_to_tablets_migration_test)
 
@@ -152,6 +161,173 @@ SEASTAR_TEST_CASE(test_tablet_map_creation_already_pow2_layout) {
         BOOST_REQUIRE(!tmap.is_converging_to_pow2());
         BOOST_REQUIRE_EQUAL(tmap.target_pow2_tablet_count(), 0);
     }, cfg);
+}
+
+namespace {
+
+// Builds a single-node topology with the given shard count, places vnode tokens at
+// the given positions in unbiased token space, and runs the migration tablet map
+// builder over it.
+//
+// target_pow2 is 0, so the only boundary added on top of the vnode tokens is the
+// maximum token. The tablets are therefore exactly the ranges the caller laid out,
+// which is what makes the resulting assignment predictable by hand.
+static locator::tablet_map build_map(const std::vector<locator::host_id>& hosts, unsigned shard_count,
+                                     const std::vector<std::vector<uint64_t>>& vnode_positions_of,
+                                     size_t rf) {
+    locator::token_metadata::config tm_cfg;
+    tm_cfg.topo_cfg.this_host_id = hosts[0];
+    tm_cfg.topo_cfg.local_dc_rack = locator::endpoint_dc_rack::default_location;
+    locator::shared_token_metadata stm([] () noexcept { return db::schema_tables::hold_merge_lock(); }, tm_cfg);
+    auto stop_stm = deferred_stop(stm);
+
+    stm.mutate_token_metadata([&] (locator::token_metadata& tm) -> future<> {
+        for (size_t n = 0; n < hosts.size(); ++n) {
+            std::unordered_set<dht::token> tokens;
+            for (auto pos : vnode_positions_of[n]) {
+                tokens.insert(dht::bias(pos));
+            }
+            tm.get_topology().add_or_update_endpoint(hosts[n], locator::endpoint_dc_rack::default_location,
+                                                     locator::node::state::normal, shard_count);
+            co_await tm.update_normal_tokens(tokens, hosts[n]);
+        }
+    }).get();
+
+    std::map<sstring, locator::replication_strategy_config_option> options = {
+        { locator::endpoint_dc_rack::default_location.dc, fmt::to_string(rf) },
+    };
+    locator::replication_strategy_params params(options, std::nullopt, std::nullopt);
+    auto rs = locator::abstract_replication_strategy::create_replication_strategy(
+            "NetworkTopologyStrategy", params, stm.get()->get_topology());
+    auto erm = locator::calculate_vnode_effective_replication_map(rs, stm.get()).get();
+
+    return service::storage_service::build_tablet_map_for_migration(stm.get(), erm, 0).get();
+}
+
+static locator::tablet_map build_single_node_map(locator::host_id host, unsigned shard_count,
+                                                 const std::vector<uint64_t>& vnode_positions) {
+    return build_map({host}, shard_count, {vnode_positions}, 1);
+}
+
+// With RF=1 on a single node every tablet has exactly one replica, so the mapping
+// from tablet to shard is unambiguous.
+static void check_shard_mapping(const locator::tablet_map& tmap, locator::host_id host,
+                                const std::vector<shard_id>& expected) {
+    BOOST_REQUIRE_EQUAL(tmap.tablet_count(), expected.size());
+    for (size_t i = 0; i < expected.size(); ++i) {
+        const auto& replicas = tmap.get_tablet_info(locator::tablet_id(i)).replicas;
+        BOOST_REQUIRE_EQUAL(replicas.size(), 1);
+        BOOST_REQUIRE_EQUAL(replicas[0].host, host);
+        BOOST_CHECK_EQUAL(replicas[0].shard, expected[i]);
+    }
+}
+
+// One hundredth of the ring, the unit the cases below express tablet widths in.
+constexpr uint64_t ring_percent = std::numeric_limits<uint64_t>::max() / 100;
+
+} // anonymous namespace
+
+// Six tablets of uneven width over four shards.
+//
+// The widths are deliberately not in descending token order, so the assignment has
+// to reorder them rather than just walking the map.
+SEASTAR_THREAD_TEST_CASE(test_shard_assignment_maps_six_tablets_onto_four_shards) {
+    auto host = locator::host_id(utils::UUID_gen::get_time_UUID());
+
+    // Tablet widths in token order, in hundredths of the ring:
+    //   t0=15  t1=30  t2=4  t3=20  t4=25  t5=the remainder, just over 6
+    auto tmap = build_single_node_map(host, 4, {
+        15 * ring_percent, 45 * ring_percent, 49 * ring_percent,
+        69 * ring_percent, 94 * ring_percent,
+    });
+
+    // Largest tablet first onto the shard owning the least so far, ties going to
+    // the lowest shard id. Shard loads after each placement:
+    //   t1(30) -> shard 0   [30,  0,  0,  0]
+    //   t4(25) -> shard 1   [30, 25,  0,  0]
+    //   t3(20) -> shard 2   [30, 25, 20,  0]
+    //   t0(15) -> shard 3   [30, 25, 20, 15]
+    //   t5( 6) -> shard 3   [30, 25, 20, 21]
+    //   t2( 4) -> shard 2   [30, 25, 24, 21]
+    check_shard_mapping(tmap, host, { 3, 0, 2, 2, 1, 3 });
+}
+
+// Eight tablets over four shards, chosen so that the assignment can reach a
+// perfectly even split: every shard ends up owning a quarter of the ring.
+SEASTAR_THREAD_TEST_CASE(test_shard_assignment_maps_eight_tablets_evenly) {
+    auto host = locator::host_id(utils::UUID_gen::get_time_UUID());
+
+    // Tablet widths in token order, in hundredths of the ring:
+    //   t0=5  t1=22  t2=3  t3=18  t4=12  t5=25  t6=7  t7=the remainder, just over 8
+    auto tmap = build_single_node_map(host, 4, {
+        5 * ring_percent, 27 * ring_percent, 30 * ring_percent, 48 * ring_percent,
+        60 * ring_percent, 85 * ring_percent, 92 * ring_percent,
+    });
+
+    //   t5(25) -> shard 0   [25,  0,  0,  0]
+    //   t1(22) -> shard 1   [25, 22,  0,  0]
+    //   t3(18) -> shard 2   [25, 22, 18,  0]
+    //   t4(12) -> shard 3   [25, 22, 18, 12]
+    //   t7( 8) -> shard 3   [25, 22, 18, 20]
+    //   t6( 7) -> shard 2   [25, 22, 25, 20]
+    //   t0( 5) -> shard 3   [25, 22, 25, 25]
+    //   t2( 3) -> shard 1   [25, 25, 25, 25]
+    check_shard_mapping(tmap, host, { 3, 1, 1, 2, 3, 0, 2, 3 });
+}
+
+// Three nodes at RF=2, so every tablet lands on two of them and each node runs its
+// own assignment over the subset it replicates.
+//
+// Tokens are laid out so the nodes own interleaved parts of the ring:
+//   node A holds 10 and 70, node B holds 25, node C holds 45
+// which gives five tablets of width 10, 15, 20, 25 and 30 hundredths, and replica
+// sets that differ from tablet to tablet.
+SEASTAR_THREAD_TEST_CASE(test_shard_assignment_across_nodes_with_replicas) {
+    std::vector<locator::host_id> hosts;
+    for (int i = 0; i < 3; ++i) {
+        hosts.push_back(locator::host_id(utils::UUID_gen::get_time_UUID()));
+    }
+
+    auto tmap = build_map(hosts, 2, {
+        { 10 * ring_percent, 70 * ring_percent },   // A
+        { 25 * ring_percent },                      // B
+        { 45 * ring_percent },                      // C
+    }, 2);
+
+    BOOST_REQUIRE_EQUAL(tmap.tablet_count(), 5);
+
+    // Tablets are offered largest first, and each host picks independently from its
+    // own shards. Walking the global order, with the per-host shard loads alongside:
+    //
+    //   t4(30) on A,B   A[30, 0]  B[30, 0]
+    //   t3(25) on A,B   A[30,25]  B[30,25]
+    //   t2(20) on C,A   C[20, 0]  A[30,45]
+    //   t1(15) on B,C   B[30,40]  C[20,15]
+    //   t0(10) on A,B   A[40,45]  B[40,40]
+    //
+    // A ends up at [40,45], B at [40,40], C at [20,15]: every host balanced within
+    // itself, which is the point -- the assignment is per host, not global.
+    const std::vector<std::vector<std::pair<size_t, shard_id>>> expected = {
+        { {0, 0}, {1, 0} },   // t0 -> A:0  B:0
+        { {1, 1}, {2, 1} },   // t1 -> B:1  C:1
+        { {2, 0}, {0, 1} },   // t2 -> C:0  A:1
+        { {0, 1}, {1, 1} },   // t3 -> A:1  B:1
+        { {0, 0}, {1, 0} },   // t4 -> A:0  B:0
+    };
+
+    for (size_t i = 0; i < expected.size(); ++i) {
+        std::vector<std::pair<size_t, shard_id>> got;
+        for (const auto& replica : tmap.get_tablet_info(locator::tablet_id(i)).replicas) {
+            auto it = std::ranges::find(hosts, replica.host);
+            BOOST_REQUIRE(it != hosts.end());
+            got.emplace_back(std::distance(hosts.begin(), it), replica.shard);
+        }
+        auto want = expected[i];
+        std::ranges::sort(got);
+        std::ranges::sort(want);
+        BOOST_CHECK_MESSAGE(got == want,
+                fmt::format("tablet {}: expected {}, got {}", i, want, got));
+    }
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Tablets created for a vnodes-to-tablets migration inherit their boundaries from the vnode token ring, so they vary widely in size. Assigning their replicas to shards round-robin weighs every tablet equally, which leaves some shards owning several times more of the ring than others for the whole duration of the migration.

Track the aggregate token range owned by each shard instead, and place each tablet on the shard owning the least. Tablets are placed largest first so that the smaller ones are left to even out whatever imbalance the large ones cause; placing them in token order leaves no room to compensate for a large tablet that comes last.

Replica hosts are unchanged, so the migration still moves no data between nodes. A node with an unknown shard count now raises an error instead of reaching a modulo by zero.

Backport is not required, it is an improvement

Fixes SCYLLADB-2607