### PR TITLE
 test/cluster: fix wait_new_coordinator_elected and crash-injection races on leadership flaps

### DIFF
--- a/test/cluster/random_failures/cluster_events.py
+++ b/test/cluster/random_failures/cluster_events.py
@@ -660,8 +660,11 @@ async def stop_coordinator_node_gracefully(manager: ScyllaClusterManager,
     yield
 
     LOGGER.info("Stop the coordinator node gracefully")
-    await manager.server_stop_gracefully(server_id=(await get_coordinator_host(manager=manager)).server_id)
-    await wait_new_coordinator_elected(manager=manager, expected_num_of_elections=2, deadline=time.time() + 60)
+    coordinator = await get_coordinator_host(manager=manager)
+    coordinator_host_id = await manager.get_host_id(server_id=coordinator.server_id)
+    await manager.server_stop_gracefully(server_id=coordinator.server_id)
+    await wait_new_coordinator_elected(manager=manager, previous_coordinator_id=coordinator_host_id,
+                                       deadline=time.time() + 60)
 
     yield
 
@@ -686,8 +689,11 @@ async def kill_coordinator_node(manager: ScyllaClusterManager,
     yield
 
     LOGGER.info("Kill the coordinator node")
-    await manager.server_stop(server_id=(await get_coordinator_host(manager=manager)).server_id, convict=True)
-    await wait_new_coordinator_elected(manager=manager, expected_num_of_elections=2, deadline=time.time() + 60)
+    coordinator = await get_coordinator_host(manager=manager)
+    coordinator_host_id = await manager.get_host_id(server_id=coordinator.server_id)
+    await manager.server_stop(server_id=coordinator.server_id, convict=True)
+    await wait_new_coordinator_elected(manager=manager, previous_coordinator_id=coordinator_host_id,
+                                       deadline=time.time() + 60)
 
     yield
 

--- a/test/cluster/test_crash_coordinator_before_streaming.py
+++ b/test/cluster/test_crash_coordinator_before_streaming.py
@@ -42,7 +42,17 @@ async def test_kill_coordinator_during_op(manager: ScyllaClusterManager, failure
     """
     # Decrease the failure detector threshold so we don't have to wait for too long.
     config = {
-        'failure_detector_timeout_in_ms': failure_detector_timeout
+        'failure_detector_timeout_in_ms': failure_detector_timeout,
+        # Raise the raft direct failure detector threshold above its 2s default.
+        # A shard 0 stall in a loaded test environment (SCYLLADB-2121) otherwise
+        # gets a live voter marked dead, the group0 leader steps down and the
+        # topology coordinator moves to another node before the injection fires.
+        'error_injections_at_startup': [
+            {
+                'name': 'raft-group-registry-fd-threshold-in-ms',
+                'value': '5000'
+            }
+        ]
     }
     cmdline = [
         '--logger-log-level', 'raft_topology=trace',

--- a/test/cluster/test_crash_coordinator_before_streaming.py
+++ b/test/cluster/test_crash_coordinator_before_streaming.py
@@ -58,10 +58,10 @@ async def test_kill_coordinator_during_op(manager: ScyllaClusterManager, failure
     logger.debug("Kill coordinator during decommission")
     coordinator_host = await get_coordinator_host(manager)
     other_nodes = [srv for srv in nodes if srv.server_id != coordinator_host.server_id]
-    num_elections = len(await get_coordinator_host_ids(manager))
+    previous_coordinator_id = await manager.get_host_id(coordinator_host.server_id)
     await manager.api.enable_injection(coordinator_host.ip_addr, "crash_coordinator_before_stream", one_shot=True)
     await manager.decommission_node(server_id=other_nodes[-1].server_id, expected_error="Decommission failed. See earlier errors")
-    await wait_new_coordinator_elected(manager, num_elections + 1, time.time() + scale_timeout(60))
+    await wait_new_coordinator_elected(manager, previous_coordinator_id, time.time() + scale_timeout(60))
     await wait_for_no_pending_topology_transition(manager, time.time() + scale_timeout(60))
     await manager.server_restart(coordinator_host.server_id, wait_others=1)
     await manager.servers_see_each_other(await manager.running_servers())
@@ -76,14 +76,14 @@ async def test_kill_coordinator_during_op(manager: ScyllaClusterManager, failure
     node_to_remove_srv_id = other_nodes[-1].server_id
     logger.debug("Stop node with srv_id %s", node_to_remove_srv_id)
     await manager.server_stop_gracefully(node_to_remove_srv_id)
-    num_elections = len(await get_coordinator_host_ids(manager))
+    previous_coordinator_id = await manager.get_host_id(coordinator_host.server_id)
     await manager.api.enable_injection(coordinator_host.ip_addr, "crash_coordinator_before_stream", one_shot=True)
     logger.debug("Start removenode with srv_id %s from node with srv_id %s", node_to_remove_srv_id, working_srv_id)
     await manager.remove_node(working_srv_id,
                               node_to_remove_srv_id,
                               expected_error="Removenode failed. See earlier errors")
 
-    await wait_new_coordinator_elected(manager, num_elections + 1, time.time() + scale_timeout(60))
+    await wait_new_coordinator_elected(manager, previous_coordinator_id, time.time() + scale_timeout(60))
     await wait_for_no_pending_topology_transition(manager, time.time() + scale_timeout(60))
 
     await manager.others_not_see_server(server_ip=coordinator_host.ip_addr)
@@ -104,10 +104,10 @@ async def test_kill_coordinator_during_op(manager: ScyllaClusterManager, failure
     coordinator_host = await get_coordinator_host(manager)
     other_nodes = [srv for srv in nodes if srv.server_id != coordinator_host.server_id]
     new_node = await manager.server_add(start=False, config=config, cmdline=cmdline)
-    num_elections = len(await get_coordinator_host_ids(manager))
+    previous_coordinator_id = await manager.get_host_id(coordinator_host.server_id)
     await manager.api.enable_injection(coordinator_host.ip_addr, "crash_coordinator_before_stream", one_shot=True)
     await manager.server_start(new_node.server_id, expected_error=f"Startup failed: std::runtime_error|{BANNED_NOTIFICATION}")
-    await wait_new_coordinator_elected(manager, num_elections + 1, time.time() + scale_timeout(60))
+    await wait_new_coordinator_elected(manager, previous_coordinator_id, time.time() + scale_timeout(60))
     await wait_for_no_pending_topology_transition(manager, time.time() + scale_timeout(60))
     await manager.server_restart(coordinator_host.server_id, wait_others=1)
     await manager.servers_see_each_other(await manager.running_servers())
@@ -120,12 +120,12 @@ async def test_kill_coordinator_during_op(manager: ScyllaClusterManager, failure
     other_nodes = [srv for srv in nodes if srv.server_id != coordinator_host.server_id]
     node_to_replace_srv_id = other_nodes[-1].server_id
     await manager.server_stop_gracefully(node_to_replace_srv_id)
-    num_elections = len(await get_coordinator_host_ids(manager))
+    previous_coordinator_id = await manager.get_host_id(coordinator_host.server_id)
     await manager.api.enable_injection(coordinator_host.ip_addr, "crash_coordinator_before_stream", one_shot=True)
     replace_cfg = ReplaceConfig(replaced_id = node_to_replace_srv_id, reuse_ip_addr = False, use_host_id = True)
     new_node = await manager.server_add(start=False, config=config, replace_cfg=replace_cfg, cmdline=cmdline)
     await manager.server_start(new_node.server_id, expected_error=f"Replace failed. See earlier errors|{BANNED_NOTIFICATION}")
-    await wait_new_coordinator_elected(manager, num_elections + 1, time.time() + scale_timeout(60))
+    await wait_new_coordinator_elected(manager, previous_coordinator_id, time.time() + scale_timeout(60))
     await wait_for_no_pending_topology_transition(manager, time.time() + scale_timeout(60))
     logger.debug("Start old coordinator node")
     await manager.others_not_see_server(server_ip=coordinator_host.ip_addr)

--- a/test/cluster/util.py
+++ b/test/cluster/util.py
@@ -502,7 +502,7 @@ async def trigger_stepdown(manager, server: ServerInfo) -> None:
 
 
 
-async def get_coordinator_host_ids(manager: ScyllaClusterManager) -> list[str]:
+async def get_coordinator_host_ids(manager: ScyllaClusterManager) -> list[HostID]:
     """ Get coordinator host id from history
 
     Select all records with elected coordinator
@@ -515,11 +515,11 @@ async def get_coordinator_host_ids(manager: ScyllaClusterManager) -> list[str]:
 
     cql = manager.get_cql()
     result = await cql.run_async(stm)
-    coordinators_ids = []
+    coordinators_ids: list[HostID] = []
     for row in result:
         coordinator_host_id = get_uuid_from_str(row.description)
         if coordinator_host_id:
-            coordinators_ids.append(coordinator_host_id)
+            coordinators_ids.append(HostID(coordinator_host_id))
     assert len(coordinators_ids) > 0, f"No coordinator ids {coordinators_ids} were found"
     return coordinators_ids
 

--- a/test/cluster/util.py
+++ b/test/cluster/util.py
@@ -591,20 +591,19 @@ def get_uuid_from_str(string: str) -> str:
     return uuid
 
 
-async def wait_new_coordinator_elected(manager: ScyllaClusterManager, expected_num_of_elections: int, deadline: float) -> None:
-    """Wait new coordinator to be elected
+async def wait_new_coordinator_elected(manager: ScyllaClusterManager, previous_coordinator_id: HostID, deadline: float) -> None:
+    """Wait for a node other than previous_coordinator_id to become topology coordinator
 
-    Wait while the table 'system.group0_history' will have at least
-    expected_num_of_elections lines with 'new topology coordinator',
-    and the latest host_id coordinator differs from the previous one.
+    previous_coordinator_id is the host id of the node which held the coordinator
+    role and then stopped or crashed, taken from that node itself.
     """
     async def new_coordinator_elected():
         coordinators_ids = await get_coordinator_host_ids(manager)
         logger.debug(f"Coordinators ids in history: {coordinators_ids}")
-        if len(coordinators_ids) >= expected_num_of_elections \
-            and coordinators_ids[0] != coordinators_ids[1]:
+        if coordinators_ids[0] != previous_coordinator_id:
             return True
-        logger.warning("New coordinator was not elected %s", coordinators_ids)
+        logger.warning("New coordinator was not elected, still %s, history %s",
+                       previous_coordinator_id, coordinators_ids)
 
     await wait_for(new_coordinator_elected, deadline=deadline)
 


### PR DESCRIPTION
Two test-framework bugs in the coordinator crash/restart tests. Both are
triggered by the same environment condition: under test load a shard 0 stall
(SCYLLADB-2121) makes the raft direct failure detector mark a live voter dead,
the group0 leader loses quorum and steps down, and the topology coordinator
role flaps. Neither test tolerated that.

1. `wait_new_coordinator_elected()` compared the two newest entries of
   `system.group0_history` with each other to detect a completed handover.
   When the coordinator that went away is elected again it writes a second
   identical 'Starting new topology coordinator' entry at the head of the
   history, so the comparison stays permanently false and the wait can only
   time out.

   Change the helper to take the coordinator observed before the triggering
   operation (`previous_coordinator_id`) and compare the live head against it.
   This also removes the `expected_num_of_elections` counting, which required
   every one of the 6 call sites to know how many elections had already been
   recorded.

2. `test_kill_coordinator_during_op` arms the one-shot
   `crash_coordinator_before_stream` injection on the node it observes as
   topology coordinator. If the role moves before the coordinator fiber
   reaches the injection point, the new coordinator has nothing armed and the
   operation completes successfully instead of failing as the test expects.

   Rather than arming every node and reconstructing which one fired, raise the
   raft direct failure detector threshold for this test from its 2s default to
   5s, using the existing `raft-group-registry-fd-threshold-in-ms` error
   injection (already used by `test_raft_no_quorum.py` and `test_tablets_lwt.py`).
   A stall of that length then no longer costs the leader its role, and the
   node armed at arming time is still the node that streams.

Also switches `get_coordinator_host_ids()` to the `HostID` NewType instead of
plain str, since every real caller already deals in host ids (identity at
runtime, no call-site changes required).

Measured cost of (2), `test_kill_coordinator_during_op` in dev mode, 20 reps
per arm, interleaved in alternating blocks of 4 to cancel machine drift:

| FD threshold | n | mean | median | sd | min | max |
|---|---|---|---|---|---|---|
| 2s (default) | 20 | 77.34s | 76.44s | 2.02 | 74.60s | 81.00s |
| 5s (this PR) | 20 | 86.87s | 86.81s | 1.39 | 84.42s | 90.72s |

40/40 passed, no flakes. The +9.5s (+12.3%) is the delayed post-crash election:
`raft::fsm::has_stable_leader()` keeps refreshing `_last_election_time` while
the failure detector still reports the leader alive, so each of the 4 phases
waits ~2.4s longer before a follower becomes a candidate. That is why the
threshold is 5s and not larger — 20s would add roughly 72s per run against
`scale_timeout(60)` deadlines.

Fixes: SCYLLADB-3852
Fixes: SCYLLADB-3876

No backport: Apparently these tests fail only in master CI when run 100 times
after being changed. So, there is no reason to expect them to fail in older
branches, so backporting is unneeded.
