### PR TITLE
test/boost/sstable_compaction_test: compare the capped tombstone counter to a snapshot

### DIFF
--- a/test/boost/sstable_compaction_test.cc
+++ b/test/boost/sstable_compaction_test.cc
@@ -1616,12 +1616,15 @@ future<> tombstone_purge(test_env& env) {
         // tombstones with far-into-the-future ldts by inserting tombstones
         // with a ldt greater than the date.
         auto deletion_time = gc_clock::from_time_t(sstables::max_deletion_time + 1);
+        // The counter is a process-wide (per-shard) counter that is never
+        // reset, so compare against a snapshot taken before the write.
+        auto capped_before = sstables_stats::get_shard_stats().capped_tombstone_deletion_time;
         auto sst1 = make_sstable_containing(sst_gen,
                                             {make_insert(alpha),
                                              make_delete(alpha, deletion_time)},
                                             validate::no).get();
         auto result = compact({sst1}, {sst1});
-        BOOST_CHECK_EQUAL(1, sstables_stats::get_shard_stats().capped_tombstone_deletion_time);
+        BOOST_CHECK_EQUAL(capped_before + 1, sstables_stats::get_shard_stats().capped_tombstone_deletion_time);
     }
     {
         // Verify that old live data inhibit tombstone_gc of partition tombstone


### PR DESCRIPTION
`sstables_stats::_shard_stats` is a process-wide `thread_local` that is never reset, and `tombstone_purge()` is registered as three test cases, so each one increments `capped_tombstone_deletion_time`.
Asserting its absolute value only holds for whichever case runs first in a process:

    check 1 == sstables_stats::get_shard_stats().capped_tombstone_deletion_time
    has failed [1 != 2]

The test runner gives each case its own process, so this stays hidden until several cases share one - running the suite with a single `--run_test` filter,
or enabling `tombstone_purge_s3_test` via `SCYLLA_TEST_ENV`.
Take the delta instead, as `sstable_directory_test` does for `open_for_reading`.


Backport: no, I think it's a test running edge case.