### PR TITLE
Make tablet-aware restore multi-DC capable

### DIFF
--- a/api/api-doc/storage_service.json
+++ b/api/api-doc/storage_service.json
@@ -1012,7 +1012,7 @@
                   },
                   {
                      "name":"backup_source_location",
-                     "description":"Array of backup location objects. Currently, the array must contain exactly one entry.",
+                     "description":"Array of backup location objects, exactly one entry per datacenter the keyspace replicates to.",
                      "required":true,
                      "allowMultiple":false,
                      "type":"array",

--- a/api/storage_service.cc
+++ b/api/storage_service.cc
@@ -548,9 +548,8 @@ void set_sstables_loader(http_context& ctx, routes& r, sharded<sstables_loader>&
             throw httpd::bad_param_exception("backup locations (in body) must be a JSON array");
         }
 
-        const auto& locations = parsed.GetArray();
-        if (locations.Size() != 1) {
-            throw httpd::bad_param_exception("backup locations array (in body) must contain exactly one entry");
+        if (parsed.Empty()) {
+            throw httpd::bad_param_exception("backup locations array (in body) must not be empty");
         }
 
         auto get_member = [] (const auto& location, const char* name) {
@@ -560,7 +559,8 @@ void set_sstables_loader(http_context& ctx, routes& r, sharded<sstables_loader>&
             return sstring(rjson::to_string_view(location[name]));
         };
 
-        const auto& location = locations[0];
+        std::vector<tablet_restore_location> restore_locations;
+        for (const auto& location : parsed.GetArray()) {
         if (!location.IsObject()) {
             throw httpd::bad_param_exception("backup location (in body) must be a JSON object");
         }
@@ -585,7 +585,6 @@ void set_sstables_loader(http_context& ctx, routes& r, sharded<sstables_loader>&
         apilog.info("Tablet restore for {}:{} called. Parameters: snapshot={} datacenter={} endpoint={} bucket={} prefix={} manifests_count={}",
                     keyspace, table, snapshot, dc, endpoint, bucket, prefix, manifests.size());
 
-        std::vector<tablet_restore_location> restore_locations;
         restore_locations.push_back(tablet_restore_location{
             .datacenter = std::move(dc),
             .endpoint = std::move(endpoint),
@@ -593,6 +592,7 @@ void set_sstables_loader(http_context& ctx, routes& r, sharded<sstables_loader>&
             .prefix = sstring(prefix),
             .manifests = std::move(manifests),
         });
+        }
 
         auto table_id = validate_table(ctx.db.local(), keyspace, table);
         auto task_id = co_await sst_loader.local().restore_tablets(table_id, keyspace, table, snapshot, std::move(restore_locations));

--- a/api/storage_service.cc
+++ b/api/storage_service.cc
@@ -561,37 +561,37 @@ void set_sstables_loader(http_context& ctx, routes& r, sharded<sstables_loader>&
 
         std::vector<tablet_restore_location> restore_locations;
         for (const auto& location : parsed.GetArray()) {
-        if (!location.IsObject()) {
-            throw httpd::bad_param_exception("backup location (in body) must be a JSON object");
-        }
+            if (!location.IsObject()) {
+                throw httpd::bad_param_exception("backup location (in body) must be a JSON object");
+            }
 
-        auto endpoint = get_member(location, "endpoint");
-        auto bucket = get_member(location, "bucket");
-        auto dc = get_member(location, "datacenter");
-        auto prefix = location.HasMember("prefix") ? rjson::to_string_view(location["prefix"]) : std::string_view{};
+            auto endpoint = get_member(location, "endpoint");
+            auto bucket = get_member(location, "bucket");
+            auto dc = get_member(location, "datacenter");
+            auto prefix = location.HasMember("prefix") ? rjson::to_string_view(location["prefix"]) : std::string_view{};
 
-        if (!location.HasMember("manifests") || !location["manifests"].IsArray()) {
-            throw httpd::bad_param_exception("backup location entry must have 'manifests' array");
-        }
+            if (!location.HasMember("manifests") || !location["manifests"].IsArray()) {
+                throw httpd::bad_param_exception("backup location entry must have 'manifests' array");
+            }
 
-        auto manifests = location["manifests"].GetArray() |
-            std::views::transform([] (const auto& m) { return sstring(rjson::to_string_view(m)); }) |
-            std::ranges::to<utils::chunked_vector<sstring>>();
+            auto manifests = location["manifests"].GetArray() |
+                std::views::transform([] (const auto& m) { return sstring(rjson::to_string_view(m)); }) |
+                std::ranges::to<utils::chunked_vector<sstring>>();
 
-        if (manifests.empty()) {
-            throw httpd::bad_param_exception("backup location 'manifests' array must not be empty");
-        }
+            if (manifests.empty()) {
+                throw httpd::bad_param_exception("backup location 'manifests' array must not be empty");
+            }
 
-        apilog.info("Tablet restore for {}:{} called. Parameters: snapshot={} datacenter={} endpoint={} bucket={} prefix={} manifests_count={}",
-                    keyspace, table, snapshot, dc, endpoint, bucket, prefix, manifests.size());
+            apilog.info("Tablet restore for {}:{} called. Parameters: snapshot={} datacenter={} endpoint={} bucket={} prefix={} manifests_count={}",
+                        keyspace, table, snapshot, dc, endpoint, bucket, prefix, manifests.size());
 
-        restore_locations.push_back(tablet_restore_location{
-            .datacenter = std::move(dc),
-            .endpoint = std::move(endpoint),
-            .bucket = std::move(bucket),
-            .prefix = sstring(prefix),
-            .manifests = std::move(manifests),
-        });
+            restore_locations.push_back(tablet_restore_location{
+                .datacenter = std::move(dc),
+                .endpoint = std::move(endpoint),
+                .bucket = std::move(bucket),
+                .prefix = sstring(prefix),
+                .manifests = std::move(manifests),
+            });
         }
 
         auto table_id = validate_table(ctx.db.local(), keyspace, table);

--- a/api/storage_service.cc
+++ b/api/storage_service.cc
@@ -553,14 +553,21 @@ void set_sstables_loader(http_context& ctx, routes& r, sharded<sstables_loader>&
             throw httpd::bad_param_exception("backup locations array (in body) must contain exactly one entry");
         }
 
+        auto get_member = [] (const auto& location, const char* name) {
+            if (!location.HasMember(name) || !location[name].IsString()) {
+                throw httpd::bad_param_exception(fmt::format("backup location entry must have '{}' string member", name));
+            }
+            return sstring(rjson::to_string_view(location[name]));
+        };
+
         const auto& location = locations[0];
         if (!location.IsObject()) {
             throw httpd::bad_param_exception("backup location (in body) must be a JSON object");
         }
 
-        auto endpoint = rjson::to_string_view(location["endpoint"]);
-        auto bucket = rjson::to_string_view(location["bucket"]);
-        auto dc = rjson::to_string_view(location["datacenter"]);
+        auto endpoint = get_member(location, "endpoint");
+        auto bucket = get_member(location, "bucket");
+        auto dc = get_member(location, "datacenter");
         auto prefix = location.HasMember("prefix") ? rjson::to_string_view(location["prefix"]) : std::string_view{};
 
         if (!location.HasMember("manifests") || !location["manifests"].IsArray()) {
@@ -580,9 +587,9 @@ void set_sstables_loader(http_context& ctx, routes& r, sharded<sstables_loader>&
 
         std::vector<tablet_restore_location> restore_locations;
         restore_locations.push_back(tablet_restore_location{
-            .datacenter = sstring(dc),
-            .endpoint = sstring(endpoint),
-            .bucket = sstring(bucket),
+            .datacenter = std::move(dc),
+            .endpoint = std::move(endpoint),
+            .bucket = std::move(bucket),
             .prefix = sstring(prefix),
             .manifests = std::move(manifests),
         });

--- a/api/storage_service.cc
+++ b/api/storage_service.cc
@@ -578,8 +578,17 @@ void set_sstables_loader(http_context& ctx, routes& r, sharded<sstables_loader>&
         apilog.info("Tablet restore for {}:{} called. Parameters: snapshot={} datacenter={} endpoint={} bucket={} prefix={} manifests_count={}",
                     keyspace, table, snapshot, dc, endpoint, bucket, prefix, manifests.size());
 
+        std::vector<tablet_restore_location> restore_locations;
+        restore_locations.push_back(tablet_restore_location{
+            .datacenter = sstring(dc),
+            .endpoint = sstring(endpoint),
+            .bucket = sstring(bucket),
+            .prefix = sstring(prefix),
+            .manifests = std::move(manifests),
+        });
+
         auto table_id = validate_table(ctx.db.local(), keyspace, table);
-        auto task_id = co_await sst_loader.local().restore_tablets(table_id, keyspace, table, snapshot, sstring(endpoint), sstring(bucket), sstring(prefix), std::move(manifests));
+        auto task_id = co_await sst_loader.local().restore_tablets(table_id, keyspace, table, snapshot, std::move(restore_locations));
         co_return json::json_return_type(fmt::to_string(task_id));
     });
 }

--- a/db/system_distributed_keyspace.hh
+++ b/db/system_distributed_keyspace.hh
@@ -148,11 +148,11 @@ public:
     /* Retrieves all SSTable entries for a given snapshot, keyspace, table, datacenter, and rack.
      * If `start_token` and `end_token` are provided, only entries whose `first_token` is in the range [`start_token`, `end_token`] will be returned.
      * Returns a vector of `snapshot_sstable_entry` structs containing `sstable_id`, `first_token`, `last_token`,
-     * `toc_name`, and `prefix`. Uses consistency level `LOCAL_QUORUM` by default. */
-    future<utils::chunked_vector<snapshot_sstable_entry>> get_snapshot_sstables(sstring snapshot_name, sstring ks, sstring table, sstring dc, sstring rack, db::consistency_level cl = db::consistency_level::LOCAL_QUORUM, std::optional<dht::token> start_token = std::nullopt, std::optional<dht::token> end_token = std::nullopt) const;
+     * `toc_name`, and `prefix`. Uses consistency level `QUORUM` by default. */
+    future<utils::chunked_vector<snapshot_sstable_entry>> get_snapshot_sstables(sstring snapshot_name, sstring ks, sstring table, sstring dc, sstring rack, db::consistency_level cl = db::consistency_level::QUORUM, std::optional<dht::token> start_token = std::nullopt, std::optional<dht::token> end_token = std::nullopt) const;
 
     /* Retrieves download progress for a given snapshot, keyspace, table, datacenter, and rack */
-    future<snapshot_sstables_progress> get_snapshot_sstables_progress(sstring snapshot_name, sstring ks, sstring table, sstring dc, sstring rack, db::consistency_level cl = db::consistency_level::LOCAL_QUORUM) const;
+    future<snapshot_sstables_progress> get_snapshot_sstables_progress(sstring snapshot_name, sstring ks, sstring table, sstring dc, sstring rack, db::consistency_level cl = db::consistency_level::QUORUM) const;
 
     future<> update_sstable_download_status(sstring snapshot_name,
                                             sstring ks,
@@ -164,7 +164,7 @@ public:
                                             is_downloaded downloaded) const;
 
     future<> insert_snapshot_remote_location(sstring snapshot_name, sstring datacenter, sstring endpoint, sstring bucket, sstring prefix, snapshot_state, db::consistency_level cl = db::consistency_level::EACH_QUORUM);
-    future<snapshot_remote_location_entry> get_snapshot_remote_location(sstring snapshot_name, sstring datacenter, db::consistency_level cl = db::consistency_level::LOCAL_QUORUM) const;
+    future<snapshot_remote_location_entry> get_snapshot_remote_location(sstring snapshot_name, sstring datacenter, db::consistency_level cl = db::consistency_level::QUORUM) const;
 
     /* Inserts multiple SSTable entries for a given snapshot, keyspace, table, datacenter,
      * and rack. 

--- a/sstables_loader.cc
+++ b/sstables_loader.cc
@@ -1378,16 +1378,22 @@ protected:
 };
 
 future<tasks::task_id> sstables_loader::restore_tablets(table_id tid, sstring keyspace, sstring table, sstring snap_name, std::vector<tablet_restore_location> locations) {
-    if (locations.size() != 1) {
-        throw std::invalid_argument("expected exactly one backup location");
-    }
-    auto& loc = locations.front();
-
-    auto summary = co_await populate_snapshot_sstables_from_manifests(_storage_manager, _sys_dist_ks, keyspace, table, loc.endpoint, loc.bucket, loc.prefix, snap_name, loc.datacenter, std::move(loc.manifests));
-
     db::snapshot_table_helper sth(_sys_dist_ks.qp());
-    // TODO: update state when all restored...
-    co_await sth.insert_snapshot_remote_location(snap_name, loc.datacenter, loc.endpoint, loc.bucket, loc.prefix, db::snapshot_state::remote);
+    manifest_summary summary = { .tablet_count = 0, .nr_sstables = 0 };
+
+    for (auto& loc : locations) {
+        auto loc_summary = co_await populate_snapshot_sstables_from_manifests(_storage_manager, _sys_dist_ks, keyspace, table, loc.endpoint, loc.bucket, loc.prefix, snap_name, loc.datacenter, std::move(loc.manifests));
+        if (summary.tablet_count == 0) {
+            summary.tablet_count = loc_summary.tablet_count;
+        } else if (summary.tablet_count != loc_summary.tablet_count) {
+            throw std::runtime_error(fmt::format("Inconsistent tablet_count values across backup locations: expected {}, datacenter '{}' has {}",
+                summary.tablet_count, loc.datacenter, loc_summary.tablet_count));
+        }
+        summary.nr_sstables += loc_summary.nr_sstables;
+
+        // TODO: update state when all restored...
+        co_await sth.insert_snapshot_remote_location(snap_name, loc.datacenter, loc.endpoint, loc.bucket, loc.prefix, db::snapshot_state::remote);
+    }
 
     auto task = co_await _task_manager_module->make_and_start_task<tablet_restore_task_impl>({}, container(), keyspace, tid, std::move(snap_name), summary);
     co_return task->id();

--- a/sstables_loader.cc
+++ b/sstables_loader.cc
@@ -1269,19 +1269,16 @@ class sstables_loader::tablet_restore_task_impl : public tasks::task_manager::ta
         auto s = db.find_schema(_tid);
         auto md = db.get_token_metadata_ptr();
         const auto& topo = md->get_topology();
-        auto dc = topo.get_datacenter();
-        auto dc_racks_it = topo.get_datacenter_racks().find(dc);
-        if (dc_racks_it == topo.get_datacenter_racks().end()) {
-            co_return;
-        }
 
         db::snapshot_table_helper sth(loader._sys_dist_ks.qp());
         tasks::task_manager::task::progress progress = {};
-        co_await max_concurrent_for_each(dc_racks_it->second, 16, [&](const auto& rack_entry) -> future<> {
+        for (const auto& [dc, racks] : topo.get_datacenter_racks()) {
+        co_await max_concurrent_for_each(racks, 16, [&](const auto& rack_entry) -> future<> {
             auto p = co_await sth.get_snapshot_sstables_progress(_snap_name, s->ks_name(), s->cf_name(), dc, rack_entry.first);
             progress.total += p.nr_sstables;
             progress.completed += p.nr_downloaded_sstables;
         });
+        }
         _progress = progress;
     }
 

--- a/sstables_loader.cc
+++ b/sstables_loader.cc
@@ -1377,14 +1377,17 @@ protected:
     }
 };
 
-future<tasks::task_id> sstables_loader::restore_tablets(table_id tid, sstring keyspace, sstring table, sstring snap_name, sstring endpoint, sstring bucket, sstring prefix, utils::chunked_vector<sstring> manifests) {
-    auto summary = co_await populate_snapshot_sstables_from_manifests(_storage_manager, _sys_dist_ks, keyspace, table, endpoint, bucket, prefix, snap_name, "", std::move(manifests));
+future<tasks::task_id> sstables_loader::restore_tablets(table_id tid, sstring keyspace, sstring table, sstring snap_name, std::vector<tablet_restore_location> locations) {
+    if (locations.size() != 1) {
+        throw std::invalid_argument("expected exactly one backup location");
+    }
+    auto& loc = locations.front();
 
-    auto datacenter = _db.local().get_token_metadata().get_topology().get_datacenter();
+    auto summary = co_await populate_snapshot_sstables_from_manifests(_storage_manager, _sys_dist_ks, keyspace, table, loc.endpoint, loc.bucket, loc.prefix, snap_name, "", std::move(loc.manifests));
 
     db::snapshot_table_helper sth(_sys_dist_ks.qp());
     // TODO: update state when all restored...
-    co_await sth.insert_snapshot_remote_location(snap_name, datacenter, endpoint, bucket, prefix, db::snapshot_state::remote);
+    co_await sth.insert_snapshot_remote_location(snap_name, loc.datacenter, loc.endpoint, loc.bucket, loc.prefix, db::snapshot_state::remote);
 
     auto task = co_await _task_manager_module->make_and_start_task<tablet_restore_task_impl>({}, container(), keyspace, tid, std::move(snap_name), summary);
     co_return task->id();

--- a/sstables_loader.cc
+++ b/sstables_loader.cc
@@ -1142,7 +1142,7 @@ future<std::vector<tablet_sstable_collection>> get_sstables_for_tablets_for_test
 }
 
 static future<manifest_summary> process_manifest(input_stream<char>& is, sstring keyspace, sstring table,
-                                 const sstring& expected_snapshot_name,
+                                 const sstring& expected_snapshot_name, const sstring& expected_datacenter,
                                  const sstring& manifest_prefix, db::system_distributed_keyspace& sys_dist_ks,
                                  db::consistency_level cl) {
     // Read the entire JSON content
@@ -1175,6 +1175,10 @@ static future<manifest_summary> process_manifest(input_stream<char>& is, sstring
     auto& node_obj = rjson::get(parsed, "node");
     auto datacenter = rjson::get<std::string>(node_obj, "datacenter");
     auto rack = rjson::get<std::string>(node_obj, "rack");
+    if (!expected_datacenter.empty() && datacenter != expected_datacenter) {
+        throw std::runtime_error(fmt::format("Manifest {} belongs to datacenter '{}', expected '{}'",
+            manifest_prefix, datacenter, expected_datacenter));
+    }
 
     // Process each sstable entry in the manifest
     // FIXME: cleanup of the snapshot-related rows is needed in case anything throws in here.
@@ -1212,7 +1216,7 @@ static future<manifest_summary> process_manifest(input_stream<char>& is, sstring
     co_return manifest_summary{tablet_count, sstables->Size()};
 }
 
-future<manifest_summary> populate_snapshot_sstables_from_manifests(sstables::storage_manager& sm, db::system_distributed_keyspace& sys_dist_ks, sstring keyspace, sstring table, sstring endpoint, sstring bucket, sstring prefix, sstring expected_snapshot_name, utils::chunked_vector<sstring> manifest_prefixes, db::consistency_level cl) {
+future<manifest_summary> populate_snapshot_sstables_from_manifests(sstables::storage_manager& sm, db::system_distributed_keyspace& sys_dist_ks, sstring keyspace, sstring table, sstring endpoint, sstring bucket, sstring prefix, sstring expected_snapshot_name, sstring expected_datacenter, utils::chunked_vector<sstring> manifest_prefixes, db::consistency_level cl) {
     if (manifest_prefixes.empty()) {
         throw std::invalid_argument("manifest prefixes list must not be empty");
     }
@@ -1230,7 +1234,7 @@ future<manifest_summary> populate_snapshot_sstables_from_manifests(sstables::sto
         sstables::object_name name(bucket, join_path(prefix, manifest_prefix));
         auto source = client->make_download_source(name);
         return seastar::with_closeable(input_stream<char>(std::move(source)), [&] (input_stream<char>& is) {
-            return process_manifest(is, keyspace, table, expected_snapshot_name, manifest_prefix, sys_dist_ks, cl).then([&](manifest_summary ms) {
+            return process_manifest(is, keyspace, table, expected_snapshot_name, expected_datacenter, manifest_prefix, sys_dist_ks, cl).then([&](manifest_summary ms) {
                 size_t count = ms.tablet_count;
                 if (!tablet_count) {
                     tablet_count = count;
@@ -1374,7 +1378,7 @@ protected:
 };
 
 future<tasks::task_id> sstables_loader::restore_tablets(table_id tid, sstring keyspace, sstring table, sstring snap_name, sstring endpoint, sstring bucket, sstring prefix, utils::chunked_vector<sstring> manifests) {
-    auto summary = co_await populate_snapshot_sstables_from_manifests(_storage_manager, _sys_dist_ks, keyspace, table, endpoint, bucket, prefix, snap_name, std::move(manifests));
+    auto summary = co_await populate_snapshot_sstables_from_manifests(_storage_manager, _sys_dist_ks, keyspace, table, endpoint, bucket, prefix, snap_name, "", std::move(manifests));
 
     auto datacenter = _db.local().get_token_metadata().get_topology().get_datacenter();
 

--- a/sstables_loader.cc
+++ b/sstables_loader.cc
@@ -1175,7 +1175,7 @@ static future<manifest_summary> process_manifest(input_stream<char>& is, sstring
     auto& node_obj = rjson::get(parsed, "node");
     auto datacenter = rjson::get<std::string>(node_obj, "datacenter");
     auto rack = rjson::get<std::string>(node_obj, "rack");
-    if (!expected_datacenter.empty() && datacenter != expected_datacenter) {
+    if (datacenter != expected_datacenter) {
         throw std::runtime_error(fmt::format("Manifest {} belongs to datacenter '{}', expected '{}'",
             manifest_prefix, datacenter, expected_datacenter));
     }
@@ -1383,7 +1383,7 @@ future<tasks::task_id> sstables_loader::restore_tablets(table_id tid, sstring ke
     }
     auto& loc = locations.front();
 
-    auto summary = co_await populate_snapshot_sstables_from_manifests(_storage_manager, _sys_dist_ks, keyspace, table, loc.endpoint, loc.bucket, loc.prefix, snap_name, "", std::move(loc.manifests));
+    auto summary = co_await populate_snapshot_sstables_from_manifests(_storage_manager, _sys_dist_ks, keyspace, table, loc.endpoint, loc.bucket, loc.prefix, snap_name, loc.datacenter, std::move(loc.manifests));
 
     db::snapshot_table_helper sth(_sys_dist_ks.qp());
     // TODO: update state when all restored...

--- a/sstables_loader.cc
+++ b/sstables_loader.cc
@@ -1273,11 +1273,11 @@ class sstables_loader::tablet_restore_task_impl : public tasks::task_manager::ta
         db::snapshot_table_helper sth(loader._sys_dist_ks.qp());
         tasks::task_manager::task::progress progress = {};
         for (const auto& [dc, racks] : topo.get_datacenter_racks()) {
-        co_await max_concurrent_for_each(racks, 16, [&](const auto& rack_entry) -> future<> {
-            auto p = co_await sth.get_snapshot_sstables_progress(_snap_name, s->ks_name(), s->cf_name(), dc, rack_entry.first);
-            progress.total += p.nr_sstables;
-            progress.completed += p.nr_downloaded_sstables;
-        });
+            co_await max_concurrent_for_each(racks, 16, [&](const auto& rack_entry) -> future<> {
+                auto p = co_await sth.get_snapshot_sstables_progress(_snap_name, s->ks_name(), s->cf_name(), dc, rack_entry.first);
+                progress.total += p.nr_sstables;
+                progress.completed += p.nr_downloaded_sstables;
+            });
         }
         _progress = progress;
     }

--- a/sstables_loader.cc
+++ b/sstables_loader.cc
@@ -31,6 +31,7 @@
 #include "streaming/stream_reason.hh"
 #include "readers/mutation_fragment_v1_stream.hh"
 #include "locator/abstract_replication_strategy.hh"
+#include "locator/network_topology_strategy.hh"
 #include "message/messaging_service.hh"
 #include "service/storage_service.hh"
 #include "utils/error_injection.hh"
@@ -44,6 +45,7 @@
 
 #include <cfloat>
 #include <algorithm>
+#include <set>
 
 static logging::logger llog("sstables_loader");
 
@@ -1377,7 +1379,35 @@ protected:
     }
 };
 
+// Every datacenter the table replicates to restores from its own backup location,
+// so the locations must map one-to-one to the replicated-to datacenters.
+static void check_datacenter_coverage(const replica::table& t, const std::vector<tablet_restore_location>& locations) {
+    auto& rs = t.get_effective_replication_map()->get_replication_strategy();
+    const auto* nts = dynamic_cast<const locator::network_topology_strategy*>(&rs);
+    if (!nts) {
+        throw std::invalid_argument(fmt::format("Table {}.{} does not use NetworkTopologyStrategy", t.schema()->ks_name(), t.schema()->cf_name()));
+    }
+
+    auto replicated_dcs = nts->get_datacenters()
+        | std::views::filter([nts] (const sstring& dc) { return nts->get_replication_factor(dc) > 0; })
+        | std::ranges::to<std::set<sstring>>();
+
+    auto location_dcs = locations
+        | std::views::transform(&tablet_restore_location::datacenter)
+        | std::ranges::to<std::set<sstring>>();
+    if (location_dcs.size() != locations.size()) {
+        throw std::invalid_argument("Duplicate datacenters in backup locations");
+    }
+
+    if (location_dcs != replicated_dcs) {
+        throw std::invalid_argument(fmt::format("Backup locations datacenters [{}] don't match the datacenters [{}] keyspace {} replicates to",
+            fmt::join(location_dcs, ", "), fmt::join(replicated_dcs, ", "), t.schema()->ks_name()));
+    }
+}
+
 future<tasks::task_id> sstables_loader::restore_tablets(table_id tid, sstring keyspace, sstring table, sstring snap_name, std::vector<tablet_restore_location> locations) {
+    check_datacenter_coverage(_db.local().find_column_family(tid), locations);
+
     db::snapshot_table_helper sth(_sys_dist_ks.qp());
     manifest_summary summary = { .tablet_count = 0, .nr_sstables = 0 };
 

--- a/sstables_loader.cc
+++ b/sstables_loader.cc
@@ -1000,7 +1000,7 @@ future<> sstables_loader::download_tablet_sstables(locator::global_tablet_id tid
     auto snapshot_info = co_await sth.get_snapshot_remote_location(snapshot_name, datacenter);
     llog.info("Downloading sstables for tablet {} from {}@{}/{}", tid, snapshot_name, snapshot_info.endpoint, snapshot_info.bucket);
     auto sst_infos = co_await sth.get_snapshot_sstables(snapshot_name, keyspace_name, table_name, datacenter, rack,
-            db::consistency_level::LOCAL_QUORUM, tablet_range.start().transform([] (auto& v) { return v.value(); }), tablet_range.end().transform([] (auto& v) { return v.value(); }));
+            db::consistency_level::QUORUM, tablet_range.start().transform([] (auto& v) { return v.value(); }), tablet_range.end().transform([] (auto& v) { return v.value(); }));
     llog.debug("{} SSTables found for tablet {}", sst_infos.size(), tid);
     if (sst_infos.empty()) {
         // It can happen when the restored table has more tablets than the original.

--- a/sstables_loader.hh
+++ b/sstables_loader.hh
@@ -200,4 +200,5 @@ struct manifest_summary {
     size_t nr_sstables;
 };
 
-future<manifest_summary> populate_snapshot_sstables_from_manifests(sstables::storage_manager& sm, db::system_distributed_keyspace& sys_dist_ks, sstring keyspace, sstring table, sstring endpoint, sstring bucket, sstring prefix, sstring expected_snapshot_name, utils::chunked_vector<sstring> manifest_prefixes, db::consistency_level cl = db::consistency_level::EACH_QUORUM);
+// If expected_datacenter is not empty, manifests coming from any other datacenter are rejected.
+future<manifest_summary> populate_snapshot_sstables_from_manifests(sstables::storage_manager& sm, db::system_distributed_keyspace& sys_dist_ks, sstring keyspace, sstring table, sstring endpoint, sstring bucket, sstring prefix, sstring expected_snapshot_name, sstring expected_datacenter, utils::chunked_vector<sstring> manifest_prefixes, db::consistency_level cl = db::consistency_level::EACH_QUORUM);

--- a/sstables_loader.hh
+++ b/sstables_loader.hh
@@ -212,5 +212,5 @@ struct manifest_summary {
     size_t nr_sstables;
 };
 
-// If expected_datacenter is not empty, manifests coming from any other datacenter are rejected.
+// Manifests coming from a datacenter other than the expected one are rejected.
 future<manifest_summary> populate_snapshot_sstables_from_manifests(sstables::storage_manager& sm, db::system_distributed_keyspace& sys_dist_ks, sstring keyspace, sstring table, sstring endpoint, sstring bucket, sstring prefix, sstring expected_snapshot_name, sstring expected_datacenter, utils::chunked_vector<sstring> manifest_prefixes, db::consistency_level cl = db::consistency_level::EACH_QUORUM);

--- a/sstables_loader.hh
+++ b/sstables_loader.hh
@@ -48,6 +48,17 @@ class effective_replication_map;
 class tablet_metadata_guard;
 }
 
+// A single backup location for tablet-aware restore: where in the object
+// storage the sstables of one datacenter's backup live, and the datacenter
+// of the restored cluster they are to be loaded into.
+struct tablet_restore_location {
+    sstring datacenter;
+    sstring endpoint;
+    sstring bucket;
+    sstring prefix;
+    utils::chunked_vector<sstring> manifests;
+};
+
 struct stream_progress {
     float total = 0.;
     float completed = 0.;
@@ -152,7 +163,8 @@ public:
             sstring prefix, std::vector<sstring> sstables,
             sstring endpoint, sstring bucket, stream_scope scope, bool primary_replica);
 
-    future<tasks::task_id> restore_tablets(table_id, sstring keyspace, sstring table, sstring snap_name, sstring endpoint, sstring bucket, sstring prefix, utils::chunked_vector<sstring> manifests);
+    // Takes one backup location per datacenter the keyspace replicates to.
+    future<tasks::task_id> restore_tablets(table_id, sstring keyspace, sstring table, sstring snap_name, std::vector<tablet_restore_location> locations);
 
     replica::database& local_db() {
         return _db.local();

--- a/test/boost/tablet_aware_restore_test.cc
+++ b/test/boost/tablet_aware_restore_test.cc
@@ -364,10 +364,13 @@ SEASTAR_TEST_CASE(test_populate_snapshot_sstables_from_manifests, *boost::unit_t
             auto prefix = backup(env, ep, bucket).get();
             auto manifest_path = prefix + "/manifest.json";
 
-            BOOST_REQUIRE_THROW(populate_snapshot_sstables_from_manifests(env.get_sstorage_manager().local(), env.get_system_distributed_keyspace().local(), "ks", "cf", ep, bucket, "", "unexpected_snapshot", {manifest_path}, db::consistency_level::ONE).get(), std::runtime_error);;
+            auto dc = env.get_storage_proxy().local().get_token_metadata_ptr()->get_topology().get_datacenter();
+
+            BOOST_REQUIRE_THROW(populate_snapshot_sstables_from_manifests(env.get_sstorage_manager().local(), env.get_system_distributed_keyspace().local(), "ks", "cf", ep, bucket, "", "unexpected_snapshot", dc, {manifest_path}, db::consistency_level::ONE).get(), std::runtime_error);
+            BOOST_REQUIRE_THROW(populate_snapshot_sstables_from_manifests(env.get_sstorage_manager().local(), env.get_system_distributed_keyspace().local(), "ks", "cf", ep, bucket, "", "snapshot", "unexpected_dc", {manifest_path}, db::consistency_level::ONE).get(), std::runtime_error);
 
             // populate system_distributed.snapshot_sstables with the content of the snapshot manifest
-            populate_snapshot_sstables_from_manifests(env.get_sstorage_manager().local(), env.get_system_distributed_keyspace().local(), "ks", "cf", ep, bucket, "", "snapshot", {manifest_path}, db::consistency_level::ONE).get();
+            populate_snapshot_sstables_from_manifests(env.get_sstorage_manager().local(), env.get_system_distributed_keyspace().local(), "ks", "cf", ep, bucket, "", "snapshot", dc, {manifest_path}, db::consistency_level::ONE).get();
 
             check_snapshot_sstables(env).get();
     }, false, db_cfg_ptr, 10);

--- a/test/cluster/object_store/test_backup.py
+++ b/test/cluster/object_store/test_backup.py
@@ -796,6 +796,8 @@ async def do_test_streaming_scopes(build_mode: str, manager: ScyllaClusterManage
 @pytest.mark.parametrize("topology", [
         topo(rf = 1, nodes = 2, racks = 1, dcs = 1),
         topo(rf = 2, nodes = 2, racks = 2, dcs = 1),
+        topo(rf = 1, nodes = 2, racks = 1, dcs = 2),
+        topo(rf = 2, nodes = 8, racks = 2, dcs = 2),
     ])
 @pytest.mark.parametrize("num_tables, num_restore_nodes", [
         (1, 1),  # single table via a single node
@@ -803,7 +805,7 @@ async def do_test_streaming_scopes(build_mode: str, manager: ScyllaClusterManage
         (2, 2),  # multiple tables dispatched from multiple nodes
     ])
 async def test_restore_tablets(build_mode: str, manager: ScyllaClusterManager, object_storage, topology, num_tables, num_restore_nodes):
-    '''Check that tablet-aware restore works for multiple tables backed up from multiple nodes'''
+    '''Check that tablet-aware restore works for multiple tables backed up from multiple nodes and datacenters'''
     await do_test_restore_tablets(build_mode, manager, object_storage, topology, num_tables, num_restore_nodes)
 
 
@@ -869,11 +871,27 @@ async def do_test_restore_tablets(build_mode: str, manager: ScyllaClusterManager
 
             restore_nodes = servers[:num_restore_nodes]
 
+            servers_per_dc = defaultdict(list)
+            for s in servers:
+                servers_per_dc[s.datacenter].append(s)
+
             async def restore_table(idx, cf):
                 node = restore_nodes[idx % len(restore_nodes)]
                 logger.info(f'Restore table {cf} into {dst_ks}.{cf}_restored via {node.ip_addr}')
-                manifests = [f'{s.server_id}/{cf}/manifest.json' for s in servers]
-                tid = await manager.api.restore_tablets(node.ip_addr, dst_ks, f'{cf}_restored', snap_name, servers[0].datacenter, object_storage.address, object_storage.bucket_name, manifests, restore_prefix)
+                locations = [
+                    {
+                        "datacenter": dc,
+                        "endpoint": object_storage.address,
+                        "bucket": object_storage.bucket_name,
+                        "prefix": restore_prefix,
+                        "manifests": [f'{s.server_id}/{cf}/manifest.json' for s in dc_servers]
+                    } for dc, dc_servers in servers_per_dc.items()
+                ]
+                if topology.dcs > 1:
+                    # The locations must cover all the DCs the keyspace replicates to
+                    with pytest.raises(HTTPError, match="don't match the datacenters"):
+                        await manager.api.restore_tablets_multidc(node.ip_addr, dst_ks, f'{cf}_restored', snap_name, locations[:1])
+                tid = await manager.api.restore_tablets_multidc(node.ip_addr, dst_ks, f'{cf}_restored', snap_name, locations)
                 status = await manager.api.wait_task(node.ip_addr, tid)
                 assert (status is not None) and (status['state'] == 'done'), f"Restore of {cf} via {node.ip_addr} failed: {status}"
                 assert status['progress_total'] > 0

--- a/test/pylib/rest_client.py
+++ b/test/pylib/rest_client.py
@@ -432,12 +432,7 @@ class ScyllaRESTAPIClient:
         return await self.client.post_json(f"/storage_service/restore", host=node_ip, params=params, json=sstables)
 
     async def restore_tablets(self, node_ip: str, ks: str, cf: str, snap: str, datacenter: str, endpoint: str, bucket: str, manifests, prefix: str = '') -> str:
-        """Restore tablets from a backup location"""
-        params = {
-            "keyspace": ks,
-            "table": cf,
-            "snapshot": snap
-        }
+        """Restore tablets from a single backup location"""
         backup_location = [
             {
                 "datacenter": datacenter,
@@ -447,7 +442,16 @@ class ScyllaRESTAPIClient:
                 "manifests": manifests
             }
         ]
-        return await self.client.post_json(f"/storage_service/tablets/restore", host=node_ip, params=params, json=backup_location)
+        return await self.restore_tablets_multidc(node_ip, ks, cf, snap, backup_location)
+
+    async def restore_tablets_multidc(self, node_ip: str, ks: str, cf: str, snap: str, locations: list[dict]) -> str:
+        """Restore tablets from a list of per-datacenter backup locations"""
+        params = {
+            "keyspace": ks,
+            "table": cf,
+            "snapshot": snap
+        }
+        return await self.client.post_json(f"/storage_service/tablets/restore", host=node_ip, params=params, json=locations)
 
     async def take_snapshot(self, node_ip: str, ks: str, tag: str, tables: list[str] = None, ttl: Optional[str] = None) -> None:
         """Take keyspace snapshot"""


### PR DESCRIPTION
The core restore code can already handle a multi-DC restore — each replica downloads the sstables belonging to its own datacenter and rack. The missing bits were on the front side: restore metadata population assumed a single backup location, and progress tracking only counted the local datacenter. With those fixed, the `tablets/restore` endpoint now accepts one backup location per datacenter the keyspace replicates to.

fixes SCYLLADB-1009

New feature, not backporting