### PR TITLE
topology_coordinator: don't run ordered ops under a foreign session

### DIFF
--- a/service/topology_coordinator.cc
+++ b/service/topology_coordinator.cc
@@ -2883,6 +2883,10 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
         // We should perform TRUNCATE only if the session is still valid. It could be cleared if a previous truncate
         // handler performed the truncate and cleared the session, but crashed before finalizing the request
         if (_topo_sm._topology.session) {
+            // Read the session under the guard. Once it's released below, a new coordinator
+            // may install a session of its own, and sending the RPC with someone else's
+            // session would execute this operation outside of the scope its guard bounds.
+            const session_id session = _topo_sm._topology.session;
             const auto topology_requests_entry = co_await _sys_ks.get_topology_request_entry(global_request_id);
             std::unordered_set<table_id> tables;
             try {
@@ -2917,8 +2921,15 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
                     }
                 }
 
+                // The guard was released above, so we may have been deposed since. Don't
+                // touch the replicas if this operation is no longer the current one.
+                if (_term != _raft.get_current_term() || _topo_sm._topology.session != session) {
+                    rtlogger.info("{} is no longer the current operation, not sending the RPCs", desc());
+                    throw term_changed_error{};
+                }
+
                 // Send the RPC to all replicas
-                const service::frozen_topology_guard frozen_guard { _topo_sm._topology.session };
+                const service::frozen_topology_guard frozen_guard { session };
                 co_await coroutine::parallel_for_each(replica_hosts, [&] (const locator::host_id& host_id) -> future<> {
                     co_await send_rpc(host_id, frozen_guard);
                 });
@@ -2979,7 +2990,7 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
                                 .build());
 
             try {
-                co_await update_topology_state(std::move(guard), std::move(updates), fmt::format("{}{} has completed", ::toupper(what[0]), what.substr(1)));
+                co_await update_topology_state(std::move(guard), std::move(updates), fmt::format("{}{} has completed", static_cast<char>(::toupper(what[0])), what.substr(1)));
                 break;
             } catch (group0_concurrent_modification&) {
             }

--- a/test/cluster/test_truncate_with_tablets.py
+++ b/test/cluster/test_truncate_with_tablets.py
@@ -9,7 +9,7 @@ from cassandra.cluster import TruncateError
 from cassandra.policies import FallthroughRetryPolicy
 from test.pylib.scylla_cluster_manager import ScyllaClusterManager
 from test.cluster.util import get_topology_coordinator, new_test_keyspace, FeatureConfig, feature_configs, \
-    FeatureConfigurations, count_rows
+    FeatureConfigurations, count_rows, trigger_stepdown
 from test.pylib.tablets import get_all_tablet_replicas, get_tablet_count
 from test.pylib.util import wait_for_cql_and_get_hosts, wait_for
 import time
@@ -442,3 +442,79 @@ async def test_split_emitted_during_truncate(manager: ScyllaClusterManager):
             return tablet_count >= expected_tablet_count or None
         # Give enough time for split to happen in debug mode
         await wait_for(finished_splitting, time.time() + 120)
+
+
+@pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
+async def test_truncate_by_stale_coordinator_with_foreign_session(manager: ScyllaClusterManager):
+    """A coordinator which loses leadership while parked in handle_topology_ordered_op()
+    must not truncate under a session it does not own.
+
+    handle_topology_ordered_op() reads _topology.session after releasing the group0 guard,
+    so a deposed coordinator can pick up the session of an unrelated operation which is in
+    flight. Replicas accept the RPC and truncate the table a second time, after the user's
+    TRUNCATE already returned.
+    """
+    logger.info('Bootstrapping cluster')
+    cfg = { 'tablets_mode_for_new_keyspaces': 'enabled' }
+
+    servers = []
+    servers.append(await manager.server_add(config=cfg))
+    servers.append(await manager.server_add(config=cfg))
+    servers.append(await manager.server_add(config=cfg))
+
+    cql = manager.get_cql()
+    hosts = await wait_for_cql_and_get_hosts(cql, servers, time.time() + 60)
+    # Keep the load balancer out of the picture, it would set sessions of its own
+    await manager.disable_tablet_balancing()
+
+    async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 2}") as ks:
+        await cql.run_async(f'CREATE TABLE {ks}.ta (pk int PRIMARY KEY, c int);')
+        await cql.run_async(f'CREATE TABLE {ks}.tb (pk int PRIMARY KEY, c int);')
+
+        keys = range(128)
+        await asyncio.gather(*[cql.run_async(f'INSERT INTO {ks}.ta (pk, c) VALUES ({k}, {k});') for k in keys])
+
+        (stale_coord, stale_coord_log) = await get_raft_leader_and_log(manager, servers)
+        stale_coord_host_id = await manager.get_host_id(stale_coord.server_id)
+        # Drive CQL through a node unaffected by the leadership change below
+        client_host = next(h for (s, h) in zip(servers, hosts) if s != stale_coord)
+
+        # Park the coordinator between release_guard() and the session read
+        await manager.api.enable_injection(stale_coord.ip_addr, 'truncate_table_wait', one_shot=True)
+        trunc_a = cql.run_async(f'TRUNCATE TABLE {ks}.ta', host=client_host)
+        await manager.api.wait_for_injection_enter(stale_coord.ip_addr, 'truncate_table_wait')
+
+        # Make it lose leadership while parked. The new coordinator re-runs the truncate
+        # from scratch and finalizes the request, so the client's TRUNCATE completes.
+        await trigger_stepdown(manager, stale_coord)
+
+        async def coordinator_moved():
+            return await get_topology_coordinator(manager) != stale_coord_host_id or None
+        await wait_for(coordinator_moved, time.time() + 60)
+        await trunc_a
+
+        # Data written after TRUNCATE ta completed must survive
+        await asyncio.gather(*[cql.run_async(f'INSERT INTO {ks}.ta (pk, c) VALUES ({k}, {k});') for k in keys])
+
+        # Hold an unrelated operation's session open by parking the current coordinator
+        (coord, _) = await get_raft_leader_and_log(manager, servers)
+        await manager.api.enable_injection(coord.ip_addr, 'truncate_table_wait', one_shot=True)
+        trunc_b = cql.run_async(f'TRUNCATE TABLE {ks}.tb', host=client_host)
+        await manager.api.wait_for_injection_enter(coord.ip_addr, 'truncate_table_wait')
+
+        # Release the stale coordinator. It must notice that it is not the coordinator of
+        # this truncate anymore instead of sending the ta RPCs under tb's session.
+        mark = await stale_coord_log.mark()
+        await manager.api.message_injection(stale_coord.ip_addr, 'truncate_table_wait')
+        await stale_coord_log.wait_for('is no longer the current operation', from_mark=mark, timeout=60)
+
+        # tb's finalization barrier drains tb's session, joining with any RPC admitted
+        # under it, so once trunc_b returns the stale ta truncate has completed too.
+        await manager.api.message_injection(coord.ip_addr, 'truncate_table_wait')
+        await trunc_b
+
+        row = await cql.run_async(SimpleStatement(f'SELECT COUNT(*) FROM {ks}.ta', consistency_level=ConsistencyLevel.ALL))
+        assert row[0].count == len(keys)
+
+        row = await cql.run_async(SimpleStatement(f'SELECT COUNT(*) FROM {ks}.tb', consistency_level=ConsistencyLevel.ALL))
+        assert row[0].count == 0


### PR DESCRIPTION
handle_topology_ordered_op() releases the group0 guard before sending its RPCs, but reads _topology.session afterwards. That read is covered neither by the guard's read_apply mutex nor by the term check in start_operation(), so a coordinator which lost leadership in that window can pick up the session installed by a later, unrelated operation. Replicas accept the RPC because the session exists and is open, and the operation runs after its request has already been finalized. The session is the only fence these RPCs have - they carry no term and no request id - so borrowing someone else's defeats it.

This affects every operation driven by this helper, TRUNCATE and SNAPSHOT today.

Read the session while the guard is still held, and re-check before sending the RPCs that we are still the coordinator of this operation. A deposed coordinator now sends nothing; if it does not notice in time, it presents its own session, which is either still open (a harmless duplicate joined by the finalization barrier) or already closed and rejected.

The new test reproduces the data loss deterministically: it parks the coordinator in the truncate_table_wait injection, steps it down so another coordinator completes the truncate, writes new rows, then holds an unrelated truncate's session open while releasing the stale coordinator.

Drive-by: ::toupper() returns int, so the completion message read "84runcate has completed".

Fixes: https://scylladb.atlassian.net/browse/SCYLLADB-3927.

Needs backport to all live version as they all have the bug.