### PR TITLE
alternator: set default tombstone_gc mode when creating tables and views

### DIFF
--- a/alternator/executor.cc
+++ b/alternator/executor.cc
@@ -16,6 +16,8 @@
 #include "cdc/log.hh"
 #include "cdc/cdc_options.hh"
 #include "cdc/cdc_extension.hh"
+#include "tombstone_gc_extension.hh"
+#include "tombstone_gc.hh"
 #include "auth/service.hh"
 #include "cql3/cql3_type.hh"
 #include "db/config.hh"
@@ -1333,6 +1335,13 @@ static future<> mark_view_schemas_as_built(utils::chunked_vector<mutation>& out,
     }
 }
 
+// Check whether two schemas have the same partition key - the same columns
+// in the same order (cf. database::get_base_table_for_tablet_colocation()).
+static bool same_partition_key(const schema& view, const schema& base) {
+    return std::ranges::equal(view.partition_key_columns(), base.partition_key_columns(),
+            {}, &column_definition::name, &column_definition::name);
+}
+
 // When Alternator Streams are requested on a tablet table, update the
 // already-configured enabled=true CDC options:
 // - tablet_merge_blocked=true: suppress tablet merges that would produce
@@ -1754,7 +1763,10 @@ future<executor::request_return_type> executor::create_table_on_shard0(service::
         auto ksm = create_keyspace_metadata(keyspace_name, _proxy, _gossiper, ts, tags_map, _proxy.features(), tablets_mode);
         locator::replication_strategy_params params(ksm->strategy_options(), ksm->initial_tablets(), ksm->consistency_option());
         const auto& topo = _proxy.local_db().get_token_metadata().get_topology();
-        auto rs = locator::abstract_replication_strategy::create_replication_strategy(ksm->strategy_name(), params, topo);
+        // The keyspace may have been pre-created by the user, in which case its
+        // replication strategy - not the one we would create - governs its tables.
+        auto rs = _proxy.local_db().has_keyspace(keyspace_name) ? _proxy.local_db().find_keyspace(keyspace_name).get_replication_strategy_ptr()
+                : locator::replication_strategy_ptr(locator::abstract_replication_strategy::create_replication_strategy(ksm->strategy_name(), params, topo));
 
         // Vector indexes is a new feature that we decided to only support
         // on tablets.
@@ -1803,15 +1815,20 @@ future<executor::request_return_type> executor::create_table_on_shard0(service::
             // This should never happen, the ID is supposed to be unique
             co_return api_error::internal(format("Table with ID {} already exists", schema->id()));
         }
+        // Set the default tombstone_gc mode, like CQL CREATE TABLE does via
+        // cf_prop_defs::apply_to_builder(). Co-located views don't support
+        // repair (see create_index_statement.cc), so they keep 'timeout'.
+        builder.add_extension(tombstone_gc_extension::NAME, ::make_shared<tombstone_gc_extension>(get_default_tombstone_gc_mode(*rs, true)));
+        schema = builder.build();
         std::vector<schema_ptr> schemas;
         schemas.push_back(schema);
         for (schema_builder& view_builder : view_builders) {
+            const bool colocated = rs->uses_tablets() && same_partition_key(*view_builder.build(), *schema);
+            view_builder.add_extension(tombstone_gc_extension::NAME, ::make_shared<tombstone_gc_extension>(get_default_tombstone_gc_mode(*rs, !colocated)));
             schemas.push_back(view_builder.build());
         }
         co_await service::prepare_new_column_families_announcement(schema_mutations, _proxy, *ksm, schemas, ts);
-        const bool uses_tablets = _proxy.local_db().has_keyspace(keyspace_name)
-                ? _proxy.local_db().find_keyspace(keyspace_name).uses_tablets() : ksm->uses_tablets();
-        if (uses_tablets) {
+        if (rs->uses_tablets()) {
             co_await mark_view_schemas_as_built(schema_mutations, schemas, ts, _proxy);
         }
 
@@ -2240,6 +2257,11 @@ future<executor::request_return_type> executor::update_table(client_state& clien
                         }
                         // GSIs have no tags:
                         view_builder.add_extension(db::tags_extension::NAME, ::make_shared<db::tags_extension>());
+                        // Set the default tombstone_gc mode, like CQL CREATE
+                        // INDEX does (see create_index_statement.cc).
+                        const auto& ks_rs = p.local().local_db().find_keyspace(keyspace_name).get_replication_strategy();
+                        const bool colocated = ks_rs.uses_tablets() && same_partition_key(*view_builder.build(), *schema);
+                        view_builder.add_extension(tombstone_gc_extension::NAME, ::make_shared<tombstone_gc_extension>(get_default_tombstone_gc_mode(ks_rs, !colocated)));
                         // Note below we don't need to add virtual columns, as all
                         // base columns were copied to view. TODO: reconsider the need
                         // for virtual columns when we support Projection.

--- a/alternator/executor.cc
+++ b/alternator/executor.cc
@@ -1809,7 +1809,9 @@ future<executor::request_return_type> executor::create_table_on_shard0(service::
             schemas.push_back(view_builder.build());
         }
         co_await service::prepare_new_column_families_announcement(schema_mutations, _proxy, *ksm, schemas, ts);
-        if (ksm->uses_tablets()) {
+        const bool uses_tablets = _proxy.local_db().has_keyspace(keyspace_name)
+                ? _proxy.local_db().find_keyspace(keyspace_name).uses_tablets() : ksm->uses_tablets();
+        if (uses_tablets) {
             co_await mark_view_schemas_as_built(schema_mutations, schemas, ts, _proxy);
         }
 

--- a/test/alternator/test_tablets.py
+++ b/test/alternator/test_tablets.py
@@ -13,6 +13,8 @@
 # override it. Most of these tests, or perhaps even this entire file,
 # will probably go away eventually.
 
+import ast
+
 import pytest
 from botocore.exceptions import ClientError
 
@@ -162,3 +164,67 @@ def test_alternator_tablets_without_lwt(dynamodb):
         assert_tablets_usage_follows_config(dynamodb, table)
         table.put_item(Item={'p': 'hello'})
         assert table.get_item(Key={'p': 'hello'})['Item'] == {'p': 'hello'}
+
+# Utility function for reading the tombstone_gc mode of an Alternator table,
+# or - if index_name is given - of the materialized view backing that index
+# (index_delim distinguishes the view names of GSIs (':') and LSIs ('!:')).
+# Returns the mode as a string, or None if the table or view doesn't have
+# the tombstone_gc property at all.
+def tombstone_gc_mode(cql, table, index_name=None, index_delim=None):
+    keyspace = 'alternator_' + table.name
+    if index_name:
+        describe = f'DESCRIBE MATERIALIZED VIEW "{keyspace}"."{table.name}{index_delim}{index_name}"'
+    else:
+        describe = f'DESCRIBE TABLE "{keyspace}"."{table.name}"'
+    stmt = cql.execute(describe).one().create_statement
+    # The returned create statement lists the tombstone_gc property as a map,
+    # e.g., "tombstone_gc = {'mode': 'repair', ...}", so after partition()
+    # rest begins with the map literal, which ends at the first '}' (the map
+    # has no nested braces) and is also a valid Python literal. Parse it and
+    # return its 'mode' value - 'repair' in the example above - or None if
+    # the statement has no tombstone_gc property at all.
+    _, found, rest = stmt.partition('tombstone_gc = ')
+    return ast.literal_eval(rest[:rest.index('}') + 1])['mode'] if found else None
+
+# Alternator tables and their GSI/LSI views should get the same default
+# tombstone_gc mode as CQL-created tables and indexes: 'repair', except for
+# views co-located with their base table (a view of a tablets-using table
+# with the same partition key - e.g., an LSI view), which don't support
+# repair and should get 'timeout'. This is what lsi_mode expects below.
+# Reproduces SCYLLADB-3759, where the mode was left unset - so all Alternator
+# tables silently defaulted to 'timeout'.
+@pytest.mark.parametrize('initial_tablets,lsi_mode', [
+    pytest.param('0', 'timeout', id='tablets'),
+    pytest.param('none', 'repair', id='vnodes')])
+def test_tombstone_gc_default(dynamodb, cql, initial_tablets, lsi_mode):
+    schema = {
+        'Tags': [{'Key': initial_tablets_tag, 'Value': initial_tablets}],
+        'KeySchema': [ { 'AttributeName': 'p', 'KeyType': 'HASH' },
+                       { 'AttributeName': 'c', 'KeyType': 'RANGE' } ],
+        'AttributeDefinitions': [ { 'AttributeName': 'p', 'AttributeType': 'S' },
+                                  { 'AttributeName': 'c', 'AttributeType': 'S' },
+                                  { 'AttributeName': 'x', 'AttributeType': 'S' },
+                                  { 'AttributeName': 'y', 'AttributeType': 'S' } ],
+        'GlobalSecondaryIndexes': [
+            { 'IndexName': 'gsi',
+              'KeySchema': [ { 'AttributeName': 'x', 'KeyType': 'HASH' } ],
+              'Projection': { 'ProjectionType': 'ALL' } } ],
+        'LocalSecondaryIndexes': [
+            { 'IndexName': 'lsi',
+              'KeySchema': [ { 'AttributeName': 'p', 'KeyType': 'HASH' },
+                             { 'AttributeName': 'y', 'KeyType': 'RANGE' } ],
+              'Projection': { 'ProjectionType': 'ALL' } } ]}
+    with new_test_table(dynamodb, **schema) as table:
+        assert uses_tablets(dynamodb, table) == (initial_tablets != 'none')
+        assert tombstone_gc_mode(cql, table) == 'repair'
+        assert tombstone_gc_mode(cql, table, 'gsi', ':') == 'repair'
+        assert tombstone_gc_mode(cql, table, 'lsi', '!:') == lsi_mode
+        # A GSI created later by UpdateTable takes a different code path
+        # than CreateTable, so check it too:
+        dynamodb.meta.client.update_table(TableName=table.name,
+            AttributeDefinitions=[{ 'AttributeName': 'z', 'AttributeType': 'S' }],
+            GlobalSecondaryIndexUpdates=[ { 'Create':
+                { 'IndexName': 'gsi2',
+                  'KeySchema': [ { 'AttributeName': 'z', 'KeyType': 'HASH' } ],
+                  'Projection': { 'ProjectionType': 'ALL' } }}])
+        assert tombstone_gc_mode(cql, table, 'gsi2', ':') == 'repair'


### PR DESCRIPTION
Alternator `CreateTable` and `UpdateTable` (GSI Create) built their schemas directly with `schema_builder` without the `tombstone_gc` extension. CQL `CREATE TABLE`/`CREATE INDEX` on the other hand do explicitly add `tombstone_gc`.
With the extension absent, `schema::user_properties::get_tombstone_gc_options()` falls back to a default-constructed `tombstone_gc_options`, i.e. mode `timeout` — instead of the intended default `repair`. This also means Scylla Manager (or anyone reading `system_schema.tables` extensions) cannot see the effective mode.

This adds the default extension at all three Alternator schema-creation sites (`CreateTable` base table, `CreateTable` LSI/GSI views, `UpdateTable`-created GSIs), mirroring `cf_prop_defs::apply_to_builder()` and `create_index_statement.cc`:

- base tables and views get `get_default_tombstone_gc_mode(rs, supports_repair)`;
- a view co-located with its base table (tablets keyspace + same partition key, per `database::get_base_table_for_tablet_colocation()`) doesn't support repair, so it gets `supports_repair = false` (mode `timeout`). The co-location check compares the full partition-key column lists, so it stays correct for multi-column view partition keys;

If the keyspace was pre-created by the user, its actual replication strategy is used instead of the one Alternator would create, since tablets-ness (and hence view co-location) depends on it.

Existing tables are intentionally not touched — they keep the implicit `timeout` until handled separately (relevant for the backport discussion in the ticket).

Based on #31311, which this builds on; merge after it.

Fixes SCYLLADB-3759

Backport to all active branches where the problem exists.

