### PR TITLE
cql3: index the prepared-statement cache by table

### DIFF
--- a/cql3/cql_statement.hh
+++ b/cql3/cql_statement.hh
@@ -18,6 +18,7 @@
 #include "service/raft/raft_group0_client.hh"
 #include "audit/audit.hh"
 #include "utils/chunked_string.hh"
+#include "schema/schema_fwd.hh"
 
 namespace service {
 
@@ -48,6 +49,19 @@ class query_options;
 
 // A vector of CQL warnings generated during execution of a statement.
 using cql_warnings_vec = std::vector<sstring>;
+
+// A table a statement depends on: the statement depends on the table, not
+// the other way around, so it's identified by its (stable) table_id rather
+// than a (keyspace, table) name pair. ks_name/cf_name are kept alongside so
+// the prepared-statement cache can still be driven by migration_listener's
+// name-based notifications (on_drop_column_family() etc. only get names,
+// since by the time they fire the dropped table's schema is no longer
+// registered and can't be looked up to recover its id).
+struct dependent_table {
+    table_id id;
+    sstring ks_name;
+    sstring cf_name;
+};
 
 class cql_statement {
     timeout_config_selector _timeout_config_selector;
@@ -118,7 +132,10 @@ public:
         return execute(qp, state, options, std::move(guard));
     }
 
-    virtual bool depends_on(std::string_view ks_name, std::optional<std::string_view> cf_name) const = 0;
+    // The tables this statement depends on. Used to index the
+    // prepared-statement cache by table, so a schema change only has to look
+    // up the affected table's statements instead of scanning the whole cache.
+    virtual std::vector<dependent_table> dependent_tables() const = 0;
 
     // The plan this statement scans, to be checked against the one a paging state
     // pins. Disengaged for statements that are never paged. See #18992.

--- a/cql3/prepared_statements_cache.hh
+++ b/cql3/prepared_statements_cache.hh
@@ -10,22 +10,17 @@
 
 #pragma once
 
+#include <unordered_map>
+#include <unordered_set>
+#include <string_view>
+
 #include "utils/loading_cache.hh"
-#include "utils/hash.hh"
 #include "cql3/statements/prepared_statement.hh"
 #include "cql3/column_specification.hh"
+#include "cql3/cql_statement.hh"
 #include "cql3/dialect.hh"
 
 namespace cql3 {
-
-using prepared_cache_entry = std::unique_ptr<statements::prepared_statement>;
-
-struct prepared_cache_entry_size {
-    size_t operator()(const prepared_cache_entry& val) {
-        // TODO: improve the size approximation
-        return 10000;
-    }
-};
 
 typedef bytes cql_prepared_id_type;
 
@@ -58,6 +53,88 @@ public:
     }
 
     bool operator==(const prepared_cache_key_type& other) const = default;
+};
+
+}
+
+namespace std {
+
+template<>
+struct hash<cql3::prepared_cache_key_type::cache_key_type> final {
+    size_t operator()(const cql3::prepared_cache_key_type::cache_key_type& k) const {
+        return std::hash<cql3::cql_prepared_id_type>()(k);
+    }
+};
+
+template<>
+struct hash<cql3::prepared_cache_key_type> final {
+    size_t operator()(const cql3::prepared_cache_key_type& k) const {
+        return std::hash<cql3::cql_prepared_id_type>()(k.key());
+    }
+};
+}
+
+// for prepared_statements_cache log printouts
+template <> struct fmt::formatter<cql3::prepared_cache_key_type::cache_key_type> {
+    constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
+    auto format(const cql3::prepared_cache_key_type::cache_key_type& p, fmt::format_context& ctx) const {
+        return fmt::format_to(ctx.out(), "{{cql_id: {}, dialect: {}}}", static_cast<const cql3::cql_prepared_id_type&>(p), p.dialect);
+    }
+};
+
+template <> struct fmt::formatter<cql3::prepared_cache_key_type> {
+    constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
+    auto format(const cql3::prepared_cache_key_type& p, fmt::format_context& ctx) const {
+        return fmt::format_to(ctx.out(), "{}", p.key());
+    }
+};
+
+namespace cql3 {
+
+class prepared_statements_cache;
+
+/// \brief Owns the prepared_statement and keeps prepared_statements_cache's
+/// per-table index in sync: on destruction (LRU/size eviction, explicit
+/// removal, or targeted invalidation) it removes its own cache key from
+/// every table bucket it was indexed under.
+///
+/// Stores the dependent_table list computed at index time so the destructor
+/// doesn't need to call dependent_tables() again, keeping unindex() noexcept.
+///
+/// A cache key can outlive the entry it was assigned to: an entry pinned by
+/// a caller survives eviction/removal from the cache, and a fresh entry can
+/// be loaded and indexed under the very same key before the old one is
+/// destroyed. _generation identifies which of those entries currently owns
+/// the key, so the old entry's destructor doesn't unindex the new entry.
+class prepared_cache_entry {
+    std::unique_ptr<statements::prepared_statement> _stmt;
+    prepared_cache_key_type::cache_key_type _key;
+    prepared_statements_cache* _owner = nullptr;
+    std::vector<dependent_table> _dependent_tables;
+    uint64_t _generation;
+
+public:
+    prepared_cache_entry(std::unique_ptr<statements::prepared_statement> stmt, prepared_cache_key_type::cache_key_type key,
+            prepared_statements_cache* owner, std::vector<dependent_table> dependent_tables, uint64_t generation)
+        : _stmt(std::move(stmt)), _key(std::move(key)), _owner(owner), _dependent_tables(std::move(dependent_tables)), _generation(generation)
+    {}
+    prepared_cache_entry(prepared_cache_entry&&) = default;
+    prepared_cache_entry& operator=(prepared_cache_entry&&) = default;
+    prepared_cache_entry(const prepared_cache_entry&) = delete;
+
+    ~prepared_cache_entry();
+
+    statements::prepared_statement* get() const { return _stmt.get(); }
+    statements::prepared_statement* operator->() const { return _stmt.get(); }
+    statements::prepared_statement& operator*() const { return *_stmt; }
+    explicit operator bool() const { return bool(_stmt); }
+};
+
+struct prepared_cache_entry_size {
+    size_t operator()(const prepared_cache_entry& val) {
+        // TODO: improve the size approximation
+        return 10000;
+    }
 };
 
 class prepared_statements_cache {
@@ -101,6 +178,98 @@ private:
     using cache_value_ptr = typename cache_type::value_ptr;
     using checked_weak_ptr = typename statements::prepared_statement::checked_weak_ptr;
 
+    // table_id -> cache keys of statements whose dependent_tables()
+    // includes it. Lets a schema change on one table find exactly the
+    // statements it may need to invalidate, instead of scanning the whole
+    // cache. Entries for statements that were evicted through some other path
+    // (LRU/size eviction) are pruned by prepared_cache_entry's destructor, so
+    // this stays in sync without a dedicated eviction hook in loading_cache.
+    std::unordered_map<table_id, std::unordered_set<cache_key_type>> _table_index;
+    // keyspace -> table name -> table_ids. Schema change notifications
+    // (migration_listener) only carry names, and by the time a drop
+    // notification fires the table's schema is no longer registered anywhere
+    // to recover its id from, so this is maintained purely to translate names
+    // back to the ids _table_index is keyed by. Also serves keyspace-wide
+    // lookups (DROP KEYSPACE) by iterating all tables of a keyspace.
+    //
+    // A set, not a single table_id: if a table is dropped and recreated
+    // under the same name before the drop notification is processed, both
+    // the old and new table_id can be indexed under the same name at once,
+    // and the drop must invalidate the old one specifically.
+    std::unordered_map<sstring, std::unordered_map<sstring, std::unordered_set<table_id>>> _keyspace_table_index;
+
+    // Which generation (see prepared_cache_entry) currently owns a cache key's
+    // indexing. Lets unindex() tell an old, stale entry apart from a newer one
+    // that has since been loaded and indexed under the same key.
+    uint64_t _next_generation = 0;
+    std::unordered_map<cache_key_type, uint64_t> _key_generation;
+
+    friend class prepared_cache_entry;
+
+    // Indexes a newly-loaded statement; returns what it inserted, plus the
+    // generation it was indexed under, so the owning prepared_cache_entry can
+    // pass them back to unindex() later without recomputing dependent_tables().
+    //
+    // The index insertions can throw (bad_alloc); on failure they're rolled
+    // back via unindex() so no partial entry is left behind.
+    std::pair<uint64_t, std::vector<dependent_table>> index(const cache_key_type& key, const cql_statement& stmt) {
+        auto tables = stmt.dependent_tables();
+        uint64_t generation = ++_next_generation;
+        try {
+            _key_generation[key] = generation;
+            for (auto& t : tables) {
+                _table_index[t.id].insert(key);
+                _keyspace_table_index[t.ks_name][t.cf_name].insert(t.id);
+            }
+        } catch (...) {
+            unindex(key, generation, tables);
+            throw;
+        }
+        return {generation, std::move(tables)};
+    }
+
+    // Uses only data the entry already owns, so this genuinely can't throw.
+    //
+    // Identity-safe: if a newer entry has since been loaded and indexed under
+    // `key` (the calling entry was pinned past its removal from the cache),
+    // that generation mismatch means this is a stale entry, and it must leave
+    // the newer entry's indexing alone.
+    void unindex(const cache_key_type& key, uint64_t generation, const std::vector<dependent_table>& dependent_tables) noexcept {
+        auto git = _key_generation.find(key);
+        if (git == _key_generation.end() || git->second != generation) {
+            return;
+        }
+        _key_generation.erase(git);
+        for (auto& tk : dependent_tables) {
+            unindex_one(key, tk);
+        }
+    }
+
+    void unindex_one(const cache_key_type& key, const dependent_table& tk) noexcept {
+        auto it = _table_index.find(tk.id);
+        if (it != _table_index.end()) {
+            it->second.erase(key);
+            if (!it->second.empty()) {
+                return;
+            }
+            _table_index.erase(it);
+        }
+        auto ks_it = _keyspace_table_index.find(tk.ks_name);
+        if (ks_it != _keyspace_table_index.end()) {
+            auto& table_map = ks_it->second;
+            auto name_it = table_map.find(tk.cf_name);
+            if (name_it != table_map.end()) {
+                name_it->second.erase(tk.id);
+                if (name_it->second.empty()) {
+                    table_map.erase(name_it);
+                }
+            }
+            if (table_map.empty()) {
+                _keyspace_table_index.erase(ks_it);
+            }
+        }
+    }
+
 public:
     static const std::chrono::minutes entry_expiry;
 
@@ -119,7 +288,20 @@ public:
 
     template <typename LoadFunc>
     future<pinned_value_type> get_pinned(const key_type& key, LoadFunc&& load) {
-        return _cache.get_ptr(key.key(), [load = std::forward<LoadFunc>(load)] (const cache_key_type&) { return load(); });
+        return _cache.get_ptr(key.key(), [this, load = std::forward<LoadFunc>(load)] (const cache_key_type& k) {
+            return load().then([this, k] (std::unique_ptr<statements::prepared_statement> stmt) {
+                auto [generation, tables] = index(k, *stmt->statement);
+                // If wrapping into the entry below throws, undo index() so the
+                // statement isn't left indexed without an owning entry to unindex it.
+                // Pass tables by copy (not moved) so it's still valid for that rollback.
+                try {
+                    return prepared_cache_entry(std::move(stmt), k, this, tables, generation);
+                } catch (...) {
+                    unindex(k, generation, tables);
+                    throw;
+                }
+            });
+        });
     }
 
     template <typename LoadFunc>
@@ -143,12 +325,38 @@ public:
         return value_type();
     }
 
-    template <typename Pred>
-    requires std::is_invocable_r_v<bool, Pred, ::shared_ptr<cql_statement>>
-    void remove_if(Pred&& pred) {
-        _cache.remove_if([&pred] (const prepared_cache_entry& e) {
-            return pred(e->statement);
-        });
+    // Removes every cached statement that depends on the given table (or, if
+    // cf_name is not set, every table in the given keyspace). O(matching
+    // statements), via the per-table index, instead of a full cache scan.
+    void remove_for_table(const sstring& ks_name, const std::optional<sstring>& cf_name) {
+        auto ks_it = _keyspace_table_index.find(ks_name);
+        if (ks_it == _keyspace_table_index.end()) {
+            return;
+        }
+        if (cf_name) {
+            auto& table_map = ks_it->second;
+            auto name_it = table_map.find(*cf_name);
+            if (name_it == table_map.end()) {
+                return;
+            }
+            // Copy out: a table can be dropped and recreated under the same
+            // name before this drop notification is processed, so more than
+            // one table_id may be indexed under it; invalidate all of them.
+            auto table_ids = std::move(name_it->second);
+            for (auto& tid : table_ids) {
+                remove_for_table_id(tid);
+            }
+            return;
+        }
+        // Copy out: collect every table_id across all tables of the keyspace.
+        std::unordered_set<table_id> table_ids;
+        for (auto& [cf, ids] : ks_it->second) {
+            table_ids.insert(ids.begin(), ids.end());
+        }
+        _keyspace_table_index.erase(ks_it);
+        for (auto& tid : table_ids) {
+            remove_for_table_id(tid);
+        }
     }
 
     size_t size() const {
@@ -162,37 +370,27 @@ public:
     future<> stop() {
         return _cache.stop();
     }
+
+private:
+    void remove_for_table_id(const table_id& tid) {
+        auto it = _table_index.find(tid);
+        if (it == _table_index.end()) {
+            return;
+        }
+        // Copy out: removing entries from the cache destroys prepared_cache_entry
+        // objects, whose destructor calls back into unindex() and mutates _table_index.
+        auto keys = std::move(it->second);
+        _table_index.erase(it);
+        for (auto& k : keys) {
+            _cache.remove(k);
+        }
+    }
 };
+
+inline prepared_cache_entry::~prepared_cache_entry() {
+    if (_owner && _stmt) {
+        _owner->unindex(_key, _generation, _dependent_tables);
+    }
 }
 
-namespace std {
-
-template<>
-struct hash<cql3::prepared_cache_key_type::cache_key_type> final {
-    size_t operator()(const cql3::prepared_cache_key_type::cache_key_type& k) const {
-        return std::hash<cql3::cql_prepared_id_type>()(k);
-    }
-};
-
-template<>
-struct hash<cql3::prepared_cache_key_type> final {
-    size_t operator()(const cql3::prepared_cache_key_type& k) const {
-        return std::hash<cql3::cql_prepared_id_type>()(k.key());
-    }
-};
 }
-
-// for prepared_statements_cache log printouts
-template <> struct fmt::formatter<cql3::prepared_cache_key_type::cache_key_type> {
-    constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
-    auto format(const cql3::prepared_cache_key_type::cache_key_type& p, fmt::format_context& ctx) const {
-        return fmt::format_to(ctx.out(), "{{cql_id: {}, dialect: {}}}", static_cast<const cql3::cql_prepared_id_type&>(p), p.dialect);
-    }
-};
-
-template <> struct fmt::formatter<cql3::prepared_cache_key_type> {
-    constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
-    auto format(const cql3::prepared_cache_key_type& p, fmt::format_context& ctx) const {
-        return fmt::format_to(ctx.out(), "{}", p.key());
-    }
-};

--- a/cql3/query_processor.cc
+++ b/cql3/query_processor.cc
@@ -1317,7 +1317,12 @@ bool query_processor::migration_subscriber::should_invalidate(
         sstring ks_name,
         std::optional<sstring> cf_name,
         ::shared_ptr<cql_statement> statement) {
-    return statement->depends_on(ks_name, cf_name);
+    for (const dependent_table& t : statement->dependent_tables()) {
+        if (t.ks_name == ks_name && (!cf_name || t.cf_name == *cf_name)) {
+            return true;
+        }
+    }
+    return false;
 }
 
 future<> query_processor::query_internal(

--- a/cql3/query_processor.cc
+++ b/cql3/query_processor.cc
@@ -1308,21 +1308,7 @@ void query_processor::migration_subscriber::on_drop_view(const sstring& ks_name,
 void query_processor::migration_subscriber::remove_invalid_prepared_statements(
         sstring ks_name,
         std::optional<sstring> cf_name) {
-    _qp->_prepared_cache.remove_if([&] (::shared_ptr<cql_statement> stmt) {
-        return this->should_invalidate(ks_name, cf_name, stmt);
-    });
-}
-
-bool query_processor::migration_subscriber::should_invalidate(
-        sstring ks_name,
-        std::optional<sstring> cf_name,
-        ::shared_ptr<cql_statement> statement) {
-    for (const dependent_table& t : statement->dependent_tables()) {
-        if (t.ks_name == ks_name && (!cf_name || t.cf_name == *cf_name)) {
-            return true;
-        }
-    }
-    return false;
+    _qp->_prepared_cache.remove_for_table(ks_name, cf_name);
 }
 
 future<> query_processor::query_internal(

--- a/cql3/query_processor.hh
+++ b/cql3/query_processor.hh
@@ -644,11 +644,6 @@ public:
 
 private:
     void remove_invalid_prepared_statements(sstring ks_name, std::optional<sstring> cf_name);
-
-    bool should_invalidate(
-            sstring ks_name,
-            std::optional<sstring> cf_name,
-            ::shared_ptr<cql_statement> statement);
 };
 
 }

--- a/cql3/statements/authentication_statement.cc
+++ b/cql3/statements/authentication_statement.cc
@@ -16,10 +16,6 @@ uint32_t cql3::statements::authentication_statement::get_bound_terms() const {
     return 0;
 }
 
-bool cql3::statements::authentication_statement::depends_on(std::string_view ks_name, std::optional<std::string_view> cf_name) const {
-    return false;
-}
-
 future<> cql3::statements::authentication_statement::check_access(query_processor& qp, const service::client_state& state) const {
     return make_ready_future<>();
 }

--- a/cql3/statements/authentication_statement.hh
+++ b/cql3/statements/authentication_statement.hh
@@ -23,7 +23,7 @@ public:
 
     uint32_t get_bound_terms() const override;
 
-    bool depends_on(std::string_view ks_name, std::optional<std::string_view> cf_name) const override;
+    std::vector<dependent_table> dependent_tables() const override { return {}; }
 
     // Manages roles/authentication, not user data.
     bool should_reclassify_control_connection() const override {

--- a/cql3/statements/authorization_statement.cc
+++ b/cql3/statements/authorization_statement.cc
@@ -19,10 +19,6 @@ uint32_t cql3::statements::authorization_statement::get_bound_terms() const {
     return 0;
 }
 
-bool cql3::statements::authorization_statement::depends_on(std::string_view ks_name, std::optional<std::string_view> cf_name) const {
-    return false;
-}
-
 future<> cql3::statements::authorization_statement::check_access(query_processor& qp, const service::client_state& state) const {
     return make_ready_future<>();
 }

--- a/cql3/statements/authorization_statement.hh
+++ b/cql3/statements/authorization_statement.hh
@@ -27,7 +27,7 @@ public:
 
     uint32_t get_bound_terms() const override;
 
-    bool depends_on(std::string_view ks_name, std::optional<std::string_view> cf_name) const override;
+    std::vector<dependent_table> dependent_tables() const override { return {}; }
 
     // Manages permissions, not user data.
     bool should_reclassify_control_connection() const override {

--- a/cql3/statements/batch_statement.cc
+++ b/cql3/statements/batch_statement.cc
@@ -73,9 +73,12 @@ batch_statement::batch_statement(type type_,
 {
 }
 
-bool batch_statement::depends_on(std::string_view ks_name, std::optional<std::string_view> cf_name) const
+std::vector<dependent_table> batch_statement::dependent_tables() const
 {
-    return std::ranges::any_of(_statements, [&ks_name, &cf_name] (auto&& s) { return s.statement->depends_on(ks_name, cf_name); });
+    return _statements
+        | std::views::transform([] (auto&& s) { return s.statement->dependent_tables(); })
+        | std::views::join
+        | std::ranges::to<std::vector>();
 }
 
 uint32_t batch_statement::get_bound_terms() const

--- a/cql3/statements/batch_statement.hh
+++ b/cql3/statements/batch_statement.hh
@@ -91,7 +91,7 @@ public:
                     std::unique_ptr<attributes> attrs,
                     cql_stats& stats);
 
-    virtual bool depends_on(std::string_view ks_name, std::optional<std::string_view> cf_name) const override;
+    virtual std::vector<dependent_table> dependent_tables() const override;
 
     // A control connection never has a legitimate reason to run a batch, so any
     // batch arriving on one means it is being used for user load.

--- a/cql3/statements/describe_statement.cc
+++ b/cql3/statements/describe_statement.cc
@@ -910,8 +910,6 @@ describe_statement::describe_statement() : cql_statement(&timeout_config::other_
 
 uint32_t describe_statement::get_bound_terms() const { return 0; }
 
-bool describe_statement::depends_on(std::string_view ks_name, std::optional<std::string_view> cf_name) const { return false; }
-
 future<> describe_statement::check_access(query_processor& qp, const service::client_state& state) const {
     state.validate_login();
     co_return;

--- a/cql3/statements/describe_statement.hh
+++ b/cql3/statements/describe_statement.hh
@@ -50,7 +50,7 @@ protected:
     virtual seastar::future<std::vector<std::vector<managed_bytes_opt>>> describe(cql3::query_processor& qp, const service::client_state& client_state) const = 0;
 public:
     virtual uint32_t get_bound_terms() const override;
-    virtual bool depends_on(std::string_view ks_name, std::optional<std::string_view> cf_name) const override;
+    virtual std::vector<dependent_table> dependent_tables() const override { return {}; }
     virtual seastar::future<> check_access(query_processor& qp, const service::client_state& state) const override;
     virtual seastar::shared_ptr<const metadata> get_result_metadata() const override;
 

--- a/cql3/statements/modification_statement.cc
+++ b/cql3/statements/modification_statement.cc
@@ -775,8 +775,8 @@ modification_statement::validate(query_processor&, const service::client_state& 
     }
 }
 
-bool modification_statement::depends_on(std::string_view ks_name, std::optional<std::string_view> cf_name) const {
-    return keyspace() == ks_name && (!cf_name || column_family() == *cf_name);
+std::vector<dependent_table> modification_statement::dependent_tables() const {
+    return {dependent_table{s->id(), s->ks_name(), s->cf_name()}};
 }
 
 void modification_statement::add_operation(std::unique_ptr<operation> op) {

--- a/cql3/statements/modification_statement.hh
+++ b/cql3/statements/modification_statement.hh
@@ -137,7 +137,7 @@ public:
     // Validate before execute, using client state and current schema
     void validate(query_processor&, const service::client_state& state) const override;
 
-    bool depends_on(std::string_view ks_name, std::optional<std::string_view> cf_name) const override;
+    std::vector<dependent_table> dependent_tables() const override;
 
     bool should_reclassify_control_connection() const override;
 

--- a/cql3/statements/schema_altering_statement.cc
+++ b/cql3/statements/schema_altering_statement.cc
@@ -42,11 +42,6 @@ future<> schema_altering_statement::grant_permissions_to_creator(const service::
     return make_ready_future<>();
 }
 
-bool schema_altering_statement::depends_on(std::string_view ks_name, std::optional<std::string_view> cf_name) const
-{
-    return false;
-}
-
 uint32_t schema_altering_statement::get_bound_terms() const
 {
     return 0;

--- a/cql3/statements/schema_altering_statement.hh
+++ b/cql3/statements/schema_altering_statement.hh
@@ -44,7 +44,10 @@ protected:
     
     virtual bool needs_guard(query_processor& qp, service::query_state& state) const override;
 
-    virtual bool depends_on(std::string_view ks_name, std::optional<std::string_view> cf_name) const override;
+    // DDL statements resolve their target table by name at execute time
+    // rather than caching a schema_ptr, so there's no stale schema state
+    // for a table-indexed invalidation to guard against.
+    virtual std::vector<dependent_table> dependent_tables() const override { return {}; }
 
     virtual uint32_t get_bound_terms() const override;
 

--- a/cql3/statements/select_statement.cc
+++ b/cql3/statements/select_statement.cc
@@ -109,6 +109,12 @@ struct result_to_error_message_wrapper {
     }
 };
 
+std::vector<dependent_table> view_indexed_table_select_statement::dependent_tables() const {
+    auto ret = select_statement::dependent_tables();
+    ret.push_back(dependent_table{_view_schema->id(), _view_schema->ks_name(), _view_schema->cf_name()});
+    return ret;
+}
+
 template<typename C>
 auto wrap_result_to_error_message(C&& c) {
     return result_to_error_message_wrapper<C>{std::move(c)};
@@ -292,8 +298,12 @@ future<> select_statement::check_access(query_processor& qp, const service::clie
     }
 }
 
-bool select_statement::depends_on(std::string_view ks_name, std::optional<std::string_view> cf_name) const {
-    return keyspace() == ks_name && (!cf_name || column_family() == *cf_name);
+std::vector<dependent_table> select_statement::dependent_tables() const {
+    return {dependent_table{_schema->id(), _schema->ks_name(), _schema->cf_name()}};
+}
+
+std::vector<dependent_table> mutation_fragments_select_statement::dependent_tables() const {
+    return {dependent_table{_underlying_schema->id(), _underlying_schema->ks_name(), _underlying_schema->cf_name()}};
 }
 
 const sstring& select_statement::keyspace() const {

--- a/cql3/statements/select_statement.hh
+++ b/cql3/statements/select_statement.hh
@@ -125,7 +125,7 @@ public:
     virtual ::shared_ptr<const cql3::metadata> get_result_metadata() const override;
     virtual uint32_t get_bound_terms() const override;
     virtual future<> check_access(query_processor& qp, const service::client_state& state) const override;
-    virtual bool depends_on(std::string_view ks_name, std::optional<std::string_view> cf_name) const override;
+    virtual std::vector<dependent_table> dependent_tables() const override;
 
     virtual std::optional<service::pager::query_plan> query_plan_for_paging() const override {
         return scanned_plan();
@@ -243,6 +243,10 @@ public:
                                    const secondary_index::index& index,
                                    schema_ptr view_schema,
                                    std::unique_ptr<cql3::attributes> attrs);
+
+    // Also depends on the underlying view/index table: a schema change there
+    // (e.g. altering the index table) must invalidate this statement too.
+    std::vector<dependent_table> dependent_tables() const override;
 
 protected:
     virtual service::pager::query_plan scanned_plan() const override;
@@ -365,6 +369,9 @@ public:
 
     // This statement has a schema that is different from that of the underlying table.
     static schema_ptr generate_output_schema(schema_ptr underlying_schema);
+
+    // The output schema is synthetic; the real dependency is the underlying table.
+    std::vector<dependent_table> dependent_tables() const override;
 
 private:
     future<exceptions::coordinator_result<service::storage_proxy_coordinator_query_result>>

--- a/cql3/statements/service_level_statement.cc
+++ b/cql3/statements/service_level_statement.cc
@@ -18,10 +18,6 @@ uint32_t service_level_statement::get_bound_terms() const {
     return 0;
 }
 
-bool service_level_statement::depends_on(std::string_view ks_name, std::optional<std::string_view> cf_name) const {
-    return false;
-}
-
 future<> service_level_statement::check_access(query_processor& qp, const service::client_state &state) const {
     return make_ready_future<>();
 }

--- a/cql3/statements/service_level_statement.hh
+++ b/cql3/statements/service_level_statement.hh
@@ -47,7 +47,7 @@ public:
 
     uint32_t get_bound_terms() const override;
 
-    bool depends_on(std::string_view ks_name, std::optional<std::string_view> cf_name) const override;
+    std::vector<dependent_table> dependent_tables() const override { return {}; }
 
     // Manages service levels, not user data.
     bool should_reclassify_control_connection() const override {

--- a/cql3/statements/strong_consistency/batch_statement.cc
+++ b/cql3/statements/strong_consistency/batch_statement.cc
@@ -9,6 +9,7 @@
 #include "cql3/statements/modification_statement.hh"
 #include "batch_statement.hh"
 
+#include <ranges>
 #include "db/timeout_clock.hh"
 #include "transport/messages/result_message.hh"
 #include "cql3/query_processor.hh"
@@ -130,8 +131,11 @@ uint32_t batch_statement::get_bound_terms() const {
     return _bound_terms;
 }
 
-bool batch_statement::depends_on(std::string_view ks_name, std::optional<std::string_view> cf_name) const {
-    return std::ranges::any_of(_statements, [&ks_name, &cf_name] (auto&& s) { return s.statement->depends_on(ks_name, cf_name); });
+std::vector<dependent_table> batch_statement::dependent_tables() const {
+    return _statements
+        | std::views::transform([] (auto&& s) { return s.statement->dependent_tables(); })
+        | std::views::join
+        | std::ranges::to<std::vector>();
 }
 
 void batch_statement::validate() const {

--- a/cql3/statements/strong_consistency/batch_statement.hh
+++ b/cql3/statements/strong_consistency/batch_statement.hh
@@ -54,7 +54,7 @@ public:
 
     virtual uint32_t get_bound_terms() const override;
 
-    virtual bool depends_on(std::string_view ks_name, std::optional<std::string_view> cf_name) const override;
+    virtual std::vector<dependent_table> dependent_tables() const override;
 
     void validate() const;
 

--- a/cql3/statements/strong_consistency/modification_statement.cc
+++ b/cql3/statements/strong_consistency/modification_statement.cc
@@ -119,8 +119,4 @@ void modification_statement::validate(query_processor& qp, const service::client
 uint32_t modification_statement::get_bound_terms() const {
     return _statement->get_bound_terms();
 }
-
-bool modification_statement::depends_on(std::string_view ks_name, std::optional<std::string_view> cf_name) const {
-    return _statement->depends_on(ks_name, cf_name);
-}
 }

--- a/cql3/statements/strong_consistency/modification_statement.hh
+++ b/cql3/statements/strong_consistency/modification_statement.hh
@@ -46,7 +46,9 @@ public:
 
     uint32_t get_bound_terms() const override;
 
-    bool depends_on(std::string_view ks_name, std::optional<std::string_view> cf_name) const override;
+    std::vector<dependent_table> dependent_tables() const override {
+        return _statement->dependent_tables();
+    }
 
     // Wraps a regular modification, so it carries user load exactly when the
     // wrapped statement does.

--- a/cql3/statements/truncate_statement.cc
+++ b/cql3/statements/truncate_statement.cc
@@ -75,9 +75,9 @@ uint32_t truncate_statement::get_bound_terms() const
     return _bound_terms;
 }
 
-bool truncate_statement::depends_on(std::string_view ks_name, std::optional<std::string_view> cf_name) const
-{
-    return false;
+std::vector<dependent_table> truncate_statement::dependent_tables() const {
+    // TRUNCATE only needs the table to exist, so schema changes needn't evict it (pre-existing behaviour).
+    return {};
 }
 
 future<> truncate_statement::check_access(query_processor& qp, const service::client_state& state) const

--- a/cql3/statements/truncate_statement.hh
+++ b/cql3/statements/truncate_statement.hh
@@ -34,7 +34,7 @@ public:
 
     virtual uint32_t get_bound_terms() const override;
 
-    virtual bool depends_on(std::string_view ks_name, std::optional<std::string_view> cf_name) const override;
+    virtual std::vector<dependent_table> dependent_tables() const override;
 
     // TRUNCATE is an administrative operation a driver never runs on its control
     // connection, so we should reclassify on it.

--- a/cql3/statements/use_statement.cc
+++ b/cql3/statements/use_statement.cc
@@ -48,11 +48,6 @@ audit::statement_category use_statement::category() const {
 
 }
 
-bool use_statement::depends_on(std::string_view ks_name, std::optional<std::string_view> cf_name) const
-{
-    return false;
-}
-
 future<> use_statement::check_access(query_processor& qp, const service::client_state& state) const
 {
     state.validate_login();

--- a/cql3/statements/use_statement.hh
+++ b/cql3/statements/use_statement.hh
@@ -28,7 +28,7 @@ public:
 
     virtual uint32_t get_bound_terms() const override;
 
-    virtual bool depends_on(std::string_view ks_name, std::optional<std::string_view> cf_name) const override;
+    std::vector<dependent_table> dependent_tables() const override { return {}; }
 
     // Only selects the active keyspace, it does not touch user data.
     bool should_reclassify_control_connection() const override {

--- a/scylla-gdb.py
+++ b/scylla-gdb.py
@@ -6748,7 +6748,8 @@ class scylla_prepared_statements(gdb.Command):
                 e = seastar_lw_shared_ptr(x["_ts_val_ptr"]["_e"]).get().dereference()
                 val = std_optional(e['_val'])
                 if val:
-                    value = std_unique_ptr(val.get()['_value']).get().dereference()
+                    entry = val.get()['_value']
+                    value = std_unique_ptr(entry['_stmt']).get().dereference()
                     stmt = seastar_shared_ptr(value['statement']).get().dereference()
                     if stmt['raw_cql_statement'].type == chunked_string_type:
                         stmt_str = try_decode(managed_bytes(stmt['raw_cql_statement']['_data']).get())

--- a/test/boost/schema_change_test.cc
+++ b/test/boost/schema_change_test.cc
@@ -33,8 +33,16 @@
 #include "test/lib/exception_utils.hh"
 #include "test/lib/log.hh"
 #include "test/lib/test_utils.hh"
+#include "test/lib/eventually.hh"
+#include "utils/error_injection.hh"
 
 BOOST_AUTO_TEST_SUITE(schema_change_test)
+
+// Common setup shared by the prepared-statement table-index tests below.
+static future<> create_tests_table1(cql_test_env& e) {
+    co_await e.execute_cql("create keyspace tests with replication = { 'class' : 'NetworkTopologyStrategy', 'replication_factor' : 1 };");
+    co_await e.execute_cql("create table tests.table1 (pk int primary key, c1 int);");
+}
 
 SEASTAR_TEST_CASE(test_new_schema_with_no_structural_change_is_propagated) {
     return do_with_cql_env([](cql_test_env& e) {
@@ -616,6 +624,285 @@ SEASTAR_TEST_CASE(test_statement_prepared_before_table_recreation_is_rejected) {
                 insert_stmt->execute(qp, qs, options, std::nullopt).get(),
                 exceptions::invalid_request_exception,
                 exception_predicate::message_contains("unconfigured table tbl"));
+    });
+}
+
+// Regression test for the prepared-statement cache's per-table index
+// (query_processor::migration_subscriber::remove_invalid_prepared_statements()
+// now looks up only the altered table's cache entries instead of scanning
+// every cached statement). A schema change on one table must still leave
+// prepared statements against every other table untouched.
+SEASTAR_TEST_CASE(test_schema_change_does_not_invalidate_unrelated_prepared_statements) {
+    return do_with_cql_env([](cql_test_env& e) {
+        return seastar::async([&] {
+            create_tests_table1(e).get();
+            e.execute_cql("create table tests.table2 (pk int primary key, c1 int);").get();
+
+            auto id1 = e.prepare("select * from tests.table1;").get();
+            auto id2 = e.prepare("select * from tests.table2;").get();
+
+            // Both statements are valid before any schema change.
+            e.execute_prepared(id1, {}).get();
+            e.execute_prepared(id2, {}).get();
+
+            e.execute_cql("alter table tests.table2 add s1 int;").get();
+
+            // table2's statement was invalidated by the ALTER...
+            try {
+                e.execute_prepared(id2, {}).get();
+                BOOST_FAIL("Should have failed");
+            } catch (const not_prepared_exception&) {
+                // expected
+            }
+
+            // ...but table1's statement, which doesn't depend on table2, must
+            // still be usable without re-preparing.
+            e.execute_prepared(id1, {}).get();
+        });
+    });
+}
+
+// TRUNCATE has no dependent tables, so ALTER evicts the SELECT but not the
+// TRUNCATE (pre-existing behaviour, kept).
+SEASTAR_TEST_CASE(test_truncate_prepared_statement_vs_schema_change) {
+    return do_with_cql_env([](cql_test_env& e) {
+        return seastar::async([&] {
+            e.execute_cql("create keyspace tests with replication = { 'class' : 'NetworkTopologyStrategy', 'replication_factor' : 1 };").get();
+            e.execute_cql("create table tests.table1 (pk int primary key, c1 int);").get();
+
+            auto trunc_id = e.prepare("truncate tests.table1;").get();
+            auto sel_id = e.prepare("select * from tests.table1;").get();
+
+            BOOST_REQUIRE(bool(e.local_qp().get_prepared(trunc_id)));
+            BOOST_REQUIRE(bool(e.local_qp().get_prepared(sel_id)));
+
+            e.execute_cql("alter table tests.table1 add s1 int;").get();
+
+            BOOST_CHECK(!bool(e.local_qp().get_prepared(sel_id)));
+            BOOST_CHECK(bool(e.local_qp().get_prepared(trunc_id)));
+        });
+    });
+}
+
+// DROP TABLE must invalidate cached statements against it, same as ALTER.
+SEASTAR_TEST_CASE(test_drop_table_invalidates_prepared_statement) {
+    return do_with_cql_env([](cql_test_env& e) {
+        return seastar::async([&] {
+            create_tests_table1(e).get();
+
+            auto id = e.prepare("select * from tests.table1;").get();
+            e.execute_prepared(id, {}).get();
+
+            e.execute_cql("drop table tests.table1;").get();
+
+            try {
+                e.execute_prepared(id, {}).get();
+                BOOST_FAIL("Should have failed");
+            } catch (const not_prepared_exception&) {
+                // expected
+            }
+        });
+    });
+}
+
+// DROP KEYSPACE must invalidate cached statements against every table in it
+// (exercises prepared_statements_cache's keyspace-wide index lookup), while
+// leaving statements against unrelated keyspaces untouched.
+SEASTAR_TEST_CASE(test_drop_keyspace_invalidates_all_its_tables_prepared_statements) {
+    return do_with_cql_env([](cql_test_env& e) {
+        return seastar::async([&] {
+            create_tests_table1(e).get();
+            e.execute_cql("create table tests.table2 (pk int primary key, c1 int);").get();
+            e.execute_cql("create keyspace tests_other with replication = { 'class' : 'NetworkTopologyStrategy', 'replication_factor' : 1 };").get();
+            e.execute_cql("create table tests_other.table1 (pk int primary key, c1 int);").get();
+
+            auto id1 = e.prepare("select * from tests.table1;").get();
+            auto id2 = e.prepare("select * from tests.table2;").get();
+            auto other_id = e.prepare("select * from tests_other.table1;").get();
+
+            e.execute_prepared(id1, {}).get();
+            e.execute_prepared(id2, {}).get();
+            e.execute_prepared(other_id, {}).get();
+
+            e.execute_cql("drop keyspace tests;").get();
+
+            for (auto id : {id1, id2}) {
+                try {
+                    e.execute_prepared(id, {}).get();
+                    BOOST_FAIL("Should have failed");
+                } catch (const not_prepared_exception&) {
+                    // expected
+                }
+            }
+
+            // Unrelated keyspace's statement must survive.
+            e.execute_prepared(other_id, {}).get();
+        });
+    });
+}
+
+// If a table is dropped and a new table is created under the same name
+// (getting a different table_id), a statement prepared against the *old*
+// table must not be left dangling in the cache pointing at a table_id that
+// no longer maps to anything reachable by name.
+SEASTAR_TEST_CASE(test_drop_and_recreate_same_table_name_invalidates_old_statement) {
+    return do_with_cql_env([](cql_test_env& e) {
+        return seastar::async([&] {
+            create_tests_table1(e).get();
+
+            // Distinct query text from the one used after recreate, so both
+            // end up as separate prepared-statement cache entries (the cache
+            // key is derived from query text, not from the target table_id).
+            auto old_id = e.prepare("select pk, c1 from tests.table1;").get();
+            e.execute_prepared(old_id, {}).get();
+
+            e.execute_cql("drop table tests.table1;").get();
+            e.execute_cql("create table tests.table1 (pk int primary key, c1 int, c2 int);").get();
+
+            auto new_id = e.prepare("select pk, c1, c2 from tests.table1;").get();
+            e.execute_prepared(new_id, {}).get();
+
+            // The old statement, prepared against the dropped table, must be
+            // invalidated rather than executable against the new table's schema.
+            try {
+                e.execute_prepared(old_id, {}).get();
+                BOOST_FAIL("Should have failed");
+            } catch (const not_prepared_exception&) {
+                // expected
+            }
+
+            // The new statement must remain valid.
+            e.execute_prepared(new_id, {}).get();
+        });
+    });
+}
+
+// A batch statement spanning two tables must be invalidated when *either*
+// table it depends on changes, exercising batch_statement::dependent_tables().
+SEASTAR_TEST_CASE(test_schema_change_invalidates_batch_statement_over_either_table) {
+    return do_with_cql_env([](cql_test_env& e) {
+        return seastar::async([&] {
+            create_tests_table1(e).get();
+            e.execute_cql("create table tests.table2 (pk int primary key, c1 int);").get();
+
+            auto id = e.prepare(
+                "begin batch "
+                "insert into tests.table1 (pk, c1) values (1, 1); "
+                "insert into tests.table2 (pk, c1) values (1, 1); "
+                "apply batch;").get();
+            e.execute_prepared(id, {}).get();
+
+            e.execute_cql("alter table tests.table2 add s1 int;").get();
+
+            try {
+                e.execute_prepared(id, {}).get();
+                BOOST_FAIL("Should have failed");
+            } catch (const not_prepared_exception&) {
+                // expected
+            }
+        });
+    });
+}
+
+// Regression test for prepared_statements_cache's unindex-on-destruction not
+// being identity-safe: an old, evicted-but-still-pinned entry destructing
+// after a new entry has been re-indexed under the same cache key must not
+// erase the new entry's table-index mapping.
+SEASTAR_TEST_CASE(test_pinned_reprepare_race_does_not_corrupt_table_index) {
+#ifdef SCYLLA_ENABLE_ERROR_INJECTION
+    return do_with_cql_env([](cql_test_env& e) {
+        return seastar::async([&] {
+            create_tests_table1(e).get();
+
+            auto& errj = utils::get_local_injector();
+            errj.enable("query_processor_prepare_wait_after_cache_get", true);
+
+            // Pause the first prepare() right after it pins its cache entry,
+            // holding that pin alive on the suspended fiber.
+            auto old_prepare_fut = e.prepare("select * from tests.table1;");
+            BOOST_REQUIRE(eventually_true([&] {
+                return errj.waiters("query_processor_prepare_wait_after_cache_get") > 0;
+            }));
+
+            // Unlinks the still-pinned old entry from the cache's lookup
+            // structures, but it stays alive because it's pinned.
+            e.execute_cql("alter table tests.table1 add s1 int;").get();
+
+            // Re-prepares the exact same query text: same cache key, but a
+            // brand-new entry gets loaded and indexed under it.
+            auto new_id = e.prepare("select * from tests.table1;").get();
+
+            // Unpause the first prepare(); its entry is now destroyed. That
+            // destructor must not unindex the table via the (shared) key alone,
+            // or it would corrupt the new entry's indexing.
+            errj.receive_message("query_processor_prepare_wait_after_cache_get");
+            old_prepare_fut.get();
+
+            e.execute_prepared(new_id, {}).get();
+
+            // A further schema change on the table must still find and
+            // invalidate the new statement.
+            e.execute_cql("alter table tests.table1 add s2 int;").get();
+            try {
+                e.execute_prepared(new_id, {}).get();
+                BOOST_FAIL("Should have failed");
+            } catch (const not_prepared_exception&) {
+                // expected
+            }
+        });
+    });
+#else
+    BOOST_TEST_MESSAGE("Skipping test as it depends on error injection. Please run in mode where it's enabled (debug,dev)");
+    return make_ready_future<>();
+#endif
+}
+
+// view_indexed_table_select_statement depends on both the base table and the
+// underlying view/index table; a schema change on the view must also
+// invalidate the statement, not just a change on the base table.
+SEASTAR_TEST_CASE(test_schema_change_on_view_invalidates_indexed_select_statement) {
+    return do_with_cql_env([](cql_test_env& e) {
+        return seastar::async([&] {
+            e.execute_cql("create keyspace tests with replication = { 'class' : 'NetworkTopologyStrategy', 'replication_factor' : 1 };").get();
+            e.execute_cql("create table tests.table1 (pk int primary key, c1 int, c2 int);").get();
+            e.execute_cql("create index on tests.table1 (c1);").get();
+
+            auto id = e.prepare("select * from tests.table1 where c1 = 1;").get();
+            e.execute_prepared(id, {}).get();
+
+            // Alter the index's backing view/table, not the base table.
+            e.execute_cql("alter materialized view tests.table1_c1_idx_index with compaction = {'class': 'SizeTieredCompactionStrategy'};").get();
+
+            try {
+                e.execute_prepared(id, {}).get();
+                BOOST_FAIL("Should have failed");
+            } catch (const not_prepared_exception&) {
+                // expected
+            }
+        });
+    });
+}
+
+// A SELECT ... FROM MUTATION_FRAGMENTS(tbl) statement has a synthetic output
+// schema, but must still be invalidated by a schema change on the real
+// underlying table.
+SEASTAR_TEST_CASE(test_schema_change_invalidates_mutation_fragments_select_statement) {
+    return do_with_cql_env([](cql_test_env& e) {
+        return seastar::async([&] {
+            create_tests_table1(e).get();
+
+            auto id = e.prepare("select * from MUTATION_FRAGMENTS(tests.table1);").get();
+            e.execute_prepared(id, {}).get();
+
+            e.execute_cql("alter table tests.table1 add c2 int;").get();
+
+            try {
+                e.execute_prepared(id, {}).get();
+                BOOST_FAIL("Should have failed");
+            } catch (const not_prepared_exception&) {
+                // expected
+            }
+        });
     });
 }
 


### PR DESCRIPTION
## Motivation

Any schema change (`ALTER`/`DROP TABLE`/`DROP KEYSPACE`) invalidates prepared statements via `query_processor::migration_subscriber::remove_invalid_prepared_statements()`, which called `prepared_statements_cache::remove_if()` — a full scan of *every* cached statement, filtering each one by `cql_statement::depends_on(ks_name, cf_name)`.

That means ALTERing one table does work proportional to the size of the whole prepared-statement cache, not to the number of statements that actually reference that table. In a workload with many tables and a large prepared-statement cache, frequent schema changes on any single table pay for scanning statements against every other, unrelated table.

It's a small step in a longer trail towards not invalidating prepared statements when there's no real reason to.


## Change

- Added `cql_statement::dependent_tables()`, a pure virtual returning the `(keyspace, table)` pairs a statement depends on, mirroring the existing `depends_on()` logic in every one of the 12 classes that implement it (the compiler enforces every implementer covers it, so this can't drift silently out of sync).
- `prepared_statements_cache` now maintains a `(keyspace, table) -> cache keys` index, populated when a statement is first cached.
- `remove_invalid_prepared_statements()` now calls `remove_for_table()`, which looks up the affected table's cache keys directly instead of scanning the whole cache.
- The index is kept in sync without adding an eviction hook to the generic `loading_cache` template: `prepared_cache_entry`'s destructor (fired on LRU/size eviction, explicit removal, or targeted invalidation — whatever path an entry goes through) prunes its own key from the index.

This is purely a mechanism change — invalidation **scope** is unchanged. A statement is still invalidated whenever it depends on the altered table, exactly as before; this only removes the cost of scanning statements for unrelated tables.

## Tests

Added to `test/boost/schema_change_test.cc`:
- `test_schema_change_does_not_invalidate_unrelated_prepared_statements` — ALTER on one table doesn't invalidate a prepared statement against another
- `test_truncate_prepared_statement_vs_schema_change` — TRUNCATE keeps no cache dependency, unaffected by schema changes
- `test_drop_and_recreate_same_table_name_invalidates_old_statement` — recreated table under the same name doesn't inherit the old cache entry
- `test_schema_change_invalidates_batch_statement_over_either_table` — a batch depends on every table it touches
- `test_pinned_reprepare_race_does_not_corrupt_table_index` — a pinned, unlinked entry re-prepared under the same key can't corrupt the table index
- `test_schema_change_on_view_invalidates_indexed_select_statement` — an indexed SELECT also depends on the index/view table, not just the base table
- `test_schema_change_invalidates_mutation_fragments_select_statement` — depends on the real underlying table, not its synthetic schema
- plus drop-table and drop-keyspace invalidation cases

## Results

Built and run via `combined_tests_g` (dev mode):
- `schema_change_test` — all 27 cases pass, including the new test and the pre-existing `test_prepared_statement_is_invalidated_by_schema_change`
- `table_helper_test` — both cases pass, including `test_concurrent_invalidation`, the existing use-after-free regression test that exercises the exact `remove_invalid_prepared_statements()` → cache-removal path this PR rewires

---

Backport: no, improvement
