### PR TITLE
cql3: validate the table by id when executing a statement

### DIFF
--- a/cql3/statements/modification_statement.cc
+++ b/cql3/statements/modification_statement.cc
@@ -268,7 +268,11 @@ modification_statement::execute_without_checking_exception_message(query_process
 
 future<::shared_ptr<cql_transport::messages::result_message>>
 modification_statement::do_execute(query_processor& qp, service::query_state& qs, const query_options& options) const {
-    (void)validation::validate_column_family(qp.db(), keyspace(), column_family());
+    if (!qp.db().try_find_table(s->id())) {
+        co_return coroutine::exception(
+                std::make_exception_ptr(exceptions::invalid_request_exception(
+                        format("unconfigured table {}", column_family()))));
+    }
 
     tracing::add_table_name(qs.get_trace_state(), keyspace(), column_family());
 

--- a/cql3/statements/select_statement.cc
+++ b/cql3/statements/select_statement.cc
@@ -428,7 +428,10 @@ select_statement::do_execute(query_processor& qp,
                           service::query_state& state,
                           const query_options& options) const
 {
-    (void)validation::validate_column_family(qp.db(), keyspace(), column_family());
+    if (!qp.db().try_find_table(_schema->id())) {
+        return make_exception_future<shared_ptr<cql_transport::messages::result_message>>(
+                exceptions::invalid_request_exception(format("unconfigured table {}", column_family())));
+    }
 
     tracing::add_table_name(state.get_trace_state(), keyspace(), column_family());
 

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -1449,11 +1449,11 @@ future<> database::legacy_drop_table_on_all_shards(sharded<database>& sharded_db
 }
 
 table_id database::find_uuid(std::string_view ks, std::string_view cf) const {
-    try {
-        return _tables_metadata.get_table_id(std::make_pair(ks, cf));
-    } catch (std::out_of_range&) {
+    auto id = _tables_metadata.get_table_id_if_exists(std::make_pair(ks, cf));
+    if (!id) {
         throw no_such_column_family(ks, cf);
     }
+    return id;
 }
 
 table_id database::find_uuid(const schema_ptr& schema) const {
@@ -3614,10 +3614,6 @@ void database::tables_metadata::remove_table(database& db, table& cf) noexcept {
 
 table& database::tables_metadata::get_table(table_id id) const {
     return *_column_families.at(id);
-}
-
-table_id database::tables_metadata::get_table_id(const std::pair<std::string_view, std::string_view>& kscf) const {
-    return _ks_cf_to_uuid.at(ks_cf_t{kscf});
 }
 
 lw_shared_ptr<table> database::tables_metadata::get_table_if_exists(table_id id) const {

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -1666,7 +1666,6 @@ public:
         void remove_table(database& db, table& cf) noexcept;
 
         table& get_table(table_id id) const;
-        table_id get_table_id(const std::pair<std::string_view, std::string_view>& kscf) const;
         lw_shared_ptr<table> get_table_if_exists(table_id id) const;
         table_id get_table_id_if_exists(const std::pair<std::string_view, std::string_view>& kscf) const;
         bool contains(table_id id) const;

--- a/test/boost/schema_change_test.cc
+++ b/test/boost/schema_change_test.cc
@@ -19,7 +19,11 @@
 #include "test/lib/cql_test_env.hh"
 #include "test/lib/cql_assertions.hh"
 #include "service/migration_manager.hh"
+#include "service/query_state.hh"
 #include "service/storage_proxy.hh"
+#include "cql3/dialect.hh"
+#include "cql3/query_options.hh"
+#include "cql3/statements/prepared_statement.hh"
 #include "schema/schema_builder.hh"
 #include "schema/schema_registry.hh"
 #include "db/schema_tables.hh"
@@ -572,6 +576,46 @@ SEASTAR_TEST_CASE(test_prepared_statement_is_invalidated_by_schema_change) {
                 // expected
             }
         });
+    });
+}
+
+// A prepared statement captures the table's schema, and with it the table's id.
+// Dropping the table and recreating it under the same name produces a different
+// table with a different id, so a statement prepared before the drop refers to a
+// table which no longer exists and must be rejected. Validating by name instead
+// would find the recreated table, let the query proceed against the stale id, and
+// fail deeper down with a server error (or, for some read paths, silently return
+// an empty result).
+//
+// The statements are obtained through get_statement() rather than prepare() on
+// purpose: prepare() registers them in the prepared statements cache, where the
+// drop would evict them, so a client would be told to re-prepare and would never
+// reach the validation under test. Holding the statement directly is what an
+// in-flight request does when the drop lands while it is already executing.
+SEASTAR_TEST_CASE(test_statement_prepared_before_table_recreation_is_rejected) {
+    return do_with_cql_env_thread([] (cql_test_env& e) {
+        e.execute_cql("create table ks.tbl (pk int primary key, v int);").get();
+
+        service::query_state qs(service::client_state::for_internal_calls(), empty_service_permit());
+        auto& qp = e.local_qp();
+
+        auto select_stmt = qp.get_statement("select * from ks.tbl where pk = 0;",
+                qs.get_client_state(), cql3::internal_dialect())->statement;
+        auto insert_stmt = qp.get_statement("insert into ks.tbl (pk, v) values (0, 0);",
+                qs.get_client_state(), cql3::internal_dialect())->statement;
+
+        e.execute_cql("drop table ks.tbl;").get();
+        e.execute_cql("create table ks.tbl (pk int primary key, v int);").get();
+
+        auto& options = cql3::query_options::DEFAULT;
+        BOOST_REQUIRE_EXCEPTION(
+                select_stmt->execute(qp, qs, options, std::nullopt).get(),
+                exceptions::invalid_request_exception,
+                exception_predicate::message_contains("unconfigured table tbl"));
+        BOOST_REQUIRE_EXCEPTION(
+                insert_stmt->execute(qp, qs, options, std::nullopt).get(),
+                exceptions::invalid_request_exception,
+                exception_predicate::message_contains("unconfigured table tbl"));
     });
 }
 


### PR DESCRIPTION
select_statement::do_execute() and modification_statement::do_execute()
checked that their table still exists by looking it up by keyspace and
table name. Both statements hold a schema snapshot taken when they were
prepared, so the question the check needs to answer is "does the table
this statement was prepared against still exist", and the table name
does not answer it.

If a table is dropped and recreated under the same name, the recreated
table is a different table with a different id. The name lookup finds
the recreated table, the check passes, and execution proceeds with the
stale table id from the schema snapshot. The read path then resolves the
stale schema's table through schema::table(), which throws
no_such_column_family - a std::runtime_error rather than a request
validation exception - so the client is handed a server error where an
invalid request is what it should get. Paths which do not resolve the
table first fare no better: storage_proxy swallows
no_such_column_family for single partition reads and returns an empty
result.

Normally the prepared statements cache masks this. Dropping a table
invalidates the statements which depend on it by name, so a client
holding one is told to re-prepare and then binds to the recreated table.
What is not covered by that is a statement which is already executing
when the drop lands, which is what the new test reproduces by holding a
statement outside the cache.

Look the table up by id instead. A table cannot be renamed, so an id
which is present implies its name is present too: this only rejects
requests which the name-based check wrongly accepted, and never the
reverse. Dropping a table without recreating it is unaffected, since
both lookups miss and the reported error does not change.

Validating by id is also cheaper. The name lookup tested the keyspace,
then probed the name-to-id map and hashed a keyspace and table name, and
only then probed the id-to-table map; the id lookup probes the
id-to-table map once. Measured with perf-simple-query on a release build
(-O3, thin LTO, PGO), a single shard pinned to one core, 5 interleaved
rounds per variant of 20 one-second samples each, comparing the median
instructions per operation:

    ./build/release/scylla perf-simple-query -c 1 -m 4G --duration 20 --random-seed 42
    ./build/release/scylla perf-simple-query -c 1 -m 4G --duration 20 --random-seed 42 --write

    read:  32320.1 -> 31796.5 instructions/op  (-523.6, -1.62%)
    write: 42032.7 -> 41249.0 instructions/op  (-783.7, -1.86%)

Allocations per operation are unchanged. The measured build also carries
the preceding commit, whose contribution on this workload is not
separable: it removed a cost from the very lookup this commit stops
performing.

backport not needed