### PR TITLE
repair: Use seastar::formattable() for exception_ptr formatting

### DIFF
--- a/repair/repair.cc
+++ b/repair/repair.cc
@@ -1246,7 +1246,7 @@ future<> repair::shard_repair_task_impl::run() {
     try {
         co_await do_repair_ranges();
     } catch (...) {
-        _failed_because.emplace(fmt::to_string(std::current_exception()));
+        _failed_because.emplace(fmt::to_string(seastar::formattable(std::current_exception())));
         rlogger.debug("repair[{}]: got error in do_repair_ranges: {}",
             global_repair_id.uuid(), std::current_exception());
     }


### PR DESCRIPTION
fmt::formatter<std::exception_ptr> is deprecated in favor of seastar::formattable(), to avoid formatting a std::exception_ptr directly.

Compilation fix, not backporting