### PR TITLE
[DO NOT MERGE for the time being] alternator: fix O(total tablets) TTL scan probe, unbounded ERM hold

### DIFF
--- a/alternator/ttl.cc
+++ b/alternator/ttl.cc
@@ -6,6 +6,7 @@
  * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
  */
 
+#include <algorithm>
 #include <chrono>
 #include <cstdint>
 #include <exception>
@@ -762,61 +763,83 @@ static future<bool> scan_table(
     scan_ranges_context scan_ctx{s, proxy, std::move(column_name), std::move(member)};
 
     if (s->table().uses_tablets()) {
-        std::optional<dht::token> last_token;
-        do {
+        // Candidates are the tablets this shard hosts, taken from its
+        // storage-group map, so enumeration is O(tablets hosted by this
+        // shard), not O(tablets in the table) (SCYLLADB-3891). Each candidate
+        // is recorded by its last token, which resolves to a covering tablet
+        // in any tablet map, unlike a tablet id, which a split or merge
+        // renumbers.
+        std::vector<dht::token> candidates;
+        {
+            auto erm = s->table().get_effective_replication_map();
+            const auto& tablet_map = erm->get_token_metadata().tablets().get_tablet_map(s->id());
+            auto local_tablets = s->table().local_tablet_ids();
+            candidates.reserve(local_tablets.size());
+            for (auto tid : local_tablets) {
+                candidates.push_back(tablet_map.get_last_token(tid));
+            }
+        } // No yield above: the ERM is dropped before any preemption point.
+        std::sort(candidates.begin(), candidates.end());
+
+        // Start from a random candidate (same rationale as the vnode path
+        // below), so a partial scan doesn't always restart at the same tablet.
+        const size_t start_idx = candidates.empty() ? 0 : random_offset(0, candidates.size() - 1);
+        for (size_t i = 0; i < candidates.size(); ++i) {
+            if (abort_source.abort_requested()) {
+                break;
+            }
+            const dht::token token = candidates[(start_idx + i) % candidates.size()];
             std::optional<locator::tablet_metadata_guard> tablet_guard;
             std::optional<dht::partition_range> range;
             {
+                // Resolve the candidate token and re-check ownership against a
+                // fresh ERM immediately before scanning: tablets can migrate,
+                // split or merge after enumeration.
                 auto erm = s->table().get_effective_replication_map();
-                auto my_host_id = erm->get_topology().my_host_id();
                 const auto& tablet_map = erm->get_token_metadata().tablets().get_tablet_map(s->id());
-                std::optional<locator::tablet_id> tablet = last_token ? tablet_map.get_tablet_id(dht::next_token(*last_token)) : tablet_map.first_tablet();
-
-                // The loop finds the tablet range to scan, one which we are the primary replica for,
-                // or if the primary replica is down, one which we are the secondary replica for.
-                do {
-                    auto tablet_token_range = tablet_map.get_token_range(*tablet);
-                    last_token = tablet_map.get_last_token(*tablet);
-                    auto tablet_primary_replica = tablet_map.get_primary_replica(*tablet, erm->get_topology());
-                    if (tablet_primary_replica.host == my_host_id && tablet_primary_replica.shard == this_shard_id()) {
-                        range = dht::to_partition_range(std::move(tablet_token_range));
-                    } else if (erm->get_replication_factor() > 1) {
-                        // If each node only scans its own primary ranges, then when any node is
-                        // down part of the token range will not get scanned. This can be viewed
-                        // as acceptable (when it comes back online, it will resume its scan),
-                        // but as noted in issue #9787, we can allow more prompt expiration
-                        // by tasking another node to take over scanning of the dead node's primary
-                        // ranges. What we do here is that this node will also check expiration
-                        // on its *secondary* ranges - but only those whose primary owner is down.
-                        auto tablet_secondary_replica = tablet_map.get_secondary_replica(*tablet, erm->get_topology()); // throws if no secondary replica
-                        if (tablet_secondary_replica.host == my_host_id && tablet_secondary_replica.shard == this_shard_id()) {
-                            if (!gossiper.is_alive(tablet_primary_replica.host)) {
-                                range = dht::to_partition_range(std::move(tablet_token_range));
-                            }
+                auto tid = tablet_map.get_tablet_id(token);
+                expiration_stats.tablets_probed++;
+                auto my_host_id = erm->get_topology().my_host_id();
+                auto tablet_token_range = tablet_map.get_token_range(tid);
+                auto tablet_primary_replica = tablet_map.get_primary_replica(tid, erm->get_topology());
+                if (tablet_primary_replica.host == my_host_id && tablet_primary_replica.shard == this_shard_id()) {
+                    range = dht::to_partition_range(std::move(tablet_token_range));
+                    expiration_stats.tablets_scanned++;
+                } else if (tablet_map.get_tablet_info(tid).replicas.size() > 1) {
+                    // If each node only scans its own primary ranges, then when any node is
+                    // down part of the token range will not get scanned. This can be viewed
+                    // as acceptable (when it comes back online, it will resume its scan),
+                    // but as noted in issue #9787, we can allow more prompt expiration
+                    // by tasking another node to take over scanning of the dead node's primary
+                    // ranges. What we do here is that this node will also check expiration
+                    // on its *secondary* ranges - but only those whose primary owner is down.
+                    auto tablet_secondary_replica = tablet_map.get_secondary_replica(tid, erm->get_topology()); // throws if no secondary replica
+                    if (tablet_secondary_replica.host == my_host_id && tablet_secondary_replica.shard == this_shard_id()) {
+                        if (!gossiper.is_alive(tablet_primary_replica.host)) {
+                            range = dht::to_partition_range(std::move(tablet_token_range));
+                            expiration_stats.secondary_tablets_scanned++;
                         }
                     }
-                    if (range) {
-                        break;
-                    }
-                    tablet = tablet_map.next_tablet(*tablet);
-                } while (tablet);
-
+                }
                 if (range) {
                     // Take the tablet guard to protect the tablet while we scan it.
-                    tablet_guard.emplace(s->table(), locator::global_tablet_id{s->id(), *tablet});
-                } else {
-                    // No range was found means all tablets have been iterated and we are done.
-                    break;
+                    tablet_guard.emplace(s->table(), locator::global_tablet_id{s->id(), tid});
                 }
             } // Drop the ERM before the scan so to unblock any tablet operations,
               // which would otherwise be held up by us keeping the ERM.
               // tablet_guard blocks only the selected tablet.
+            if (!range) {
+                // Not ours to scan (anymore); yield so a long stretch of
+                // skipped candidates can't starve the reactor.
+                co_await coroutine::maybe_yield();
+                continue;
+            }
 
             // Note that because of issue #9167 we need to run a separate query on each partition range, and can't pass
             // several of them into one partition_range_vector that is passed to scan_table_ranges().
             co_await scan_table_ranges(proxy, scan_ctx, {std::move(*range)}, abort_source, page_sem, expiration_stats);
             tablet_guard.reset();
-        } while (*last_token < dht::last_token());
+        }
     } else {  // VNodes
         locator::static_effective_replication_map_ptr ermp =
                 db.real_database().find_keyspace(s->ks_name()).get_static_effective_replication_map();
@@ -950,6 +973,12 @@ expiration_service::stats::stats() {
             seastar::metrics::description("number of items deleted after expiration"))(basic_level)(alternator_label).set_skip_when_empty(),
         seastar::metrics::make_total_operations("secondary_ranges_scanned", secondary_ranges_scanned,
             seastar::metrics::description("number of token ranges scanned by this node while their primary owner was down"))(alternator_label).set_skip_when_empty(),
+        seastar::metrics::make_total_operations("tablets_probed", tablets_probed,
+            seastar::metrics::description("number of tablet ownership checks performed by the expiration scan"))(alternator_label).set_skip_when_empty(),
+        seastar::metrics::make_total_operations("tablets_scanned", tablets_scanned,
+            seastar::metrics::description("number of tablets scanned by this shard as their primary replica"))(alternator_label).set_skip_when_empty(),
+        seastar::metrics::make_total_operations("secondary_tablets_scanned", secondary_tablets_scanned,
+            seastar::metrics::description("number of tablets scanned by this shard as a secondary replica while the primary was down"))(alternator_label).set_skip_when_empty(),
     });
 }
 

--- a/alternator/ttl.hh
+++ b/alternator/ttl.hh
@@ -43,6 +43,9 @@ public:
         uint64_t scan_table = 0;
         uint64_t items_deleted = 0;
         uint64_t secondary_ranges_scanned = 0;
+        uint64_t tablets_probed = 0;
+        uint64_t tablets_scanned = 0;
+        uint64_t secondary_tablets_scanned = 0;
     private:
         // The metric_groups object holds this stat object's metrics registered
         // as long as the stats object is alive.

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -700,6 +700,12 @@ private:
     future<> delete_sstables_atomically(const sstable_list_permit&, std::vector<sstables::shared_sstable> sstables_to_remove);
 
 public:
+    // Ids of the tablets hosted by this shard (those with a storage group).
+    // The ids are copied out, so the result is safe to use across preemption
+    // points, but can go stale: re-validate against a fresh ERM before use.
+    // Valid only for tablet-based tables.
+    std::vector<locator::tablet_id> local_tablet_ids() const;
+
     // Precondition: table needs tablet splitting.
     // Returns true if all storage of table is ready for splitting.
     bool all_storage_groups_split();

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -1636,6 +1636,16 @@ const storage_group_map& table::storage_groups() const {
     return _sg_manager->storage_groups();
 }
 
+std::vector<locator::tablet_id> table::local_tablet_ids() const {
+    const auto& sgs = storage_groups();
+    std::vector<locator::tablet_id> ids;
+    ids.reserve(sgs.size());
+    for (const auto& [id, sg] : sgs) {
+        ids.push_back(locator::tablet_id(id));
+    }
+    return ids;
+}
+
 future<utils::chunked_vector<sstables::sstable_files_snapshot>> table::take_storage_snapshot(dht::token_range tr) {
     utils::chunked_vector<sstables::sstable_files_snapshot> ret;
 

--- a/test/cqlpy/test_ttl_row.py
+++ b/test/cqlpy/test_ttl_row.py
@@ -16,7 +16,7 @@
 import pytest
 import time
 from cassandra.protocol import InvalidRequest
-from .util import new_test_table, new_materialized_view, new_secondary_index, ScyllaMetrics
+from .util import new_test_table, new_test_keyspace, new_materialized_view, new_secondary_index, ScyllaMetrics
 
 # All tests in this file check the Scylla-only per-row TTL feature, so
 # let's mark them all scylla_only with an autouse fixture:
@@ -599,3 +599,30 @@ def test_row_ttl_metrics(cql, test_keyspace, ttl_period):
         # the exactly 2 items deleted (we assume that no other TTL activity
         # is running on the same Scylla instance in parallel...)
         assert end.get('scylla_expiration_items_deleted') == (start.get('scylla_expiration_items_deleted') or 0) + 2
+
+# Drives scan_table()'s real tablet path (SCYLLADB-3891) with many tablets,
+# unlike the default keyspace used above which has few or none.
+def test_row_ttl_expiration_many_tablets(cql, this_dc, ttl_period, skip_without_tablets):
+    typ = 'bigint'
+    nrows = 200
+    with new_test_keyspace(cql,
+            " WITH REPLICATION = {'class': 'NetworkTopologyStrategy', '" + this_dc + "': 1}"
+            " AND TABLETS = {'initial': 32}") as keyspace:
+        with new_test_table(cql, keyspace, f'p int primary key, e {typ} ttl, x int') as table:
+            start = ScyllaMetrics.query(cql)
+            e = to_ttl(typ, time.time()-60)
+            for p in range(nrows):
+                cql.execute(f'INSERT INTO {table} (p, e, x) values ({p}, {e}, {p})')
+            deadline = time.time() + 3*ttl_period + 3
+            while time.time() < deadline:
+                if len(list(cql.execute(f'SELECT p from {table}'))) == 0:
+                    break
+                time.sleep(0.1)
+            assert list(cql.execute(f'SELECT p from {table}')) == []
+            # The expiration must have probed and scanned tablets. Every
+            # scanned tablet is first probed, so probed >= scanned.
+            end = ScyllaMetrics.query(cql)
+            probed = (end.get('scylla_expiration_tablets_probed') or 0) - (start.get('scylla_expiration_tablets_probed') or 0)
+            scanned = (end.get('scylla_expiration_tablets_scanned') or 0) - (start.get('scylla_expiration_tablets_scanned') or 0)
+            assert scanned > 0
+            assert probed >= scanned


### PR DESCRIPTION
## Motivation

SCYLLADB-3891: the alternator TTL scanner's tablet-ownership search in `scan_table()` walks the table's whole `tablet_map`, so:

1. Each shard performs one ownership probe per tablet *in the table* per pass — O(total tablets), not O(tablets this shard hosts) — and each probe copies and sorts the tablet's replica set (`get_primary_replica()`, plus `get_secondary_replica()` for non-owned tablets at RF > 1).
2. The walk is one synchronous stretch holding a single `effective_replication_map` (ERM) reference, pinning a `token_metadata` version that topology barriers (tablet migration/rebalance) must wait out.

## Changes

Following the approach proposed in SCYLLADB-3891:

- New `replica::table::local_tablet_ids()` copies the tablet ids out of the shard's storage-group map — exactly the locally-hosted tablets. Candidate enumeration is O(hosted) and holds the ERM only across a non-yielding stretch.
- Candidates are identified by their last token, not tablet id. Before scanning each one, a fresh ERM is fetched, the token re-resolved with `get_tablet_id(token)`, and ownership re-checked (primary, or secondary while the primary's node is down). Splits/merges/migrations after enumeration are tolerated by construction — no tablet-count guard, no abandoned pass.
- The ERM is never held across a preemption point; the scanned tablet remains protected by `tablet_metadata_guard`, as before.
- `get_secondary_replica()` (which throws below 2 replicas) is now gated on the tablet's own `replicas.size()` rather than the keyspace RF.
- Each pass starts at a random candidate offset (like the vnode path), so repeatedly-interrupted scans don't starve the same tablets.
- New counters: `expiration_tablets_probed`, `expiration_tablets_scanned`, `expiration_secondary_tablets_scanned`.

## Tests

New `test/cqlpy/test_ttl_row.py::test_row_ttl_expiration_many_tablets`: end-to-end expiration of 200 rows spread across a 32-tablet table, driving the production `scan_table()` path, asserting `tablets_scanned > 0` and `tablets_probed >= tablets_scanned` from the new metrics.

## Results

All 28 tests in `test/cqlpy/test_ttl_row.py` (dev mode) pass, including the new one; rows expire and the new counters report the expected values. The O(hosted) bound is by construction and not directly measurable on a single node (hosted = total there); the counters expose it in multi-node deployments.

Fixes SCYLLADB-3891.
