### PR TITLE
test/boost/sstable_datafile_test : don't require page-granular growth in the small sstable memory test

### DIFF
--- a/test/boost/sstable_datafile_test.cc
+++ b/test/boost/sstable_datafile_test.cc
@@ -3521,11 +3521,15 @@ SEASTAR_THREAD_TEST_CASE(test_small_sstable_has_reasonable_memory_usage) {
         return make_sstable_containing(env.make_sst_factory(s), {std::move(m)}).get();
     };
 
-    // Warm up: write and discard one sstable, so that any lazily-initialized,
-    // one-off allocations on the write path (and the single shared, deduplicated
-    // dictionary copy) are already accounted for before we start measuring.
-    auto warmup = write_one();
-    BOOST_REQUIRE(warmup->get_compression().get_compressor().get_algorithm() == compressor::algorithm::zstd_with_dicts);
+    // Warm up: write and discard a full batch, so the write path's one-off allocations
+    // (including the shared dictionary copy) and the pools are in steady state.
+    {
+        std::vector<shared_sstable> warmup;
+        for (int i = 0; i < num_sstables; ++i) {
+            warmup.push_back(write_one());
+        }
+        BOOST_REQUIRE(warmup.front()->get_compression().get_compressor().get_algorithm() == compressor::algorithm::zstd_with_dicts);
+    }
 
     // Now measure the live-memory growth by holding onto N freshly written
     // sstables with the same dict.
@@ -3535,20 +3539,21 @@ SEASTAR_THREAD_TEST_CASE(test_small_sstable_has_reasonable_memory_usage) {
         ssts.push_back(write_one());
     }
     auto allocated_after = memory::stats().allocated_memory();
-    auto growth = allocated_after - allocated_before;
+    // Signed: allocated_memory() can also drop across the batch.
+    auto growth = int64_t(allocated_after) - int64_t(allocated_before);
 
     // The single shared dictionary copy was already allocated during warm-up, so
     // the growth should be bounded by just the per-sstable overhead.
-    const size_t upper_bound = num_sstables * per_sstable_allowance;
-    const size_t lower_bound = num_sstables * sizeof(sstable);
+    const int64_t upper_bound = num_sstables * per_sstable_allowance;
     testlog.info("live-memory growth from holding {} dict-compressed sstables: {} bytes "
-            "(lower_bound: {} bytes, upper_bound: {} bytes, dict_size: {} bytes)",
-            num_sstables, growth, lower_bound, upper_bound, dict_size);
+            "(upper_bound: {} bytes, dict_size: {} bytes)",
+            num_sstables, growth, upper_bound, dict_size);
 
 #ifndef SEASTAR_DEFAULT_ALLOCATOR
     // memory::stats() only reflects real usage with the seastar allocator; under
     // the default allocator (e.g. sanitizer builds) the numbers are meaningless.
+    // Upper bound only: allocated_memory() is page occupancy, not live bytes, so warm
+    // pools can absorb the batch and a growth of 0 is legitimate.
     BOOST_REQUIRE_LT(growth, upper_bound);
-    BOOST_REQUIRE_GE(growth, lower_bound);
 #endif
 }


### PR DESCRIPTION
`test_small_sstable_has_reasonable_memory_usage` fails deterministically whenever it is not the first thing the process does:

```
$ ./build/dev/test/boost/sstable_datafile_test -- -c1 -m2G
test/boost/sstable_datafile_test.cc(3552): fatal error in "test_small_sstable_has_reasonable_memory_usage":
    critical check growth >= lower_bound has failed [0 < 11584]
INFO  testlog - live-memory growth from holding 8 dict-compressed sstables: 0 bytes
    (lower_bound: 11584 bytes, upper_bound: 262144 bytes, dict_size: 112640 bytes)
```

| how it is run | measured growth | result |
|---|---|---|
| `--run_test=test_small_sstable_has_reasonable_memory_usage` | 184320 | pass |
| after 5 preceding cases | 73728 | pass |
| whole binary | 0 | **fail** |

The lower bound, `growth >= num_sstables * sizeof(sstable)`, is not an invariant of what it measures. `memory::stats().allocated_memory()` is `(nr_pages - nr_free_pages) * page_size`
- memory the allocator holds **in pages**, not live bytes. A `small_pool` retains up to `_max_free = max(100, span_bytes*2/object_size)` free objects and trims only down to
`(_min_free+_max_free)/2` (`seastar/src/core/memory.cc:1437`, `:1525`), so once warm it keeps those pages for good. In a process that has already run a few hundred cases, the whole
measured batch is served from pool free lists and page occupancy does not move at all.

CI has never hit this: `test/pylib/cpp/boost.py` passes `--run_test=<case>` and forks one process per case unless the suite is in `no_parallel_cases`, which `sstable_datafile_test` is not.
It only shows up when the binary is run directly.

The upper bound is the guard that matters, and it does not need the lower one - a per-sstable copy of the dictionary is far too large for a small pool, so it can only come from free pages,
and 8 live copies cannot hide inside `8 * 32 KiB`. Verified by reverting the fix this test was written for (`691f20b40e`, `compression.discard_hidden_options()`): it then fails in **both**
modes, at 1093632 / 1081344 bytes against the 262144 bound.

Two adjacent fragilities fixed while here:

- `growth` was computed in `size_t`. `allocated_memory()` can legitimately **drop** across the batch, when the write path's churn makes a pool trim its free list and hand spans back - that
  underflowed to a huge positive number and failed the *upper* bound. Compute it signed.
- Warm up with a full batch rather than a single sstable, so the pools are in the steady state the measured batch will find them in. Cold-process growth drops from 184320 to 45056 bytes,
  well clear of the bound instead of sitting at 70% of it.

Test-only change. Built and run under `dbuild`, dev mode, `-c1 -m2G`: passes both standalone and as part of the full `sstable_datafile_test` binary.

Fixes: SCYLLADB-3875
Fixes: #31199

Backport: no, edge case in testing.