### PR TITLE
mutation: build the partition in place when deserializing a canonical_mutation

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -689,6 +689,7 @@ scylla_tests = set([
     'test/manual/sstable_scan_footprint_test',
     'test/perf/memory_footprint_test',
     'test/perf/perf_cache_eviction',
+    'test/perf/perf_canonical_mutation',
     'test/perf/perf_commitlog',
     'test/perf/perf_cql_parser',
     'test/perf/perf_hash',
@@ -1648,6 +1649,7 @@ tests_not_using_seastar_test_framework = set([
     'test/manual/message',
     'test/perf/memory_footprint_test',
     'test/perf/perf_cache_eviction',
+    'test/perf/perf_canonical_mutation',
     'test/perf/perf_cql_parser',
     'test/perf/perf_hash',
     'test/perf/perf_mutation',
@@ -1806,6 +1808,7 @@ deps['test/boost/rolling_max_tracker_test'] = ['test/boost/rolling_max_tracker_t
 deps['test/boost/estimated_histogram_test'] = ['test/boost/estimated_histogram_test.cc']
 deps['test/boost/summary_test'] = ['test/boost/summary_test.cc']
 deps['test/boost/anchorless_list_test'] = ['test/boost/anchorless_list_test.cc']
+deps['test/perf/perf_canonical_mutation'] += ['seastar/tests/perf/linux_perf_event.cc']
 deps['test/perf/perf_commitlog'] += ['test/perf/perf.cc', 'seastar/tests/perf/linux_perf_event.cc']
 deps['test/perf/perf_row_cache_reads'] += ['test/perf/perf.cc', 'seastar/tests/perf/linux_perf_event.cc']
 deps['test/boost/reusable_buffer_test'] = [

--- a/mutation/async_utils.cc
+++ b/mutation/async_utils.cc
@@ -85,8 +85,8 @@ future<mutation> to_mutation_gently(const canonical_mutation& cm, schema_ptr s) 
 
     if (version == m.schema()->version()) {
         auto partition_view = mutation_partition_view::from_view(mv.partition());
-        mutation_application_stats app_stats;
-        co_await apply_gently(m.partition(), *m.schema(), partition_view, *m.schema(), app_stats);
+        partition_builder b(*m.schema(), m.partition());
+        co_await partition_view.accept_gently(*m.schema(), b);
     } else {
         column_mapping cm = mv.mapping();
         converting_mutation_partition_applier v(cm, *m.schema(), m.partition());

--- a/mutation/canonical_mutation.cc
+++ b/mutation/canonical_mutation.cc
@@ -13,6 +13,7 @@
 #include "mutation_partition_serializer.hh"
 #include "counters.hh"
 #include "converting_mutation_partition_applier.hh"
+#include "partition_builder.hh"
 #include "idl/mutation.dist.impl.hh"
 
 canonical_mutation::canonical_mutation(bytes_ostream data)
@@ -62,8 +63,8 @@ mutation canonical_mutation::to_mutation(schema_ptr s) const {
 
     if (version == m.schema()->version()) {
         auto partition_view = mutation_partition_view::from_view(mv.partition());
-        mutation_application_stats app_stats;
-        m.partition().apply(*m.schema(), partition_view, *m.schema(), app_stats);
+        partition_builder b(*m.schema(), m.partition());
+        partition_view.accept(*m.schema(), b);
     } else {
         column_mapping cm = mv.mapping();
         converting_mutation_partition_applier v(cm, *m.schema(), m.partition());

--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -5538,11 +5538,13 @@ public:
             auto it = std::ranges::find_if(v, [] (auto&& ver) {
                     return bool(ver.par);
             });
-            auto m = mutation(_schema, it->par->mut().key());
-            for (const version& ver : v) {
-                if (ver.par) {
+            // The first version has nothing to be merged with, so it is unfrozen
+            // into the reconciled mutation directly instead of being applied to it.
+            auto m = co_await unfreeze_gently(it->par->mut(), _schema);
+            for (auto i = std::next(it); i != v.end(); ++i) {
+                if (i->par) {
                     mutation_application_stats app_stats;
-                    co_await apply_gently(m.partition(), schema, ver.par->mut().partition(), schema, app_stats);
+                    co_await apply_gently(m.partition(), schema, i->par->mut().partition(), schema, app_stats);
                 }
             }
             auto live_row_count = m.live_row_count();

--- a/test/perf/CMakeLists.txt
+++ b/test/perf/CMakeLists.txt
@@ -65,6 +65,10 @@ add_perf_test(perf_big_decimal
     mutation
     schema)
 add_perf_test(perf_cache_eviction)
+add_perf_test(perf_canonical_mutation
+  LIBRARIES
+    mutation
+    schema)
 add_perf_test(perf_checksum)
 add_perf_test(perf_commitlog
   LIBRARIES

--- a/test/perf/perf_canonical_mutation.cc
+++ b/test/perf/perf_canonical_mutation.cc
@@ -1,0 +1,122 @@
+/*
+ * Copyright (C) 2026-present ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
+ */
+
+#include "mutation/canonical_mutation.hh"
+#include "mutation/mutation.hh"
+#include "schema/schema_builder.hh"
+#include "utils/UUID_gen.hh"
+#include <seastar/core/app-template.hh>
+#include <seastar/core/memory.hh>
+#include <seastar/core/reactor.hh>
+#include <seastar/testing/linux_perf_event.hh>
+
+// Builds a partition with rows [first_row, first_row + rows), all columns set.
+static mutation make_mutation(schema_ptr s, const partition_key& key, int first_row, int rows,
+        const std::vector<sstring>& cnames, const bytes& value, api::timestamp_type ts) {
+    mutation m(s, key);
+    for (int i = 0; i < rows; i++) {
+        auto ck = clustering_key::from_exploded(*s, {int32_type->decompose(first_row + i)});
+        deletable_row& dr = m.partition().clustered_row(*s, ck);
+        dr.apply(row_marker(ts));
+        for (const sstring& cname : cnames) {
+            const column_definition& col = *s->get_column_definition(to_bytes(cname));
+            dr.cells().apply(col, atomic_cell::make_live(*col.type, ts, value));
+        }
+    }
+    return m;
+}
+
+// Prints the average duration, retired instruction count and allocation count of a
+// single call of @op. The instruction and allocation counts are the more telling of
+// the three, as they do not depend on whatever else the machine happens to be running.
+template <typename Op>
+static void time_op(const char* name, size_t iterations, Op op) {
+    using clk = std::chrono::steady_clock;
+    clk::duration total{};
+    uint64_t allocations = 0;
+    uint64_t instructions = 0;
+    auto instructions_counter = linux_perf_event::user_instructions_retired();
+    instructions_counter.enable();
+    for (size_t i = 0; i < iterations; i++) {
+        auto allocations_before = memory::stats().mallocs();
+        auto instructions_before = instructions_counter.read();
+        auto start = clk::now();
+        op();
+        auto end = clk::now();
+        instructions += instructions_counter.read() - instructions_before;
+        total += end - start;
+        allocations += memory::stats().mallocs() - allocations_before;
+    }
+    instructions_counter.disable();
+    fmt::print("{:<46}{:>8.1f} us {:>12.0f} instr {:>9.0f} allocs\n", name,
+            std::chrono::duration<double, std::micro>(total).count() / iterations,
+            double(instructions) / iterations, double(allocations) / iterations);
+}
+
+// Builds a schema with @column_count blob columns, and a second version of the same
+// table which can represent everything the first can, so that a mutation of the one
+// has to be converted to be deserialized with the other. Both are versions of one
+// table, as to_mutation() refuses to deserialize a mutation of another one.
+static std::pair<schema_ptr, schema_ptr> make_schemas(size_t column_count, std::vector<sstring>& cnames) {
+    auto make_builder = [id = table_id(utils::UUID_gen::get_time_UUID())] {
+        return schema_builder(this_smp_shard_count(), "ks", "cf", id)
+            .with_column("p1", utf8_type, column_kind::partition_key)
+            .with_column("c1", int32_type, column_kind::clustering_key);
+    };
+    auto builder = make_builder();
+    for (size_t i = 0; i < column_count; i++) {
+        cnames.push_back(fmt::format("b{}", i + 1));
+        builder.with_column(to_bytes(cnames.back()), bytes_type);
+    }
+    auto other_version_builder = make_builder();
+    for (const sstring& cname : cnames) {
+        other_version_builder.with_column(to_bytes(cname), bytes_type);
+    }
+    return {builder.build(), other_version_builder.with_column("b_extra", bytes_type).build()};
+}
+
+// Times deserialization of a canonical_mutation, which is what group0 command
+// application and merging, topology coordinator operations, tablet metadata change
+// hints and validation, batchlog replay and schema mutation merging all do for every
+// mutation they handle. The source of the same schema version is the common case, the
+// one of another version is measured to show what the conversion costs on top.
+static void time_canonical_mutation_deserialization(int rows, size_t column_count, size_t value_size,
+        size_t iterations) {
+    std::vector<sstring> cnames;
+    auto [s, s2] = make_schemas(column_count, cnames);
+
+    fmt::print("\nTiming deserialization of a canonical_mutation of {} rows x {} columns x {} bytes...\n",
+            rows, column_count, value_size);
+
+    const api::timestamp_type ts = 1;
+    const bytes value(bytes::initialized_later(), value_size);
+    auto key = partition_key::from_exploded(*s, {to_bytes("key1")});
+    const canonical_mutation cm(make_mutation(s, key, 0, rows, cnames, value, ts));
+    const canonical_mutation cm_other_version(make_mutation(s2, key, 0, rows, cnames, value, ts));
+
+    time_op("to_mutation", iterations, [&, s = s] { auto m = cm.to_mutation(s); });
+    time_op("to_mutation, other schema version", iterations,
+            [&, s = s] { auto m = cm_other_version.to_mutation(s); });
+}
+
+int main(int argc, char* argv[]) {
+    namespace bpo = boost::program_options;
+    app_template app;
+    app.add_options()
+        ("column-count", bpo::value<size_t>()->default_value(1), "column count")
+        ("rows", bpo::value<int>()->default_value(1000), "rows per partition")
+        ("value-size", bpo::value<size_t>()->default_value(64), "cell value size")
+        ("iterations", bpo::value<size_t>()->default_value(300), "number of iterations to average over");
+    return app.run_deprecated(argc, argv, [&] {
+        time_canonical_mutation_deserialization(app.configuration()["rows"].as<int>(),
+                app.configuration()["column-count"].as<size_t>(),
+                app.configuration()["value-size"].as<size_t>(),
+                app.configuration()["iterations"].as<size_t>());
+        engine().exit(0);
+    });
+}


### PR DESCRIPTION
Both flavours of canonical_mutation::to_mutation() construct an empty
mutation and then apply the serialized partition to it, which materializes
the partition into a temporary and then merges that temporary into the empty
one row by row. Their own else branches, taken when the source is of another
schema version, already apply directly to the partition, and so does
frozen_mutation::unfreeze().

Build the partition with partition_builder instead, which drops both the
temporary and the merge pass, and with it an allocation per row of the
partition for the nodes of the tree the rows are moved into.

Callers are group0 command application and merging, topology coordinator
operations, tablet metadata change hints and validation, batchlog replay,
schema mutations.

measurement of canonical_mutation::to_mutation():
```
=== 1000 rows x 1 col x 64B                before        after       delta
  to_mutation
    instructions                          7016363      6433650   -582713 (-8.3%)
    allocations                              5576         4789      -787 (-14.1%)
  to_mutation, other schema version
    instructions                         15016372     15017034      +662 (+0.0%)
    allocations                              5798         5798        +0 (+0.0%)

=== 10000 rows x 1 col x 64B
  to_mutation
    instructions                         70994319     64764380  -6229939 (-8.8%)
    allocations                             58828        49415     -9413 (-16.0%)
  to_mutation, other schema version
    instructions                        182654904    182655350      +446 (+0.0%)
    allocations                             59425        59425        +0 (+0.0%)

=== 1000 rows x 8 col x 16B
  to_mutation
    instructions                         19209214     18624714   -584500 (-3.0%)
    allocations                             13576        12789      -787 (-5.8%)
  to_mutation, other schema version
    instructions                         35279611     35279405      -206 (-0.0%)
    allocations                             20826        20826        +0 (+0.0%)
```

measurement of 'apply first to empty' vs 'unfreeze first' (the reconcile change):
```
--rows 1000 --column-count 1 --value-size 64, one pinned CPU:

versions   variant                            instructions      allocs
1          apply first version to empty            7015420        5575
           unfreeze first version                  6432796        4788
                                                   -582624      -787
                                                    (-8.3%)    (-14.1%)
3          apply first version to empty           33997589       15149
           unfreeze first version                 33413485       14362
                                                   -584104      -787
                                                    (-1.7%)     (-5.2%)
5          apply first version to empty           60961546       24723
           unfreeze first version                 60373967       23936
                                                   -587579      -787
                                                    (-1.0%)     (-3.2%)

Other shapes, 3 versions:

10000 rows x 1 col     382577449 -> 376353445   (-6224004, -1.6%)   157653 -> 1
1000 rows x 8 col x16B  76619034 ->  76036660    (-582374, -0.8%)    39149 ->  38362   (-787, -2.0%)
```

backport not needed