### PR TITLE
test: accept 'Connection reset' for untrusted-cert rejection

### DIFF
--- a/test/cluster/test_auth_certificate_or_password.py
+++ b/test/cluster/test_auth_certificate_or_password.py
@@ -250,7 +250,8 @@ async def test_cql_optional_client_cert(manager: ManagerClient, tmp_path):
         # server may close the connection prematurely and the driver reports a
         # generic connection closed message instead. Accept that too.
         # The important thing is that the connection failed.
-        assert any('SSL' in t or 'tls' in t.lower() or 'certificate' in t.lower() or 'Broken pipe' in t or 'already closed' in t.lower() for t in error_texts), \
+        assert any('SSL' in t or 'tls' in t.lower() or 'certificate' in t.lower() or 'Broken pipe' in t
+                   or 'Connection reset' in t or 'already closed' in t.lower() for t in error_texts), \
             f"Expected an SSL/TLS error for untrusted cert, got: {error_texts}"
     finally:
         safe_driver_shutdown(cluster_bad_cert)


### PR DESCRIPTION
Test 4 of test_cql_optional_client_cert connects with a client certificate signed by an untrusted CA and asserts the resulting error text looks like a TLS failure. When the server rejects the certificate and closes the connection, what the client observes is timing-dependent: a clean TLS alert, BrokenPipeError (write side), or ConnectionResetError (RST on read). The whitelist already accepted 'Broken pipe' for this race but not 'Connection reset by peer', so the test failed when the rejection surfaced as the latter:

    AssertionError: Expected an SSL/TLS error for untrusted cert,
    got: ['[Errno 104] Connection reset by peer']

Add 'Connection reset' to the accepted error texts.

Fixes: SCYLLADB-3785