### PR TITLE
rest/client: Avoid reading the deprecated request::content field

### DIFF
--- a/ent/encryption/azure_host.cc
+++ b/ent/encryption/azure_host.cc
@@ -397,7 +397,7 @@ future<rjson::value> azure_host::impl::send_request(const sstring& host, unsigne
     client.add_header("Authorization", fmt::format("Bearer {}", token.token));
     client.content("application/json", std::move(rjson::print(body)));
 
-    azlog.trace("Sending request: {}", rest::redacted_request_type{ client.request(), filter });
+    azlog.trace("Sending request: {}", rest::redacted_request_type{ client, filter });
 
     auto res = co_await client.send();
     if (res.result() == http::reply::status_type::ok) {

--- a/utils/azure/identity/managed_identity_credentials.cc
+++ b/utils/azure/identity/managed_identity_credentials.cc
@@ -175,7 +175,7 @@ future<> managed_identity_credentials::refresh(const resource_type& resource_uri
         client.add_header("Metadata", "true");
 
         if (az_creds_logger.is_enabled(log_level::trace)) {
-            az_creds_logger.trace("[{}] Sending request: {}", *this, rest::redacted_request_type{ client.request(), filter });
+            az_creds_logger.trace("[{}] Sending request: {}", *this, rest::redacted_request_type{ client, filter });
         }
 
         auto res = co_await client.send();

--- a/utils/azure/identity/service_principal_credentials.cc
+++ b/utils/azure/identity/service_principal_credentials.cc
@@ -173,7 +173,7 @@ future<sstring> service_principal_credentials::post(const sstring& body) {
     client.content(mime_type, std::move(body));
 
     if (az_creds_logger.is_enabled(log_level::trace)) {
-        az_creds_logger.trace("[{}] Sending request: {}", *this, rest::redacted_request_type{ client.request(), filter });
+        az_creds_logger.trace("[{}] Sending request: {}", *this, rest::redacted_request_type{ client, filter });
     }
 
     auto res = co_await client.send();

--- a/utils/gcp/object_storage.cc
+++ b/utils/gcp/object_storage.cc
@@ -558,7 +558,7 @@ utils::gcp::storage::client::impl::send_with_retry(const std::string& path, cons
     req.add_header("Content-Length", std::to_string(req.request().content_length));
 
     gcp_storage.trace("Sending: {}", redacted_request_type {
-        req.request(),
+        req,
         bearer_filter()
     });
 

--- a/utils/rest/client.cc
+++ b/utils/rest/client.cc
@@ -40,10 +40,15 @@ void rest::request_wrapper::method(method_type type) {
 }
 
 void rest::request_wrapper::content(std::string_view content_type, std::string_view content) {
-    _req.write_body(sstring(content_type), sstring(content));
+    _content = make_lw_shared<sstring>(sstring(content));
+    auto body = _content;
+    _req.write_body(sstring(content_type), body->size(), [body] (output_stream<char>& out) -> future<> {
+        return out.write(*body);
+    });
 }
 
 void rest::request_wrapper::content(std::string_view content_type, body_writer w, size_t len) {
+    _content = {};
     _req.write_body(sstring(content_type), len, std::move(w));
 }
 
@@ -255,12 +260,13 @@ fmt::formatter<rest::httpclient::result_type>::format(const rest::httpclient::re
 
 auto
 fmt::formatter<rest::redacted_request_type>::format(const rest::redacted_request_type& rr, fmt::format_context& ctx) const -> decltype(ctx.out()) {
-    const auto& r = rr.original;
+    const auto& r = rr.original.request();
     auto os = fmt::format_to(ctx.out(), "{} {} HTTP/{}{}", r._method, r._url, r._version, linesep);
     for (auto& [k, v] : r._headers) {
         os = fmt::format_to(os, "{}: {}{}", k, rr.filter_header(k, v).value_or(v), linesep);
     }
-    os = fmt::format_to(os, "{}{}", linesep, rr.filter_body(r.content).value_or(r.content));
+    auto content = rr.original.content();
+    os = fmt::format_to(os, "{}{}", linesep, rr.filter_body(content).value_or(std::string(content)));
     return os;
 }
 

--- a/utils/rest/client.hh
+++ b/utils/rest/client.hh
@@ -9,6 +9,7 @@
 
 #pragma once
 #include <seastar/core/future.hh>
+#include <seastar/core/shared_ptr.hh>
 #include <seastar/http/url.hh>
 #include <seastar/http/client.hh>
 #include <seastar/http/request.hh>
@@ -62,8 +63,18 @@ public:
     operator const request_type&() const {
         return request();
     }
+    // Body set via the string overload of content() above. request::content
+    // is deprecated with no replacement accessor, so we keep our own copy --
+    // it also doubles as the buffer the write_body() writer streams out
+    // from, so there's no duplicate copy involved. Held via a shared_ptr
+    // (not captured by `this` in the writer) so it stays valid regardless
+    // of whether/where the request_wrapper itself gets moved.
+    std::string_view content() const {
+        return _content ? std::string_view(*_content) : std::string_view();
+    }
 protected:
     request_type _req;
+    seastar::lw_shared_ptr<sstring> _content;
 };
 
 /**
@@ -152,7 +163,7 @@ struct redacted {
     }
 };
 
-using redacted_request_type = redacted<httpclient::request_type, http_log_filter::body_type::request>;
+using redacted_request_type = redacted<request_wrapper, http_log_filter::body_type::request>;
 using redacted_result_type  = redacted<httpclient::result_type, http_log_filter::body_type::response>;
 
 using key_value = std::pair<std::string_view, std::string_view>;


### PR DESCRIPTION
seastar::http::request::content is deprecated with no replacement accessor, but our redacted-request formatter (used for trace/debug logging) needed the body text to pass through redaction filters before printing.

Instead, request_wrapper now keeps its own copy of the body and streams it to the request via write_body()'s functor overload rather than the plain string overload. This has two benefits: our copy serves both the actual send and the logging path (no duplicate copy), and since request::body_writer ends up set, any incidental formatting of the raw seastar request (outside our redacted formatter) no longer prints the raw, unredacted body either.

Compilation fix, not backporting