### PR TITLE
Move database API endpoints into api/column_family.cc

### DIFF
--- a/api/column_family.cc
+++ b/api/column_family.cc
@@ -1171,6 +1171,21 @@ void set_column_family(http_context& ctx, routes& r, sharded<replica::database>&
             return make_ready_future<json::json_return_type>(json_void());
         });
     });
+
+    ss::force_flush.set(r, [&db] (std::unique_ptr<http::request> req) -> future<json::json_return_type> {
+        apilog.info("flush all tables");
+        co_await db.invoke_on_all([] (replica::database& db) {
+            return db.flush_all_tables();
+        });
+        co_return json_void();
+    });
+
+    ss::force_keyspace_flush.set(r, [&ctx, &db] (std::unique_ptr<http::request> req) -> future<json::json_return_type> {
+        auto [keyspace, table_infos] = parse_table_infos(ctx, *req);
+        apilog.info("perform_keyspace_flush: keyspace={} tables={}", keyspace, table_infos);
+        co_await replica::database::flush_tables_on_all_shards(db, std::move(table_infos));
+        co_return json_void();
+    });
 }
 
 void unset_column_family(http_context& ctx, routes& r) {
@@ -1288,5 +1303,7 @@ void unset_column_family(http_context& ctx, routes& r) {
     ss::get_metrics_load.unset(r);
     ss::get_keyspaces.unset(r);
     hs::drop_sstable_caches.unset(r);
+    ss::force_flush.unset(r);
+    ss::force_keyspace_flush.unset(r);
 }
 }

--- a/api/column_family.cc
+++ b/api/column_family.cc
@@ -12,6 +12,7 @@
 #include "api/validate.hh"
 #include "api/api-doc/column_family.json.hh"
 #include "api/api-doc/storage_service.json.hh"
+#include "api/api-doc/system.json.hh"
 #include <vector>
 #include <seastar/http/exception.hh>
 #include "sstables/sstables.hh"
@@ -34,6 +35,7 @@ using namespace httpd;
 using namespace json;
 namespace cf = httpd::column_family_json;
 namespace ss = httpd::storage_service_json;
+namespace hs = httpd::system_json;
 
 std::tuple<sstring, sstring> parse_fully_qualified_cf_name(sstring name) {
     auto pos = name.find("%3A");
@@ -1159,6 +1161,16 @@ void set_column_family(http_context& ctx, routes& r, sharded<replica::database>&
             return db.local().find_keyspace(ks).get_replication_strategy().uses_tablets() == want_tablets;
         }) | std::ranges::to<std::vector>();
     });
+
+    hs::drop_sstable_caches.set(r, [&db] (std::unique_ptr<http::request> req) {
+        apilog.info("Dropping sstable caches");
+        return db.invoke_on_all([] (replica::database& db) {
+            return db.drop_caches();
+        }).then([] {
+            apilog.info("Caches dropped");
+            return make_ready_future<json::json_return_type>(json_void());
+        });
+    });
 }
 
 void unset_column_family(http_context& ctx, routes& r) {
@@ -1275,5 +1287,6 @@ void unset_column_family(http_context& ctx, routes& r) {
     ss::get_load.unset(r);
     ss::get_metrics_load.unset(r);
     ss::get_keyspaces.unset(r);
+    hs::drop_sstable_caches.unset(r);
 }
 }

--- a/api/column_family.cc
+++ b/api/column_family.cc
@@ -1186,6 +1186,42 @@ void set_column_family(http_context& ctx, routes& r, sharded<replica::database>&
         co_await replica::database::flush_tables_on_all_shards(db, std::move(table_infos));
         co_return json_void();
     });
+
+    ss::is_incremental_backups_enabled.set(r, [&db] (std::unique_ptr<http::request> req) {
+        // If this is issued in parallel with an ongoing change, we may see values not agreeing.
+        // Reissuing is asking for trouble, so we will just return true upon seeing any true value.
+        return db.map_reduce(adder<bool>(), [] (replica::database& db) {
+            for (auto& pair: db.get_keyspaces()) {
+                auto& ks = pair.second;
+                if (ks.incremental_backups_enabled()) {
+                    return true;
+                }
+            }
+            return false;
+        }).then([] (bool val) {
+            return make_ready_future<json::json_return_type>(val);
+        });
+    });
+
+    ss::set_incremental_backups_enabled.set(r, [&db] (std::unique_ptr<http::request> req) {
+        auto val_str = req->get_query_param("value");
+        bool value = (val_str == "True") || (val_str == "true") || (val_str == "1");
+        return db.invoke_on_all([value] (replica::database& db) {
+            db.set_enable_incremental_backups(value);
+
+            // Change both KS and CF, so they are in sync
+            for (auto& pair: db.get_keyspaces()) {
+                auto& ks = pair.second;
+                ks.set_incremental_backups(value);
+            }
+
+            db.get_tables_metadata().for_each_table([&] (table_id, lw_shared_ptr<replica::table> table) {
+                table->set_incremental_backups(value);
+            });
+        }).then([] {
+            return make_ready_future<json::json_return_type>(json_void());
+        });
+    });
 }
 
 void unset_column_family(http_context& ctx, routes& r) {
@@ -1305,5 +1341,7 @@ void unset_column_family(http_context& ctx, routes& r) {
     hs::drop_sstable_caches.unset(r);
     ss::force_flush.unset(r);
     ss::force_keyspace_flush.unset(r);
+    ss::is_incremental_backups_enabled.unset(r);
+    ss::set_incremental_backups_enabled.unset(r);
 }
 }

--- a/api/storage_service.cc
+++ b/api/storage_service.cc
@@ -1065,46 +1065,6 @@ rest_is_joined(sharded<service::storage_service>& ss, std::unique_ptr<http::requ
 
 static
 future<json::json_return_type>
-rest_is_incremental_backups_enabled(http_context& ctx, std::unique_ptr<http::request> req) {
-        // If this is issued in parallel with an ongoing change, we may see values not agreeing.
-        // Reissuing is asking for trouble, so we will just return true upon seeing any true value.
-        return ctx.db.map_reduce(adder<bool>(), [] (replica::database& db) {
-            for (auto& pair: db.get_keyspaces()) {
-                auto& ks = pair.second;
-                if (ks.incremental_backups_enabled()) {
-                    return true;
-                }
-            }
-            return false;
-        }).then([] (bool val) {
-            return make_ready_future<json::json_return_type>(val);
-        });
-}
-
-static
-future<json::json_return_type>
-rest_set_incremental_backups_enabled(http_context& ctx, std::unique_ptr<http::request> req) {
-        auto val_str = req->get_query_param("value");
-        bool value = (val_str == "True") || (val_str == "true") || (val_str == "1");
-        return ctx.db.invoke_on_all([value] (replica::database& db) {
-            db.set_enable_incremental_backups(value);
-
-            // Change both KS and CF, so they are in sync
-            for (auto& pair: db.get_keyspaces()) {
-                auto& ks = pair.second;
-                ks.set_incremental_backups(value);
-            }
-
-            db.get_tables_metadata().for_each_table([&] (table_id, lw_shared_ptr<replica::table> table) {
-                table->set_incremental_backups(value);
-            });
-        }).then([] {
-            return make_ready_future<json::json_return_type>(json_void());
-        });
-}
-
-static
-future<json::json_return_type>
 rest_rebuild(sharded<service::storage_service>& ss, std::unique_ptr<http::request> req) {
         utils::optional_param source_dc;
         if (auto source_dc_str = req->get_query_param("source_dc"); !source_dc_str.empty()) {
@@ -2090,8 +2050,6 @@ void set_storage_service(http_context& ctx, routes& r, sharded<service::storage_
     ss::is_initialized.set(r, gated(ss, rest_bind(rest_is_initialized, ss)));
     ss::join_ring.set(r, gated(ss, rest_bind(rest_join_ring)));
     ss::is_joined.set(r, gated(ss, rest_bind(rest_is_joined, ss)));
-    ss::is_incremental_backups_enabled.set(r, gated(ss, rest_bind(rest_is_incremental_backups_enabled, ctx)));
-    ss::set_incremental_backups_enabled.set(r, gated(ss, rest_bind(rest_set_incremental_backups_enabled, ctx)));
     ss::rebuild.set(r, gated(ss, rest_bind(rest_rebuild, ss)));
     ss::bulk_load.set(r, gated(ss, rest_bind(rest_bulk_load)));
     ss::bulk_load_async.set(r, gated(ss, rest_bind(rest_bulk_load_async)));
@@ -2176,8 +2134,6 @@ void unset_storage_service(http_context& ctx, routes& r) {
     ss::is_initialized.unset(r);
     ss::join_ring.unset(r);
     ss::is_joined.unset(r);
-    ss::is_incremental_backups_enabled.unset(r);
-    ss::set_incremental_backups_enabled.unset(r);
     ss::rebuild.unset(r);
     ss::bulk_load.unset(r);
     ss::bulk_load_async.unset(r);

--- a/api/storage_service.cc
+++ b/api/storage_service.cc
@@ -844,26 +844,6 @@ rest_reset_cleanup_needed(http_context& ctx, sharded<service::storage_service>& 
 
 static
 future<json::json_return_type>
-rest_force_flush(http_context& ctx, std::unique_ptr<http::request> req) {
-        apilog.info("flush all tables");
-        co_await ctx.db.invoke_on_all([] (replica::database& db) {
-            return db.flush_all_tables();
-        });
-        co_return json_void();
-}
-
-static
-future<json::json_return_type>
-rest_force_keyspace_flush(http_context& ctx, std::unique_ptr<http::request> req) {
-        auto [keyspace, table_infos] = parse_table_infos(ctx, *req);
-        apilog.info("perform_keyspace_flush: keyspace={} tables={}", keyspace, table_infos);
-        auto& db = ctx.db;
-        co_await replica::database::flush_tables_on_all_shards(db, std::move(table_infos));
-        co_return json_void();
-}
-
-static
-future<json::json_return_type>
 rest_logstor_compaction(http_context& ctx, std::unique_ptr<http::request> req) {
         bool major = false;
         if (auto major_param = req->get_query_param("major"); !major_param.empty()) {
@@ -2089,8 +2069,6 @@ void set_storage_service(http_context& ctx, routes& r, sharded<service::storage_
         }
         co_return json::json_return_type(0);
     });
-    ss::force_flush.set(r, gated(ss, rest_bind(rest_force_flush, ctx)));
-    ss::force_keyspace_flush.set(r, gated(ss, rest_bind(rest_force_keyspace_flush, ctx)));
     ss::decommission.set(r, gated(ss, rest_bind(rest_decommission, ss, ssc)));
     ss::logstor_compaction.set(r, gated(ss, rest_bind(rest_logstor_compaction, ctx)));
     ss::logstor_flush.set(r, gated(ss, rest_bind(rest_logstor_flush, ctx)));
@@ -2177,8 +2155,6 @@ void unset_storage_service(http_context& ctx, routes& r) {
     ss::reset_cleanup_needed.unset(r);
     t::force_keyspace_cleanup_async.unset(r);
     ss::force_keyspace_cleanup.unset(r);
-    ss::force_flush.unset(r);
-    ss::force_keyspace_flush.unset(r);
     ss::logstor_compaction.unset(r);
     ss::logstor_flush.unset(r);
     ss::decommission.unset(r);

--- a/api/system.cc
+++ b/api/system.cc
@@ -153,16 +153,6 @@ void set_system(http_context& ctx, routes& r) {
         return json::json_void();
     });
 
-    hs::drop_sstable_caches.set(r, [&ctx](std::unique_ptr<request> req) {
-        apilog.info("Dropping sstable caches");
-        return ctx.db.invoke_on_all([] (replica::database& db) {
-            return db.drop_caches();
-        }).then([] {
-            apilog.info("Caches dropped");
-            return json::json_return_type(json::json_void());
-        });
-    });
-
     hs::dump_profile.set(r, [](std::unique_ptr<request> req) {
         if (!__llvm_profile_dump) {
             apilog.info("Profile will not be dumped, executable is not instrumented with profile dumping.");


### PR DESCRIPTION
One more step towards removing sharded\<replica::database\>& from api::http_context. Several endpoints sitting in api/storage_service.cc are genuinely replica::database ones. For those, there's api/column_family.cc block.

Improving components inter-dependencies, not backporting