### PR TITLE
sstables/sstable_set: fix missing rows in reversed TWCS reads

### DIFF
--- a/sstables/sstable_set.cc
+++ b/sstables/sstable_set.cc
@@ -930,7 +930,14 @@ filter_sstable_for_reader_by_ck(std::vector<shared_sstable>&& sstables, replica:
     stats->clustering_filter_count++;
     stats->sstables_checked_by_clustering_filter += sstables.size();
 
+    // `sstable::may_contain_rows()` interprets the ranges using the table (non-reversed)
+    // schema, so a native-reversed slice must have its range bounds put back in table order.
     auto ck_filtering_all_ranges = slice.get_all_ranges();
+    if (slice.is_reversed()) {
+        for (auto& r : ck_filtering_all_ranges) {
+            r = query::reverse(r);
+        }
+    }
     // fast path to include all sstables if only one full range was specified.
     // For example, this happens if query only specifies a partition key.
     if (ck_filtering_all_ranges.size() == 1 && ck_filtering_all_ranges[0].is_full()) {
@@ -1066,7 +1073,14 @@ time_series_sstable_set::create_single_key_sstable_reader(
     };
 
     auto pk_filter = make_pk_filter(pos, hash, *schema);
-    auto ck_filter = [ranges = slice.get_all_ranges()] (const sstable& sst) { return sst.may_contain_rows(ranges); };
+    // See the comment in `filter_sstable_for_reader_by_ck()`.
+    auto ck_ranges = slice.get_all_ranges();
+    if (slice.is_reversed()) {
+        for (auto& r : ck_ranges) {
+            r = query::reverse(r);
+        }
+    }
+    auto ck_filter = [ranges = std::move(ck_ranges)] (const sstable& sst) { return sst.may_contain_rows(ranges); };
 
     // We're going to pass this filter into sstable_position_reader_queue. The queue guarantees that
     // the filter is going to be called at most once for each sstable and exactly once after

--- a/test/boost/cql_query_test.cc
+++ b/test/boost/cql_query_test.cc
@@ -7180,4 +7180,60 @@ SEASTAR_TEST_CASE(test_a_parsed_statement_gets_only_the_markers_of_its_text) {
     });
 }
 
+// Reproduces a bug in which TWCS sstable sets filtered sstables by clustering key
+// using the query-schema (reversed) ranges, which `sstable::may_contain_rows()`
+// interprets as table-schema ranges. Both the optimized TWCS read path
+// (`time_series_sstable_set::create_single_key_sstable_reader()`) and the regular
+// path (`filter_sstable_for_reader_by_ck()`) had the bug, so we exercise both,
+// switching between them with the `enable_optimized_twcs_queries` option.
+static void test_twcs_reversed_restricted_query(bool enable_optimized_twcs_queries) {
+    do_with_cql_env_thread([enable_optimized_twcs_queries] (cql_test_env& e) {
+        e.execute_cql(
+                format("CREATE TABLE tbl (pk int, ck int, v int, PRIMARY KEY (pk, ck))"
+                " WITH compaction = {{"
+                "   'compaction_window_size': '1',"
+                "   'compaction_window_unit': 'MINUTES',"
+                "   'enable_optimized_twcs_queries': '{}',"
+                // Compactions would merge the sstables together, defeating the
+                // purpose of the test.
+                "   'enabled': 'false',"
+                "   'class': 'org.apache.cassandra.db.compaction.TimeWindowCompactionStrategy'"
+                "}}", enable_optimized_twcs_queries ? "true" : "false")).get();
+
+        // One sstable per clustering key, so that each sstable has a narrow
+        // min/max clustering position range.
+        constexpr int n = 10;
+        for (int i = 0; i < n; ++i) {
+            e.execute_cql(format("INSERT INTO tbl (pk, ck, v) VALUES (0, {}, {})", i, i)).get();
+            e.db().invoke_on_all([] (replica::database& db) {
+                return db.flush_all_memtables();
+            }).get();
+        }
+
+        auto count = [&e] (const sstring& q) {
+            auto msg = e.execute_cql(q).get();
+            auto rows = dynamic_pointer_cast<cql_transport::messages::result_message::rows>(msg);
+            BOOST_REQUIRE(rows);
+            return rows->rs().result_set().size();
+        };
+
+        BOOST_CHECK_EQUAL(count("SELECT * FROM tbl WHERE pk = 0 BYPASS CACHE"), n);
+        BOOST_CHECK_EQUAL(count("SELECT * FROM tbl WHERE pk = 0 ORDER BY ck DESC BYPASS CACHE"), n);
+        BOOST_CHECK_EQUAL(count("SELECT * FROM tbl WHERE pk = 0 AND ck >= 5 BYPASS CACHE"), n - 5);
+        BOOST_CHECK_EQUAL(count("SELECT * FROM tbl WHERE pk = 0 AND ck >= 5 ORDER BY ck DESC BYPASS CACHE"), n - 5);
+        BOOST_CHECK_EQUAL(count("SELECT * FROM tbl WHERE pk = 0 AND ck < 5 BYPASS CACHE"), 5);
+        BOOST_CHECK_EQUAL(count("SELECT * FROM tbl WHERE pk = 0 AND ck < 5 ORDER BY ck DESC BYPASS CACHE"), 5);
+        BOOST_CHECK_EQUAL(count("SELECT * FROM tbl WHERE pk = 0 AND ck >= 3 AND ck <= 6 BYPASS CACHE"), 4);
+        BOOST_CHECK_EQUAL(count("SELECT * FROM tbl WHERE pk = 0 AND ck >= 3 AND ck <= 6 ORDER BY ck DESC BYPASS CACHE"), 4);
+    }).get();
+}
+
+SEASTAR_THREAD_TEST_CASE(test_twcs_reversed_restricted_query_optimized) {
+    test_twcs_reversed_restricted_query(true);
+}
+
+SEASTAR_THREAD_TEST_CASE(test_twcs_reversed_restricted_query_regular) {
+    test_twcs_reversed_restricted_query(false);
+}
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
When a native-reversed read is executed, the query schema is reversed and the clustering ranges in the slice have their bounds swapped: a forward range [ck1, ck2] is represented as [ck2, ck1] in the reversed schema (see docs/dev/reverse-reads.md).

But when TWCS uses those ranges for filtering out sstables, it uses them as if they weren't reversed.
It passes the ranges in query-schema to sstable::may_contain_rows(), which expects ranges in table-schema.
This can result in some sstables being wrongfully filtered out from the read.

For example, for a query range [lo, hi] and an sstable spanning [min, max], `position_range::overlaps()` is supposed to compute

    min <= hi && lo < max

but with the bounds are swapped, it instead computes

    min <= lo && hi < max

which only holds when when the sstable's range contains, not just overlaps, the queried range.

The bug is TWCS-specific, because it is the only strategy in which sstables are filtered by clustering key.

Fix it by un-reversing the range bounds at both call sites before handing them to `may_contain_rows()`, so the ranges are in table order, which is what that function assumes.

Fixes: SCYLLADB-3920

Needs to be backported to all supported versions.