### PR TITLE
Revert "build: avoid fast unwind in the sanitizer"

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -157,7 +157,6 @@ adjust_bin() {
 export GNUTLS_SYSTEM_PRIORITY_FILE="\${GNUTLS_SYSTEM_PRIORITY_FILE-$prefix/libreloc/gnutls.config}"
 export LD_LIBRARY_PATH="$prefix/libreloc"
 export UBSAN_OPTIONS="${UBSAN_OPTIONS:+$UBSAN_OPTIONS:}suppressions=$prefix/libexec/ubsan-suppressions.supp"
-export ASAN_OPTIONS="\${ASAN_OPTIONS:+\$ASAN_OPTIONS:}fast_unwind_on_malloc=0:symbolize=1"
 export LSAN_OPTIONS="${LSAN_OPTIONS:+$LSAN_OPTIONS:}suppressions=$prefix/libexec/lsan-suppressions.supp"
 ${p11_trust_paths:+export SCYLLA_P11_TRUST_PATHS="$p11_trust_paths"}
 exec -a "\$0" "$prefix/libexec/$bin" "\$@"


### PR DESCRIPTION
This reverts commit f037aef074a376dee7df9a0acbbeedaf126b7108.

The commit set ASAN_OPTIONS=fast_unwind_on_malloc=0 in the relocatable launcher thunk, to work around the sanitizer's fast unwinder producing garbage backtraces for aarch64 pointer-authenticated return addresses, which prevented a liblttng-ust leak from being suppressed.

Two reasons to drop it:

First, the leak it was chasing is gone: e61ce1b88024 disabled LTTng altogether.

Second, it is expensive. In debug and sanitize builds seastar uses the default allocator, so every allocation goes through the sanitizer's allocator and records a backtrace. A microbenchmark (10-deep call stack, malloc+free of 64 bytes, x86_64, our clang 22 toolchain) measures 161 ns/alloc with the fast unwinder and 2052 ns/alloc with the slow one - 13x. Lowering malloc_context_size to 5 only brings it down to 1494 ns/alloc, so capping the depth is not a way out. The cost showed up as across-the-board wall-clock growth in scylla-master/dtest-debug, which went from finishing in 3.4h-5.8h to hitting its 8h Jenkins timeout in 4 of the 5 runs after the change.

The underlying aarch64 problem is ours, not the sanitizer's: compiler-rt strips the pointer authentication code in StackTrace::UnwindFast, but only if the runtime itself was built with -mbranch-protection. Fedora builds its aarch64 packages that way; tools/toolchain/optimized_clang.sh does not, so our libclang_rt.asan.a has the strip compiled out. That is fixed separately in the toolchain.

Fixes https://scylladb.atlassian.net/browse/SCYLLADB-3906

No backport, the lttng fiasco is not in any branch.