### PR TITLE
test: scale the graceful stop timeout by build mode

### DIFF
--- a/test/cluster/test_aggregation.py
+++ b/test/cluster/test_aggregation.py
@@ -70,7 +70,7 @@ async def test_cancel_mapreduce(manager: ScyllaClusterManager):
                     # Make sure that node 2 is preventing its local mapreduce task from finishing.
                     await manager.api.wait_for_injection_enter(s2.ip_addr, "mapreduce_pause_dispatch_to_shards")
                     # Verify that the supercoordinator stops without an issue despite the ongoing mapreduce task.
-                    await manager.server_stop_gracefully(s1.server_id, timeout=120)
+                    await manager.server_stop_gracefully(s1.server_id)
 
                 async with asyncio.TaskGroup() as tg:
                     _ = tg.create_task(do_select())

--- a/test/cluster/test_aggregation.py
+++ b/test/cluster/test_aggregation.py
@@ -13,7 +13,7 @@ from cassandra.cluster import NoHostAvailable  # type: ignore
 
 from test.pylib.scylla_cluster_manager import ScyllaClusterManager
 from test.pylib.rest_client import inject_error
-from test.pylib.util import wait_for, wait_for_cql_and_get_hosts
+from test.pylib.util import graceful_stop_timeout, wait_for, wait_for_cql_and_get_hosts
 from test.cluster.util import new_test_keyspace, new_test_table
 
 logger = logging.getLogger(__name__)
@@ -21,7 +21,7 @@ pytestmark = pytest.mark.prepare_3_racks_cluster
 
 
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
-async def test_cancel_mapreduce(manager: ScyllaClusterManager):
+async def test_cancel_mapreduce(manager: ScyllaClusterManager, build_mode: str):
     """
     This test verifies that stopping the supercoordinator of a mapreduce task cancels
     outgoing queries to other nodes, which would otherwise prevent the shutdown.
@@ -54,12 +54,16 @@ async def test_cancel_mapreduce(manager: ScyllaClusterManager):
 
             # Prevent finishing local mapreduce tasks on node 2.
             async with inject_error(manager.api, s2.ip_addr, "mapreduce_pause_dispatch_to_shards"):
+                # For the test to be reliable the query cannot end on its own, so it has to
+                # outlast the steps below. The longest of them is the graceful stop, whose
+                # budget scales with the build mode, leaving at least 180s of headroom here.
+                query_timeout = graceful_stop_timeout(build_mode) + 300
+
                 async def do_select():
                     # Make node 1 the supercoordinator of the mapreduce task corresponding to aggregation.
-                    # We use this timeout because it's longer than the cumulative timeout of the following
-                    # steps. For the test to be reliable, the query cannot end on its own.
                     try:
-                        await cql.run_async(f"SELECT count(*) FROM {t} BYPASS CACHE USING TIMEOUT 600s", host=host1)
+                        await cql.run_async(f"SELECT count(*) FROM {t} BYPASS CACHE"
+                                            f" USING TIMEOUT {query_timeout}s", host=host1)
                         pytest.fail(f"Query finished, but it wasn't supposed to")
                     except NoHostAvailable:
                         pass

--- a/test/cluster/test_tablets2.py
+++ b/test/cluster/test_tablets2.py
@@ -522,7 +522,7 @@ async def test_tablet_cleanup(manager: ScyllaClusterManager):
 
         # Wipe data on second node.
         logger.info("Wipe data on second node")
-        await manager.server_stop_gracefully(servers[1].server_id, timeout=120)
+        await manager.server_stop_gracefully(servers[1].server_id)
         await manager.server_wipe_sstables(servers[1].server_id, ks, "test")
         await manager.server_start(servers[1].server_id)
         await wait_for_cql_and_get_hosts(cql, servers, time.time() + 60)
@@ -617,7 +617,7 @@ async def test_tablet_resharding(manager: ScyllaClusterManager):
     await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY);")
     await asyncio.gather(*[cql.run_async(f"INSERT INTO {ks}.test (pk) VALUES ({k});") for k in range(n_partitions)])
 
-    await manager.server_stop_gracefully(server.server_id, timeout=120)
+    await manager.server_stop_gracefully(server.server_id)
     await manager.server_update_cmdline(server.server_id, ['--smp=2'])
 
     await manager.server_start(
@@ -751,7 +751,7 @@ async def test_correctness_of_tablet_split_finalization_after_restart(manager: S
         time.sleep(1)
         await manager.disable_tablet_balancing()
 
-        await manager.server_stop_gracefully(servers[1].server_id, timeout=120)
+        await manager.server_stop_gracefully(servers[1].server_id)
         await manager.server_start(servers[1].server_id)
         await wait_for_cql_and_get_hosts(cql, servers, time.time() + 60)
         await manager.servers_see_each_other(servers)

--- a/test/pylib/scylla_cluster.py
+++ b/test/pylib/scylla_cluster.py
@@ -30,7 +30,7 @@ from test.pylib.scylla_server import (
     make_scylla_conf,
     merge_cmdline_options,
 )
-from test.pylib.util import gather_safely
+from test.pylib.util import gather_safely, graceful_stop_timeout
 
 
 type ClusterFactory = Callable[[logging.Logger | logging.LoggerAdapter], Awaitable[ScyllaCluster]]
@@ -229,7 +229,8 @@ class ScyllaCluster:
             self.logger.info("Cluster %s stopping gracefully", self)
             self.is_dirty = True
             # If self.running is empty, no-op
-            await gather_safely(*(server.stop_gracefully() for server in self.running.values()))
+            await gather_safely(*(server.stop_gracefully(graceful_stop_timeout(self.mode))
+                                  for server in self.running.values()))
             self.stopped.update(self.running)
             self.running.clear()
 
@@ -508,7 +509,7 @@ class ScyllaCluster:
         # Remove the server from `running` only after we successfully stop it.
         # Stopping may fail and if we removed it from `running` now it might leak.
         if gracefully:
-            await server.stop_gracefully()
+            await server.stop_gracefully(graceful_stop_timeout(self.mode))
         else:
             await server.stop()
         if server_id in self.running:

--- a/test/pylib/scylla_cluster_manager.py
+++ b/test/pylib/scylla_cluster_manager.py
@@ -52,6 +52,7 @@ from test.pylib.util import (
     Host,
     LogPrefixAdapter,
     gather_safely,
+    graceful_stop_timeout,
     universalasync_typed_wrap,
     wait_for,
     wait_for_cql_and_get_hosts,
@@ -1082,8 +1083,16 @@ class ScyllaClusterManager:
                 # In some scenarios errors are expected, e.g. when server_stop() is called concurrently on many servers.
                 pass
 
-    async def server_stop_gracefully(self, server_id: ServerNum, timeout: float = 180) -> None:
-        """Stop specified server gracefully."""
+    async def server_stop_gracefully(self, server_id: ServerNum, timeout: float | None = None) -> None:
+        """Stop specified server gracefully.
+
+        With no timeout given, outlast the server's own graceful-stop timeout
+        for this build mode, so that a slow stop is reported by the server --
+        which knows why it was slow -- instead of timing out here first.
+        """
+        assert self.cluster, "ScyllaClusterManager is not running"
+        if timeout is None:
+            timeout = graceful_stop_timeout(self.cluster.mode) + 60
 
         async with asyncio.timeout(timeout):
             await self._server_stop_gracefully(server_id)

--- a/test/pylib/scylla_cluster_manager.py
+++ b/test/pylib/scylla_cluster_manager.py
@@ -394,7 +394,10 @@ class ScyllaClusterManager:
 
     # fence=False: this operation raises the fence itself, and has to stay
     # reachable afterwards to report what the test left behind.
-    @manager_op(fence=False)
+    # timeout=None: the drain below carries its own budget, which scales with
+    # the build mode and so can exceed DEFAULT_OP_TIMEOUT.  A bridge cap
+    # shorter than the drain would abandon the cleanup half-way through.
+    @manager_op(fence=False, timeout=None)
     async def after_test(self, success: bool) -> dict[str, Any]:
         """After-test hook of the manager fixture.
 
@@ -414,12 +417,20 @@ class ScyllaClusterManager:
         current = asyncio.current_task()
         assert current is not None  # ops always run as a task (see manager_op)
         self.tasks_history.pop(current, None)
-        # wait for the operations the test left running
+        # Wait for the operations the test left running.  The budget has to
+        # outlast the longest of them, because asyncio.wait_for() cancels the
+        # task when it expires -- and the task here is the operation itself,
+        # not the shield the caller awaited.  The longest is a graceful stop,
+        # and cancelling one mid-flight is not merely a lost result: the
+        # CancelledError skips stop_gracefully()'s SIGKILL path while its
+        # finally clause still clears self.cmd, disowning a process that is
+        # still shutting down, after which stop() finds nothing left to kill.
+        drain_timeout = graceful_stop_timeout(self.cluster.mode) + 60
         for task, descr in list(self.tasks_history.items()):
             if not task.done():
                 self.logger.info("wait for task:%s, op:%s", task, descr)
                 try:
-                    await asyncio.wait_for(task, timeout=120)
+                    await asyncio.wait_for(task, timeout=drain_timeout)
                 except asyncio.TimeoutError:
                     self.break_manager(f"error on waiting coro {task.get_name()}", self.current_test_case_full_name)
                     break

--- a/test/pylib/scylla_server.py
+++ b/test/pylib/scylla_server.py
@@ -1026,9 +1026,11 @@ class ScyllaServer:
 
     @stop_event
     @start_stop_lock
-    async def stop_gracefully(self) -> None:
+    async def stop_gracefully(self, timeout: float) -> None:
         """Stop a running server. No-op if not running. Uses SIGTERM to
-        stop, so it is graceful. Waits for the process to exit before return."""
+        stop, so it is graceful. Waits up to `timeout` seconds for the process
+        to exit, then kills it and raises. The caller picks the timeout because
+        it scales with the build mode, which the server does not know."""
         self.logger.info("gracefully stopping %s", self)
         if not self.cmd:
             return
@@ -1039,17 +1041,16 @@ class ScyllaServer:
         except ProcessLookupError:
             pass
         else:
-            STOP_TIMEOUT_SECONDS = 120
             wait_task = self.cmd.wait()
             try:
-                await asyncio.wait_for(wait_task, timeout=STOP_TIMEOUT_SECONDS)
+                await asyncio.wait_for(wait_task, timeout=timeout)
                 if self.cmd.returncode != 0:
                     raise RuntimeError(f"Server {self} exited with non-zero exit code: {self.cmd.returncode}")
             except asyncio.TimeoutError:
                 self.cmd.kill()
                 await self.cmd.wait()
                 raise RuntimeError(
-                    f"Stopping server {self} gracefully took longer than {STOP_TIMEOUT_SECONDS}s")
+                    f"Stopping server {self} gracefully took longer than {timeout}s")
         finally:
             if self.cmd:
                 self.logger.info("gracefully stopped %s", self)

--- a/test/pylib/util.py
+++ b/test/pylib/util.py
@@ -407,6 +407,19 @@ def scale_timeout_by_mode(mode: str, timeout: int | float) -> int | float:
     return MODES_TIMEOUT_FACTOR.get(mode, 1) * timeout
 
 
+# Base timeout for stopping a Scylla server gracefully, before mode scaling.
+# A graceful stop flushes every memtable, and the flushes are serialized per
+# shard by the dirty memory manager's flush serializer. On a loaded CI machine
+# that takes minutes, against well under a second locally, so the timeout has
+# to be generous enough not to fire on slowness alone (SCYLLADB-3213).
+GRACEFUL_STOP_TIMEOUT_SECONDS = 300
+
+
+def graceful_stop_timeout(mode: str) -> int | float:
+    """Timeout for stopping a server gracefully in the given build mode."""
+    return scale_timeout_by_mode(mode, GRACEFUL_STOP_TIMEOUT_SECONDS)
+
+
 async def gather_safely(*awaitables: Awaitable):
     """
     Developers using asyncio.gather() often assume that it waits for all futures (awaitables) givens.


### PR DESCRIPTION
Tests in `test/cluster/storage/test_out_of_space_prevention.py` fail intermittently in nightly runs with 

    "Stopping server gracefully took longer than 120s". 

This only happens on overloaded CI machines, never locally, and the nodes are not stuck -- one such stop was logged at 120.2s, just over the budget. Shutdown flushes every memtable, serialized per shard by the dirty memory manager's flush serializer, and on an overloaded machine a single memtable takes ~7s against ~0.08s locally. 120s is not enough headroom there.

Feed the timeout through the existing `scale_timeout_by_mode()` instead of hardcoding it: five minutes for release and coverage, ten for dev, fifteen for debug and sanitize.

Both sides of the stop were hardcoded and the smaller wins, so raising one alone does nothing. `ScyllaServer.stop_gracefully()` allowed 120s and ManagerClient separately capped its wait at 180s. The caller's expiry is the worse one to hit -- manager_op shields the operation, so it does not abort the stop and reports a bare TimeoutError -- so ManagerClient now takes the build mode and derives its default from the manager's timeout plus a margin.

Four call sites passed timeout=120, exactly the old ceiling and none of them asserting a quick stop; they now inherit the scaled default. The two set deliberately tighter (30s, 60s) are promptness assertions and are untouched.

Fixes https://scylladb.atlassian.net/browse/SCYLLADB-3213

**Backport is not required, this is a test-only change**