### PR TITLE
Enable tablet-aware restore into object-storage tables

### DIFF
--- a/docs/dev/object_storage.md
+++ b/docs/dev/object_storage.md
@@ -273,6 +273,7 @@ The `manifest` member contains the following attributes:
 - `version` - representing the version of the manifest itself. It is incremented when members are added or removed from the manifest.
 - `scope` - the scope of metadata stored in this manifest file.  The following scopes are supported:
     - `node` - the manifest describes all SSTables owned by this node in this snapshot.
+    - `dc` - the manifest describes all SSTables backed up from one datacenter. Written by cluster backup.
 
 The `node` member contains metadata about this node that enables datacenter- or rack-aware restore.
 - `host_id` - is the node's unique host_id (a UUID).
@@ -369,6 +370,14 @@ Object-storage SSTable lifecycle:
 - Final cleanup: component objects are deleted only after no reference objects remain for the `sstable_id`. This prevents one node from deleting shared data still referenced by another node.
 
 The `status` and `state` fields in `system.sstables` describe the local SSTable entry lifecycle. They do not describe a global lifecycle state for the object-storage component set identified by `sstable_id`.
+
+### Restore into object-storage tables
+
+Tablet-aware restore, the `/storage_service/tablets/restore` API, writes the downloaded components through the storage of the destination table, so a table which uses object storage receives them as objects of its own bucket.
+
+A restore is a copy, so every restored SSTable receives a fresh `sstable_id` derived from its new generation, the same way a newly written SSTable does. The component objects of a table are named `sstables/{sstable_id}/{component}`, and every object-storage table of a bucket shares that prefix. Reusing the `sstable_id` of the backup SSTable would therefore make the copies which different replicas create of it overwrite each other, and would overwrite the objects of the table the backup was taken from, if that table still uses the bucket.
+
+A copy is created like any other new SSTable: a `system.sstables` entry with the `creating` status and a `refs/nodes/{host_id}/{generation}` reference object are created before the first component object is uploaded, and the status is changed to `sealed` once the SSTable is attached to the table. A restore which fails or is aborted therefore leaves behind entries whose status is not `sealed`, which boot time garbage collection removes together with their component objects on the next start of the node.
 
 ## Downloading, deleting, uploading SSTables
 

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -4511,9 +4511,21 @@ public:
         , _checksum(DEFAULT_CHUNK_SIZE, {})
         , _digest(crc32_utils::init_checksum())
     {
+        // create_stream_sink() replaces component_type::TOC with TemporaryTOC for
+        // filesystem storage, so TOC reaches the sink only for object storage.
+        SCYLLA_ASSERT(_type != component_type::TOC || _sst->_storage->is_object_storage());
         sstlog.debug("Creating stream sink for SSTable gen={} sid={} type={} last={} leave_unsealed={}", _sst->generation(), _sst->sstable_identifier(), _type, _last_component, _leave_unsealed);
     }
 private:
+    // TOC and scylla components are guaranteed not to depend on metadata. Ignore these (chicken, egg)
+    // TemporaryTOC is the name filesystem storage writes the TOC under, TOC the name
+    // object storage writes it under.
+    static bool depends_on_metadata(component_type type) {
+        return type != component_type::TOC
+                && type != component_type::TemporaryTOC
+                && type != component_type::Scylla;
+    }
+
     future<> load_metadata() const {
         if (!co_await _sst->_storage->exists(*_sst, component_type::Scylla)) {
             // for compatibility with streaming a non-scylla table (no scylla component)
@@ -4575,9 +4587,7 @@ private:
     }
 public:
     future<output_stream<char>> output(const file_open_options& foptions, const file_output_stream_options& stream_options) override {
-        assert(_type != component_type::TOC);
-        // TOC and scylla components are guaranteed not to depend on metadata. Ignore these (chicken, egg)
-        bool load_save_meta = _type != component_type::TemporaryTOC && _type != component_type::Scylla;
+        bool load_save_meta = depends_on_metadata(_type);
 
         // otherwise, first load scylla metadata from disk as written so far.
         if (load_save_meta) {
@@ -4623,10 +4633,10 @@ public:
         co_await _sst->_storage->unlink_component(*_sst, _type);
     }
     future<> validate_integrity() override {
-        if (_type == component_type::TemporaryTOC || _type == component_type::Scylla) {
+        if (!depends_on_metadata(_type)) {
             co_return;
         }
-        
+
         co_await load_metadata();
         do_validate_component_integrity(_type, _digest);
     }
@@ -4637,8 +4647,9 @@ std::unique_ptr<sstable_stream_sink> create_stream_sink(schema_ptr schema, sstab
 
     auto type = desc.component;
     // Don't write actual TOC. Write temp, if successful, storage::seal will rename this to actual
-    // TOC (see above close_and_seal).
-    if (type == component_type::TOC) {
+    // TOC (see above close_and_seal). Object storage records sealing as a status change of the
+    // system.sstables entry and renames no object, so there the TOC is written under its final name.
+    if (type == component_type::TOC && !s_opts.is_object_storage_type()) {
         type = component_type::TemporaryTOC;
     }
 

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -4543,6 +4543,15 @@ private:
         }
         auto& metadata = *_sst->get_shared_components().scylla_metadata;
 
+        // download_sstable() in sstables_loader_helpers.cc streams the Scylla
+        // component of the backup sstable verbatim, so scylla_metadata still holds
+        // the sstable_id of the backup sstable. Replace the sstable_id with the one
+        // of the sstable being written, before serialized_checksum() below computes
+        // the digest over scylla_metadata::data.
+        if (auto sid = _sst->sstable_identifier()) {
+            metadata.set_sstable_identifier(*sid);
+        }
+
         file_output_stream_options options;
         options.buffer_size = default_sstable_buffer_size;
         co_await seastar::async([&] {

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -4498,6 +4498,7 @@ future<std::vector<std::unique_ptr<sstable_stream_source>>> create_stream_source
 class sstable_stream_sink_impl : public sstable_stream_sink {
     shared_sstable _sst;
     component_type _type;
+    bool _first_component;
     bool _last_component;
     bool _leave_unsealed;
     checksum _checksum;
@@ -4506,6 +4507,7 @@ public:
     sstable_stream_sink_impl(shared_sstable sst, component_type type, sstable_stream_sink_cfg cfg)
         : _sst(std::move(sst))
         , _type(type)
+        , _first_component(cfg.first_component)
         , _last_component(cfg.last_component)
         , _leave_unsealed(cfg.leave_unsealed)
         , _checksum(DEFAULT_CHUNK_SIZE, {})
@@ -4514,7 +4516,7 @@ public:
         // create_stream_sink() replaces component_type::TOC with TemporaryTOC for
         // filesystem storage, so TOC reaches the sink only for object storage.
         SCYLLA_ASSERT(_type != component_type::TOC || _sst->_storage->is_object_storage());
-        sstlog.debug("Creating stream sink for SSTable gen={} sid={} type={} last={} leave_unsealed={}", _sst->generation(), _sst->sstable_identifier(), _type, _last_component, _leave_unsealed);
+        sstlog.debug("Creating stream sink for SSTable gen={} sid={} type={} first={} last={} leave_unsealed={}", _sst->generation(), _sst->sstable_identifier(), _type, _first_component, _last_component, _leave_unsealed);
     }
 private:
     // TOC and scylla components are guaranteed not to depend on metadata. Ignore these (chicken, egg)
@@ -4596,6 +4598,9 @@ private:
     }
 public:
     future<output_stream<char>> output(const file_open_options& foptions, const file_output_stream_options& stream_options) override {
+        if (_first_component) {
+            co_await _sst->_storage->open_for_stream(*_sst);
+        }
         bool load_save_meta = depends_on_metadata(_type);
 
         // otherwise, first load scylla metadata from disk as written so far.

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -1414,6 +1414,10 @@ public:
 };
 
 struct sstable_stream_sink_cfg {
+    // Set on the sink of the component which is written first. That sink calls
+    // storage::open_for_stream(), which registers the sstable in the sstables
+    // registry for object storage and does nothing for filesystem storage.
+    bool first_component = false;
     bool last_component = false;
     bool leave_unsealed = false;
 };

--- a/sstables/storage.cc
+++ b/sstables/storage.cc
@@ -96,6 +96,7 @@ public:
     virtual future<> change_state(const sstable& sst, sstable_state state, generation_type generation, delayed_commit_changes* delay) override;
     // runs in async context
     virtual void open(sstable& sst) override;
+    virtual future<> open_for_stream(sstable&) override { return make_ready_future<>(); }
     virtual future<> wipe(sstable& sst, const atomic_deletion* deletion = nullptr) noexcept override;
     virtual future<file> open_component(const sstable& sst, component_type type, open_flags flags, file_open_options options, bool check_integrity) override;
     virtual future<data_sink> make_data_or_index_sink(sstable& sst, component_type type) override;
@@ -687,6 +688,10 @@ protected:
         return object_name(_bucket, prefix(), sid, fmt::format("refs/nodes/{}/{}", host_id, gen));
     }
 
+    // Code shared by object_storage_base::open() and
+    // object_storage_base::open_for_stream().
+    future<> create_registry_entry_and_reference(sstable& sst);
+
     table_id owner() const {
         if (_uses_foreign_location) {
             on_internal_error(sstlog, format("Storage holds '{}' prefix, but registry owner is expected", prefix()));
@@ -715,6 +720,7 @@ public:
     future<> change_state(const sstable& sst, sstable_state state, generation_type generation, delayed_commit_changes* delay) override;
     // runs in async context
     void open(sstable& sst) override;
+    future<> open_for_stream(sstable& sst) override;
     future<> wipe(sstable& sst, const atomic_deletion* deletion = nullptr) noexcept override;
     future<file> open_component(const sstable& sst, component_type type, open_flags flags, file_open_options options, bool check_integrity) override;
     future<data_sink> make_data_or_index_sink(sstable& sst, component_type type) override;
@@ -869,14 +875,19 @@ future<> object_storage_base::delete_components(sstable_version_types version, s
     co_await delete_component(sstable_version_constants::TOC_SUFFIX);
 }
 
-void object_storage_base::open(sstable& sst) {
+future<> object_storage_base::create_registry_entry_and_reference(sstable& sst) {
     auto sid = get_sstable_identifier(sst);
     entry_descriptor desc(sst._generation, sid, sst._version, sst._format, component_type::TOC);
     auto host_id = sst.manager().get_local_host_id();
-    sst.manager().sstables_registry().create_entry(owner(), host_id, status_creating, sst._state, std::move(desc)).get();
+    co_await sst.manager().sstables_registry().create_entry(owner(), host_id, status_creating, sst._state, std::move(desc));
 
     auto ref_name = make_ref_object_name(sid, sst.generation(), host_id);
-    put_object(ref_name, memory_data_sink_buffers()).get();
+    co_await put_object(ref_name, memory_data_sink_buffers());
+    sstlog.debug("Created reference {}: {}", sst.get_filename(), ref_name);
+}
+
+void object_storage_base::open(sstable& sst) {
+    create_registry_entry_and_reference(sst).get();
 
     memory_data_sink_buffers bufs;
     auto out = data_sink(std::make_unique<memory_data_sink>(bufs));
@@ -884,7 +895,16 @@ void object_storage_base::open(sstable& sst) {
 
     sst.write_toc(std::move(w));
     put_object(make_object_name(sst, component_type::TOC), std::move(bufs)).get();
-    sstlog.debug("Created reference {}: {}", sst.get_filename(), ref_name);
+}
+
+future<> object_storage_base::open_for_stream(sstable& sst) {
+    // Create the system.sstables entry and the node reference object before the
+    // first component object is uploaded, so that an sstable whose upload is
+    // interrupted always owns an entry with a status other than "sealed".
+    // sstable_directory::sstables_registry_components_lister::garbage_collect()
+    // removes such an entry together with the component objects on the next boot.
+    // Changing the status to "sealed" is left to the caller.
+    return create_registry_entry_and_reference(sst);
 }
 
 future<file> object_storage_base::open_component(const sstable& sst, component_type type, open_flags flags, file_open_options options, bool check_integrity) {

--- a/sstables/storage.hh
+++ b/sstables/storage.hh
@@ -125,6 +125,13 @@ public:
     virtual future<> change_state(const sstable& sst, sstable_state to, generation_type generation, delayed_commit_changes* delay) = 0;
     // runs in async context
     virtual void open(sstable& sst) = 0;
+    // Registers an sstable which is written through sstable_stream_sink instead
+    // of through open(). The sink writes every component including the TOC, so
+    // open_for_stream() must not write the TOC, unlike open().
+    // filesystem_storage implements open_for_stream() as a no-op: for filesystem
+    // storage the sink writes the TOC under the TemporaryTOC name, which already
+    // marks the sstable as incomplete.
+    virtual future<> open_for_stream(sstable& sst) = 0;
     // Must never return an exceptional future: implementations are expected
     // to catch and log any errors internally.
     virtual future<> wipe(sstable& sst, const atomic_deletion* deletion = nullptr) noexcept = 0;

--- a/sstables_loader.cc
+++ b/sstables_loader.cc
@@ -223,7 +223,7 @@ private:
         auto& table = db.find_column_family(ks, cf);
         auto& sst_manager = table.get_sstables_manager();
         auto sst = sst_manager.make_sstable(
-            table.schema(), table.get_storage_options(), min_info.generation, sstables::sstable_state::normal, min_info.version, min_info.format);
+            table.schema(), table.get_storage_options(), min_info.generation, min_info.sid, sstables::sstable_state::normal, min_info.version, min_info.format);
         sst->set_sstable_level(0);
         auto units = co_await sst_manager.dir_semaphore().get_units(1);
         sstables::sstable_open_config cfg {
@@ -937,7 +937,7 @@ future<sstables::shared_sstable> sstables_loader::attach_sstable(table_id tid, c
     llog.debug("Adding downloaded SSTable gen={} to the table {}.{} on shard {}", min_info.generation, table.schema()->ks_name(), table.schema()->cf_name(), this_shard_id());
     auto& sst_manager = table.get_sstables_manager();
     auto sst = sst_manager.make_sstable(
-        table.schema(), table.get_storage_options(), min_info.generation, sstables::sstable_state::normal, min_info.version, min_info.format);
+        table.schema(), table.get_storage_options(), min_info.generation, min_info.sid, sstables::sstable_state::normal, min_info.version, min_info.format);
     sst->set_sstable_level(0);
     auto erm = table.get_effective_replication_map();
     sstables::sstable_open_config cfg {
@@ -1108,12 +1108,16 @@ future<> sstables_loader::download_tablet_sstables(locator::global_tablet_id tid
             db::snapshot_table_helper sth(loader._sys_dist_ks.qp());
             co_await max_concurrent_for_each(shard_ssts, 16, [&sth, &loader, tid, snap_name, keyspace_name, table_name, datacenter, rack](const auto& min_info) -> future<> {
                 sstables::shared_sstable attached_sst = co_await loader.attach_sstable(tid.table, min_info);
+                // The system_distributed.snapshot_sstables row is keyed by the
+                // sstable_id of the backup sstable, not by the sstable_id of the
+                // restored copy, so that a restore which is retried skips the
+                // sstables a previous attempt already downloaded.
                 co_await sth.update_sstable_download_status(snap_name,
                                                             keyspace_name,
                                                             table_name,
                                                             datacenter,
                                                             rack,
-                                                            *attached_sst->sstable_identifier(),
+                                                            min_info.source_sid,
                                                             attached_sst->get_first_decorated_key().token(),
                                                             db::is_downloaded::yes);
             });

--- a/sstables_loader_helpers.cc
+++ b/sstables_loader_helpers.cc
@@ -49,17 +49,36 @@ future<minimal_sst_info> download_sstable(replica::database& db, replica::table&
     //
     // In short: Scylla must be written second so that all following output() calls
     // can properly update its metadata instead of silently skipping it.
+    //
+    // save_metadata() is also what replaces the sstable_id of the backup sstable
+    // with the sstable_id assigned below, so the same ordering is what makes the
+    // new sstable_id reach the copy.
     auto scylla_it = std::ranges::find_if(components, [](const auto& component) { return component.first == component_type::Scylla; });
     if (scylla_it != std::next(components.begin())) {
         swap(*scylla_it, *std::next(components.begin()));
     }
 
+    // sstable::load() assigns an sstable_id to every sstable it opens, taken from
+    // scylla_metadata or derived from the generation, so a backup sstable opened
+    // for restore always has one.
+    auto source_sid = sstable->sstable_identifier();
+    if (!source_sid) {
+        on_internal_error(logger, fmt::format("Backup sstable {} has no sstable_id", sstable->get_filename()));
+    }
+
     auto gen = table.get_sstable_generation_generator()();
+    // A restored sstable is a copy and gets its own sstable_id, derived from the
+    // new generation the same way sstable::clone() derives one. For object storage
+    // the sstable_id is the prefix of the component object keys, so reusing the
+    // sstable_id of the backup sstable would make the copies which different
+    // replicas create of it overwrite each other.
+    auto sid = sstables::sstable_id(gen.as_uuid());
     auto files = co_await sstable->readable_file_for_all_components();
     for (auto it = components.cbegin(); it != components.cend(); ++it) {
         try {
             auto descriptor = sstable->get_descriptor(it->first);
             descriptor.generation = gen;
+            descriptor.sid = sid;
             auto sstable_sink =
                 sstables::create_stream_sink(table.schema(),
                                              table.get_sstables_manager(),
@@ -102,7 +121,7 @@ future<minimal_sst_info> download_sstable(replica::database& db, replica::table&
                     on_internal_error(logger, "Fully-contained sstable must belong to one shard only");
                 }
                 logger.debug("SSTable gen={} sid={}: shards {}", gen, sst->sstable_identifier(), fmt::join(shards, ", "));
-                co_return minimal_sst_info{shards.front(), gen, descriptor.version, descriptor.format};
+                co_return minimal_sst_info{shards.front(), gen, descriptor.version, descriptor.format, sid, *source_sid};
             }
         } catch (...) {
             logger.info("Error downloading SSTable component {}. Reason: {}", it->first, std::current_exception());

--- a/sstables_loader_helpers.cc
+++ b/sstables_loader_helpers.cc
@@ -28,6 +28,9 @@ future<minimal_sst_info> download_sstable(replica::database& db, replica::table&
     // Move the TOC to the front to be processed first since `sstables::create_stream_sink` takes care
     // of creating behind the scene TemporaryTOC instead of usual one. This assures that in case of failure
     // this partially created SSTable will be cleaned up properly at some point.
+    // Object storage writes no TemporaryTOC. There the sink of the first component
+    // registers the sstable in the sstables registry, which marks it incomplete
+    // until it is sealed, so an interrupted download is cleaned up on the next boot.
     auto toc_it = std::ranges::find_if(components, [](const auto& component) { return component.first == component_type::TOC; });
     if (toc_it != components.begin()) {
         swap(*toc_it, components.front());
@@ -85,7 +88,9 @@ future<minimal_sst_info> download_sstable(replica::database& db, replica::table&
                                              table.get_storage_options(),
                                              sstables::sstable_state::normal,
                                              descriptor,
-                                             sstables::sstable_stream_sink_cfg{.last_component = std::next(it) == components.cend(), .leave_unsealed = true});
+                                             sstables::sstable_stream_sink_cfg{.first_component = it == components.cbegin(),
+                                                                               .last_component = std::next(it) == components.cend(),
+                                                                               .leave_unsealed = true});
             auto out = co_await sstable_sink->output(foptions, stream_options);
 
             input_stream src(co_await [&it, sstable, f = files.at(it->first), &db, &table]() -> future<input_stream<char>> {

--- a/sstables_loader_helpers.cc
+++ b/sstables_loader_helpers.cc
@@ -79,6 +79,12 @@ future<minimal_sst_info> download_sstable(replica::database& db, replica::table&
     auto files = co_await sstable->readable_file_for_all_components();
     for (auto it = components.cbegin(); it != components.cend(); ++it) {
         try {
+            if (it != components.cbegin()) {
+                // Injected once the first component was fully written, so that the
+                // sstable is already registered in the sstables registry.
+                utils::get_local_injector().inject("fail_download_sstable_mid_stream",
+                        [] { throw std::runtime_error("Failing sstable download mid-stream"); });
+            }
             auto descriptor = sstable->get_descriptor(it->first);
             descriptor.generation = gen;
             descriptor.sid = sid;

--- a/sstables_loader_helpers.hh
+++ b/sstables_loader_helpers.hh
@@ -14,6 +14,7 @@
 #include "dht/token.hh"
 #include "sstables/generation_type.hh"
 #include "sstables/shared_sstable.hh"
+#include "sstables/types.hh"
 #include "sstables/version.hh"
 #include "utils/log.hh"
 
@@ -29,6 +30,13 @@ struct minimal_sst_info {
     sstables::generation_type generation;
     sstables::sstable_version_types version;
     sstables::sstable_format_types format;
+    // sstable_id of the restored copy; for object storage the sstable_id is the
+    // prefix of the component object keys
+    sstables::sstable_id sid;
+    // sstable_id of the backup sstable the copy was made from; keys the rows in
+    // system_distributed.snapshot_sstables which record what a restore already
+    // downloaded
+    sstables::sstable_id source_sid;
 };
 
 future<minimal_sst_info> download_sstable(replica::database& db, replica::table& table, sstables::shared_sstable sstable, logging::logger& logger);

--- a/test/cluster/object_store/test_backup.py
+++ b/test/cluster/object_store/test_backup.py
@@ -17,7 +17,8 @@ import random
 from typing import Callable, Awaitable
 from functools import partial
 from test.pylib.manager_client import ManagerClient, ServerInfo
-from test.cluster.util import wait_for_cql_and_get_hosts, get_replication, new_test_keyspace, new_test_table
+from test.cluster.util import wait_for_cql_and_get_hosts, get_replication, new_test_keyspace, new_test_table, reconnect_driver
+from test.pylib.object_storage import keyspace_options
 from test.pylib.rest_client import read_barrier, HTTPError
 from test.pylib.util import unique_name, wait_all
 from test.pylib.tablets import get_tablet_replica, get_all_tablet_replicas
@@ -1805,3 +1806,203 @@ async def test_cluster_snapshot_repair_set_unique(manager: ManagerClient, object
     Tests a cluster snapshot reduces the snapshot sstable set by the current repair set for each tablet
     """
     await do_test_snapshot_on_all_nodes(manager, partial(run_cluster_backup_and_check_redundancy, object_storage), object_storage, True, True)
+
+
+async def get_table_id(cql, ks, cf):
+    return (await cql.run_async(f"SELECT id FROM system_schema.tables WHERE keyspace_name = '{ks}' AND table_name = '{cf}'"))[0].id
+
+
+async def get_sstables_registry_rows(cql, manager, servers, table_id):
+    '''system.sstables is node-local; collect every node's rows for the table'''
+    rows = []
+    for s in servers:
+        host = (await wait_for_cql_and_get_hosts(cql, [s], time.time() + 60))[0]
+        rows.extend(await cql.run_async(f"SELECT * FROM system.sstables WHERE table_id = {table_id} ALLOW FILTERING", host=host))
+    return rows
+
+def bucket_objects(object_storage):
+    '''Every object of the test bucket, mapped to its size'''
+    bucket = object_storage.get_resource().Bucket(object_storage.bucket_name)
+    return {o.key: o.size for o in bucket.objects.all()}
+
+
+def assert_objects_intact(expected, actual, what):
+    for key, size in expected.items():
+        assert actual.get(key) == size, f'{what}: object {key} was modified or removed'
+
+
+async def insert_keys(cql, ks, cf, num_keys):
+    insert_stmt = cql.prepare(f"INSERT INTO {ks}.{cf} (pk, value) VALUES (?, ?)")
+    insert_stmt.consistency_level = ConsistencyLevel.ALL
+    await asyncio.gather(*(cql.run_async(insert_stmt, (str(i), i)) for i in range(num_keys)))
+
+
+async def test_restore_tablets_into_object_storage_keyspace(build_mode: str, manager: ManagerClient, object_storage):
+    '''Restore into a keyspace backed by the same bucket the backup lives in.
+    The restored sstables must be registered and sealed in system.sstables,
+    every copy (including replicas of the same backup sstable) must get its
+    own sstable_id so the object keys don't collide, the backup must be left
+    intact, and the data must survive a restart.'''
+
+    topology = topo(rf = 2, nodes = 2, racks = 2, dcs = 1)
+    servers, host_ids = await create_cluster(topology, manager, logger, object_storage)
+    cql = manager.get_cql()
+
+    num_keys = 10
+    cf = 'test'
+
+    async with new_test_keyspace(manager, f"WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor': {topology.rf}}}") as ks:
+        await cql.run_async(f"CREATE TABLE {ks}.{cf} ( pk text primary key, value int ) WITH tablets = {{'min_tablet_count': 4}};")
+        await insert_keys(cql, ks, cf, num_keys)
+        snap_name, _ = await take_snapshot(ks, servers, manager, logger)
+        await asyncio.gather(*(do_backup(s, snap_name, f'{s.server_id}/{snap_name}', ks, cf, object_storage, manager, logger) for s in servers))
+
+    backup_objects = bucket_objects(object_storage)
+
+    async with new_test_keyspace(manager, keyspace_options(object_storage, rf=topology.rf)) as ks:
+        await cql.run_async(f"CREATE TABLE {ks}.{cf} ( pk text primary key, value int );")
+        table_id = await get_table_id(cql, ks, cf)
+
+        manifests = [f'{s.server_id}/{snap_name}/manifest.json' for s in servers]
+        tid = await manager.api.restore_tablets(servers[0].ip_addr, ks, cf, snap_name, servers[0].datacenter,
+                                                object_storage.address, object_storage.bucket_name, manifests)
+        status = await manager.api.wait_task(servers[0].ip_addr, tid)
+        assert (status is not None) and (status['state'] == 'done'), f'Restore failed: {status}'
+        assert status['progress_total'] > 0
+        assert status['progress_completed'] == status['progress_total']
+
+        # The restore reports done while the balancer is still moving the restored
+        # tablets. A migration in flight clones an sstable under its source's
+        # sstable_id, which the checks below would read as a duplicate.
+        await manager.api.quiesce_topology(servers[0].ip_addr)
+
+        await check_mutation_replicas(cql, manager, servers, range(num_keys), topology, logger, ks, cf)
+
+        rows = await get_sstables_registry_rows(cql, manager, servers, table_id)
+        assert rows, 'No system.sstables entries after restore'
+        not_sealed = [r for r in rows if r.status != 'sealed']
+        assert not not_sealed, f'Non-sealed registry entries after restore: {not_sealed}'
+        sids = [r.sstable_id for r in rows]
+        assert len(sids) == len(set(sids)), f'Restored sstables share an sstable_id: {sorted(str(s) for s in sids)}'
+
+        assert_objects_intact(backup_objects, bucket_objects(object_storage), 'restore')
+
+        for s in servers:
+            await manager.server_restart(s.server_id)
+        cql = await reconnect_driver(manager)
+        await check_mutation_replicas(cql, manager, servers, range(num_keys), topology, logger, ks, cf)
+
+
+@pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
+async def test_restore_tablets_object_storage_failure_cleanup(build_mode: str, manager: ManagerClient, object_storage):
+    '''A restore interrupted mid-download leaves partially streamed sstables
+    behind, registered but never sealed; boot-time garbage collection must
+    remove them together with their bucket objects, and a retried restore
+    must complete, skipping what the first attempt already fetched.'''
+
+    # Two nodes because system_distributed uses SimpleStrategy with a replication
+    # factor of 3, so a single node cannot satisfy the QUORUM consistency levels
+    # of the backup and restore bookkeeping.
+    topology = topo(rf = 1, nodes = 2, racks = 1, dcs = 1)
+    servers, host_ids = await create_cluster(topology, manager, logger, object_storage)
+    cql = manager.get_cql()
+
+    num_keys = 12
+    cf = 'test'
+
+    async with new_test_keyspace(manager, f"WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor': {topology.rf}}}") as ks:
+        await cql.run_async(f"CREATE TABLE {ks}.{cf} ( pk text primary key, value int ) WITH tablets = {{'min_tablet_count': 4}};")
+        await insert_keys(cql, ks, cf, num_keys)
+        snap_name, _ = await take_snapshot(ks, servers, manager, logger)
+        await asyncio.gather(*(do_backup(s, snap_name, f'{s.server_id}/{snap_name}', ks, cf, object_storage, manager, logger) for s in servers))
+
+    async with new_test_keyspace(manager, keyspace_options(object_storage, rf=topology.rf)) as ks:
+        await cql.run_async(f"CREATE TABLE {ks}.{cf} ( pk text primary key, value int );")
+        table_id = await get_table_id(cql, ks, cf)
+
+        # Any of the nodes can be the one which downloads first, so arm all of them.
+        await asyncio.gather(*(manager.api.enable_injection(s.ip_addr, 'fail_download_sstable_mid_stream', one_shot=True)
+                               for s in servers))
+
+        manifests = [f'{s.server_id}/{snap_name}/manifest.json' for s in servers]
+        tid = await manager.api.restore_tablets(servers[0].ip_addr, ks, cf, snap_name, servers[0].datacenter,
+                                                object_storage.address, object_storage.bucket_name, manifests)
+        status = await manager.api.wait_task(servers[0].ip_addr, tid)
+        assert (status is not None) and (status['state'] == 'failed'), f'Expected restore to fail: {status}'
+        assert 'Failing sstable download mid-stream' in status['error']
+
+        for s in servers:
+            await manager.server_restart(s.server_id)
+        cql = await reconnect_driver(manager)
+
+        # everything the failed restore left behind was garbage-collected on
+        # boot: every sstables/{sid}/ object belongs to a sealed registry entry
+        rows = await get_sstables_registry_rows(cql, manager, servers, table_id)
+        not_sealed = [r for r in rows if r.status != 'sealed']
+        assert not not_sealed, f'Non-sealed registry entries survived the restart: {not_sealed}'
+        sealed_sids = {str(r.sstable_id) for r in rows}
+        bucket = object_storage.get_resource().Bucket(object_storage.bucket_name)
+        bucket_sids = {o.key.split('/')[1] for o in bucket.objects.filter(Prefix='sstables/')}
+        assert bucket_sids == sealed_sids, f'Orphan sstable objects left in the bucket: {bucket_sids - sealed_sids}'
+
+        tid = await manager.api.restore_tablets(servers[0].ip_addr, ks, cf, snap_name, servers[0].datacenter,
+                                                object_storage.address, object_storage.bucket_name, manifests)
+        status = await manager.api.wait_task(servers[0].ip_addr, tid)
+        assert (status is not None) and (status['state'] == 'done'), f'Retried restore failed: {status}'
+
+        await check_mutation_replicas(cql, manager, servers, range(num_keys), topology, logger, ks, cf)
+
+
+async def test_restore_tablets_dropping_destination_keeps_backup(build_mode: str, manager: ManagerClient, object_storage):
+    '''A restored sstable gets its own sstable_id, so its component objects are
+    stored under a prefix of their own. Dropping the restored keyspace must
+    therefore delete the objects of the restored copies only, and leave every
+    other object of the bucket, the backup included, untouched.'''
+
+    # Two nodes because system_distributed uses SimpleStrategy with a replication
+    # factor of 3, so a single node cannot satisfy the QUORUM consistency levels
+    # of the backup and restore bookkeeping.
+    topology = topo(rf = 1, nodes = 2, racks = 1, dcs = 1)
+    servers, host_ids = await create_cluster(topology, manager, logger, object_storage)
+    cql = manager.get_cql()
+
+    num_keys = 10
+    cf = 'test'
+
+    async with new_test_keyspace(manager, f"WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor': {topology.rf}}}") as ks:
+        await cql.run_async(f"CREATE TABLE {ks}.{cf} ( pk text primary key, value int ) WITH tablets = {{'min_tablet_count': 4}};")
+        await insert_keys(cql, ks, cf, num_keys)
+        snap_name, _ = await take_snapshot(ks, servers, manager, logger)
+        await asyncio.gather(*(do_backup(s, snap_name, f'{s.server_id}/{snap_name}', ks, cf, object_storage, manager, logger) for s in servers))
+
+    backup_objects = bucket_objects(object_storage)
+
+    async with new_test_keyspace(manager, keyspace_options(object_storage, rf=topology.rf)) as ks:
+        await cql.run_async(f"CREATE TABLE {ks}.{cf} ( pk text primary key, value int );")
+        table_id = await get_table_id(cql, ks, cf)
+
+        manifests = [f'{s.server_id}/{snap_name}/manifest.json' for s in servers]
+        tid = await manager.api.restore_tablets(servers[0].ip_addr, ks, cf, snap_name, servers[0].datacenter,
+                                                object_storage.address, object_storage.bucket_name, manifests)
+        status = await manager.api.wait_task(servers[0].ip_addr, tid)
+        assert (status is not None) and (status['state'] == 'done'), f'Restore failed: {status}'
+
+        # The restore reports done while the balancer is still moving the restored
+        # tablets. A migration landing after the drop below references the restored
+        # objects once more, and nothing deletes them afterwards.
+        await manager.api.quiesce_topology(servers[0].ip_addr)
+
+        restored_sids = {str(r.sstable_id) for r in await get_sstables_registry_rows(cql, manager, servers, table_id)}
+        assert restored_sids, 'No system.sstables entries after restore'
+
+    # Leaving the context dropped the restored keyspace. Restart the nodes so that
+    # boot time garbage collection removes whatever the drop left behind.
+    for s in servers:
+        await manager.server_restart(s.server_id)
+    cql = await reconnect_driver(manager)
+
+    objects_after_drop = bucket_objects(object_storage)
+    assert_objects_intact(backup_objects, objects_after_drop, 'drop of the restored keyspace')
+    left_over = {key for key in objects_after_drop if key.split('/')[0] == 'sstables' and key.split('/')[1] in restored_sids}
+    assert not left_over, f'Objects of the dropped restored keyspace were not removed: {sorted(left_over)}'
+


### PR DESCRIPTION
Tablet-aware restore writes downloaded sstables through the destination table's
storage abstraction, but that path was never exercised with an object-storage
destination, and it is broken there in three ways:

* The stream sink writes the TOC under the TemporaryTOC name and relies on
  `seal()` renaming it. Object storage renames no object, so the TOC never got
  its final name.
* `create_stream_sink()` never calls `storage::open()`, so a restored sstable had
  no `system.sstables` entry and no refs object. The next boot did not see the
  sstable and nothing ever removed its component objects.
* `download_sstable()` reused the `sstable_id` of the backup sstable. On object
  storage the `sstable_id` is the prefix of the component object keys, so the
  copies that different replicas make of one backup sstable overwrote each other,
  and restoring into a keyspace that shares the bucket with the backup overwrote
  the backup itself.

Object storage now writes the TOC under its final name, the sink of the first
component registers the sstable in the sstables registry so that an interrupted
restore is garbage-collected on the next boot, and every restored copy gets a
fresh `sstable_id` derived from its own generation.

The tests restore into an object-storage keyspace backed by the same bucket the
backup lives in, and check that the restored sstables are registered and sealed,
that every copy has its own `sstable_id`, that the backup survives both the
restore and a drop of the restored keyspace, that the data survives a restart,
and that a restore interrupted mid-download leaves nothing behind and can be
retried.

After the PR #31138 is merged (related to dc-scoped manifests), I will open a 
follow-up PR with additional tests covering restore from cluster backup.

Fixes: [SCYLLADB-3502](https://scylladb.atlassian.net/browse/SCYLLADB-3502)

[SCYLLADB-3502]: https://scylladb.atlassian.net/browse/SCYLLADB-3502?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ