### PR TITLE
POC: shard-wide batched raft IO for strongly-consistent tablets

### DIFF
--- a/db/commitlog/commitlog.cc
+++ b/db/commitlog/commitlog.cc
@@ -3227,22 +3227,20 @@ db::commitlog::add_entries(utils::chunked_vector<commitlog_mutation_entry_writer
     return _segment_manager->allocate_when_possible(cl_entries_writer(sync, std::move(entry_writers)), timeout);
 }
 future<utils::chunked_vector<db::rp_handle>> db::commitlog::add_raft_entries(
-        const cf_id_type& id, utils::chunked_vector<commitlog_raft_log_entry_writer> entry_writers) {
+        utils::chunked_vector<commitlog_raft_log_entry_writer> entry_writers) {
     class cl_raft_entries_writer final : public entry_writer {
         utils::chunked_vector<commitlog_raft_log_entry_writer> _writers;
-        cf_id_type _id;
 
     public:
         utils::chunked_vector<rp_handle> res;
 
-        cl_raft_entries_writer(utils::chunked_vector<commitlog_raft_log_entry_writer> entry_writers, cf_id_type id)
+        cl_raft_entries_writer(utils::chunked_vector<commitlog_raft_log_entry_writer> entry_writers)
             : entry_writer(force_sync::yes, entry_writers.size())
-            , _writers(std::move(entry_writers))
-            , _id(id) {
+            , _writers(std::move(entry_writers)) {
             res.reserve(_writers.size());
         }
-        const cf_id_type& id(size_t) const override {
-            return _id;
+        const cf_id_type& id(size_t i) const override {
+            return _writers.at(i).cf_id();
         }
         size_t size(segment&) override {
             size_t res = 0;
@@ -3275,7 +3273,7 @@ future<utils::chunked_vector<db::rp_handle>> db::commitlog::add_raft_entries(
             return std::move(res);
         }
     };
-    return _segment_manager->allocate_when_possible(cl_raft_entries_writer(std::move(entry_writers), id), db::no_timeout);
+    return _segment_manager->allocate_when_possible(cl_raft_entries_writer(std::move(entry_writers)), db::no_timeout);
 }
 
 db::commitlog::commitlog(config cfg)

--- a/db/commitlog/commitlog.hh
+++ b/db/commitlog/commitlog.hh
@@ -239,10 +239,13 @@ public:
 
     /**
      * Add N raft log entries to the commit log as a single operation (in a single segment).
-     * Always uses force_sync::yes.
+     * Each entry writer carries its own cf_id, so a single batch can contain
+     * entries destined for different column families (e.g. raft log entries
+     * for the target table and a trailing commit_idx entry attached to
+     * system.raft_groups). Always uses force_sync::yes.
      */
     future<utils::chunked_vector<rp_handle>> add_raft_entries(
-            const cf_id_type& id, utils::chunked_vector<commitlog_raft_log_entry_writer> entry_writers);
+            utils::chunked_vector<commitlog_raft_log_entry_writer> entry_writers);
 
     /**
      * Modifies the per-CF dirty cursors of any commit log segments for the column family according to the position

--- a/db/commitlog/commitlog_entry.cc
+++ b/db/commitlog/commitlog_entry.cc
@@ -44,7 +44,16 @@ void commitlog_mutation_entry_writer::compute_size() {
 
 template<typename Output>
 inline void commitlog_raft_log_entry_writer::serialize(Output& out) const {
-    ser::writer_of_commitlog_entry<Output>(out).write_item_raft_commitlog_entry(_item).end_commitlog_entry();
+    auto writer = ser::writer_of_commitlog_entry<Output>(out);
+    std::visit([&] (const auto& item) {
+        using item_type = std::decay_t<decltype(item)>;
+        if constexpr (std::is_same_v<item_type, raft_commitlog_entry>) {
+            std::move(writer).write_item_raft_commitlog_entry(item).end_commitlog_entry();
+        } else {
+            static_assert(std::is_same_v<item_type, raft_commit_idx_entry>);
+            std::move(writer).write_item_raft_commit_idx_entry(item).end_commitlog_entry();
+        }
+    }, _item);
 }
 
 void commitlog_raft_log_entry_writer::write(ostream& out) const {
@@ -80,6 +89,9 @@ auto read_variant_commitlog_entry(const fragmented_temporary_buffer& buffer) {
             },
             [](const ser::mutation_entry_view& entry_view) {
                 return commitlog_entry{.item = mutation_entry(entry_view.mapping(), entry_view.mutation())};
+            },
+            [](raft_commit_idx_entry entry) {
+                return commitlog_entry{.item = std::move(entry)};
             },
             [](ser::unknown_variant_type) -> commitlog_entry {
                 throw std::runtime_error("Unknown variant type in commitlog entry");

--- a/db/commitlog/commitlog_entry.hh
+++ b/db/commitlog/commitlog_entry.hh
@@ -196,10 +196,15 @@ public:
 // (raft_commitlog_entry) and the per-batch commit-index entry
 // (raft_commit_idx_entry); both are produced by raft_commitlog::
 // store_log_entries as part of a single batched commit_log.add_raft_entries().
+//
+// Each writer carries its own cf_id_type so a single batch can contain
+// entries destined for different column families — used to associate the
+// commit_idx entry with system.raft_groups rather than the raft log's target table.
 class commitlog_raft_log_entry_writer {
 public:
     using item_variant = std::variant<raft_commitlog_entry, raft_commit_idx_entry>;
 protected:
+    db::cf_id_type _cf_id;
     item_variant _item;
     std::size_t _size = std::numeric_limits<std::size_t>::max();
 
@@ -208,10 +213,10 @@ protected:
     void compute_size();
 
 public:
-    explicit commitlog_raft_log_entry_writer(raft_commitlog_entry item)
-        : _item(std::move(item)) { compute_size(); }
-    explicit commitlog_raft_log_entry_writer(raft_commit_idx_entry item)
-        : _item(std::move(item)) { compute_size(); }
+    explicit commitlog_raft_log_entry_writer(db::cf_id_type cf_id, raft_commitlog_entry item)
+        : _cf_id(cf_id), _item(std::move(item)) { compute_size(); }
+    explicit commitlog_raft_log_entry_writer(db::cf_id_type cf_id, raft_commit_idx_entry item)
+        : _cf_id(cf_id), _item(std::move(item)) { compute_size(); }
 
     size_t size() const {
         SCYLLA_ASSERT(_size != std::numeric_limits<size_t>::max());
@@ -221,6 +226,9 @@ public:
     using ostream = typename seastar::memory_output_stream<detail::sector_split_iterator>;
     void write(ostream& out) const;
 
+    const db::cf_id_type& cf_id() const {
+        return _cf_id;
+    }
     raft::group_id group_id() const {
         return std::visit([] (const auto& item) { return item.group_id; }, _item);
     }

--- a/db/commitlog/commitlog_entry.hh
+++ b/db/commitlog/commitlog_entry.hh
@@ -102,11 +102,24 @@ struct raft_commitlog_entry {
     raft::log_entry_ptr entry;
 };
 
-// The on-disk envelope for variant-format commitlog segments. Each
-// entry contains exactly one of the variant alternatives: a mutation_entry
-// (normal table write) or a raft_commitlog_entry (Raft log entry for
-// strongly-consistent tables).
-using commitlog_entry_variant = std::variant<raft_commitlog_entry, mutation_entry>;
+// Commitlog entry that carries the current commit index of a strongly-consistent
+// raft group. Used to persist the commit index (see raft_commitlog::store_log_entries
+// and raft_groups_storage::store_log_entries).
+struct raft_commit_idx_entry {
+    raft::group_id group_id;
+    raft::index_t commit_idx{0};
+};
+
+// The on-disk envelope for variant-format commitlog segments. Each entry
+// contains exactly one of the variant alternatives: a mutation_entry (normal
+// table write), a raft_commitlog_entry (Raft log entry for a strongly-consistent
+// table), or a raft_commit_idx_entry (per-batch commit_idx entry).
+//
+// NOTE: the variant alternative index is the on-disk discriminator, so new
+// alternatives must only ever be appended at the end. Reordering or inserting
+// in the middle would change the discriminator of existing alternatives and
+// corrupt the reading of previously written segments.
+using commitlog_entry_variant = std::variant<raft_commitlog_entry, mutation_entry, raft_commit_idx_entry>;
 struct commitlog_entry {
     commitlog_entry_variant item;
 };
@@ -178,11 +191,16 @@ public:
     frozen_mutation&& mutation() && { return std::move(_me).mutation(); }
 };
 
-// Writer for Raft log entries to the database commit log using the commitlog_entry format.
+// Writer for Raft-related entries in the database commit log using the
+// commitlog_entry format. Handles both the raft log entry variant
+// (raft_commitlog_entry) and the per-batch commit-index entry
+// (raft_commit_idx_entry); both are produced by raft_commitlog::
+// store_log_entries as part of a single batched commit_log.add_raft_entries().
 class commitlog_raft_log_entry_writer {
 public:
+    using item_variant = std::variant<raft_commitlog_entry, raft_commit_idx_entry>;
 protected:
-    raft_commitlog_entry _item;
+    item_variant _item;
     std::size_t _size = std::numeric_limits<std::size_t>::max();
 
     template<typename Output>
@@ -192,6 +210,8 @@ protected:
 public:
     explicit commitlog_raft_log_entry_writer(raft_commitlog_entry item)
         : _item(std::move(item)) { compute_size(); }
+    explicit commitlog_raft_log_entry_writer(raft_commit_idx_entry item)
+        : _item(std::move(item)) { compute_size(); }
 
     size_t size() const {
         SCYLLA_ASSERT(_size != std::numeric_limits<size_t>::max());
@@ -200,7 +220,19 @@ public:
 
     using ostream = typename seastar::memory_output_stream<detail::sector_split_iterator>;
     void write(ostream& out) const;
-    const raft_commitlog_entry& get_log_entry() const {
+
+    raft::group_id group_id() const {
+        return std::visit([] (const auto& item) { return item.group_id; }, _item);
+    }
+    // Returns the underlying raft_commitlog_entry when this writer holds one.
+    // Guarded by holds_raft_log_entry(); prefer visiting item() instead.
+    const raft_commitlog_entry& get_raft_log_entry() const {
+        return std::get<raft_commitlog_entry>(_item);
+    }
+    bool holds_raft_log_entry() const {
+        return std::holds_alternative<raft_commitlog_entry>(_item);
+    }
+    const item_variant& item() const {
         return _item;
     }
 };

--- a/db/commitlog/commitlog_replayer.cc
+++ b/db/commitlog/commitlog_replayer.cc
@@ -235,6 +235,12 @@ future<> db::commitlog_replayer::impl::process(
             rlogger.debug("Adding raft log entry for group {} at {} to replay buffer", raft_entry.group_id, rp);
             _raft_buffer->local().add(raft_entry.group_id, raft_entry.entry);
             co_return;
+        } else if (std::holds_alternative<raft_commit_idx_entry>(read_entry)) {
+            // Commit index entry for a strongly-consistent raft group.
+            const auto& commit_idx_entry = std::get<raft_commit_idx_entry>(read_entry);
+            rlogger.debug("Skipping commit_idx entry at {} for group {} (commit_idx={})",
+                    rp, commit_idx_entry.group_id, commit_idx_entry.commit_idx);
+            co_return;
         } else if (std::holds_alternative<mutation_entry>(read_entry)) {
             const auto& mut_entry = std::get<mutation_entry>(read_entry);
 

--- a/db/commitlog/commitlog_replayer.cc
+++ b/db/commitlog/commitlog_replayer.cc
@@ -236,10 +236,14 @@ future<> db::commitlog_replayer::impl::process(
             _raft_buffer->local().add(raft_entry.group_id, raft_entry.entry);
             co_return;
         } else if (std::holds_alternative<raft_commit_idx_entry>(read_entry)) {
-            // Commit index entry for a strongly-consistent raft group.
+            // Commit index entry for a strongly-consistent raft group. Record it
+            // so process_raft_replayed_items() can restore commit_idx that a
+            // crash dropped from the raft_groups memtable before it flushed.
             const auto& commit_idx_entry = std::get<raft_commit_idx_entry>(read_entry);
-            rlogger.debug("Skipping commit_idx entry at {} for group {} (commit_idx={})",
+            SCYLLA_ASSERT(_raft_buffer);
+            rlogger.debug("Recording commit_idx entry at {} for group {} (commit_idx={})",
                     rp, commit_idx_entry.group_id, commit_idx_entry.commit_idx);
+            _raft_buffer->local().add_commit_idx(commit_idx_entry.group_id, commit_idx_entry.commit_idx);
             co_return;
         } else if (std::holds_alternative<mutation_entry>(read_entry)) {
             const auto& mut_entry = std::get<mutation_entry>(read_entry);

--- a/db/commitlog/raft_commitlog_replay_buffer.cc
+++ b/db/commitlog/raft_commitlog_replay_buffer.cc
@@ -27,6 +27,7 @@
 
 #include <algorithm>
 #include <seastar/core/coroutine.hh>
+#include <seastar/coroutine/parallel_for_each.hh>
 #include <seastar/core/on_internal_error.hh>
 #include <seastar/coroutine/maybe_yield.hh>
 
@@ -126,7 +127,7 @@ filter_entries_result filter_entries(utils::chunked_vector<raft::log_entry_ptr>&
 } // anonymous namespace
 
 future<> raft_commitlog_replay_buffer::process_raft_replayed_items(replica::database& db, cql3::query_processor& qp, db::system_keyspace& sys_ks) {
-    if (remaining_groups() == 0) {
+    if (remaining_groups() == 0 && _replayed_commit_idx_by_group.empty()) {
         co_return;
     }
 
@@ -137,6 +138,30 @@ future<> raft_commitlog_replay_buffer::process_raft_replayed_items(replica::data
     SCYLLA_ASSERT(new_commitlog_ptr);
 
     logger.info("processing {} raft groups with {} total entries from commitlog replay", remaining_groups(), total_entries());
+
+    // Restore commit_idx recovered from the commitlog. On a crash before the
+    // raft_groups memtable flushed, the per-batch commit_idx (applied in memory
+    // via a fake mutation) is lost, but the commitlog's commit_idx entries
+    // survived. Write the highest recovered value per group back to
+    // system.raft_groups so the apply loop below — and bump_snapshot_indices()
+    // afterwards — observe the correct commit_idx and re-apply / snapshot the
+    // committed entries rather than treating them as uncommitted. The per-group
+    // writes are independent, so run them concurrently (as bump_snapshot_indices
+    // does).
+    co_await seastar::coroutine::parallel_for_each(_replayed_commit_idx_by_group,
+            [&qp, &group_to_table] (const auto& entry) -> future<> {
+        const auto group_id = entry.first;
+        const auto recovered_commit_idx = entry.second;
+        if (!group_to_table.contains(group_id)) {
+            // Same rule as the entries loop below: the tablet was moved away or
+            // dropped, so don't resurrect a system.raft_groups row for it.
+            logger.debug("group {} not found in tablet metadata, discarding recovered commit_idx {}",
+                    group_id, recovered_commit_idx);
+            co_return;
+        }
+        co_await service::strong_consistency::raft_groups_storage::store_commit_idx_if_higher(
+                qp, group_id, this_shard_id(), recovered_commit_idx);
+    });
 
     for (auto& [group_id, entries_list] : _replayed_commitlog_entries_by_group) {
         if (entries_list.empty()) {
@@ -170,9 +195,6 @@ future<> raft_commitlog_replay_buffer::process_raft_replayed_items(replica::data
         uint64_t rewritten = 0;
         auto& group_data = _per_group_data[group_id];
 
-        // Track the term of the last committed entry to update the snapshot descriptor.
-        std::optional<raft::term_t> last_committed_term;
-
         for (auto& entry : filtered.entries) {
             // Apply committed command entries to the memtables. It is safe not to append them
             // to the new commitlog, because the old commitlog (currently being replayed) will
@@ -185,10 +207,6 @@ future<> raft_commitlog_replay_buffer::process_raft_replayed_items(replica::data
                 auto schemas = co_await service::strong_consistency::resolve_and_upgrade_mutations(muts, table_id, db, sys_ks);
                 co_await db.apply_in_memory(muts[0], schemas[0], db::rp_handle(), db::no_timeout, db::noop_large_data_guardrail::instance());
                 ++applied;
-            }
-
-            if (entry->idx <= commit_idx) {
-                last_committed_term = entry->term;
             }
 
             // Rewrite uncommitted entries to the new commitlog to obtain rp_handles
@@ -205,29 +223,14 @@ future<> raft_commitlog_replay_buffer::process_raft_replayed_items(replica::data
             }
 
             // Only add uncommitted entries to the raft log. Committed entries have
-            // already been applied to memtables above and will be covered by the
-            // updated snapshot descriptor (see below).
+            // already been applied to memtables above and are covered by the
+            // snapshot index that bump_snapshot_indices() advances to commit_idx
+            // after replay (the sole snapshot-index advancer on startup).
             if (entry->idx > commit_idx) {
                 group_data.entries.push_back(std::move(entry));
             }
 
             co_await seastar::coroutine::maybe_yield();
-        }
-
-        // Advance the persisted snapshot index to commit_idx. This tells the raft
-        // server (which sets _applied_idx = snapshot.idx on restart) that all
-        // committed entries have already been applied, preventing double-application
-        // through the state machine.
-        if (last_committed_term) {
-            // Strongly-consistent tablet raft groups don't use real snapshots,
-            // so we generate a random snapshot ID just to satisfy the schema requirement.
-            co_await service::strong_consistency::raft_groups_storage::store_snapshot_index(
-                    qp, group_id, this_shard_id(), raft::snapshot_descriptor{
-                        .idx = commit_idx,
-                        .term = *last_committed_term,
-                        .id = raft::snapshot_id(utils::make_random_uuid()),
-                    });
-            logger.debug("group {}: advanced snapshot to idx={}, term={}", group_id, commit_idx, *last_committed_term);
         }
 
         logger.debug("group {}: discarded_leader_change={}, applied={}, rewritten={}, total_in_log={}", group_id, filtered.discarded_leader_change, applied,
@@ -236,7 +239,47 @@ future<> raft_commitlog_replay_buffer::process_raft_replayed_items(replica::data
 
     // The old items are not needed anymore.
     _replayed_commitlog_entries_by_group.clear();
+    _replayed_commit_idx_by_group.clear();
     logger.info("Raft groups commit log replayed data processing complete");
+}
+
+future<> raft_commitlog_replay_buffer::bump_snapshot_indices(replica::database& db, cql3::query_processor& qp) {
+    // See header for rationale. Runs for every known raft group and is the sole
+    // place that advances the persisted snapshot index on startup. store_snapshot_index
+    // has an internal "only advance" guard, so groups whose snapshot is already at or
+    // beyond commit_idx (e.g. from a prior run) are left untouched.
+    const auto token_metadata = db.get_shared_token_metadata().get();
+    const auto group_to_table = build_group_to_table_map(*token_metadata);
+
+    // Process groups concurrently: each does independent CQL reads/writes, and
+    // doing them serially would make startup O(groups) round-trips.
+    co_await seastar::coroutine::parallel_for_each(group_to_table,
+            [&qp] (const auto& entry) -> future<> {
+        const auto group_id = entry.first;
+        const auto commit_idx = co_await service::strong_consistency::raft_groups_storage::load_commit_idx(qp, group_id, this_shard_id());
+        if (commit_idx.value() == 0) {
+            co_return;
+        }
+        auto [snap_idx, snap_term] = co_await service::strong_consistency::raft_groups_storage::load_snapshot_idx_and_term(qp, group_id, this_shard_id());
+        if (snap_idx >= commit_idx) {
+            co_return;
+        }
+        // Reuse the previously-recorded snapshot term (the term of the last real
+        // raft snapshot). It is <= term(commit_idx), so it errs conservative /
+        // too-low, which is safe: the replica looks no more up-to-date than its
+        // data, and any log-matching mismatch is repaired by InstallSnapshot from
+        // a peer. The exact term(commit_idx) is not recoverable here once the
+        // commitlog is empty; persisting it for an exact bump is tracked in
+        // SCYLLADB-3357.
+        co_await service::strong_consistency::raft_groups_storage::store_snapshot_index(
+                qp, group_id, this_shard_id(), raft::snapshot_descriptor{
+                    .idx = commit_idx,
+                    .term = snap_term,
+                    .id = raft::snapshot_id(utils::make_random_uuid()),
+                });
+        logger.debug("group {}: post-replay catch-up, advanced snapshot idx {} -> {} (term={})",
+                group_id, snap_idx, commit_idx, snap_term);
+    });
 }
 namespace raft_buffer_detail {
 entry_ordering_check_result check_entry_ordering(raft_term_and_idx current, raft_term_and_idx last) {

--- a/db/commitlog/raft_commitlog_replay_buffer.cc
+++ b/db/commitlog/raft_commitlog_replay_buffer.cc
@@ -194,7 +194,7 @@ future<> raft_commitlog_replay_buffer::process_raft_replayed_items(replica::data
             // Rewrite uncommitted entries to the new commitlog to obtain rp_handles
             // that ensure the commitlog segments won't be deleted.
             if (entry->idx > commit_idx) {
-                commitlog_raft_log_entry_writer writer(raft_commitlog_entry{.group_id = group_id, .entry = entry});
+                commitlog_raft_log_entry_writer writer(table_id, raft_commitlog_entry{.group_id = group_id, .entry = entry});
                 const auto write_fn = [&writer](auto& out) {
                     return writer.write(out);
                 };

--- a/db/commitlog/raft_commitlog_replay_buffer.hh
+++ b/db/commitlog/raft_commitlog_replay_buffer.hh
@@ -112,6 +112,11 @@ class raft_commitlog_replay_buffer {
     // Populated via add() during replay, then consumed and cleared by process_raft_replayed_items().
     std::unordered_map<raft::group_id, utils::chunked_vector<raft::log_entry_ptr>> _replayed_commitlog_entries_by_group;
 
+    // Highest commit_idx seen per group across the commitlog's commit_idx entries.
+    // Used by process_raft_replayed_items() to restore commit_idx after a crash
+    // that dropped it from the raft_groups memtable before it could flush.
+    std::unordered_map<raft::group_id, raft::index_t> _replayed_commit_idx_by_group;
+
     // Resulting entries and rp_handles written to the new (post-crash) commitlog,
     // raft_commitlog instances when tablet Raft groups start.
     std::unordered_map<raft::group_id, service::strong_consistency::replayed_data_per_group> _per_group_data;
@@ -122,6 +127,15 @@ public:
     void add(const raft::group_id group_id, raft::log_entry_ptr entry) {
         _replayed_commitlog_entries_by_group[group_id].push_back(std::move(entry));
         ++_total_entries;
+    }
+
+    // Record a commit_idx recovered from a commitlog commit_idx entry during
+    // replay, keeping the highest value seen per group.
+    void add_commit_idx(const raft::group_id group_id, raft::index_t commit_idx) {
+        auto& slot = _replayed_commit_idx_by_group[group_id];
+        if (commit_idx > slot) {
+            slot = commit_idx;
+        }
     }
 
     // Get the replayed items for a group. These are removed from the buffer since they are now owned by the caller (raft_commitlog).
@@ -151,7 +165,11 @@ public:
     // Process the raft replay items after commitlog replay completes but before
     // old commitlog segments are deleted and memtables are flushed.
     //
-    // For each raft group in the buffer:
+    // First restores commit_idx values recovered from the commitlog's commit_idx
+    // entries (see add_commit_idx()) into system.raft_groups, only-advance, so
+    // the steps below and bump_snapshot_indices() read the post-crash value.
+    //
+    // Then, for each raft group in the buffer:
     //   1. Reads commit_idx from the raft system tables.
     //   2. Filters entries: detects leader changes (discards replaced uncommitted
     //      entries) and stops at out-of-order tails from older pre-crash segments.
@@ -168,5 +186,24 @@ public:
     //   6. Non-command entries (configuration, dummy) are kept in the raft log but
     //      don't need mutation application or commitlog rewrite.
     future<> process_raft_replayed_items(replica::database& db, cql3::query_processor& qp, db::system_keyspace& sys_ks);
+
+    // For every strongly-consistent raft group known to this shard, ensure that
+    // system.raft_groups_snapshots.idx >= system.raft_groups.commit_idx.
+    //
+    // The fake-mutation apply in raft_groups_storage::store_log_entries writes
+    // commit_idx into system.raft_groups via the raft_groups memtable → sstable
+    // path, without going through store_snapshot_descriptor. On a clean shutdown
+    // the SC tablet memtables flush and their commitlog segments are reclaimed,
+    // so on the next startup the commitlog can be empty (or contain only
+    // uncommitted entries) for a group even though its persisted commit_idx > 0.
+    //
+    // Without this bump, raft::server::start would observe
+    // commit_idx > log.stable_idx (== snapshot.idx for an empty log) and trip
+    // its "committed index cannot be larger then persisted one" assert.
+    //
+    // This is the sole place that advances the persisted snapshot index during
+    // startup; it must be called unconditionally on every startup (independent
+    // of whether there were any commitlog segments to replay).
+    future<> bump_snapshot_indices(replica::database& db, cql3::query_processor& qp);
 };
 } // namespace db

--- a/idl/commitlog.idl.hh
+++ b/idl/commitlog.idl.hh
@@ -21,6 +21,11 @@ struct raft_commitlog_entry [[writable]] {
     raft::log_entry_ptr entry;
 };
 
+struct raft_commit_idx_entry [[writable]] {
+    raft::group_id group_id;
+    raft::index_t commit_idx;
+};
+
 struct commitlog_entry [[writable]] {
-    std::variant<raft_commitlog_entry, mutation_entry> item;
+    std::variant<raft_commitlog_entry, mutation_entry, raft_commit_idx_entry> item;
 };

--- a/main.cc
+++ b/main.cc
@@ -2208,10 +2208,11 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
                     // uncommitted entries are now in new segments).
                     supervisor::notify("processing raft replay buffer");
                     raft_replay_buffer.invoke_on_all([&db, &qp](db::raft_commitlog_replay_buffer& buffer) mutable {
-                        if (buffer.remaining_groups()) {
-                            return buffer.process_raft_replayed_items(db.local(), qp.local(), sys_ks.local());
-                        }
-                        return make_ready_future<>();
+                        // Called unconditionally — the buffer returns early when it
+                        // holds nothing. A group may have a recovered commit_idx to
+                        // restore even with no replayed log entries (its entries'
+                        // segment was reclaimed while the commit_idx entry's was not).
+                        return buffer.process_raft_replayed_items(db.local(), qp.local(), sys_ks.local());
                     }).get();
 
                     startlog.info("replaying commit log - flushing memtables");
@@ -2228,6 +2229,18 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
                         return make_ready_future<>();
                     }).get();
                 }
+
+                // Reconcile system.raft_groups_snapshots.idx with system.raft_groups.commit_idx
+                // for every known strongly-consistent tablet raft group. Must run unconditionally
+                // (independent of whether there were commitlog segments to replay): after a clean
+                // shutdown all SC tablet segments have been reclaimed, yet the persisted
+                // commit_idx may still be ahead of the persisted snapshot idx, which would
+                // otherwise trip the "committed index cannot be larger then persisted one"
+                // assert in raft::server::start.
+                supervisor::notify("bumping raft snapshot indices");
+                raft_replay_buffer.invoke_on_all([&db, &qp](db::raft_commitlog_replay_buffer& buffer) mutable {
+                    return buffer.bump_snapshot_indices(db.local(), qp.local());
+                }).get();
             }
 
             // Once stuff is replayed, we can empty RP:s from truncation records. 

--- a/service/strong_consistency/groups_manager.cc
+++ b/service/strong_consistency/groups_manager.cc
@@ -154,8 +154,13 @@ future<> groups_manager::start_raft_group(global_tablet_id tablet,
 
     auto* commitlog = _db.commitlog();
     SCYLLA_ASSERT(commitlog);
+    if (!_sc_io_batcher) {
+        _sc_io_batcher = std::make_unique<sc_io_batcher>(_qp, *commitlog);
+        _sc_io_batcher->start();
+    }
     auto storage = std::make_unique<raft_groups_storage>(_qp, group_id, my_id, this_shard_id(),
         *commitlog, tablet.table, _raft_replay_buffer.take_replayed_group_entries(group_id));
+    storage->set_batcher(_sc_io_batcher.get());
 
     auto state_machine = make_state_machine(tablet, group_id, _db, _mm, _sys_ks, *storage);
 
@@ -546,6 +551,8 @@ void groups_manager::start() {
     }
 }
 
+groups_manager::~groups_manager() = default;
+
 future<> groups_manager::stop() {
     co_await uninit_messaging_service();
 
@@ -559,6 +566,11 @@ future<> groups_manager::stop() {
 
     while (!_raft_groups.empty()) {
         co_await _raft_groups.begin()->second.server_control_op.get_future();
+    }
+
+    // After all groups: their io_fibers are done, no submit can arrive.
+    if (_sc_io_batcher) {
+        co_await _sc_io_batcher->stop();
     }
 
     logger.info("stop() completed");

--- a/service/strong_consistency/groups_manager.hh
+++ b/service/strong_consistency/groups_manager.hh
@@ -30,6 +30,8 @@ class migration_manager;
 
 namespace service::strong_consistency {
 
+class sc_io_batcher;
+
 class raft_server;
 
 /// A cache of leader locations for raft groups where this node is not a replica.
@@ -132,6 +134,9 @@ class groups_manager : public peering_sharded_service<groups_manager> {
     netw::messaging_service& _ms;
     raft_group_registry& _raft_gr;
     cql3::query_processor& _qp;
+    // Shard-wide batched raft IO (rounds); created lazily with the first
+    // group, stopped after all groups in stop().
+    std::unique_ptr<sc_io_batcher> _sc_io_batcher;
     replica::database& _db;
     service::migration_manager& _mm;
     db::system_keyspace& _sys_ks;
@@ -181,6 +186,8 @@ public:
     void start();
 
     // Called during node shutdown. Waits for all raft::server instances to stop.
+    ~groups_manager();
+
     future<> stop();
 
     future<> wait_for_groups_to_start(lowres_clock::time_point timeout);

--- a/service/strong_consistency/raft_commitlog.cc
+++ b/service/strong_consistency/raft_commitlog.cc
@@ -92,7 +92,11 @@ seastar::future<> raft_commitlog::store_log_entries(const raft::log_entry_ptr_li
         writers.emplace_back(_table_id, raft_commitlog_entry{.group_id = _group_id, .entry = log_entry_ptr});
     }
 
-    auto replay_handles = co_await _commit_log.add_raft_entries(std::move(writers));
+    // Through the shard batcher when wired (one shared synced write per round
+    // across all groups); direct write otherwise (unit tests).
+    auto replay_handles = _batcher
+            ? co_await _batcher->submit_append(std::move(writers))
+            : co_await _commit_log.add_raft_entries(std::move(writers));
 
     for (size_t i = 0; i < entries.size(); ++i) {
         const auto& log_entry_ptr = entries[i];

--- a/service/strong_consistency/raft_commitlog.cc
+++ b/service/strong_consistency/raft_commitlog.cc
@@ -89,10 +89,10 @@ seastar::future<> raft_commitlog::store_log_entries(const raft::log_entry_ptr_li
 
     for (const auto& log_entry_ptr : entries) {
         logger.debug("  storing log entry: idx={}, term={}", log_entry_ptr->idx, log_entry_ptr->term);
-        writers.emplace_back(raft_commitlog_entry{.group_id = _group_id, .entry = log_entry_ptr});
+        writers.emplace_back(_table_id, raft_commitlog_entry{.group_id = _group_id, .entry = log_entry_ptr});
     }
 
-    auto replay_handles = co_await _commit_log.add_raft_entries(_table_id, std::move(writers));
+    auto replay_handles = co_await _commit_log.add_raft_entries(std::move(writers));
 
     for (size_t i = 0; i < entries.size(); ++i) {
         const auto& log_entry_ptr = entries[i];

--- a/service/strong_consistency/raft_commitlog.cc
+++ b/service/strong_consistency/raft_commitlog.cc
@@ -21,15 +21,46 @@
 namespace service::strong_consistency {
 namespace {
 seastar::logger logger("raft_commitlog");
+
+// Command entries are the ones state_machine::apply() will consume.
+// Everything else (configuration, dummy) is a "non-command" entry.
+bool is_command_entry(const raft::log_entry& e) {
+    return std::holds_alternative<raft::command>(e.data);
 }
+
+// Configuration entries are non-command entries that carry state, so their
+// handles follow a different release rule than dummies (see SCYLLADB-3842).
+bool is_config_entry(const raft::log_entry& e) {
+    return std::holds_alternative<raft::configuration>(e.data);
+}
+} // namespace
 
 raft_commitlog::raft_commitlog(raft::group_id group_id, db::commitlog& commitlog, table_id target_table_id, replayed_data_per_group replayed_data)
     : _group_id(group_id)
     , _table_id(target_table_id)
     , _commit_log(commitlog)
-    , _replay_positions(std::move(replayed_data.replay_positions))
     , _replayed_entries(std::move(replayed_data.entries)) {
-    logger.debug("starting raft_commitlog group_id={}, table_id={}, replayed_entries={}", _group_id, _table_id, _replayed_entries.size());
+    // Classify each replay position as command / non-command by the entry it
+    // belongs to. Replay positions are a subset of the replayed entries (only
+    // uncommitted entries are rewritten to the new commitlog on replay) and
+    // both are in raft-index order, so we match them by index with a single
+    // forward walk over _replayed_entries.
+    auto entry_it = _replayed_entries.begin();
+    for (auto& pos : replayed_data.replay_positions) {
+        while (entry_it != _replayed_entries.end() && (*entry_it)->idx != pos.index) {
+            ++entry_it;
+        }
+        SCYLLA_ASSERT(entry_it != _replayed_entries.end());
+        const raft::log_entry& e = **entry_it;
+        auto& target = is_command_entry(e) ? _command_positions
+                : is_config_entry(e) ? _config_positions
+                : _dummy_positions;
+        target.push_back(std::move(pos));
+    }
+    logger.debug("starting raft_commitlog group_id={}, table_id={}, replayed_entries={}, "
+            "command_positions={}, dummy_positions={}, config_positions={}", _group_id, _table_id,
+            _replayed_entries.size(), _command_positions.size(), _dummy_positions.size(),
+            _config_positions.size());
 }
 
 raft_commitlog::~raft_commitlog() {
@@ -37,10 +68,17 @@ raft_commitlog::~raft_commitlog() {
     // segment dirty counts. This keeps commitlog segments alive after this
     // object is destroyed, ensuring uncommitted raft entries remain
     // available for replay after restart.
-    for (auto& entry : _replay_positions) {
+    for (auto& entry : _command_positions) {
         entry.replay_position_handle.release();
     }
-    logger.debug("released {} replay position handles for group_id={}", _replay_positions.size(), _group_id);
+    for (auto& entry : _dummy_positions) {
+        entry.replay_position_handle.release();
+    }
+    for (auto& entry : _config_positions) {
+        entry.replay_position_handle.release();
+    }
+    logger.debug("released {} command + {} dummy + {} config replay position handles for group_id={}",
+            _command_positions.size(), _dummy_positions.size(), _config_positions.size(), _group_id);
 }
 
 seastar::future<> raft_commitlog::store_log_entries(const raft::log_entry_ptr_list& entries) {
@@ -58,10 +96,14 @@ seastar::future<> raft_commitlog::store_log_entries(const raft::log_entry_ptr_li
 
     for (size_t i = 0; i < entries.size(); ++i) {
         const auto& log_entry_ptr = entries[i];
-        _replay_positions.push_back(
+        auto& target = is_command_entry(*log_entry_ptr) ? _command_positions
+                : is_config_entry(*log_entry_ptr) ? _config_positions
+                : _dummy_positions;
+        target.push_back(
                 index_and_replay_position{.index = log_entry_ptr->idx, .replay_position_handle = std::move(replay_handles[i])});
     }
-    logger.debug("store_log_entries completed: total_entries_in_map={}", _replay_positions.size());
+    logger.debug("store_log_entries completed: total_command={}, total_dummy={}, total_config={}",
+            _command_positions.size(), _dummy_positions.size(), _config_positions.size());
 }
 
 raft::log_entries raft_commitlog::load_log() {
@@ -72,9 +114,14 @@ raft::log_entries raft_commitlog::load_log() {
 void raft_commitlog::truncate_log(const raft::index_t idx) {
     logger.debug("truncate_log: group_id={}, idx={}", _group_id, idx);
     // Remove entries with index >= idx (Raft semantics: truncate from idx onward).
-    // The deque is sorted by index, so binary search finds the cut point.
-    auto it = std::ranges::lower_bound(_replay_positions, idx, {}, &index_and_replay_position::index);
-    _replay_positions.erase(it, _replay_positions.end());
+    // Both deques are sorted by index, so binary search finds the cut point.
+    auto trim = [idx] (replay_position_list& l) {
+        auto it = std::ranges::lower_bound(l, idx, {}, &index_and_replay_position::index);
+        l.erase(it, l.end());
+    };
+    trim(_command_positions);
+    trim(_dummy_positions);
+    trim(_config_positions);
 }
 
 void raft_commitlog::truncate_log_tail(const raft::index_t index) {
@@ -82,39 +129,57 @@ void raft_commitlog::truncate_log_tail(const raft::index_t index) {
     // Remove entries with index <= the given index. The handles are destructed
     // normally, decrementing segment dirty counts and allowing commitlog
     // segments to be reclaimed once no other references hold them.
-    auto it = std::ranges::upper_bound(_replay_positions, index, {}, &index_and_replay_position::index);
-    _replay_positions.erase(_replay_positions.begin(), it);
-    logger.debug("truncate_log_tail completed: remaining_map_size={}", _replay_positions.size());
+    auto it = std::ranges::upper_bound(_command_positions, index, {}, &index_and_replay_position::index);
+    _command_positions.erase(_command_positions.begin(), it);
+    // Dummies follow the same rule; share the impl.
+    release_dummy_rp_handles(index);
+    // Configuration handles are released here and only here: the snapshot whose
+    // descriptor we just persisted carries the configuration, so it is durable
+    // now and the segments holding those entries can be reclaimed.
+    auto cfg_it = std::ranges::upper_bound(_config_positions, index, {}, &index_and_replay_position::index);
+    _config_positions.erase(_config_positions.begin(), cfg_it);
+    logger.debug("truncate_log_tail completed: command={}, dummy={}, config={}",
+            _command_positions.size(), _dummy_positions.size(), _config_positions.size());
+}
+
+void raft_commitlog::release_dummy_rp_handles(const raft::index_t index) {
+    auto it = std::ranges::upper_bound(_dummy_positions, index, {}, &index_and_replay_position::index);
+    _dummy_positions.erase(_dummy_positions.begin(), it);
+    logger.debug("release_dummy_rp_handles: group_id={}, up_to_idx={}, remaining_dummy={}, retained_config={}",
+            _group_id, index, _dummy_positions.size(), _config_positions.size());
 }
 
 std::vector<index_and_replay_position> raft_commitlog::acquire_replay_position_handles_for(const raft::log_entry_ptr_list& entries) {
-    logger.debug("acquire_replay_position_handles_for: group_id={}, entries_count={}, current_map_size={}", _group_id, entries.size(),
-            _replay_positions.size());
+    logger.debug("acquire_replay_position_handles_for: group_id={}, entries_count={}, current_command_size={}",
+            _group_id, entries.size(), _command_positions.size());
 
     std::vector<index_and_replay_position> ret;
     ret.reserve(entries.size());
 
-    // Move replay position handles for requested entries. The entries may not be
-    // contiguous in _replay_positions because non-command entries (configuration,
-    // dummy) are also tracked there but are not passed to state_machine::apply().
-    // We scan forward through _replay_positions, skipping non-matching entries
-    // (which are the non-command items). This is O(n) since both sequences are
-    // sorted by index and we only move forward.
-    auto it = _replay_positions.begin();
+    // Command entries are already contiguous in _command_positions: non-command
+    // entries have their own deque and are not passed to apply(). Scan forward.
+    auto it = _command_positions.begin();
     for (const auto& entry : entries) {
-        // Skip non-command entries that have indices below the one we're looking for.
-        while (it != _replay_positions.end() && it->index < entry->idx) {
+        // The raft applier fiber only hands command entries to apply(); a
+        // non-command entry here would indicate a raft bug.
+        if (!is_command_entry(*entry)) {
+            on_internal_error(logger, fmt::format(
+                    "acquire_replay_position_handles_for: unexpected non-command entry for group_id={}, idx={}",
+                    _group_id, entry->idx));
+        }
+        while (it != _command_positions.end() && it->index < entry->idx) {
             ++it;
         }
-        if (it == _replay_positions.end() || it->index != entry->idx) {
+        if (it == _command_positions.end() || it->index != entry->idx) {
             on_internal_error(logger, fmt::format("missing replay position handle for group_id={}, idx={}", _group_id, entry->idx));
         }
         ret.emplace_back(index_and_replay_position{.index = it->index, .replay_position_handle = std::move(it->replay_position_handle)});
-        it = _replay_positions.erase(it);
+        it = _command_positions.erase(it);
     }
 
     logger.debug(
-            "acquire_replay_position_handles_for completed: returned_count={}, remaining_map_size={}", ret.size(), _replay_positions.size());
+            "acquire_replay_position_handles_for completed: returned_count={}, remaining_command_size={}",
+            ret.size(), _command_positions.size());
     return ret;
 }
 } // namespace service::strong_consistency

--- a/service/strong_consistency/raft_commitlog.hh
+++ b/service/strong_consistency/raft_commitlog.hh
@@ -35,13 +35,23 @@ private:
     const db::cf_id_type _table_id;
     // Common commit log.
     db::commitlog& _commit_log;
-    // Replay positions in the commit log for each raft log entry.
-    // Contains entries that have been added but not yet removed by either:
-    //  - truncate_log() (leader change discarding uncommitted tail)
-    //  - truncate_log_tail() (snapshot allowing old entries to be reclaimed)
-    // After a snapshot, some entries with index below the snapshot index may
-    // still be present, in accordance with raft trailing log settings.
-    replay_position_list _replay_positions;
+    // Replay position handles for committed and uncommitted command entries
+    // (raft::command). Consumed by
+    // acquire_replay_position_handles_for() when state_machine::apply() hands
+    // the entry to its target memtable, which takes over segment lifetime.
+    replay_position_list _command_positions;
+    // Replay position handles for dummy entries (raft::log_entry::dummy).
+    // Never consumed by apply(). A dummy carries no state, so once commit_idx
+    // covers it a restart has no need of it and its handle can be released;
+    // see release_dummy_rp_handles().
+    replay_position_list _dummy_positions;
+    // Replay position handles for configuration entries (raft::configuration).
+    // Never consumed by apply(). Unlike dummies these carry state that is only
+    // persisted by store_snapshot_descriptor(), and commitlog replay discards
+    // committed non-command entries — so their handles must stay held until a
+    // snapshot has written the configuration durably. Released only by
+    // truncate_log() / truncate_log_tail().
+    replay_position_list _config_positions;
     // The log entries that were loaded from database commit log on startup.
     raft::log_entries _replayed_entries;
 
@@ -50,7 +60,9 @@ public:
 
     ~raft_commitlog();
 
-    // Persist the given log entries in the commit log and get the replay position handles for them.
+    // Persist the given log entries in the commit log. Each entry's rp_handle
+    // is placed into _command_positions, _config_positions or _dummy_positions
+    // based on the entry data type.
     future<> store_log_entries(const raft::log_entry_ptr_list& entries);
 
     // Get the log items that were loaded from database commit log on startup.
@@ -65,10 +77,22 @@ public:
     // Called from store_snapshot_descriptor after the snapshot is persisted.
     void truncate_log_tail(raft::index_t index);
 
-    // Move replay position handles out of the map for the specified indices.
-    // The handles are handed to memtables in the raft state machine apply(),
-    // and removed from the map since the memtable now owns segment lifetime.
-    // Triggers on_internal_error if an entry is missing from the map.
+    // Release dummy-entry rp_handles with index <= idx. Safe only after
+    // system.raft_groups.commit_idx has been durably persisted at or above
+    // idx: below that watermark raft would need those entries on restart.
+    //
+    // Configuration entries are deliberately NOT released here. commit_idx
+    // covering a configuration entry means raft will not replay it, but the
+    // configuration it carries is durable only once store_snapshot_descriptor()
+    // has written it. Releasing on the commit_idx watermark would let the
+    // segment be recycled while the configuration exists nowhere durable, and
+    // the group would come back with a stale configuration. See SCYLLADB-3842.
+    void release_dummy_rp_handles(raft::index_t idx);
+
+    // Move replay position handles out of _command_positions for the specified
+    // entries. The handles are handed to memtables in the raft state machine
+    // apply(), transferring segment ownership. Triggers on_internal_error if a
+    // requested entry is missing.
     std::vector<index_and_replay_position> acquire_replay_position_handles_for(const raft::log_entry_ptr_list& entries);
 };
 } // namespace service::strong_consistency

--- a/service/strong_consistency/raft_commitlog.hh
+++ b/service/strong_consistency/raft_commitlog.hh
@@ -9,9 +9,63 @@
 #pragma once
 #include "raft/raft.hh"
 #include "db/commitlog/commitlog.hh"
+#include "db/commitlog/commitlog_entry.hh"
+#include <seastar/core/condition-variable.hh>
+#include <seastar/core/gate.hh>
+#include <seastar/core/shared_future.hh>
+#include <unordered_map>
+
+namespace cql3 { class query_processor; }
 #include <deque>
 
 namespace service::strong_consistency {
+// Shard-wide batched raft IO ("rounds").
+//
+// One fiber per shard turns per-group commitlog writes into shared rounds:
+// each round is ONE multi-entry commitlog write (force-synced) carrying
+//   * every group's data-batch entries submitted while the previous round was
+//     in flight (submit_append — awaited by the group's raft io_fiber,
+//     preserving raft's log-before-message rule), and
+//   * a commit_idx entry for every group whose commit advanced
+//     (submit_commit_idx — awaited by the io_fiber before entries are pushed
+//     to the applier, preserving raft's persist-before-apply ordering: once
+//     anything reaches a memtable, its commit_idx is already durable, so
+//     memtable flush and segment discard need no SC-side cooperation).
+// Commit values ride the same synced write as the appends whenever appends
+// are flowing, and get their own round only when idle. The accumulation
+// window is the in-flight write's duration (write-behind; no timer), so the
+// coalescing factor self-tunes: it grows exactly when syncs are expensive.
+class sc_io_batcher {
+public:
+    sc_io_batcher(cql3::query_processor& qp, db::commitlog& cl);
+    void start();
+    future<> stop();
+    // Returns this call's rp_handles, in writer order, once the round covering
+    // them is durable.
+    future<utils::chunked_vector<db::rp_handle>> submit_append(utils::chunked_vector<commitlog_raft_log_entry_writer> writers);
+    // Resolves once a value >= idx for gid is durable and its fake
+    // system.raft_groups mutation has been applied in memory.
+    future<> submit_commit_idx(raft::group_id gid, raft::index_t idx);
+private:
+    future<> run();
+    struct append_item {
+        utils::chunked_vector<commitlog_raft_log_entry_writer> writers;
+        promise<utils::chunked_vector<db::rp_handle>> done;
+    };
+    future<> write_round(std::deque<append_item>& appends,
+            const std::vector<std::pair<raft::group_id, raft::index_t>>& commits);
+
+    cql3::query_processor& _qp;
+    db::commitlog& _commitlog;
+    std::deque<append_item> _appends;
+    std::unordered_map<raft::group_id, raft::index_t> _pending_commit;
+    shared_promise<> _round_done;
+    condition_variable _cv;
+    seastar::named_gate _gate{"sc_io_batcher"};
+    bool _stopping = false;
+    uint64_t _rounds = 0, _append_calls = 0, _entries = 0, _commit_values = 0;
+};
+
 struct index_and_replay_position {
     raft::index_t index;
     db::rp_handle replay_position_handle;
@@ -54,6 +108,7 @@ private:
     replay_position_list _config_positions;
     // The log entries that were loaded from database commit log on startup.
     raft::log_entries _replayed_entries;
+    sc_io_batcher* _batcher = nullptr;
 
 public:
     raft_commitlog(raft::group_id group_id, db::commitlog& commit_log, table_id target_table_id, replayed_data_per_group replayed_data);
@@ -64,6 +119,10 @@ public:
     // is placed into _command_positions, _config_positions or _dummy_positions
     // based on the entry data type.
     future<> store_log_entries(const raft::log_entry_ptr_list& entries);
+
+    void set_batcher(sc_io_batcher* b) { _batcher = b; }
+
+    db::commitlog& commit_log() noexcept { return _commit_log; }
 
     // Get the log items that were loaded from database commit log on startup.
     raft::log_entries load_log();

--- a/service/strong_consistency/raft_groups_storage.cc
+++ b/service/strong_consistency/raft_groups_storage.cc
@@ -281,6 +281,35 @@ std::vector<index_and_replay_position> raft_groups_storage::acquire_replay_posit
 }
 
 
+future<> raft_groups_storage::store_commit_idx_if_higher(cql3::query_processor& qp, raft::group_id gid, shard_id shard, raft::index_t commit_idx) {
+    // Only advance, never regress: an earlier replay may already have
+    // persisted a value at or beyond the recovered one.
+    const auto persisted = co_await load_commit_idx(qp, gid, shard);
+    if (commit_idx <= persisted) {
+        co_return;
+    }
+    static const auto store_cql = format("INSERT INTO system.{} (shard, group_id, commit_idx) VALUES (?, ?, ?)",
+        db::system_keyspace::RAFT_GROUPS);
+    co_await qp.execute_internal(
+        store_cql,
+        {int16_t(shard), gid.id, int64_t(commit_idx.value())},
+        cql3::query_processor::cache_internal::yes).discard_result();
+}
+
+future<std::pair<raft::index_t, raft::term_t>>
+raft_groups_storage::load_snapshot_idx_and_term(cql3::query_processor& qp, raft::group_id gid, shard_id shard) {
+    static const auto load_cql = format("SELECT idx, term FROM system.{} WHERE shard = ? AND group_id = ?",
+        db::system_keyspace::RAFT_GROUPS_SNAPSHOTS);
+    auto rs = co_await qp.execute_internal(load_cql, {int16_t(shard), gid.id}, cql3::query_processor::cache_internal::yes);
+    if (rs->empty()) {
+        co_return std::pair(raft::index_t(0), raft::term_t(0));
+    }
+    const auto& row = rs->one();
+    co_return std::pair(
+            raft::index_t(row.get_or<int64_t>("idx", 0)),
+            raft::term_t(row.get_or<int64_t>("term", 0)));
+}
+
 // ============================ sc_io_batcher ================================
 
 // Build a static-only system.raft_groups mutation that sets commit_idx for the

--- a/service/strong_consistency/raft_groups_storage.cc
+++ b/service/strong_consistency/raft_groups_storage.cc
@@ -21,10 +21,19 @@
 #include "cql3/query_processor.hh"
 
 #include <seastar/core/coroutine.hh>
+#include <seastar/core/gate.hh>
+#include "mutation/mutation.hh"
+#include "mutation/timestamp.hh"
+#include "replica/database.hh"
+#include "service/storage_proxy.hh"
+#include "types/types.hh"
+#include "utils/assert.hh"
 
 namespace service::strong_consistency {
 
 logging::logger rgslog("raft_groups_storage");
+
+static mutation make_commit_idx_mutation(shard_id shard, raft::group_id group_id, raft::index_t commit_idx, api::timestamp_type ts);
 
 raft_groups_storage::raft_groups_storage(cql3::query_processor& qp, raft::group_id gid, raft::server_id server_id, shard_id shard, db::commitlog& commit_log,
         table_id target_table_id, replayed_data_per_group replayed_data)
@@ -65,22 +74,34 @@ future<std::pair<raft::term_t, raft::server_id>> raft_groups_storage::load_term_
 }
 
 future<> raft_groups_storage::store_commit_idx(raft::index_t idx) {
-    return execute_with_linearization_point([this, idx] {
-        static const auto store_cql = format("INSERT INTO system.{} (shard, group_id, commit_idx) VALUES (?, ?, ?)",
-            db::system_keyspace::RAFT_GROUPS);
-        return _qp.execute_internal(
-            store_cql,
-            {int16_t(_shard), _group_id.id, int64_t(idx.value())},
-            cql3::query_processor::cache_internal::yes).discard_result().then([this, idx] {
-                // Dummy entries at or below commit_idx are committed and, now that
-                // commit_idx is persisted, are covered by it on restart — raft won't
-                // replay them, and a dummy carries no state — so release their
-                // rp_handles and let the commitlog segments be reclaimed. (Command
-                // entries are handled by apply(), which hands their rp_handles to
-                // the target memtable. Configuration entries are deliberately kept:
-                // see release_dummy_rp_handles() and SCYLLADB-3842.)
-                _raft_commitlog.release_dummy_rp_handles(idx);
-            });
+    if (_batcher) {
+        // The io_fiber co_awaits this before pushing committed entries to the
+        // applier fiber, so resolving only after the round's forced sync keeps
+        // raft's persist-before-apply ordering — batched across all groups on
+        // the shard instead of one synced write per group per commit.
+        return _batcher->submit_commit_idx(_group_id, idx).then([this, idx] {
+            _raft_commitlog.release_dummy_rp_handles(idx);
+        });
+    }
+    // No batcher wired (unit tests): persist through the same representation a
+    // round would produce — one force-synced commit_idx entry whose rp_handle
+    // is attached to a fake system.raft_groups mutation. Single format either
+    // way; no CQL write path exists for commit_idx.
+    return execute_with_linearization_point([this, idx] () -> future<> {
+        utils::chunked_vector<commitlog_raft_log_entry_writer> writers;
+        writers.emplace_back(db::system_keyspace::raft_groups()->id(),
+                raft_commit_idx_entry{.group_id = _group_id, .commit_idx = idx});
+        auto handles = co_await _raft_commitlog.commit_log().add_raft_entries(std::move(writers));
+        SCYLLA_ASSERT(handles.size() == 1);
+        auto m = make_commit_idx_mutation(_shard, _group_id, idx, api::new_timestamp());
+        auto& db = _qp.proxy().local_db();
+        auto& cf = db.find_column_family(m.schema()->id());
+        co_await db.apply_in_memory(m, cf, std::move(handles[0]), db::no_timeout);
+        // Dummy entries at or below commit_idx are committed and covered on
+        // restart — raft won't replay them, and a dummy carries no state.
+        // (Configuration entries are deliberately kept: see
+        // release_dummy_rp_handles() and SCYLLADB-3842.)
+        _raft_commitlog.release_dummy_rp_handles(idx);
     });
 }
 
@@ -257,6 +278,158 @@ future<> raft_groups_storage::bootstrap(raft::configuration initial_configuation
 
 std::vector<index_and_replay_position> raft_groups_storage::acquire_replay_position_handles_for(const raft::log_entry_ptr_list& entries) {
     return _raft_commitlog.acquire_replay_position_handles_for(entries);
+}
+
+
+// ============================ sc_io_batcher ================================
+
+// Build a static-only system.raft_groups mutation that sets commit_idx for the
+// (shard, group_id) partition. Applied in-memory with the round's commit_idx
+// entry rp_handle attached, so the value rides the raft_groups memtable to an
+// SSTable before the segment holding the entry can be recycled.
+static mutation make_commit_idx_mutation(shard_id shard, raft::group_id group_id, raft::index_t commit_idx, api::timestamp_type ts) {
+    auto schema = db::system_keyspace::raft_groups();
+    auto pk = partition_key::from_exploded(*schema, {
+        short_type->decompose(int16_t(shard)),
+        timeuuid_type->decompose(group_id.id),
+    });
+    mutation m(schema, std::move(pk));
+    m.set_static_cell("commit_idx", data_value(int64_t(commit_idx.value())), ts);
+    return m;
+}
+
+sc_io_batcher::sc_io_batcher(cql3::query_processor& qp, db::commitlog& cl)
+    : _qp(qp)
+    , _commitlog(cl) {
+}
+
+void sc_io_batcher::start() {
+    (void)with_gate(_gate, [this] { return run(); });
+}
+
+future<> sc_io_batcher::stop() {
+    _stopping = true;
+    _cv.signal();
+    co_await _gate.close();
+    rgslog.info("sc_io_batcher: {} rounds, {} append calls, {} entries, {} commit values"
+            " (avg appends/round {:.2f}, avg entries/round {:.2f})",
+            _rounds, _append_calls, _entries, _commit_values,
+            _rounds ? double(_append_calls) / double(_rounds) : 0.0,
+            _rounds ? double(_entries) / double(_rounds) : 0.0);
+}
+
+future<utils::chunked_vector<db::rp_handle>> sc_io_batcher::submit_append(utils::chunked_vector<commitlog_raft_log_entry_writer> writers) {
+    if (_stopping) {
+        return make_exception_future<utils::chunked_vector<db::rp_handle>>(gate_closed_exception());
+    }
+    _appends.emplace_back(append_item{.writers = std::move(writers)});
+    auto f = _appends.back().done.get_future();
+    _cv.signal();
+    return f;
+}
+
+future<> sc_io_batcher::submit_commit_idx(raft::group_id gid, raft::index_t idx) {
+    if (_stopping) {
+        return make_exception_future<>(gate_closed_exception());
+    }
+    auto [it, inserted] = _pending_commit.try_emplace(gid, idx);
+    if (!inserted) {
+        // commit_idx is a watermark: superseded values carry no information.
+        it->second = std::max(it->second, idx);
+    }
+    _cv.signal();
+    return _round_done.get_shared_future();
+}
+
+future<> sc_io_batcher::run() {
+    while (true) {
+        co_await _cv.when([this] { return !_appends.empty() || !_pending_commit.empty() || _stopping; });
+        if (_stopping) {
+            break;
+        }
+        // Snapshot: everything accumulated so far is THIS round; arrivals during
+        // the write go to the next one.
+        auto appends = std::exchange(_appends, {});
+        std::vector<std::pair<raft::group_id, raft::index_t>> commits;
+        commits.reserve(_pending_commit.size());
+        for (const auto& [gid, idx] : _pending_commit) {
+            commits.emplace_back(gid, idx);
+        }
+        _pending_commit.clear();
+        auto commit_done = std::exchange(_round_done, shared_promise<>());
+
+        std::exception_ptr ex;
+        try {
+            co_await write_round(appends, commits);
+        } catch (...) {
+            ex = std::current_exception();
+        }
+        ++_rounds;
+        _append_calls += appends.size();
+        _commit_values += commits.size();
+        if (ex) {
+            // Waiters are group io_fibers; the error surfaces per group via
+            // raft's background_error.
+            for (auto& a : appends) {
+                a.done.set_exception(ex);
+            }
+            commit_done.set_exception(std::move(ex));
+        } else {
+            commit_done.set_value();
+        }
+    }
+    for (auto& a : _appends) {
+        a.done.set_exception(std::make_exception_ptr(gate_closed_exception()));
+    }
+    _round_done.set_exception(std::make_exception_ptr(gate_closed_exception()));
+}
+
+future<> sc_io_batcher::write_round(std::deque<append_item>& appends,
+        const std::vector<std::pair<raft::group_id, raft::index_t>>& commits) {
+    const auto rg_cf = db::system_keyspace::raft_groups()->id();
+    // ONE multi-entry, force-synced commitlog write for the whole shard: every
+    // group's data batch plus a commit_idx entry per group whose commit
+    // advanced. One sync regardless of how many groups took part.
+    utils::chunked_vector<commitlog_raft_log_entry_writer> writers;
+    size_t n_append_writers = 0;
+    for (auto& a : appends) {
+        n_append_writers += a.writers.size();
+    }
+    writers.reserve(n_append_writers + commits.size());
+    for (auto& a : appends) {
+        for (auto& w : a.writers) {
+            writers.emplace_back(std::move(w));
+        }
+    }
+    for (const auto& [gid, idx] : commits) {
+        writers.emplace_back(rg_cf, raft_commit_idx_entry{.group_id = gid, .commit_idx = idx});
+    }
+    _entries += n_append_writers;
+
+    auto handles = co_await _commitlog.add_raft_entries(std::move(writers));
+    SCYLLA_ASSERT(handles.size() == n_append_writers + commits.size());
+
+    // Hand each append item its slice, in submission order.
+    size_t i = 0;
+    for (auto& a : appends) {
+        utils::chunked_vector<db::rp_handle> slice;
+        slice.reserve(a.writers.size());
+        for (size_t k = 0; k < a.writers.size(); ++k) {
+            slice.emplace_back(std::move(handles[i++]));
+        }
+        a.done.set_value(std::move(slice));
+    }
+
+    // Commit values are durable. Attach each handle to a fake
+    // system.raft_groups mutation so the value also reaches an SSTable before
+    // its segment can be recycled (memory-only applies; nothing here allocates
+    // commitlog space).
+    auto& db = _qp.proxy().local_db();
+    auto& cf = db.find_column_family(rg_cf);
+    for (const auto& [gid, idx] : commits) {
+        auto m = make_commit_idx_mutation(this_shard_id(), gid, idx, api::new_timestamp());
+        co_await db.apply_in_memory(m, cf, std::move(handles[i++]), db::no_timeout);
+    }
 }
 
 } // namespace service::strong_consistency

--- a/service/strong_consistency/raft_groups_storage.cc
+++ b/service/strong_consistency/raft_groups_storage.cc
@@ -71,7 +71,16 @@ future<> raft_groups_storage::store_commit_idx(raft::index_t idx) {
         return _qp.execute_internal(
             store_cql,
             {int16_t(_shard), _group_id.id, int64_t(idx.value())},
-            cql3::query_processor::cache_internal::yes).discard_result();
+            cql3::query_processor::cache_internal::yes).discard_result().then([this, idx] {
+                // Dummy entries at or below commit_idx are committed and, now that
+                // commit_idx is persisted, are covered by it on restart — raft won't
+                // replay them, and a dummy carries no state — so release their
+                // rp_handles and let the commitlog segments be reclaimed. (Command
+                // entries are handled by apply(), which hands their rp_handles to
+                // the target memtable. Configuration entries are deliberately kept:
+                // see release_dummy_rp_handles() and SCYLLADB-3842.)
+                _raft_commitlog.release_dummy_rp_handles(idx);
+            });
     });
 }
 

--- a/service/strong_consistency/raft_groups_storage.hh
+++ b/service/strong_consistency/raft_groups_storage.hh
@@ -39,6 +39,7 @@ namespace service::strong_consistency {
 // on the same shard as the tablet replica.
 class raft_groups_storage : public raft::persistence {
     raft_commitlog _raft_commitlog;
+    sc_io_batcher* _batcher = nullptr;
     raft::group_id _group_id;
     raft::server_id _server_id;
     uint16_t _shard;
@@ -56,6 +57,14 @@ public:
     future<> store_term_and_vote(raft::term_t term, raft::server_id vote) override;
     future<std::pair<raft::term_t, raft::server_id>> load_term_and_vote() override;
     future<> store_commit_idx(raft::index_t) override;
+
+    // Wire the shard-wide IO batcher (append + commit_idx rounds). When unset
+    // (unit tests), appends write directly and commit_idx keeps the direct
+    // CQL write.
+    void set_batcher(sc_io_batcher* b) {
+        _batcher = b;
+        _raft_commitlog.set_batcher(b);
+    }
     future<raft::index_t> load_commit_idx() override;
     future<raft::log_entries> load_log() override;
     future<raft::snapshot_descriptor> load_snapshot_descriptor() override;

--- a/service/strong_consistency/raft_groups_storage.hh
+++ b/service/strong_consistency/raft_groups_storage.hh
@@ -84,6 +84,13 @@ public:
     // Static version that doesn't require constructing a full raft_groups_storage object.
     // Useful during commitlog replay when only read access to metadata is needed.
     static future<raft::index_t> load_commit_idx(cql3::query_processor& qp, raft::group_id gid, shard_id shard);
+    // Persist commit_idx only if higher than the stored value. Used by
+    // commitlog replay to restore the recovered commit_idx.
+    static future<> store_commit_idx_if_higher(cql3::query_processor& qp, raft::group_id gid, shard_id shard, raft::index_t commit_idx);
+    // Load the current persisted snapshot's (idx, term) for this group.
+    // Returns (0, 0) if no snapshot has been recorded yet.
+    static future<std::pair<raft::index_t, raft::term_t>> load_snapshot_idx_and_term(
+            cql3::query_processor& qp, raft::group_id gid, shard_id shard);
     // Store snapshot idx and term without updating the configuration.
     // Used to advance the persisted snapshot index so that raft does not
     // re-apply already applied entries on restart. Only writes if the new

--- a/test/boost/commitlog_raft_replay_test.cc
+++ b/test/boost/commitlog_raft_replay_test.cc
@@ -116,8 +116,8 @@ SEASTAR_TEST_CASE(test_commitlog_raft_log_entry_writer) {
             // the writer wraps it in a commitlog_entry + raft_commitlog_entry envelope.
             BOOST_REQUIRE_GT(writer.size(), 0u);
             BOOST_REQUIRE_GT(writer.size(), ser::get_sizeof(*entry));
-            BOOST_REQUIRE_EQUAL(writer.get_log_entry().group_id, gid);
-            BOOST_REQUIRE_EQUAL(writer.get_log_entry().entry->idx, entry->idx);
+            BOOST_REQUIRE_EQUAL(writer.get_raft_log_entry().group_id, gid);
+            BOOST_REQUIRE_EQUAL(writer.get_raft_log_entry().entry->idx, entry->idx);
 
             auto handle = co_await write_raft_entry_to_commitlog(log, tid, gid, entry);
             rps.push_back(handle.rp());

--- a/test/boost/commitlog_raft_replay_test.cc
+++ b/test/boost/commitlog_raft_replay_test.cc
@@ -1793,6 +1793,10 @@ SEASTAR_TEST_CASE(test_raft_commitlog_load_log_one_shot) {
         replayed_data.entries.push_back(make_command_entry(raft::term_t(1), raft::index_t(1)));
         replayed_data.entries.push_back(make_dummy_entry(raft::term_t(1), raft::index_t(2)));
         replayed_data.entries.push_back(make_config_entry(raft::term_t(2), raft::index_t(3)));
+        // replay_positions must be 1:1 with entries (raft_commitlog ctor invariant).
+        replayed_data.replay_positions.push_back({.index = raft::index_t(1), .replay_position_handle = {}});
+        replayed_data.replay_positions.push_back({.index = raft::index_t(2), .replay_position_handle = {}});
+        replayed_data.replay_positions.push_back({.index = raft::index_t(3), .replay_position_handle = {}});
 
         service::strong_consistency::raft_commitlog persistence(gid, log, tid, std::move(replayed_data));
 

--- a/test/boost/commitlog_raft_replay_test.cc
+++ b/test/boost/commitlog_raft_replay_test.cc
@@ -30,6 +30,7 @@
 #include "idl/commitlog.dist.impl.hh"
 #include "test/lib/mutation_source_test.hh"
 #include "service/strong_consistency/raft_commitlog.hh"
+#include "service/strong_consistency/raft_groups_storage.hh"
 #include "idl/raft_storage.dist.hh"
 #include "idl/raft_storage.dist.impl.hh"
 
@@ -347,6 +348,38 @@ SEASTAR_TEST_CASE(test_raft_replay_buffer_process_discards_unknown_groups) {
                 auto data = buffer.take_replayed_group_entries(gid);
                 BOOST_CHECK(data.entries.empty());
                 BOOST_CHECK(data.replay_positions.empty());
+            },
+            std::move(db_cfg_ptr));
+}
+
+// Test that a group whose only replayed record is a commit_idx entry (no log
+// entries) is still processed: process_raft_replayed_items runs its restore
+// pass even when remaining_groups() == 0, and — since the group is not in
+// tablet metadata — discards the recovered commit_idx instead of resurrecting
+// a system.raft_groups row for a moved-away/dropped tablet.
+SEASTAR_TEST_CASE(test_raft_replay_buffer_commit_idx_only_group) {
+    auto db_cfg_ptr = make_shared<db::config>();
+    db_cfg_ptr->experimental_features({db::experimental_features_t::feature::STRONGLY_CONSISTENT_TABLES});
+    return do_with_cql_env(
+            [](cql_test_env& env) -> future<> {
+                db::raft_commitlog_replay_buffer buffer;
+
+                auto gid = make_group_id();
+                // Only commit_idx entries survived replay for this group (e.g. the
+                // segment holding its raft log entries was already reclaimed).
+                // The highest value wins.
+                buffer.add_commit_idx(gid, raft::index_t(3));
+                buffer.add_commit_idx(gid, raft::index_t(7));
+                buffer.add_commit_idx(gid, raft::index_t(5));
+
+                BOOST_CHECK_EQUAL(buffer.remaining_groups(), 0);
+
+                co_await buffer.process_raft_replayed_items(env.local_db(), env.local_qp(), env.get_system_keyspace().local());
+
+                // The group has no tablet metadata, so nothing may be written.
+                const auto persisted = co_await service::strong_consistency::raft_groups_storage::load_commit_idx(
+                        env.local_qp(), gid, this_shard_id());
+                BOOST_CHECK_EQUAL(persisted, raft::index_t(0));
             },
             std::move(db_cfg_ptr));
 }
@@ -1813,5 +1846,159 @@ SEASTAR_TEST_CASE(test_raft_commitlog_load_log_one_shot) {
         co_return;
     });
 }
+
+// Test: raft_commitlog::store_log_entries writes a trailing commit_idx entry
+// after the raft log entries and returns that entry's rp_handle. Ensures:
+//   * The batch produces exactly N raft entries + 1 commit_idx entry in the commitlog.
+//   * The commit_idx entry carries the expected group_id and commit_idx.
+//
+// Test for: SCYLLADB-2877
+// store_log_entries writes exactly the raft entries — no trailing commit_idx
+// entry. Explicit commit-time persistence (sc_io_batcher::submit_commit_idx)
+// replaced it; a trailing entry would be pure duplication.
+SEASTAR_TEST_CASE(test_raft_commitlog_store_log_entries_writes_only_raft_entries) {
+    return cl_test([](commitlog& log) -> future<> {
+        auto gid = make_group_id();
+        auto tid = make_table_id();
+
+        service::strong_consistency::replayed_data_per_group replayed_data;
+        service::strong_consistency::raft_commitlog persistence(gid, log, tid, std::move(replayed_data));
+
+        raft::log_entry_ptr_list entries;
+        for (int i = 1; i <= 3; ++i) {
+            entries.push_back(make_command_entry(raft::term_t(1), raft::index_t(i)));
+        }
+
+        co_await persistence.store_log_entries(entries);
+
+        co_await log.sync_all_segments();
+
+        auto segments = log.get_active_segment_names();
+        BOOST_REQUIRE(!segments.empty());
+
+        size_t raft_entries = 0;
+        size_t commit_idx_entries = 0;
+        for (auto& seg : segments) {
+            co_await db::commitlog::read_log_file(
+                    seg, db::commitlog::descriptor::FILENAME_PREFIX,
+                    [&](db::commitlog::buffer_and_replay_position buf_rp) -> future<> {
+                        auto&& [buf, _] = buf_rp;
+                        commitlog_entry_reader reader(buf, detail::commitlog_entry_serialization_format::variant);
+                        auto& entry_var = reader.entry().item;
+
+                        if (std::holds_alternative<raft_commitlog_entry>(entry_var)) {
+                            const auto& rle = std::get<raft_commitlog_entry>(entry_var);
+                            BOOST_REQUIRE_EQUAL(rle.group_id, gid);
+                            ++raft_entries;
+                        } else {
+                            BOOST_REQUIRE(std::holds_alternative<raft_commit_idx_entry>(entry_var));
+                            ++commit_idx_entries;
+                        }
+                        co_return;
+                    });
+        }
+
+        BOOST_REQUIRE_EQUAL(raft_entries, entries.size());
+        BOOST_REQUIRE_EQUAL(commit_idx_entries, 0);
+
+        // Entry handles are held by the persistence deques; the destructor's
+        // release() keeps the segments on disk, as on shutdown.
+    });
+}
+
+// Test: mixed command / non-command batches are routed into the correct
+// deques. acquire_replay_position_handles_for() must find command entries,
+// non-command entries are pinned by their separate deque until truncation.
+SEASTAR_TEST_CASE(test_raft_commitlog_splits_command_config_and_dummy_positions) {
+    return cl_test([](commitlog& log) -> future<> {
+        auto gid = make_group_id();
+        auto tid = make_table_id();
+
+        service::strong_consistency::replayed_data_per_group replayed_data;
+        service::strong_consistency::raft_commitlog persistence(gid, log, tid, std::move(replayed_data));
+
+        // 3 command entries interleaved with 10 non-command entries
+        // (commands at idx 1, 7, 13; configuration/dummy fill the rest).
+        auto is_command_idx = [](int i) { return i == 1 || i == 7 || i == 13; };
+        raft::log_entry_ptr_list entries;
+        for (int i = 1; i <= 13; ++i) {
+            if (is_command_idx(i)) {
+                entries.push_back(make_command_entry(raft::term_t(1), raft::index_t(i)));
+            } else if (i % 2 == 0) {
+                entries.push_back(make_config_entry(raft::term_t(1), raft::index_t(i)));
+            } else {
+                entries.push_back(make_dummy_entry(raft::term_t(1), raft::index_t(i)));
+            }
+        }
+
+        co_await persistence.store_log_entries(entries);
+
+        // acquire_* only walks _command_positions; the 10 non-command entries
+        // live in a separate deque and must not appear there. Requesting the 3
+        // commands (the full contiguous command prefix) succeeds.
+        raft::log_entry_ptr_list commands = {entries[0], entries[6], entries[12]};
+        auto handles = persistence.acquire_replay_position_handles_for(commands);
+        BOOST_REQUIRE_EQUAL(handles.size(), 3);
+        BOOST_REQUIRE_EQUAL(handles[0].index, raft::index_t(1));
+        BOOST_REQUIRE_EQUAL(handles[1].index, raft::index_t(7));
+        BOOST_REQUIRE_EQUAL(handles[2].index, raft::index_t(13));
+
+        // Truncate the non-command tail (<= idx 10): non-command entries with
+        // idx <= 10 are released, while those above (11, 12) remain. The command
+        // deque was already drained by the acquire above, so it is unaffected.
+        // This must not crash and the class' destructor must succeed.
+        persistence.truncate_log_tail(raft::index_t(10));
+    });
+}
+
+// Test: release_dummy_rp_handles drops dummy rp_handles up to and including the
+// given idx and leaves command handles untouched. Configuration handles are
+// deliberately retained here and released only by truncate_log_tail(), once
+// store_snapshot_descriptor() has made the configuration durable
+// (SCYLLADB-3842).
+//
+// Note this exercises the code path but cannot *observe* the retention:
+// commitlog::get_num_dirty_segments() only counts segments that have stopped
+// allocating, and this test writes a single still-allocating segment, so it
+// reads 0 whether or not a handle is held. End-to-end coverage (a configuration
+// change surviving a crash or a segment recycle with no intervening snapshot)
+// is tracked with the fix in SCYLLADB-3842.
+SEASTAR_TEST_CASE(test_raft_commitlog_release_dummy_rp_handles) {
+    return cl_test([](commitlog& log) -> future<> {
+        auto gid = make_group_id();
+        auto tid = make_table_id();
+
+        service::strong_consistency::replayed_data_per_group replayed_data;
+        service::strong_consistency::raft_commitlog persistence(gid, log, tid, std::move(replayed_data));
+
+        raft::log_entry_ptr_list entries;
+        entries.push_back(make_command_entry(raft::term_t(1), raft::index_t(1)));
+        entries.push_back(make_config_entry (raft::term_t(1), raft::index_t(2)));
+        entries.push_back(make_dummy_entry  (raft::term_t(1), raft::index_t(3)));
+        entries.push_back(make_command_entry(raft::term_t(1), raft::index_t(4)));
+        entries.push_back(make_dummy_entry  (raft::term_t(1), raft::index_t(5)));
+
+        co_await persistence.store_log_entries(entries);
+
+        // Release dummy handles up to idx 3. dummy@3 is released; dummy@5 stays
+        // (idx > 3); config@2 must be retained even though idx <= 3, so that its
+        // segment cannot be recycled before store_snapshot_descriptor() has made
+        // the configuration durable.
+        persistence.release_dummy_rp_handles(raft::index_t(3));
+
+        // Commands are unaffected and can still be acquired at their indices.
+        raft::log_entry_ptr_list commands = {entries[0], entries[3]};
+        auto handles = persistence.acquire_replay_position_handles_for(commands);
+        BOOST_REQUIRE_EQUAL(handles.size(), 2);
+        BOOST_REQUIRE_EQUAL(handles[0].index, raft::index_t(1));
+        BOOST_REQUIRE_EQUAL(handles[1].index, raft::index_t(4));
+
+        // truncate_log_tail() is the only path that releases configuration
+        // handles. It must accept the retained config@2 without error, and the
+        // destructor below must then find nothing left to release for it.
+        persistence.truncate_log_tail(raft::index_t(5));
+    });
+}
+
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/boost/commitlog_raft_replay_test.cc
+++ b/test/boost/commitlog_raft_replay_test.cc
@@ -84,10 +84,10 @@ future<> cl_test(noncopyable_function<future<>(commitlog&)> f) {
 
 // Write a raft log entry to the commitlog and return the rp_handle.
 future<rp_handle> write_raft_entry_to_commitlog(commitlog& cl, table_id tid, raft::group_id gid, raft::log_entry_ptr entry) {
-    commitlog_raft_log_entry_writer writer(raft_commitlog_entry{.group_id = gid, .entry = entry});
+    commitlog_raft_log_entry_writer writer(tid, raft_commitlog_entry{.group_id = gid, .entry = entry});
     const auto target_size = writer.size();
-    co_return co_await cl.add(tid, target_size, db::no_timeout, db::commitlog_force_sync::yes, [entry, gid](auto& out) {
-        commitlog_raft_log_entry_writer w(raft_commitlog_entry{.group_id = gid, .entry = entry});
+    co_return co_await cl.add(tid, target_size, db::no_timeout, db::commitlog_force_sync::yes, [entry, gid, tid](auto& out) {
+        commitlog_raft_log_entry_writer w(tid, raft_commitlog_entry{.group_id = gid, .entry = entry});
         w.write(out);
     });
 }
@@ -111,7 +111,7 @@ SEASTAR_TEST_CASE(test_commitlog_raft_log_entry_writer) {
         // Verify size() and accessor for each entry type, then write to commitlog.
         std::vector<replay_position> rps;
         for (const auto& entry : entries) {
-            commitlog_raft_log_entry_writer writer(raft_commitlog_entry{.group_id = gid, .entry = entry});
+            commitlog_raft_log_entry_writer writer(tid, raft_commitlog_entry{.group_id = gid, .entry = entry});
             // size() must exceed the bare raft::log_entry serialization because
             // the writer wraps it in a commitlog_entry + raft_commitlog_entry envelope.
             BOOST_REQUIRE_GT(writer.size(), 0u);

--- a/test/cluster/test_strong_consistency_commitlog.py
+++ b/test/cluster/test_strong_consistency_commitlog.py
@@ -303,3 +303,73 @@ async def test_crash_recovery_after_flush(manager: ManagerClient):
             assert rows[0].c == pk * 10, f"pk={pk}: expected c={pk * 10}, got c={rows[0].c}"
 
     await manager.server_stop_gracefully(server.server_id)
+
+
+@pytest.mark.asyncio
+async def test_commit_idx_persisted_on_graceful_shutdown(manager: ManagerClient):
+    """A graceful shutdown must leave system.raft_groups.commit_idx covering every
+    write that was committed and applied, not just the value that was known when
+    the last raft batch was appended (the commit_idx entries in the commitlog
+    carry only the append-time value, and a clean shutdown discards the
+    commitlog).
+
+    That guarantee comes from the memtable-flush hook: storage_service::do_drain()
+    is registered last, so it runs before groups_manager::stop(), and the drain
+    flush therefore seals the SC tablet's memtable while the group is still alive
+    and wired — firing save_commit_log_index(). This test pins that ordering: if
+    the groups were torn down before the drain flush, the hook would not run and
+    the persisted commit_idx would lag."""
+    config = {
+        'experimental_features': ['strongly-consistent-tables'],
+        'commitlog_total_space_in_mb': 10000,
+    }
+    server = await manager.server_add(config=config)
+    (cql, hosts) = await manager.get_ready_cql([server])
+
+    async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 1} AND consistency = 'global'") as ks:
+        await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int);")
+        for pk in range(10):
+            await cql.run_async(f"INSERT INTO {ks}.test (pk, c) VALUES ({pk}, {pk * 10})")
+
+        table_id = await manager.get_table_id(ks.replace('"', ''), "test")
+        tablet_rows = await cql.run_async(f"SELECT raft_group_id FROM system.tablets WHERE table_id = {table_id}")
+        assert len(tablet_rows) == 1
+        group_id = tablet_rows[0].raft_group_id
+
+        # commit_idx as recorded by the per-batch fake mutation: this is the
+        # append-time value and is expected to lag the last commit.
+        pre_rows = await cql.run_async(f"SELECT commit_idx FROM system.raft_groups WHERE shard = 0 AND group_id = {group_id}")
+        assert len(pre_rows) == 1
+        pre_commit_idx = pre_rows[0].commit_idx
+
+        await manager.server_stop_gracefully(server.server_id)
+        await manager.server_start(server.server_id)
+        await reconnect_driver(manager)
+        cql = manager.get_cql()
+
+        for pk in range(10):
+            rows = await cql.run_async(f"SELECT * FROM {ks}.test WHERE pk = {pk};")
+            assert len(rows) == 1, f"Expected 1 row for pk={pk}, got {len(rows)}"
+            assert rows[0].c == pk * 10
+
+        # The startup bump sets raft_groups_snapshots.idx from the commit_idx that
+        # was persisted at shutdown, and nothing after startup moves it (post-restart
+        # commits advance system.raft_groups.commit_idx, not the snapshot index), so
+        # it is a stable witness of what shutdown actually persisted.
+        #
+        # The drain flush fires the hook while the group is still alive, so the
+        # persisted value covers every committed insert and the bump lands strictly
+        # past the append-time value. Were the groups torn down before the drain
+        # flush, the bump could only reach the append-time value itself.
+        snp_rows = await cql.run_async(f"SELECT idx FROM system.raft_groups_snapshots WHERE shard = 0 AND group_id = {group_id}")
+        assert len(snp_rows) == 1
+        # With batched commit-time persistence (rounds) the pre-shutdown read
+        # already returns the fully current commit_idx, so the bump lands exactly
+        # on it; >= is the design-agnostic invariant ("shutdown lost nothing").
+        # The old strict > encoded the flush-hook design, where the pre-read was
+        # the lagging append-time value and shutdown persisted a fresher one.
+        assert snp_rows[0].idx >= pre_commit_idx, \
+            f"snapshot idx {snp_rows[0].idx} fell behind the pre-shutdown commit_idx {pre_commit_idx} " \
+            f"— commit_idx was lost across the restart"
+
+    await manager.server_stop_gracefully(server.server_id)

--- a/test/raft/raft_sys_table_storage_test.cc
+++ b/test/raft/raft_sys_table_storage_test.cc
@@ -135,6 +135,34 @@ static std::vector<raft::log_entry_ptr> create_test_log(size_t min_entries = 0, 
     return entries;
 }
 
+// Like create_test_log() but with command entries only, randomized the same
+// way (length, first index, payloads, non-decreasing terms all derive from
+// tests::random). acquire_replay_position_handles_for() serves command
+// entries only (see state_machine::apply, which is handed only commands), so
+// tests exercising it use an all-command log rather than create_test_log()'s
+// mixed types.
+static std::vector<raft::log_entry_ptr> create_test_command_log(size_t min_entries = 3, size_t max_entries = 20) {
+    SCYLLA_ASSERT(min_entries >= 1 && min_entries <= max_entries);
+
+    uint64_t first_idx = tests::random::get_int<uint64_t>(1, 1000);
+    size_t count = tests::random::get_int(min_entries, max_entries);
+
+    std::vector<raft::log_entry_ptr> entries;
+    entries.reserve(count);
+    uint64_t term = 1;
+    for (size_t i = 0; i < count; ++i) {
+        raft::command cmd;
+        ser::serialize(cmd, tests::random::get_int(0, 100000));
+        term += tests::random::get_int(0, 3);
+        entries.push_back(make_lw_shared(raft::log_entry{
+            .term = raft::term_t(term),
+            .idx  = raft::index_t(first_idx + i),
+            .data = std::move(cmd)}));
+    }
+    testlog.info("create_test_command_log: {} entries, first_idx={}", entries.size(), first_idx);
+    return entries;
+}
+
 // Factory functions to create storage instances with uniform interface
 static service::raft_sys_table_storage make_sys_table_storage(cql_test_env& env, raft::group_id group_id) {
     return service::raft_sys_table_storage(env.local_qp(), group_id, raft::server_id::create_random_id());
@@ -384,7 +412,7 @@ SEASTAR_TEST_CASE(test_groups_truncate_log) {
         raft_groups_storage storage(qp, gid, raft::server_id::create_random_id(), test_shard,
                 cl, dummy_table, {});
 
-        std::vector<raft::log_entry_ptr> entries = create_test_log(3, 20);
+        std::vector<raft::log_entry_ptr> entries = create_test_command_log(3, 20);
         co_await storage.store_log_entries(entries);
 
         // Truncate the last entry from the log (entries with idx >= entries.back()->idx)
@@ -585,7 +613,7 @@ SEASTAR_TEST_CASE(test_groups_store_and_get_replay_positions) {
         raft_groups_storage storage(qp, gid, raft::server_id::create_random_id(), test_shard,
                 cl, dummy_table, {});
 
-        std::vector<raft::log_entry_ptr> entries = create_test_log(3, 20);
+        std::vector<raft::log_entry_ptr> entries = create_test_command_log(3, 20);
         co_await storage.store_log_entries(entries);
 
         // Acquire replay position handles for all entries.
@@ -612,7 +640,7 @@ SEASTAR_TEST_CASE(test_groups_get_partial_replay_positions) {
         raft_groups_storage storage(qp, gid, raft::server_id::create_random_id(), test_shard,
                 cl, dummy_table, {});
 
-        std::vector<raft::log_entry_ptr> entries = create_test_log(3, 20);
+        std::vector<raft::log_entry_ptr> entries = create_test_command_log(3, 20);
         co_await storage.store_log_entries(entries);
 
         // Get handles only for the first half of entries
@@ -697,7 +725,7 @@ SEASTAR_TEST_CASE(test_groups_truncate_log_then_get_handles_for_remaining) {
         raft_groups_storage storage(qp, gid, raft::server_id::create_random_id(), test_shard,
                 cl, dummy_table, {});
 
-        std::vector<raft::log_entry_ptr> entries = create_test_log(3, 20);
+        std::vector<raft::log_entry_ptr> entries = create_test_command_log(3, 20);
         co_await storage.store_log_entries(entries);
 
         // Truncate at the second entry's idx — entries with idx >= entries[1]->idx are removed.
@@ -742,7 +770,7 @@ SEASTAR_TEST_CASE(test_groups_store_snapshot_truncate_tail_then_get_handles) {
             }, raft::is_voter::yes};
         co_await storage.bootstrap(raft::configuration({srv}), false);
 
-        std::vector<raft::log_entry_ptr> entries = create_test_log(3, 20);
+        std::vector<raft::log_entry_ptr> entries = create_test_command_log(3, 20);
         co_await storage.store_log_entries(entries);
 
         // Store snapshot at entries[1]->idx with preserve_log_entries=1.


### PR DESCRIPTION
## Purpose

Proof of concept for evaluation — **not intended to merge as-is**. Replaces per-group raft persistence IO for strongly-consistent tablets with shard-wide write-behind batching ("rounds"), as an alternative direction to the deferred-persistence approach of #30394. Opened as a draft to get a CI build for SCT comparison runs and to make the design reviewable.

Based directly on master; 6 commits, independent of #30394 (the two claim the same problem, not the same code):

1. `commitlog: add raft_commit_idx_entry variant` — wire format for commit_idx records in the commitlog (append-only variant discriminator).
2. `raft_commitlog: split rp_handles into command / config / dummy deques` — separate release rules: dummies release once commit_idx covers them; configuration entries stay pinned until a snapshot persists the configuration (SCYLLADB-3842).
3. `commitlog: take a cf_id per writer in add_raft_entries` — lets one batched write span column families. No behavior change on its own.
4. `strong_consistency: batch raft IO across groups in shard-wide rounds` — the idea. One fiber per shard; each round is ONE force-synced multi-entry commitlog write carrying every group's data-batch entries (submit_append, awaited by the group's io_fiber — log-before-message preserved) plus a commit_idx entry per group whose commit advanced (submit_commit_idx, awaited before entries reach the applier — **persist-before-apply preserved**, so memtable flush and segment discard need no SC-side cooperation; `replica/table.cc` is untouched). Each commit_idx entry's rp_handle is attached to a fake `system.raft_groups` mutation, so the value also reaches an SSTable before its segment can be recycled.
5. `commitlog: restore commit_idx from replay and bump the snapshot index` — recovery reads the rounds' commit_idx entries, and a startup pass reconciles the persisted snapshot index with the recovered commit_idx (raft's "committed index cannot be larger then persisted one" assert). Exact-term persistence stays tracked in SCYLLADB-3357.
6. `test: cover batched raft IO`.

## Why

Measured SC write amplification is driven by per-group forced commitlog syncs: 1.2–4.5× EC's commitlog bytes and 5–139× the disk write ops, worst at low per-shard concurrency where cross-group coalescing is opportunistic only (`batch_cycle`). Rounds make the coalescing deterministic, with no raft-library changes — the ordering guarantees ride the awaits raft already does. Prior art: TiKV raftstore (batched Ready persistence incl. HardState), CockroachDB raft scheduler + engine group commit.

## Measurements

**AWS i4i.4xlarge, 3 nodes on-box, `commitlog_sync: batch` (real fsync), 300 s, conc=4096, 5 B values, 128 tablets, leader-aware driver (scylla-rust-driver#1788), EC control run per arm:**

| build | EC control | SC | SC avg | SC/EC |
|---|--:|--:|--:|--:|
| master | 157.3k | 176.7k | 23.2 ms | 112% |
| #30394 | 155.8k | 171.8k | 23.8 ms | 110% |
| **this PR** | 150.6k | **206.7k** | **19.8 ms** | **137%** |

+17% over master, +20% over #30394; EC controls agree within ±4%.

**Measured coalescing** (the batcher logs its stats at stop): **5.5–6.5 append calls (45–58 raft entries) + ~5 commit_idx values fused per forced sync** with the leader-aware driver; 3.7–3.9 appends with the stock driver. On local no-fsync rigs the factor is ~1.0 — the accumulation window equals the in-flight write's duration, so batching engages exactly when syncs are expensive.

Caveats: single box hosting all 3 nodes (shared NVMe/CPU, loopback), dev-mode builds, one pass per arm, sc-bench rather than cql-stress. The definitive comparison is an SCT run of this PR's CI build with the job parameters of the existing runs for master (`bdf63317ef67`) and #30394 (`d0499946a822`).

All SC suites pass at the tip: boost commitlog_raft_replay, raft_sys_table_storage, cluster commitlog 7/7, cluster main 22 passed. Release build passes. Every commit builds standalone.

## Known POC gaps

* No round size cap (an oversized round would take the fragmented-entry commitlog path).
* Unit tests construct raft_commitlog/storage without a batcher and keep the direct-write path.
* Error policy: a failed round write fails every waiting group's io_fiber on the shard (surfaced per group via raft's `background_error`); acceptable for a shared commitlog, but deliberate review wanted.

## Test changes

Existing suites adapted and extended; the boost cases add ~10 s reported to already-running suites, the new cluster test ~3 s reported / ~4.5 s wall. No new test binary or cluster fixture.

Refs #30394
Fixes: SCYLLADB-3520
