### PR TITLE
cql3: replace function_call::lwt_cache_id with an expr::temporary

### DIFF
--- a/cql3/expr/expression.cc
+++ b/cql3/expr/expression.cc
@@ -1526,7 +1526,7 @@ cql3::raw_value evaluate(const expression& e, const evaluation_inputs& inputs) {
 }
 
 cql3::raw_value evaluate(const expression& e, const query_options& options) {
-    return evaluate(e, evaluation_inputs{.options = &options});
+    return evaluate(e, evaluation_inputs{.options = &options, .temporaries = options.cached_pk_function_calls()});
 }
 
 // Takes a value and reserializes it where needs_to_be_reserialized() says it's needed
@@ -1894,20 +1894,7 @@ static cql3::raw_value do_evaluate(const function_call& fun_call, const evaluati
         arguments.emplace_back(to_bytes_opt(std::move(arg_val)));
     }
 
-    bool has_cache_id = fun_call.lwt_cache_id.get() != nullptr && fun_call.lwt_cache_id->has_value();
-    if (has_cache_id) {
-        computed_function_values::mapped_type* cached_value =
-            inputs.options->find_cached_pk_function_call(**fun_call.lwt_cache_id);
-        if (cached_value != nullptr) {
-            return raw_value::make_value(*cached_value);
-        }
-    }
-
     bytes_opt result = scalar_fun->execute(arguments);
-
-    if (has_cache_id) {
-        inputs.options->cache_pk_function_call(**fun_call.lwt_cache_id, result);
-    }
 
     if (!result.has_value()) {
         return cql3::raw_value::make_null();
@@ -2060,13 +2047,15 @@ void fill_prepare_context(expression& e, prepare_context& ctx) {
             }
         },
         [&](function_call& f) {
-            const shared_ptr<functions::function>& func = std::get<shared_ptr<functions::function>>(f.func);
-            if (ctx.is_processing_pk_restrictions() && !func->is_pure()) {
-                ctx.add_pk_function_call(f);
-            }
-
             for (expr::expression& argument : f.args) {
                 fill_prepare_context(argument, ctx);
+            }
+
+            const shared_ptr<functions::function>& func = std::get<shared_ptr<functions::function>>(f.func);
+            if (ctx.is_processing_pk_restrictions() && !func->is_pure()) {
+                // Replaces e with a temporary standing in for the call, so that the
+                // call is evaluated once per request rather than once per evaluation.
+                ctx.add_pk_function_call(e);
             }
         },
         [&](binary_operator& binop) {

--- a/cql3/expr/expression.hh
+++ b/cql3/expr/expression.hh
@@ -306,35 +306,6 @@ struct function_call {
     std::variant<functions::function_name, shared_ptr<db::functions::function>> func;
     std::vector<expression> args;
 
-    // 0-based index of the function call within a CQL statement.
-    // Used to populate the cache of execution results while passing to
-    // another shard (handling `bounce_to_shard` messages) in LWT statements.
-    //
-    // The id is set only for the function calls that are a part of LWT
-    // statement restrictions for the partition key. Otherwise, the id is not
-    // set and the call is not considered when using or populating the cache.
-    //
-    // For example in a query like:
-    // INSERT INTO t (pk) VALUES (uuid()) IF NOT EXISTS
-    // The query should be executed on a shard that has the pk partition,
-    // but it changes with each uuid() call.
-    // uuid() call result is cached and sent to the proper shard.
-    //
-    // Cache id is kept in shared_ptr because of how prepare_context works.
-    // During fill_prepare_context all function cache ids are collected
-    // inside prepare_context.
-    // Later when some condition occurs we might decide to clear
-    // cache ids of all function calls found in prepare_context.
-    // However by this time these function calls could have been
-    // copied multiple times. Prepare_context keeps a shared_ptr
-    // to function_call ids, and then clearing the shared id
-    // clears it in all possible copies.
-    // This logic was introduced back when everything was shared_ptr<term>,
-    // now a better solution might exist.
-    //
-    // This field can be nullptr, it means that there is no cache id set.
-    ::shared_ptr<std::optional<uint8_t>> lwt_cache_id;
-
     friend bool operator==(const function_call&, const function_call&) = default;
 };
 
@@ -478,9 +449,19 @@ struct usertype_constructor {
 // writes them. Each slot has exactly one writer and any number of readers. What
 // writes a slot is not a property of the slot - the writers in use today are an
 // aggregation inner-loop step, holding state that accumulates across the rows of
-// a group (e.g. a running SUM), and an external_values_provider, supplying per-row
+// a group (e.g. a running SUM), an external_values_provider, supplying per-row
 // input that doesn't come from the base table (e.g. a BM25 relevance score
-// returned by the vector store). Slots are allocated in one space, in the order
+// returned by the vector store), and statement_restrictions, which evaluates a
+// non-pure function call in a partition key restriction (e.g. uuid()) once per
+// request, so that a shard bounce sees the value the bouncing shard computed.
+//
+// An index is an index into the temporaries vector the evaluation is given, and
+// there is more than one such vector: a selection builds its own, sized by the
+// temporary_allocator that hands out the selection's slots, while query_options
+// carries the one holding the partition key function call values. The two are
+// separate index spaces, which is sound only because no expression reads both:
+// restrictions are evaluated against query_options', selectors against the
+// selection's. Within one vector, slots are allocated in one space, in the order
 // their writers appear: prepare first, then split_aggregation().
 //
 // A slot is restored to an initial value at the start of a group if its writer

--- a/cql3/expr/prepare_expr.cc
+++ b/cql3/expr/prepare_expr.cc
@@ -1501,7 +1501,6 @@ prepare_function_call(const expr::function_call& fc, data_dictionary::database d
     expr::function_call fun_call {
         .func = fun,
         .args = std::move(parameters),
-        .lwt_cache_id = fc.lwt_cache_id
     };
     if (all_terminal && fun->is_pure() && !fun->is_aggregate() && !fun->requires_thread()) {
         return constant(expr::evaluate(fun_call, query_options::DEFAULT), fun->return_type());

--- a/cql3/prepare_context.cc
+++ b/cql3/prepare_context.cc
@@ -13,6 +13,7 @@
 #include "cql3/prepare_context.hh"
 #include "cql3/column_identifier.hh"
 #include "cql3/column_specification.hh"
+#include "cql3/functions/function.hh"
 #include "exceptions/exceptions.hh"
 
 namespace cql3 {
@@ -87,23 +88,20 @@ const dialect& prepare_context::get_dialect() const {
     return *_dialect;
 }
 
-void prepare_context::clear_pk_function_calls_cache() {
-    for (::shared_ptr<std::optional<uint8_t>>& cache_id : _pk_function_calls_cache_ids) {
-        if (cache_id.get() != nullptr) {
-            *cache_id = std::nullopt;
-        }
-    }
-}
-
-void prepare_context::add_pk_function_call(expr::function_call& fn) {
+void prepare_context::add_pk_function_call(expr::expression& e) {
+    // The slot index travels between shards as a uint8_t, see
+    // cql3::computed_function_values.
     constexpr auto fn_limit = std::numeric_limits<uint8_t>::max();
-    if (_pk_function_calls_cache_ids.size() == fn_limit) {
+    if (_pk_function_calls.size() == fn_limit) {
         throw exceptions::invalid_request_exception(
             format("Too many function calls within one statement. Max supported number is {}", fn_limit));
     }
 
-    fn.lwt_cache_id = ::make_shared<std::optional<uint8_t>>(_pk_function_calls_cache_ids.size());
-    _pk_function_calls_cache_ids.emplace_back(fn.lwt_cache_id);
+    auto& fn = expr::as<expr::function_call>(e);
+    auto type = std::get<shared_ptr<db::functions::function>>(fn.func)->return_type();
+    size_t index = _pk_function_calls.size();
+    _pk_function_calls.push_back(e);
+    e = expr::temporary{.index = index, .type = std::move(type), .replaced_expr = std::move(fn)};
 }
 
 

--- a/cql3/prepare_context.hh
+++ b/cql3/prepare_context.hh
@@ -46,15 +46,17 @@ private:
     // The driver needs this information in order to compute the partition token and send the request to the right node.
     std::vector<std::pair<std::size_t, lw_shared_ptr<column_specification>>> _targets;
 
-    // A list of pointers to prepared `function_call` cache ids, that
-    // participate in partition key ranges computation within an LWT statement.
-    std::vector<::shared_ptr<std::optional<uint8_t>>> _pk_function_calls_cache_ids;
+    // The non-pure `function_call`s that participate in partition key ranges
+    // computation, in the order they were found. Each was replaced in the
+    // statement's expressions by an `expr::temporary` holding its index here,
+    // which is also its slot in the temporaries vector query_options carries.
+    std::vector<expr::expression> _pk_function_calls;
 
     // The flag denoting whether the context is currently in partition key
     // processing mode (inside query restrictions AST nodes). If set to true,
-    // then every `function_call` instance will be recorded in the context and
-    // will be assigned an identifier, which will then be used for caching
-    // the function call results.
+    // then every non-pure `function_call` instance will be recorded in the
+    // context and replaced by a temporary, whose value is computed once per
+    // request and survives a bounce to another shard.
     bool _processing_pk_restrictions = false;
 
     // The dialect the statement is parsed and prepared under. Captured when the
@@ -85,11 +87,17 @@ public:
 
     const dialect& get_dialect() const;
 
-    void clear_pk_function_calls_cache();
+    // Record a new function call, which evaluates a partition key constraint,
+    // and replace it in `e` with the temporary that stands in for it. The
+    // caller has to make sure `e` holds a prepared `expr::function_call`.
+    void add_pk_function_call(cql3::expr::expression& e);
 
-    // Record a new function call, which evaluates a partition key constraint.
-    // Also automatically assigns an id to the AST node for caching purposes.
-    void add_pk_function_call(cql3::expr::function_call& fn);
+    // The function calls recorded by add_pk_function_call(), indexed by the
+    // slot of the temporary that replaced them. Whoever evaluates expressions
+    // holding those temporaries is responsible for filling their slots.
+    const std::vector<expr::expression>& pk_function_calls() const {
+        return _pk_function_calls;
+    }
 
     // Inform the context object that it has started or ended processing the
     // partition key part of statement restrictions.

--- a/cql3/query_options.cc
+++ b/cql3/query_options.cc
@@ -13,7 +13,12 @@
 #include "db/consistency_level_type.hh"
 #include "cql3/column_identifier.hh"
 
+#include <seastar/core/on_internal_error.hh>
+#include "utils/log.hh"
+
 namespace cql3 {
+
+static logging::logger query_options_logger("query_options");
 
 const cql_config default_cql_config(cql_config::default_tag{});
 
@@ -167,28 +172,38 @@ utils::result_with_exception_ptr<db::consistency_level> query_options::check_ser
     return bo::failure(std::make_exception_ptr(exceptions::protocol_exception("Consistency level for LWT is missing for a request with conditions")));
 }
 
-void query_options::cache_pk_function_call(computed_function_values::key_type id, computed_function_values::mapped_type value) const {
-    _cached_pk_fn_calls.emplace(id, std::move(value));
-}
-
-const computed_function_values& query_options::cached_pk_function_calls() const {
-    return _cached_pk_fn_calls;
-}
-
-computed_function_values&& query_options::take_cached_pk_function_calls() {
-    return std::move(_cached_pk_fn_calls);
-}
-
-void query_options::set_cached_pk_function_calls(computed_function_values vals) {
-    _cached_pk_fn_calls = std::move(vals);
-}
-
-computed_function_values::mapped_type* query_options::find_cached_pk_function_call(computed_function_values::key_type id) const {
-    auto it = _cached_pk_fn_calls.find(id);
-    if (it != _cached_pk_fn_calls.end()) {
-        return &it->second;
+void query_options::cache_pk_function_call(size_t index, raw_value value) const {
+    if (index != _cached_pk_fn_calls.size()) {
+        on_internal_error(query_options_logger,
+                format("caching partition key function call {} out of order, {} calls are cached",
+                        index, _cached_pk_fn_calls.size()));
     }
-    return nullptr;
+    _cached_pk_fn_calls.push_back(std::move(value));
+}
+
+computed_function_values query_options::take_cached_pk_function_calls() {
+    computed_function_values vals;
+    for (size_t i = 0; i < _cached_pk_fn_calls.size(); ++i) {
+        vals.emplace(i, std::move(_cached_pk_fn_calls[i]).to_bytes_opt());
+    }
+    _cached_pk_fn_calls.clear();
+    return vals;
+}
+
+void query_options::set_cached_pk_function_calls(const computed_function_values& vals) {
+    // The calls were computed in slot order before they were handed to us, so
+    // the keys are 0..vals.size()-1 and the vector can be rebuilt by indexing
+    // into them.
+    _cached_pk_fn_calls.clear();
+    _cached_pk_fn_calls.reserve(vals.size());
+    for (size_t i = 0; i < vals.size(); ++i) {
+        auto it = vals.find(i);
+        if (it == vals.end()) {
+            on_internal_error(query_options_logger,
+                    format("cached partition key function call values have a hole at slot {}", i));
+        }
+        _cached_pk_fn_calls.push_back(raw_value::make_value(it->second));
+    }
 }
 
 }

--- a/cql3/query_options.hh
+++ b/cql3/query_options.hh
@@ -12,6 +12,7 @@
 
 #include <concepts>
 #include <initializer_list>
+#include <span>
 #include "mutation/timestamp.hh"
 #include "bytes.hh"
 #include "db/consistency_level_type.hh"
@@ -30,6 +31,10 @@ extern const cql_config default_cql_config;
 
 class column_specification;
 
+// The values of the temporaries standing in for non-pure function calls in
+// partition key restrictions, keyed by temporary slot. This is the form they
+// travel in when a request bounces to another shard or node, which is why the
+// key is a uint8_t rather than the size_t a temporary slot really is.
 using computed_function_values = std::unordered_map<uint8_t, bytes_opt>;
 
 using unset_bind_variable_vector = utils::small_vector<bool, 16>;
@@ -101,25 +106,26 @@ private:
     // 3) unique.
     mutable int _list_append_seq = 0;
 
-    // Cached `function_call` evaluation results. `function_call` AST nodes
-    // are created for each function with side effects in a CQL query, i.e.
-    // non-deterministic functions (`uuid()`, `now()` and some others
-    // timeuuid-related).
+    // The results of the non-pure function calls the prepare step found in the
+    // partition key restrictions (`uuid()`, `now()` and some others
+    // timeuuid-related), indexed by the expr::temporary slot that stands in for
+    // the call. statement_restrictions computes them, once per request, before
+    // evaluating anything that reads them; see
+    // statement_restrictions::evaluate_pk_function_calls().
     //
-    // These nodes are evaluated either when a query itself is executed
-    // or query restrictions are computed (e.g. partition/clustering
-    // key ranges for LWT requests).
+    // Entries [0, size) are all computed: the vector only grows by caching one
+    // more call, so its size is how many calls have a result.
     //
-    // We need to cache the calls since otherwise when handling a
-    // `bounce_to_shard` request for an LWT query, we can possibly enter an
-    // infinite bouncing loop (in case a function is used to calculate
+    // The values have to be computed once and then reused, since otherwise when
+    // handling a `bounce_to_shard` request for an LWT query, we can possibly
+    // enter an infinite bouncing loop (in case a function is used to calculate
     // partition key ranges for a query), since the results can be different
     // each time. Furthermore, we don't support bouncing more than one time.
     // Refs: #8604 (https://github.com/scylladb/scylla/issues/8604)
     //
     // Using mutable because `query_state` is not available at
     // evaluation sites and we only have a const reference to `query_options`.
-    mutable computed_function_values _cached_pk_fn_calls;
+    mutable std::vector<raw_value> _cached_pk_fn_calls;
 private:
     // Batch constructor.
     template <typename Values>
@@ -284,11 +290,24 @@ public:
 
     void prepare(const std::vector<lw_shared_ptr<column_specification>>& specs);
 
-    void cache_pk_function_call(computed_function_values::key_type id, computed_function_values::mapped_type value) const;
-    const computed_function_values& cached_pk_function_calls() const;
-    computed_function_values&& take_cached_pk_function_calls();
-    void set_cached_pk_function_calls(computed_function_values vals);
-    computed_function_values::mapped_type* find_cached_pk_function_call(computed_function_values::key_type id) const;
+    // The results the partition key function calls of an expression evaluated
+    // against these options read, indexed by temporary slot.
+    std::span<const raw_value> cached_pk_function_calls() const {
+        return _cached_pk_fn_calls;
+    }
+
+    // How many calls already have a result. They are computed in slot order, so
+    // a statement with more calls than this has to compute the rest itself.
+    size_t nr_cached_pk_function_calls() const {
+        return _cached_pk_fn_calls.size();
+    }
+
+    // Caches the result of the call in slot `index`, which must be the first
+    // one without a result.
+    void cache_pk_function_call(size_t index, raw_value value) const;
+
+    computed_function_values take_cached_pk_function_calls();
+    void set_cached_pk_function_calls(const computed_function_values& vals);
 
 private:
     void fill_value_views();

--- a/cql3/query_processor.cc
+++ b/cql3/query_processor.cc
@@ -592,7 +592,7 @@ future<::shared_ptr<cql_transport::messages::result_message>> query_processor::e
         ::shared_ptr<cql_statement> statement, service::query_state& query_state, const query_options& options) {
     // execute all statements that need group0 guard on shard0
     if (this_shard_id() != 0) {
-        co_return bounce_to_shard(0, std::move(const_cast<cql3::query_options&>(options).take_cached_pk_function_calls()), false);
+        co_return bounce_to_shard(0, const_cast<cql3::query_options&>(options).take_cached_pk_function_calls(), false);
     }
 
     auto [remote_, holder] = remote();

--- a/cql3/restrictions/statement_restrictions.cc
+++ b/cql3/restrictions/statement_restrictions.cc
@@ -1295,6 +1295,8 @@ statement_restrictions::statement_restrictions(private_tag,
     _get_global_index_token_clustering_ranges_fn = build_get_global_index_token_clustering_ranges_fn();
     _get_local_index_clustering_ranges_fn = build_get_local_index_clustering_ranges_fn();
     _value_for_index_partition_key_fn = build_value_for_index_partition_key_fn();
+
+    _pk_function_calls = ctx.pk_function_calls();
 }
 
 bool
@@ -1706,7 +1708,20 @@ dht::partition_range_vector partition_ranges_from_EQs(
 
 } // anonymous namespace
 
+void statement_restrictions::evaluate_pk_function_calls(const query_options& options) const {
+    // The calls are evaluated in slot order and the ones already cached keep
+    // their result: on a bounce the results computed by the bouncing shard
+    // arrive in the options, and computing them again is exactly what the
+    // caching is here to prevent. In a BATCH all statements share the prepare
+    // context, so the statements sharing one query_options also share the
+    // cached results.
+    for (size_t i = options.nr_cached_pk_function_calls(); i < _pk_function_calls.size(); ++i) {
+        options.cache_pk_function_call(i, expr::evaluate(_pk_function_calls[i], options));
+    }
+}
+
 dht::partition_range_vector statement_restrictions::get_partition_key_ranges(const query_options& options) const {
+    evaluate_pk_function_calls(options);
     return _get_partition_key_ranges_fn(options);
 }
 
@@ -2359,6 +2374,7 @@ statement_restrictions::build_get_clustering_bounds_fn() const {
     }
 
 std::vector<query::clustering_range> statement_restrictions::get_clustering_bounds(const query_options& options) const {
+    evaluate_pk_function_calls(options);
     return _get_clustering_bounds_fn(options);
 }
 
@@ -2636,6 +2652,7 @@ statement_restrictions::build_get_global_index_clustering_ranges_fn() const {
 
 std::vector<query::clustering_range> statement_restrictions::get_global_index_clustering_ranges(
         const query_options& options) const {
+    evaluate_pk_function_calls(options);
     return _get_global_index_clustering_ranges_fn(options);
 }
 
@@ -2662,6 +2679,7 @@ statement_restrictions::build_get_global_index_token_clustering_ranges_fn() cons
 
 std::vector<query::clustering_range> statement_restrictions::get_global_index_token_clustering_ranges(
     const query_options& options) const {
+    evaluate_pk_function_calls(options);
     return _get_global_index_token_clustering_ranges_fn(options);
 }
 
@@ -2679,6 +2697,7 @@ statement_restrictions::build_get_local_index_clustering_ranges_fn() const {
 
 std::vector<query::clustering_range> statement_restrictions::get_local_index_clustering_ranges(
         const query_options& options) const {
+    evaluate_pk_function_calls(options);
     return _get_local_index_clustering_ranges_fn(options);
 }
 
@@ -2714,6 +2733,7 @@ statement_restrictions::build_value_for_index_partition_key_fn() const {
 
 bytes_opt
 statement_restrictions::value_for_index_partition_key(const query_options& options) const {
+    evaluate_pk_function_calls(options);
     return _value_for_index_partition_key_fn(options);
 }
 
@@ -2740,6 +2760,7 @@ static void validate_primary_key_restrictions(const query_options& options, std:
 }
 
 void statement_restrictions::validate_primary_key(const query_options& options) const {
+    evaluate_pk_function_calls(options);
     std::visit(overloaded_functor{
         [&] (const no_partition_range_restrictions&) {
         },

--- a/cql3/restrictions/statement_restrictions.hh
+++ b/cql3/restrictions/statement_restrictions.hh
@@ -237,6 +237,12 @@ private:
     schema_ptr _view_schema;
     std::unique_ptr<secondary_index::index> _idx_opt;
     std::vector<predicate> _idx_column_predicates; ///< Predicates for the chosen index's target column.
+    // Non-pure function calls found in the partition key restrictions, indexed
+    // by the slot of the expr::temporary that replaced them; see
+    // prepare_context::add_pk_function_call(). evaluate_pk_function_calls()
+    // gives them their values.
+    std::vector<expr::expression> _pk_function_calls;
+
     get_partition_key_ranges_fn_t _get_partition_key_ranges_fn;
     get_clustering_bounds_fn_t _get_clustering_bounds_fn;
     get_clustering_bounds_fn_t _get_global_index_clustering_ranges_fn;
@@ -437,6 +443,14 @@ public:
      * @return the specified bound of the partition key
      * @throws InvalidRequestException if the boundary cannot be retrieved
      */
+    // Evaluates the non-pure function calls of the partition key restrictions
+    // that `options` doesn't already have a result for, caching them there for
+    // the temporaries standing in for the calls to read. Every method here that
+    // evaluates restrictions calls it first; anyone evaluating a restriction
+    // expression outside this class (e.g. the filter returned by
+    // get_partition_level_filter()) has to call it too.
+    void evaluate_pk_function_calls(const query_options& options) const;
+
     dht::partition_range_vector get_partition_key_ranges(const query_options& options) const;
 
 

--- a/cql3/selection/selection.cc
+++ b/cql3/selection/selection.cc
@@ -841,7 +841,12 @@ result_set_builder::restrictions_filter::restrictions_filter(::shared_ptr<const 
     , _per_partition_remaining(_per_partition_limit)
     , _rows_fetched_for_last_partition(rows_fetched_for_last_partition)
     , _last_pkey(std::move(last_pkey))
-{ }
+{
+    // The filters can hold temporaries standing in for non-pure function calls
+    // in partition key restrictions, and this is an evaluation site outside
+    // statement_restrictions.
+    _restrictions->evaluate_pk_function_calls(_options);
+}
 
 bool result_set_builder::restrictions_filter::do_filter(const selection& selection,
                                                          const std::vector<bytes>& partition_key,
@@ -864,6 +869,7 @@ bool result_set_builder::restrictions_filter::do_filter(const selection& selecti
                         .static_and_regular_columns = static_and_regular_columns,
                         .selection = &selection,
                         .options = &_options,
+                        .temporaries = _options.cached_pk_function_calls(),
                     })) {
         _current_partition_does_not_match = true;
         return false;
@@ -877,6 +883,7 @@ bool result_set_builder::restrictions_filter::do_filter(const selection& selecti
                         .static_and_regular_columns = static_and_regular_columns,
                         .selection = &selection,
                         .options = &_options,
+                        .temporaries = _options.cached_pk_function_calls(),
                     })) {
         return false;
     }

--- a/cql3/statements/batch_statement.cc
+++ b/cql3/statements/batch_statement.cc
@@ -395,7 +395,7 @@ future<shared_ptr<cql_transport::messages::result_message>> batch_statement::exe
         } else if (keys.size() != 1 || keys.front().equal(request->key().front(), dht::ring_position_comparator(*schema)) == false) {
             throw exceptions::invalid_request_exception("BATCH with conditions cannot span multiple partitions");
         }
-        cached_fn_calls.merge(std::move(const_cast<cql3::query_options&>(statement_options).take_cached_pk_function_calls()));
+        cached_fn_calls.merge(const_cast<cql3::query_options&>(statement_options).take_cached_pk_function_calls());
 
         std::vector<query::clustering_range> ranges = statement.create_clustering_ranges(statement_options, json_cache);
 

--- a/cql3/statements/modification_statement.cc
+++ b/cql3/statements/modification_statement.cc
@@ -420,7 +420,7 @@ process_forced_rebounce(unsigned shard, query_processor& qp, const query_options
 
     logger.info("Applying forced_bounce_to_shard_counter, re-bouncing to shard {}.", shard);
     co_return co_await make_ready_future<shared_ptr<cql_transport::messages::result_message>>(
-        qp.bounce_to_shard(shard, std::move(const_cast<cql3::query_options&>(options).take_cached_pk_function_calls())));
+        qp.bounce_to_shard(shard, const_cast<cql3::query_options&>(options).take_cached_pk_function_calls()));
 }
 
 } // namespace
@@ -468,7 +468,7 @@ modification_statement::execute_with_condition(query_processor& qp, service::que
     }
     if (!cas_shard.this_shard()) {
         return make_ready_future<shared_ptr<cql_transport::messages::result_message>>(
-                qp.bounce_to_shard(cas_shard.shard(), std::move(const_cast<cql3::query_options&>(options).take_cached_pk_function_calls()))
+                qp.bounce_to_shard(cas_shard.shard(), const_cast<cql3::query_options&>(options).take_cached_pk_function_calls())
             );
     }
 
@@ -645,29 +645,6 @@ modification_statement::prepare(data_dictionary::database db, prepare_context& c
         }
     }
 
-    // At this point the prepare context instance should have a list of
-    // `function_call` AST nodes corresponding to non-pure functions that
-    // evaluate partition key constraints.
-    //
-    // These calls can affect partition key ranges computation and target shard
-    // selection for LWT statements.
-    // For such cases we need to forward the computed execution result of the
-    // function when redirecting the query execution to another shard.
-    // Otherwise, it's possible that we end up bouncing indefinitely between
-    // various shards when evaluating a non-deterministic function each time on
-    // each shard.
-    //
-    // Prepare context is used to keep track of such AST nodes and also modifies
-    // them to include an id, that will be used for caching the results.
-    // At this point we don't yet know if it's an LWT query or not, because the
-    // prepared statement object is constructed later.
-    //
-    // Since this cache is only meaningful for LWT queries, just clear the ids
-    // if it's not a conditional statement so that the AST nodes don't
-    // participate in the caching mechanism later.
-    if (!prepared_stmt->has_conditions() && prepared_stmt->_restrictions) {
-        ctx.clear_pk_function_calls_cache();
-    }
     prepared_stmt->_may_use_token_aware_routing = ctx.get_partition_key_bind_indexes(*schema).size() != 0;
     return prepared_stmt;
 }

--- a/cql3/statements/select_statement.cc
+++ b/cql3/statements/select_statement.cc
@@ -523,8 +523,9 @@ select_statement::do_execute(query_processor& qp,
         const auto token = key_ranges[0].start()->value().as_decorated_key().token();
         cas_shard.emplace(*_schema, token);
         if (!cas_shard->this_shard()) {
+            // The const_cast is gross, but at least we're returning now and we're sure it won't be used again.
             return make_ready_future<shared_ptr<cql_transport::messages::result_message>>(
-                    qp.bounce_to_shard(cas_shard->shard(), std::move(const_cast<cql3::query_options&>(options).take_cached_pk_function_calls()))
+                    qp.bounce_to_shard(cas_shard->shard(), const_cast<cql3::query_options&>(options).take_cached_pk_function_calls())
                 );
         }
     }


### PR DESCRIPTION
A non-pure function call in a partition key restriction (uuid(), now()) has to be evaluated once per request: the value picks the shard, so re-evaluating it on the shard we bounced to would pick another shard, and we don't support bouncing twice.

That was done with a mechanism built for this one case. function_call carried an lwt_cache_id, held in a shared_ptr purely so that clearing the id in prepare_context would reach every copy the node had been through, and do_evaluate() read and wrote a side cache in query_options behind the expression's back. The comment on the field said it: "This logic was introduced back when everything was shared_ptr<term>, now a better solution might exist."

expr::temporary is that solution, and it already exists: a slot holding a value that something outside the expression computes, which aggregation state and BM25 scores are also expressed with. Prepare now replaces the call with a temporary standing in for it, and statement_restrictions, which owns the calls, evaluates them into query_options before it evaluates anything that reads them. The value still travels to the target shard as computed_function_values, unchanged, since that is an RPC type.

An index surviving copies needs no shared_ptr, so the aliasing trick and clear_pk_function_calls_cache() are gone. Clearing the ids for non-conditional statements goes with them: such a statement now computes the call once per request too, rather than once per evaluation.

Refs #8604

A minor refactoring, not backporting.