### PR TITLE
utils/gcp: finalize zero-length resumable uploads with "bytes */N"

### DIFF
--- a/test/boost/gcp_object_storage_test.cc
+++ b/test/boost/gcp_object_storage_test.cc
@@ -174,6 +174,24 @@ SEASTAR_FIXTURE_TEST_CASE(test_gcp_storage_create_large_object, local_gcs_wrappe
     co_await test_read_write_helper(*this, 32*1024*1024 + 357 + 1022*67);
 }
 
+// SCYLLADB-3889: a zero-length object must finalize the resumable upload with
+// "bytes */0". Emitting "bytes 0-0/0" claims a byte that cannot exist in a
+// zero-byte object and real GCS rejects it with 400. Zero-length objects are
+// not exotic here -- every object-storage sstable starts by writing an empty
+// refs/nodes/<host_id>/<gen> marker, so this breaks every memtable flush.
+SEASTAR_FIXTURE_TEST_CASE(test_gcp_storage_create_empty_object, local_gcs_wrapper, *check_gcp_storage_test_enabled()) {
+    co_await test_read_write_helper(*this, 0);
+}
+
+// SCYLLADB-3889: same malformed range, reached from the other direction. The
+// sink only uploads whole multiples of 256k while the stream is open, so an
+// object whose size is an exact multiple of the chunk size leaves nothing
+// buffered at close() and finalizes with a zero-length chunk at a non-zero
+// offset ("bytes N-N/N").
+SEASTAR_FIXTURE_TEST_CASE(test_gcp_storage_create_chunk_aligned_object, local_gcs_wrapper, *check_gcp_storage_test_enabled()) {
+    co_await test_read_write_helper(*this, 8*1024*1024, 256*1024);
+}
+
 SEASTAR_FIXTURE_TEST_CASE(test_gcp_storage_create_small_object_64kbuf, local_gcs_wrapper, *check_gcp_storage_test_enabled()) {
     co_await test_read_write_helper(*this, 618480, 64*1024);
 }

--- a/utils/gcp/object_storage.cc
+++ b/utils/gcp/object_storage.cc
@@ -751,11 +751,19 @@ future<> utils::gcp::storage::client::object_data_sink::do_single_upload(std::de
     auto end = offset + len;
 
     for (;;) {
-        auto range = fmt::format("bytes {}-{}/{}"
-            , offset // first byte
-            , last // last byte
-            , final ? std::to_string(end) : "*"s
-        );
+        // A zero-length chunk names no bytes, so it must not name a last byte:
+        // "bytes 0-0/0" claims byte 0 exists in an object declared to be empty,
+        // and GCS rejects it with 400. "bytes */<total>" is the documented form
+        // for finalizing a session without sending data. This covers both a
+        // genuinely empty object and the case where earlier writes happened to
+        // drain the buffer exactly, leaving nothing for the final chunk.
+        auto range = len == 0
+            ? fmt::format("bytes */{}", end)
+            : fmt::format("bytes {}-{}/{}"
+                , offset // first byte
+                , last // last byte
+                , final ? std::to_string(end) : "*"s
+            );
 
         try {
             if (_session_path.empty()) {


### PR DESCRIPTION
do_single_upload() built its Content-Range as "bytes <first>-<last>/<total>" even when the chunk carried no bytes, using max(len, 1) to pick a last byte that does not exist. For an empty object that yields "bytes 0-0/0", which claims byte 0 is present in an object declared to be zero bytes long. Real GCS rejects this with 400 Bad Request.

Every object-storage sstable starts by writing an empty refs/nodes/<host_id>/<gen> marker (object_storage_base::open), so the first memtable flush to a GS-backed table failed, and a failed flush is fatal. All nodes aborted and crash-looped, making GCS-backed keyspaces unusable.

A second, independent path reaches the same malformed header: the sink only uploads whole multiples of 256k while the stream is open, so an object whose size is an exact multiple of the chunk size leaves nothing buffered at close() and finalizes a zero-length chunk at a non-zero offset, emitting "bytes N-N/N". An 8 MiB object written in 256k buffers hits this.

Use the documented finalize form "bytes */<total>" whenever the chunk is empty. Both cases then send a valid header. The 308 partial-upload retry logic is left untouched.

This completes 85adb28b96 ("gcp: fix resumable upload sink for zero-length objects"), which made zero-length uploads acquire a session instead of PUTing to an empty path, turning a 404 into the 400 fixed here.

Note on test coverage: the added cases only fail against an endpoint that validates Content-Range. fake-gcs-server, which the fixture starts by default, answers "bytes 0-0/0" with 200 OK, which is why this went unnoticed. They were verified to fail before this change and pass after it against a GCS-strict validating proxy. Teaching gcs_fixture to validate Content-Range is left as a follow-up.

Fixes: SCYLLADB-3889

**Needs a backport to 2026.3. It's a regression of 85adb28b96 that landed there.**