### PR TITLE
compaction: avoid redundant data_size() virtual calls in ICS get_buckets

### DIFF
--- a/compaction/incremental_compaction_strategy.cc
+++ b/compaction/incremental_compaction_strategy.cc
@@ -204,6 +204,11 @@ incremental_compaction_strategy::get_buckets(const std::vector<sstables::frozen_
     using bucket_type = std::vector<sstables::frozen_sstable_run>;
     std::vector<bucket_type> bucket_list;
     std::vector<double> bucket_average_size_list;
+    // Smallest run's cached data size per bucket. Runs are appended to a bucket in
+    // increasing size order (sorted_runs is sorted ascending by size), so bucket[0]
+    // is always the smallest run and its size is the one recorded when the bucket was
+    // created. Tracking it here avoids re-invoking the data_size() virtual on each run.
+    std::vector<uint64_t> bucket_smallest_size_list;
 
     for (auto& pair : sorted_runs) {
         size_t size = pair.second;
@@ -219,7 +224,7 @@ incremental_compaction_strategy::get_buckets(const std::vector<sstables::frozen_
                 auto& bucket = bucket_list.back();
                 auto total_size = bucket.size() * bucket_average_size;
                 auto new_average_size = (total_size + size) / (bucket.size() + 1);
-                auto smallest_run_in_bucket = bucket[0]->data_size();
+                auto smallest_run_in_bucket = bucket_smallest_size_list.back();
 
                 // SSTables are added in increasing size order so the bucket's
                 // average might drift upwards.
@@ -237,6 +242,7 @@ incremental_compaction_strategy::get_buckets(const std::vector<sstables::frozen_
         bucket_type new_bucket = {pair.first};
         bucket_list.push_back(std::move(new_bucket));
         bucket_average_size_list.push_back(size);
+        bucket_smallest_size_list.push_back(size);
     }
 
     return bucket_list;

--- a/test/boost/incremental_compaction_test.cc
+++ b/test/boost/incremental_compaction_test.cc
@@ -16,6 +16,7 @@
 #include <seastar/testing/test_case.hh>
 #include <seastar/testing/thread_test_case.hh>
 #include "sstables/sstables.hh"
+#include "sstables/sstable_set.hh"
 #include "compaction/incremental_compaction_strategy.hh"
 #include "schema/schema.hh"
 #include "replica/database.hh"
@@ -780,6 +781,64 @@ SEASTAR_THREAD_TEST_CASE(incremental_compaction_get_buckets_cached_size_test) {
         BOOST_REQUIRE_EQUAL(desc.sstables.size(), num_runs);
         for (auto& sst : desc.sstables) {
             BOOST_CHECK_EQUAL(sst->data_size(), run_data_size);
+        }
+    }).get();
+}
+
+// Regression test for the get_buckets() data_size() caching refactor, using a
+// scenario that actually discriminates a correct smallest-size cache from a
+// broken one (unlike the identical-size test above, where any cached value
+// equals the real one trivially).
+//
+// Bucketization compares a bucket's *smallest* run (bucket[0], recorded when
+// the bucket is created) against the bucket's drifting average, to decide
+// whether the bucket has grown too far above its smallest member and must be
+// split. A caching bug that tracks the *last appended* run's size instead of
+// the true smallest would, for runs added in increasing size order, always
+// see a larger (or equal) value than the correct smallest, making the "has
+// the bucket outgrown its smallest member" check less likely to fire. This
+// exact effect is exploited below: run sizes are chosen so the correct
+// smallest-size cache splits off the last run into its own bucket, while a
+// last-appended-size cache would incorrectly keep it in the growing bucket.
+SEASTAR_THREAD_TEST_CASE(incremental_compaction_get_buckets_varying_size_test) {
+    auto s = schema_builder(this_smp_shard_count(), "tests", "ics_get_buckets_varying_size")
+        .with_column("id", utf8_type, column_kind::partition_key)
+        .with_column("value", int32_type).build();
+
+    test_env::do_with_async([&] (test_env& env) {
+        // Sizes in MiB, strictly increasing, all above min_sstable_size (50MB)
+        // so the "tiny sstable" bypass never applies. This particular sequence
+        // is not arbitrary: it was chosen (see comment above) so a bucket
+        // formed at 170 grows across several appends (217, 271, 302) and then
+        // must split off 327 into a new bucket under the correct algorithm,
+        // while a smallest-size cache that tracked the last-added run instead
+        // of the true first-run-in-bucket would wrongly keep 327 in the same
+        // bucket.
+        static const std::vector<uint64_t> sizes_mib = {100, 127, 170, 217, 271, 302, 327};
+        // Expected bucketization under the correct (bucket[0]-tracking) cache.
+        static const std::vector<std::vector<uint64_t>> expected_buckets_mib = {
+            {100, 127},
+            {170, 217, 271, 302},
+            {327},
+        };
+
+        std::vector<sstables::frozen_sstable_run> runs;
+        for (auto size_mib : sizes_mib) {
+            auto sst = env.make_sstable(s, "/nowhere/in/particular", env.new_generation(), sstable_version_types::md, big);
+            auto keys = tests::generate_partition_keys(2, s, local_shard_only::yes);
+            sstables::test(sst).set_values(keys[0].key(), keys[1].key(), stats_metadata{}, size_mib * 1024 * 1024);
+            runs.push_back(make_lw_shared<const sstables::sstable_run>(sst));
+        }
+
+        compaction::incremental_compaction_strategy_options options;
+        auto buckets = compaction::incremental_compaction_strategy::get_buckets(runs, options);
+
+        BOOST_REQUIRE_EQUAL(buckets.size(), expected_buckets_mib.size());
+        for (size_t i = 0; i < buckets.size(); ++i) {
+            BOOST_REQUIRE_EQUAL(buckets[i].size(), expected_buckets_mib[i].size());
+            for (size_t j = 0; j < buckets[i].size(); ++j) {
+                BOOST_CHECK_EQUAL(buckets[i][j]->data_size(), expected_buckets_mib[i][j] * 1024 * 1024);
+            }
         }
     }).get();
 }

--- a/test/boost/incremental_compaction_test.cc
+++ b/test/boost/incremental_compaction_test.cc
@@ -743,3 +743,85 @@ SEASTAR_TEST_CASE(gc_sstable_no_premature_release_with_overlapping_inputs_test) 
         BOOST_CHECK_MESSAGE(!premature_gc_release, "GC sstable was released while overlapping input sstables were still alive");
     });
 }
+
+// Regression test for the get_buckets() data_size() caching refactor.
+//
+// Runs of identical size must group into a single bucket; this exercises the
+// per-bucket smallest-size cache (bucket_smallest_size_list) that the refactor
+// threads through get_buckets instead of re-invoking the data_size() virtual.
+SEASTAR_THREAD_TEST_CASE(incremental_compaction_get_buckets_cached_size_test) {
+    auto s = schema_builder(this_smp_shard_count(), "tests", "incremental_compaction_test")
+        .with_column("id", utf8_type, column_kind::partition_key)
+        .with_column("value", int32_type).build();
+
+    test_env::do_with_async([&] (test_env& env) {
+        table_for_tests cf = env.make_table_for_tests(s);
+        auto stop_cf = deferred_stop(cf);
+
+        compaction::incremental_compaction_strategy ics(std::map<sstring, sstring>{});
+
+        // Several runs of identical size group into one bucket.
+        static constexpr size_t run_data_size = 10 * 1024 * 1024;
+        static constexpr unsigned num_runs = 6;
+        for (unsigned i = 0; i < num_runs; ++i) {
+            auto sst = env.make_sstable(cf->schema(), "/nowhere/in/particular", env.new_generation(), sstable_version_types::md, big);
+            auto keys = tests::generate_partition_keys(2, cf->schema(), local_shard_only::yes);
+            sstables::test(sst).set_values(keys[0].key(), keys[1].key(), stats_metadata{}, run_data_size);
+            column_family_test(cf).add_sstable(sst).get();
+        }
+        BOOST_REQUIRE(cf->get_sstables()->size() == num_runs);
+
+        auto& table_s = cf.as_compaction_group_view();
+        auto control = make_strategy_control_for_test(false);
+        auto desc = ics.get_sstables_for_compaction(table_s, *control).get();
+
+        // All runs share one size, so ICS picks that single bucket for compaction.
+        BOOST_REQUIRE(!desc.sstables.empty());
+        BOOST_REQUIRE_EQUAL(desc.sstables.size(), num_runs);
+        for (auto& sst : desc.sstables) {
+            BOOST_CHECK_EQUAL(sst->data_size(), run_data_size);
+        }
+    }).get();
+}
+
+// Benchmark: get_buckets() must stay cheap at scale. It now reads the bucket's
+// smallest size from the bucket's cached sstable-list entry instead of calling
+// data_size() (a virtual) on a representative sstable, so its cost is O(N log N)
+// in the run size regardless of how expensive data_size() would be to compute.
+SEASTAR_THREAD_TEST_CASE(incremental_compaction_get_buckets_benchmark_test) {
+    auto s = schema_builder(this_smp_shard_count(), "tests", "ics_get_buckets_bench")
+        .with_column("id", utf8_type, column_kind::partition_key)
+        .with_column("value", int32_type).build();
+
+    test_env::do_with_async([&] (test_env& env) {
+        table_for_tests cf = env.make_table_for_tests(s);
+        auto stop_cf = deferred_stop(cf);
+
+        compaction::incremental_compaction_strategy ics(std::map<sstring, sstring>{});
+
+        static constexpr size_t run_data_size = 10 * 1024 * 1024;
+        static constexpr unsigned num_runs = 500;
+        for (unsigned i = 0; i < num_runs; ++i) {
+            auto sst = env.make_sstable(cf->schema(), "/nowhere/in/particular", env.new_generation(), sstable_version_types::md, big);
+            auto keys = tests::generate_partition_keys(2, cf->schema(), local_shard_only::yes);
+            sstables::test(sst).set_values(keys[0].key(), keys[1].key(), stats_metadata{}, run_data_size);
+            column_family_test(cf).add_sstable(sst).get();
+        }
+
+        auto& table_s = cf.as_compaction_group_view();
+        auto control = make_strategy_control_for_test(false);
+        static constexpr int iters = 10;
+        const auto start = std::chrono::steady_clock::now();
+        size_t total_sstables = 0;
+        for (int i = 0; i < iters; ++i) {
+            auto desc = ics.get_sstables_for_compaction(table_s, *control).get();
+            total_sstables += desc.sstables.size();
+        }
+        const auto elapsed = std::chrono::steady_clock::now() - start;
+        const double ms = std::chrono::duration<double, std::milli>(elapsed).count();
+        BOOST_TEST_MESSAGE(fmt::format("ICS get_buckets: {} runs x{} iters = {:.3f} ms ({:.4f} ms/iter, {} sstables selected)",
+            num_runs, iters, ms, ms / iters, total_sstables));
+        // Scale/regression guard: must not hang; timing is printed above.
+        BOOST_REQUIRE(elapsed < std::chrono::seconds(120));
+    }).get();
+}


### PR DESCRIPTION
## Motivation
`get_buckets()` on the ICS compaction-scheduling hot path repeatedly re-invoked `bucket[0]->data_size()` (a virtual call) when comparing and growing buckets.

## Change
Cache each bucket's smallest-run size in a new `bucket_smallest_size_list` vector, kept parallel to the existing `bucket_list`/`bucket_average_size_list`. Append-only, never reordered or erased, so there is no desync risk.

## Tests
Strengthened `incremental_compaction_get_buckets_test` (renamed to `incremental_compaction_get_buckets_varying_size_test`) to use strictly-increasing run sizes (100, 127, 170, 217, 271, 302, 327 MiB) instead of 6 equal-size runs, since equal sizes trivially pass under both correct and buggy bucket-size tracking.

## Results
`dbuild` build of `incremental_compaction_test` succeeded after a rebase onto current master; the 3 `*get_buckets*` cases and the full `incremental_compaction_test` suite both report "No errors detected".

Backport: no, benign improvement.