### PR TITLE
build: update to fmt 12.2.1 (preprelease)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -15,3 +15,6 @@
 [submodule "tools/cqlsh"]
 	path = tools/cqlsh
 	url = ../scylla-cqlsh
+[submodule "fmt"]
+	path = fmt
+	url = ../fmt

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,6 +62,26 @@ set(CMAKE_VISIBILITY_INLINES_HIDDEN ON)
 add_compile_definitions(SEASTAR_NO_EXCEPTION_HACK)
 # Hacks needed to expose internal APIs for xxhash dependencies
 add_compile_definitions(XXH_PRIVATE_API)
+
+# Build the bundled fmt submodule rather than relying on whatever version
+# happens to be installed on the host (matching configure.py). This must come
+# before Seastar is configured below: for the in-tree Seastar build, CMake
+# redirects Seastar's find_package(fmt) to this subdirectory's fmt::fmt target.
+# Build fmt shared in Debug/Dev and static otherwise, matching Seastar's own
+# linkage so fmt symbols don't end up in both libseastar and a static libfmt.
+if(CMAKE_BUILD_TYPE STREQUAL "Debug" OR CMAKE_BUILD_TYPE STREQUAL "Dev")
+    set(BUILD_SHARED_LIBS ON CACHE BOOL "" FORCE)
+else()
+    set(BUILD_SHARED_LIBS OFF CACHE BOOL "" FORCE)
+endif()
+set(FMT_INSTALL OFF CACHE BOOL "" FORCE)
+set(FMT_TEST OFF CACHE BOOL "" FORCE)
+set(FMT_DOC OFF CACHE BOOL "" FORCE)
+set(FMT_FUZZ OFF CACHE BOOL "" FORCE)
+# We don't consume fmt's C++20 module; building it drags in module dependency
+# scanning, which Scylla otherwise disables.
+set(FMT_MODULE OFF CACHE BOOL "" FORCE)
+add_subdirectory(fmt)
 # SEASTAR_TESTING_MAIN is added later (after add_subdirectory(seastar) and
 # add_subdirectory(abseil)) to avoid leaking into the seastar subdirectory.
 # If SEASTAR_TESTING_MAIN is defined globally before seastar, it causes a
@@ -217,7 +237,9 @@ target_link_libraries(Boost::regex
 find_package(Lua REQUIRED)
 find_package(ZLIB REQUIRED)
 find_package(ICU COMPONENTS uc i18n REQUIRED)
-find_package(fmt 10.0.0 REQUIRED)
+# Resolves to the bundled submodule added via add_subdirectory(fmt) above
+# (CMake redirects find_package to it), not the host's fmt.
+find_package(fmt REQUIRED)
 find_package(libdeflate REQUIRED)
 find_package(libxcrypt REQUIRED)
 find_package(p11-kit REQUIRED)

--- a/alternator/controller.cc
+++ b/alternator/controller.cc
@@ -151,7 +151,7 @@ future<> controller::start_server() {
             try {
                 utils::configure_tls_creds_builder(creds.value(), std::move(opts)).get();
             } catch(...) {
-                logger.error("Failed to set up Alternator TLS credentials: {}", std::current_exception());
+                logger.error("Failed to set up Alternator TLS credentials: {:t}", std::current_exception());
                 stop_server().get();
                 std::throw_with_nested(std::runtime_error("Failed to set up Alternator TLS credentials"));
             }

--- a/api/storage_service.cc
+++ b/api/storage_service.cc
@@ -167,7 +167,7 @@ std::optional<std::chrono::seconds> validate_ttl(const std::string& value) {
     try {
         res = std::stoi(match[1].str());
     } catch (...) {
-        throw bad_param_exception(fmt::format("Parsing TTL value '{}' failed: {}", value, std::current_exception()));
+        throw bad_param_exception(fmt::format("Parsing TTL value '{}' failed: {:t}", value, std::current_exception()));
     }
 
     auto suffix = match[2].str();
@@ -890,7 +890,7 @@ rest_remove_node(sharded<service::storage_service>& ss, std::unique_ptr<http::re
                 }
                 ignore_nodes.push_back(std::move(hoep));
             } catch (...) {
-                throw std::runtime_error(fmt::format("Failed to parse ignore_nodes parameter: ignore_nodes={}, node={}: {}", ignore_nodes_strs, n, std::current_exception()));
+                throw std::runtime_error(fmt::format("Failed to parse ignore_nodes parameter: ignore_nodes={}, node={}: {:t}", ignore_nodes_strs, n, std::current_exception()));
             }
         }
         return ss.local().removenode(host_id, std::move(ignore_nodes)).then([] {
@@ -1881,7 +1881,7 @@ rest_drop_quarantined_sstables(http_context& ctx, sharded<service::storage_servi
             });
         }
     } catch (...) {
-        apilog.error("drop_quarantined_sstables: failed with exception: {}", std::current_exception());
+        apilog.error("drop_quarantined_sstables: failed with exception: {:t}", std::current_exception());
         throw;
     }
 
@@ -2194,7 +2194,7 @@ void set_snapshot(http_context& ctx, routes& r, sharded<db::snapshot_ctl>& snap_
         } catch (const data_dictionary::no_such_column_family& e) {
             throw httpd::bad_param_exception(e.what());
         } catch (...) {
-            apilog.error("take_snapshot failed: {}", std::current_exception());
+            apilog.error("take_snapshot failed: {:t}", std::current_exception());
             throw;
         }
     });
@@ -2215,7 +2215,7 @@ void set_snapshot(http_context& ctx, routes& r, sharded<db::snapshot_ctl>& snap_
             co_await snap_ctl.local().take_cluster_column_family_snapshot(keynames, column_families, tag, opts);
             co_return json_void();
         } catch (...) {
-            apilog.error("take_cluster_snapshot failed: {}", std::current_exception());
+            apilog.error("take_cluster_snapshot failed: {:t}", std::current_exception());
             throw;
         }
     });
@@ -2232,7 +2232,7 @@ void set_snapshot(http_context& ctx, routes& r, sharded<db::snapshot_ctl>& snap_
         } catch (const data_dictionary::no_such_column_family& e) {
             throw httpd::bad_param_exception(e.what());
         } catch (...) {
-            apilog.error("del_snapshot failed: {}", std::current_exception());
+            apilog.error("del_snapshot failed: {:t}", std::current_exception());
             throw;
         }
     });
@@ -2263,7 +2263,7 @@ void set_snapshot(http_context& ctx, routes& r, sharded<db::snapshot_ctl>& snap_
         } catch (const compaction::compaction_aborted_exception&) {
             co_return json::json_return_type(static_cast<int>(scrub_status::aborted));
         } catch (...) {
-            apilog.error("scrub keyspace={} tables={} failed: {}", info.keyspace, info.column_families, std::current_exception());
+            apilog.error("scrub keyspace={} tables={} failed: {:t}", info.keyspace, info.column_families, std::current_exception());
             throw;
         }
 

--- a/api/task_manager.cc
+++ b/api/task_manager.cc
@@ -105,7 +105,7 @@ void set_task_manager(http_context& ctx, routes& r, sharded<tasks::task_manager>
             try {
                 module = tm.find_module(req->get_path_param("module"));
             } catch (...) {
-                throw bad_param_exception(fmt::format("{}", std::current_exception()));
+                throw bad_param_exception(fmt::format("{:t}", std::current_exception()));
             }
 
             if (auto param = req->get_query_param("keyspace"); !param.empty()) {
@@ -220,7 +220,7 @@ void set_task_manager(http_context& ctx, routes& r, sharded<tasks::task_manager>
         try {
             co_await cfg.task_ttl_seconds.set_value_on_all_shards(req->get_query_param("ttl"), utils::config_file::config_source::API);
         } catch (...) {
-            throw bad_param_exception(fmt::format("{}", std::current_exception()));
+            throw bad_param_exception(fmt::format("{:t}", std::current_exception()));
         }
         co_return json::json_return_type(ttl);
     });
@@ -235,7 +235,7 @@ void set_task_manager(http_context& ctx, routes& r, sharded<tasks::task_manager>
         try {
             co_await cfg.user_task_ttl_seconds.set_value_on_all_shards(req->get_query_param("user_ttl"), utils::config_file::config_source::API);
         } catch (...) {
-            throw bad_param_exception(fmt::format("{}", std::current_exception()));
+            throw bad_param_exception(fmt::format("{:t}", std::current_exception()));
         }
         co_return json::json_return_type(user_ttl);
     });
@@ -251,7 +251,7 @@ void set_task_manager(http_context& ctx, routes& r, sharded<tasks::task_manager>
             try {
                 module = tm.find_module(req->get_path_param("module"));
             } catch (...) {
-                throw bad_param_exception(fmt::format("{}", std::current_exception()));
+                throw bad_param_exception(fmt::format("{:t}", std::current_exception()));
             }
 
             const auto& local_tasks = module->get_local_tasks();

--- a/auth/ldap_role_manager.cc
+++ b/auth/ldap_role_manager.cc
@@ -263,7 +263,7 @@ future<> ldap_role_manager::start() {
             try {
                 co_await _cache.reload_all_permissions();
             } catch (...) {
-                mylog.warn("Cache reload all permissions failed: {}", std::current_exception());
+                mylog.warn("Cache reload all permissions failed: {:t}", std::current_exception());
             }
         }
     });
@@ -288,7 +288,7 @@ future<conn_ptr> ldap_role_manager::connect() {
             error = format("simple_bind error: {}", conn->get_error());
         }
     } catch (...) {
-        error = format("connect error: {}", std::current_exception());
+        error = format("connect error: {:t}", std::current_exception());
     }
     if (!error.empty()) {
         co_await conn->close();
@@ -309,7 +309,7 @@ future<conn_ptr> ldap_role_manager::reconnect() {
         try {
             co_return co_await connect();
         } catch (...) {
-            mylog.error("error in reconnect: {}", std::current_exception());
+            mylog.error("error in reconnect: {:t}", std::current_exception());
         }
         co_return std::nullopt;
     });
@@ -447,7 +447,7 @@ future<bool> ldap_role_manager::exists(std::string_view role_name) {
             co_await create_role(role_name);
             exists = true;
         } catch (...) {
-            mylog.error("Failed to auto-create role {}: {}", role_name, std::current_exception());
+            mylog.error("Failed to auto-create role {}: {:t}", role_name, std::current_exception());
             exists = false;
         }
         co_return exists;

--- a/bytes.hh
+++ b/bytes.hh
@@ -106,14 +106,14 @@ public:
         if (_group_size_in_bytes > 0) {
             for (size_t i = 0, size = v.size(); i < size; i++) {
                 if (i != 0 && i % _group_size_in_bytes == 0) {
-                    fmt::format_to(out, "{}{:02x}", _delimiter, std::byte(v[i]));
+                    fmt::format_to(out, "{}{:02x}", _delimiter, unsigned(uint8_t(v[i])));
                 } else {
-                    fmt::format_to(out, "{:02x}", std::byte(v[i]));
+                    fmt::format_to(out, "{:02x}", unsigned(uint8_t(v[i])));
                 }
             }
         } else {
             for (auto b : v) {
-                fmt::format_to(out, "{:02x}", std::byte(b));
+                fmt::format_to(out, "{:02x}", unsigned(uint8_t(b)));
             }
         }
         return out;

--- a/compaction/compaction.cc
+++ b/compaction/compaction.cc
@@ -1737,7 +1737,7 @@ private:
                 throw compaction_aborted_exception(
                         _schema->ks_name(),
                         _schema->cf_name(),
-                        format("scrub compaction failed due to unrecoverable error: {}", e));
+                        format("scrub compaction failed due to unrecoverable error: {:t}", e));
             }
             if (_drop_unfixable_sstables) {
                 _failed_to_fix_sstable = true;
@@ -1855,7 +1855,7 @@ private:
                     throw compaction_aborted_exception(
                             _schema->ks_name(),
                             _schema->cf_name(),
-                            format("scrub compaction failed due to unrecoverable error: {}", std::current_exception()));
+                            format("scrub compaction failed due to unrecoverable error: {:t}", std::current_exception()));
                 }
             });
         }
@@ -2219,7 +2219,7 @@ static future<compaction_result> scrub_sstables_validate_mode(compaction_descrip
             try {
                 co_await sst->change_state(sstables::sstable_state::quarantine);
             } catch (...) {
-                clogger.error("Moving {} to quarantine failed due to {}, continuing.", sst->get_filename(), std::current_exception());
+                clogger.error("Moving {} to quarantine failed due to {:t}, continuing.", sst->get_filename(), std::current_exception());
             }
         }
     }

--- a/compaction/compaction_manager.cc
+++ b/compaction/compaction_manager.cc
@@ -291,7 +291,7 @@ void compaction_manager::register_compacting_sstables(const Range& sstables) {
     try {
         _compacting_sstables.insert(std::ranges::begin(sstables), std::ranges::end(sstables));
     } catch (...) {
-        cmlog.error("Unexpected error when registering compacting SSTables: {}. Ignored...", std::current_exception());
+        cmlog.error("Unexpected error when registering compacting SSTables: {:t}. Ignored...", std::current_exception());
     }
 }
 
@@ -356,7 +356,7 @@ future<compaction_manager::compaction_stats_opt> compaction_manager::perform_tas
         do_stop();
         throw;
     } catch (...) {
-        cmlog.error("{}: failed, reason {}: stopping", *task, std::current_exception());
+        cmlog.error("{}: failed, reason {:t}: stopping", *task, std::current_exception());
         _stats.errors++;
         throw;
     }
@@ -784,7 +784,7 @@ future<> compaction_manager::await_ongoing_compactions(compaction_group_view* t)
         co_await await_tasks(std::move(tasks), task_stopped);
         cmlog.debug("Awaiting ongoing unrepaired compactions table={} tasks={} done", name, sz);
     } catch (...) {
-        cmlog.error("Awaiting ongoing unrepaired compactions table={} failed: {}", name, std::current_exception());
+        cmlog.error("Awaiting ongoing unrepaired compactions table={} failed: {:t}", name, std::current_exception());
         throw;
     }
 }
@@ -831,7 +831,7 @@ compaction_manager::stop_and_disable_compaction_no_wait(compaction_group_view& t
     try {
         do_stop_ongoing_compactions(std::move(reason), [&t] (const compaction_group_view* x) { return x == &t; } , {});
     } catch (...) {
-        cmlog.error("Stopping ongoing compactions failed: {}.  Ignored", std::current_exception());
+        cmlog.error("Stopping ongoing compactions failed: {:t}.  Ignored", std::current_exception());
     }
     return cre;
 }
@@ -1282,7 +1282,7 @@ future<> compaction_manager::await_tasks(std::vector<shared_ptr<compaction_task_
             // as it happens with reshard and reshape.
         } catch (...) {
             // just log any other errors as the callers have nothing to do with them.
-            cmlog.debug("Awaiting {}: task returned error: {}", *task, std::current_exception());
+            cmlog.debug("Awaiting {}: task returned error: {:t}", *task, std::current_exception());
             co_return;
         }
         cmlog.debug("Awaiting {}: done", *task);
@@ -1330,7 +1330,7 @@ future<> compaction_manager::stop_ongoing_compactions(sstring reason, std::funct
         bool task_stopped = true;
         co_await await_tasks(std::move(tasks), task_stopped);
     } catch (...) {
-        cmlog.error("Stopping ongoing compactions failed: {}.  Ignored", std::current_exception());
+        cmlog.error("Stopping ongoing compactions failed: {:t}.  Ignored", std::current_exception());
     }
     co_return;
 }
@@ -1421,7 +1421,7 @@ void compaction_manager::do_stop() noexcept {
         _state = state::stopped;
         _stop_future = really_do_stop();
     } catch (...) {
-        cmlog.error("Failed to stop the manager: {}", std::current_exception());
+        cmlog.error("Failed to stop the manager: {:t}", std::current_exception());
     }
 }
 
@@ -2157,7 +2157,7 @@ private:
             // expected, just continue with the other sstables when seeing
             // one.
             _cm._stats.errors++;
-            cmlog.error("Scrubbing in validate mode {} failed due to {}, continuing.", sst->get_filename(), std::current_exception());
+            cmlog.error("Scrubbing in validate mode {} failed due to {:t}, continuing.", sst->get_filename(), std::current_exception());
         }
 
         co_return compaction_result{};
@@ -2679,7 +2679,7 @@ future<> compaction_manager::stop_compaction(sstring type, std::function<bool(co
     try {
         target_type = to_compaction_type(type);
     } catch (...) {
-        throw std::runtime_error(format("Compaction of type {} cannot be stopped by compaction manager: {}", type.c_str(), std::current_exception()));
+        throw std::runtime_error(format("Compaction of type {} cannot be stopped by compaction manager: {:t}", type.c_str(), std::current_exception()));
     }
     switch (target_type) {
     case compaction_type::Validation:
@@ -2745,7 +2745,7 @@ void compaction_backlog_tracker::replace_sstables(const std::vector<sstables::sh
     try {
         _impl->replace_sstables(filter_and_revert_charges(old_ssts), filter_and_revert_charges(new_ssts));
     } catch (...) {
-        cmlog.error("Disabling backlog tracker due to exception {}", std::current_exception());
+        cmlog.error("Disabling backlog tracker due to exception {:t}", std::current_exception());
         // FIXME: tracker should be able to recover from a failure, e.g. OOM, by having its state reset. More details on https://github.com/scylladb/scylla/issues/10297.
         disable();
     }
@@ -2766,7 +2766,7 @@ void compaction_backlog_tracker::register_partially_written_sstable(sstables::sh
         // ends. The backlog will just be temporarily wrong. If we are are suffering from something
         // more serious like memory exhaustion we will soon fail again in either add / remove and
         // then we'll disable the tracker. For now, try our best.
-        cmlog.warn("backlog tracker couldn't register partially written SSTable to exception {}", std::current_exception());
+        cmlog.warn("backlog tracker couldn't register partially written SSTable to exception {:t}", std::current_exception());
     }
 }
 
@@ -2778,7 +2778,7 @@ void compaction_backlog_tracker::register_compacting_sstable(sstables::shared_ss
     try {
         _ongoing_compactions.emplace(sst, &rp);
     } catch (...) {
-        cmlog.warn("backlog tracker couldn't register partially compacting SSTable to exception {}", std::current_exception());
+        cmlog.warn("backlog tracker couldn't register partially compacting SSTable to exception {:t}", std::current_exception());
     }
 }
 

--- a/compaction/task_manager_module.cc
+++ b/compaction/task_manager_module.cc
@@ -215,7 +215,7 @@ future<> run_on_table(sstring op, replica::database& db, std::string keyspace, t
         tasks::tmlogger.warn("Skipping {} of {}.{}: {}", op, keyspace, ti.name, e.what());
     } catch (...) {
         ex = std::current_exception();
-        tasks::tmlogger.error("Failed {} of {}.{}: {}", op, keyspace, ti.name, ex);
+        tasks::tmlogger.error("Failed {} of {}.{}: {:t}", op, keyspace, ti.name, ex);
     }
     if (ex) {
         co_await coroutine::return_exception_ptr(std::move(ex));
@@ -893,7 +893,7 @@ future<> shard_reshaping_compaction_task_impl::reshape_compaction_group(compacti
             dblog.info("Table {}.{} with compaction strategy {} had reshape successfully aborted.", table.schema()->ks_name(), table.schema()->cf_name(), table.get_compaction_strategy().name());
             throw;
         } catch (...) {
-            dblog.info("Reshape failed for Table {}.{} with compaction strategy {} due to {}", table.schema()->ks_name(), table.schema()->cf_name(), table.get_compaction_strategy().name(), std::current_exception());
+            dblog.info("Reshape failed for Table {}.{} with compaction strategy {} due to {:t}", table.schema()->ks_name(), table.schema()->cf_name(), table.get_compaction_strategy().name(), std::current_exception());
             break;
         }
 

--- a/configure.py
+++ b/configure.py
@@ -2224,6 +2224,9 @@ def configure_seastar(build_dir, mode, mode_config, compiler_cache=None):
         '-DCMAKE_CXX_STANDARD=23',
         '-DCMAKE_CXX_EXTENSIONS=ON',
         '-DSeastar_CXX_FLAGS=SHELL:{}'.format(mode_config['lib_cflags'] + extra_file_prefix_map),
+        # Resolve fmt to the bundled submodule we build in configure_fmt()
+        # rather than whatever version happens to be installed on the host.
+        '-Dfmt_ROOT={}'.format(fmt_build_dir(build_dir, mode)),
         '-DSeastar_LD_FLAGS={}'.format(semicolon_separated(mode_config['lib_ldflags'], seastar_cxx_ld_flags)),
         '-DSeastar_API_LEVEL=9',
         '-DSeastar_DEPRECATED_OSTREAM_FORMATTERS=OFF',
@@ -2268,6 +2271,91 @@ def configure_seastar(build_dir, mode, mode_config, compiler_cache=None):
         print(" \\\n  ".join(seastar_cmd))
     os.makedirs(seastar_build_dir, exist_ok=True)
     subprocess.check_call(seastar_cmd, shell=False, cwd=cmake_dir)
+
+
+def fmt_build_dir(build_dir, mode):
+    # Where configure_fmt() sets up fmt's CMake build. fmt is not installed
+    # anywhere: both Scylla and Seastar consume it straight out of this build
+    # tree (fmt's own export() drops a build-tree fmt-config.cmake here, which
+    # is what Seastar's find_package(fmt) picks up via fmt_ROOT).
+    # Absolute, because it ends up in an rpath and in Seastar's fmt_ROOT.
+    return os.path.realpath(os.path.join(build_dir, mode, 'fmt'))
+
+
+def fmt_lib(mode, mode_config):
+    # The library that the fmt sub-build produces, as a ninja path. fmt is
+    # shared or static to match Seastar (build_seastar_shared_libs), so a mode
+    # doesn't end up with fmt symbols in both libseastar and a static libfmt.
+    ext = 'so' if mode_config['build_seastar_shared_libs'] else 'a'
+    return f'$builddir/{mode}/fmt/libfmt.{ext}'
+
+
+def fmt_link_flags(build_dir, mode, mode_config):
+    # Link flags for Scylla to use the fmt built by the fmt sub-build.
+    libdir = fmt_build_dir(build_dir, mode)
+    if mode_config['build_seastar_shared_libs']:
+        return f"-L{libdir} -Wl,-rpath,{libdir} -lfmt"
+    return os.path.join(libdir, 'libfmt.a')
+
+
+def configure_fmt(build_dir, mode, mode_config, compiler_cache=None):
+    # Set up the CMake build of the bundled fmt submodule (rather than relying
+    # on the host's fmt, whose version may differ from the headers we compile
+    # against). Only the configure step runs here; the library itself is built
+    # during the ninja build, like Seastar's and abseil's. Modeled on
+    # configure_abseil().
+    fmt_cflags = mode_config['lib_cflags']
+    cxx_flags = mode_config['cxxflags']
+    if '-DSANITIZE' in cxx_flags:
+        fmt_cflags += ' -fsanitize=address -fsanitize=undefined -fno-sanitize=vptr'
+
+    # We are not interested in the coverage of fmt itself.
+    if args.coverage:
+        for flag in COVERAGE_INST_FLAGS:
+            cxx_flags = cxx_flags.replace(f' {flag}', '')
+
+    cxx_flags += ' ' + fmt_cflags.strip()
+
+    cmake_mode = mode_config['cmake_build_type']
+    fmt_cmake_args = [
+        '-DCMAKE_BUILD_TYPE={}'.format(cmake_mode),
+        '-DCMAKE_C_COMPILER={}'.format(args.cc),
+        '-DCMAKE_CXX_COMPILER={}'.format(args.cxx),
+        '-DCMAKE_CXX_FLAGS_{}={}'.format(cmake_mode.upper(), cxx_flags),
+        '-DCMAKE_EXPORT_COMPILE_COMMANDS=ON',
+        '-DCMAKE_CXX_STANDARD=23',
+        # Static fmt gets linked into shared libseastar in some modes, so it
+        # must be position-independent.
+        '-DCMAKE_POSITION_INDEPENDENT_CODE=ON',
+        # Match Seastar's shared/static choice for the mode.
+        '-DBUILD_SHARED_LIBS={}'.format('ON' if mode_config['build_seastar_shared_libs'] else 'OFF'),
+        # We never run fmt's install target, but FMT_INSTALL also guards the
+        # generation of fmt-config.cmake / fmt-targets.cmake in the build tree
+        # (fmt calls export() there), which is how Seastar's find_package(fmt)
+        # finds the library we are about to build.
+        '-DFMT_INSTALL=ON',
+        # Keep the library named libfmt.{a,so} in every mode; otherwise fmt
+        # appends a 'd' in Debug builds and fmt_link_flags()'s -lfmt misses it.
+        '-DFMT_DEBUG_POSTFIX=',
+        '-DFMT_TEST=OFF',
+        '-DFMT_DOC=OFF',
+        '-DFMT_FUZZ=OFF',
+        # We don't consume fmt's C++20 module; building it drags in module
+        # dependency scanning, which Scylla otherwise disables.
+        '-DFMT_MODULE=OFF',
+    ]
+
+    if compiler_cache:
+        fmt_cmake_args += [f'-DCMAKE_CXX_COMPILER_LAUNCHER={compiler_cache}',
+                           f'-DCMAKE_C_COMPILER_LAUNCHER={compiler_cache}']
+
+    cmake_dir = fmt_build_dir(build_dir, mode)
+    fmt_cmd = ['cmake', '-G', 'Ninja', real_relpath('fmt', cmake_dir)] + fmt_cmake_args
+
+    if args.verbose:
+        print(' \\\n  '.join(fmt_cmd))
+    os.makedirs(cmake_dir, exist_ok=True)
+    subprocess.check_call(fmt_cmd, shell=False, cwd=cmake_dir)
 
 
 def configure_abseil(build_dir, mode, mode_config, compiler_cache=None):
@@ -2617,12 +2705,13 @@ def write_build_file(f,
         seastar_dep = f'$builddir/{mode}/seastar/libseastar.{seastar_lib_ext}'
         seastar_testing_dep = f'$builddir/{mode}/seastar/libseastar_testing.{seastar_lib_ext}'
         abseil_dep = ' '.join(f'$builddir/{mode}/abseil/{lib}' for lib in abseil_libs)
-        fmt_lib = 'fmt'
+        fmt_dep = fmt_lib(mode, modeval)
+        fmt_libs = fmt_link_flags(outdir, mode, modeval)
         f.write(textwrap.dedent('''\
             cxx_ld_flags_{mode} = {cxx_ld_flags}
             ld_flags_{mode} = $cxx_ld_flags_{mode} {lib_ldflags}
             cxxflags_{mode} = {lib_cflags} {cxxflags} -iquote. -iquote $builddir/{mode}/gen
-            libs_{mode} = -l{fmt_lib}
+            libs_{mode} = {fmt_libs}
             seastar_libs_{mode} = {seastar_libs}
             seastar_testing_libs_{mode} = {seastar_testing_libs}
             rule cxx.{mode}
@@ -2682,7 +2771,7 @@ def write_build_file(f,
               command = CARGO_BUILD_DEP_INFO_BASEDIR='.' CARGO_NET_RETRY=10 {rustc_wrapper}cargo build --locked --manifest-path=rust/Cargo.toml --target-dir=$builddir/{mode} --profile=rust-{mode} $
                         && touch $out
               description = RUST_LIB $out
-            ''').format(mode=mode, antlr3_exec=args.antlr3_exec, fmt_lib=fmt_lib, test_repeat=args.test_repeat, test_timeout=args.test_timeout, rustc_wrapper=rustc_wrapper, **modeval))
+            ''').format(mode=mode, antlr3_exec=args.antlr3_exec, fmt_libs=fmt_libs, test_repeat=args.test_repeat, test_timeout=args.test_timeout, rustc_wrapper=rustc_wrapper, **modeval))
         f.write(
             'build {mode}-build: phony {artifacts} {wasms}\n'.format(
                 mode=mode,
@@ -2741,7 +2830,9 @@ def write_build_file(f,
             if binary in cpp_apps:
                 # binary only needs the C++ standard library, no additional
                 # libraries.
-                f.write('build $builddir/{}/{}: {}.{} {}\n'.format(mode, binary, regular_link_rule, mode, str.join(' ', objs)))
+                # These only need the C++ standard library, but the link
+                # command still picks up $libs_<mode>, which links fmt.
+                f.write('build $builddir/{}/{}: {}.{} {} | {}\n'.format(mode, binary, regular_link_rule, mode, str.join(' ', objs), fmt_dep))
                 # In debug/sanitize modes, we compile with fsanitizers,
                 # so must use the same options during the link:
                 if '-DSANITIZE' in modes[mode]['cxxflags']:
@@ -2779,14 +2870,14 @@ def write_build_file(f,
                 # quickly re-link the test unstripped by adding a "_g"
                 # to the test name, e.g., "ninja build/release/testname_g"
                 link_rule = perf_tests_link_rule if binary.startswith('test/perf/') else tests_link_rule
-                f.write('build $builddir/{}/{}: {}.{} {} | {} {} {}\n'.format(mode, binary, link_rule, mode, str.join(' ', objs), seastar_dep, seastar_testing_dep, abseil_dep))
+                f.write('build $builddir/{}/{}: {}.{} {} | {} {} {} {}\n'.format(mode, binary, link_rule, mode, str.join(' ', objs), seastar_dep, seastar_testing_dep, abseil_dep, fmt_dep))
                 f.write('   libs = {}\n'.format(local_libs))
-                f.write('build $builddir/{}/{}_g: {}.{} {} | {} {} {}\n'.format(mode, binary, regular_link_rule, mode, str.join(' ', objs), seastar_dep, seastar_testing_dep, abseil_dep))
+                f.write('build $builddir/{}/{}_g: {}.{} {} | {} {} {} {}\n'.format(mode, binary, regular_link_rule, mode, str.join(' ', objs), seastar_dep, seastar_testing_dep, abseil_dep, fmt_dep))
                 f.write('   libs = {}\n'.format(local_libs))
             else:
                 if binary == 'scylla':
                     local_libs += f' {seastar_testing_libs}'
-                f.write('build $builddir/{}/{}: {}.{} {} | {} {} {}\n'.format(mode, binary, regular_link_rule, mode, str.join(' ', objs), seastar_dep, seastar_testing_dep, abseil_dep))
+                f.write('build $builddir/{}/{}: {}.{} {} | {} {} {} {}\n'.format(mode, binary, regular_link_rule, mode, str.join(' ', objs), seastar_dep, seastar_testing_dep, abseil_dep, fmt_dep))
                 f.write('   libs = {}\n'.format(local_libs))
                 f.write(f'build $builddir/{mode}/{binary}.stripped: strip $builddir/{mode}/{binary}\n')
                 f.write(f'build $builddir/{mode}/{binary}.debug: phony $builddir/{mode}/{binary}.stripped\n')
@@ -2918,14 +3009,20 @@ def write_build_file(f,
 
         seastar_dep = f'$builddir/{mode}/seastar/libseastar.{seastar_lib_ext}'
         seastar_testing_dep = f'$builddir/{mode}/seastar/libseastar_testing.{seastar_lib_ext}'
-        f.write(f'build {seastar_dep}: ninja $builddir/{mode}/seastar/build.ninja | always {profile_dep}\n')
+        f.write(f'build {seastar_dep}: ninja $builddir/{mode}/seastar/build.ninja | always {fmt_lib(mode, modeval)} {profile_dep}\n')
         f.write('  pool = submodule_pool\n')
         f.write(f'  subdir = $builddir/{mode}/seastar\n')
         f.write('  target = seastar\n')
-        f.write(f'build {seastar_testing_dep}: ninja $builddir/{mode}/seastar/build.ninja | always {profile_dep}\n')
+        f.write(f'build {seastar_testing_dep}: ninja $builddir/{mode}/seastar/build.ninja | always {fmt_lib(mode, modeval)} {profile_dep}\n')
         f.write('  pool = submodule_pool\n')
         f.write(f'  subdir = $builddir/{mode}/seastar\n')
         f.write('  target = seastar_testing\n')
+        f.write(f'  profile_dep = {profile_dep}\n')
+
+        f.write(f'build {fmt_lib(mode, modeval)}: ninja $builddir/{mode}/fmt/build.ninja | always {profile_dep}\n')
+        f.write(f'  pool = submodule_pool\n')
+        f.write(f'  subdir = $builddir/{mode}/fmt\n')
+        f.write(f'  target = fmt\n')
         f.write(f'  profile_dep = {profile_dep}\n')
 
         for lib in abseil_libs:
@@ -3097,6 +3194,7 @@ def write_build_file(f,
     for mode in build_modes:
         build_ninja_files += [f'{outdir}/{mode}/seastar/build.ninja']
         build_ninja_files += [f'{outdir}/{mode}/abseil/build.ninja']
+        build_ninja_files += [f'{outdir}/{mode}/fmt/build.ninja']
 
     f.write(textwrap.dedent('''\
         rule configure
@@ -3168,9 +3266,16 @@ def create_build_system(args):
         # {outdir}/{mode}/seastar/build.ninja, and
         # {outdir}/{mode}/seastar/seastar.pc is queried for building flags
         for mode, mode_config in build_modes.items():
+            # fmt must be configured before Seastar is, so that Seastar's
+            # find_package(fmt) resolves fmt's build tree (via fmt_ROOT).
+            configure_fmt(outdir, mode, mode_config, compiler_cache)
             configure_seastar(outdir, mode, mode_config, compiler_cache)
             configure_abseil(outdir, mode, mode_config, compiler_cache)
         user_cflags += ' -isystem abseil'
+        # Compile against the bundled fmt submodule headers rather than
+        # whatever version happens to be installed on the host. The matching
+        # library is built and linked per-mode (see fmt_link_flags()).
+        user_cflags += ' -isystem fmt/include'
 
     for mode, mode_config in build_modes.items():
         mode_config.update(query_seastar_flags(f'{outdir}/{mode}/seastar/seastar.pc',

--- a/cql3/query_processor.cc
+++ b/cql3/query_processor.cc
@@ -728,7 +728,7 @@ query_processor::do_execute_prepared(
         try {
             co_await _authorized_prepared_cache.insert(*query_state.get_client_state().user(), std::move(cache_key), std::move(prepared));
         } catch (...) {
-            log.error("failed to cache the entry: {}", std::current_exception());
+            log.error("failed to cache the entry: {:t}", std::current_exception());
         }
     }
 
@@ -1140,7 +1140,7 @@ query_processor::execute_batch_without_checking_exception_message(
             try {
                 co_await _authorized_prepared_cache.insert(*query_state.get_client_state().user(), e.first, std::move(e.second));
             } catch (...) {
-                log.error("failed to cache the entry: {}", std::current_exception());
+                log.error("failed to cache the entry: {:t}", std::current_exception());
             }
     });
     _stats.queries_by_cl[size_t(options.get_consistency())] += batch_size;

--- a/cql3/statements/create_table_statement.cc
+++ b/cql3/statements/create_table_statement.cc
@@ -466,7 +466,7 @@ create_table_statement::execute(query_processor& qp, service::query_state& state
         try {
             co_await qp.wait_for_table_raft_groups_on_all_hosts(cf.schema()->id(), lowres_clock::now() + state.get_client_state().get_timeout_config().other_timeout);
         } catch (...) {
-            result->add_warning(format("Failed to wait for raft groups of {}.{} to start on all hosts: {}", keyspace(), column_family(), std::current_exception()));
+            result->add_warning(format("Failed to wait for raft groups of {}.{} to start on all hosts: {:t}", keyspace(), column_family(), std::current_exception()));
         }
     }
 

--- a/cql3/statements/statement_type.hh
+++ b/cql3/statements/statement_type.hh
@@ -11,6 +11,7 @@
 #pragma once
 
 #include <fmt/core.h>
+#include <string_view>
 
 namespace cql3 {
 

--- a/db/batchlog_manager.cc
+++ b/db/batchlog_manager.cc
@@ -222,9 +222,9 @@ future<> db::batchlog_manager::batchlog_replay_loop() {
             if (_stop.abort_requested()) {
                 co_return;
             }
-            on_internal_error_noexcept(blogger, fmt::format("Unexcepted exception in batchlog reply: {}", std::current_exception()));
+            on_internal_error_noexcept(blogger, fmt::format("Unexcepted exception in batchlog reply: {:t}", std::current_exception()));
         } catch (...) {
-            blogger.error("Exception in batch replay: {}", std::current_exception());
+            blogger.error("Exception in batch replay: {:t}", std::current_exception());
         }
         delay = utils::get_local_injector().is_enabled("short_batchlog_manager_replay_interval") ?
                 std::chrono::seconds(1) : replay_interval;
@@ -311,7 +311,7 @@ future<> db::batchlog_manager::maybe_migrate_v1_to_v2() {
                     page_size,
                     std::move(batch));
         } catch (...) {
-            blogger.warn("Batchlog v1 to v2 migration failed: {}; will retry", std::current_exception());
+            blogger.warn("Batchlog v1 to v2 migration failed: {:t}; will retry", std::current_exception());
             co_return;
         }
 
@@ -434,7 +434,7 @@ static future<db::all_batches_replayed> process_batch(
     } catch (const data_dictionary::no_such_column_family&) {
         // As above -- we should drop the batch if the table doesn't exist anymore.
     } catch (...) {
-        blogger.warn("Replay failed (will retry): {}", std::current_exception());
+        blogger.warn("Replay failed (will retry): {:t}", std::current_exception());
         // timeout, overload etc.
         // Do _not_ remove the batch, assuning we got a node write error.
         // Since we don't have hints (which origin is satisfied with),

--- a/db/commitlog/commitlog.cc
+++ b/db/commitlog/commitlog.cc
@@ -1040,7 +1040,7 @@ public:
             ++_segment_manager->totals.flush_count;
             clogger.trace("{} synced to {}", *this, _flush_pos);
         } catch (...) {
-            clogger.error("Failed to flush commits to disk: {}", std::current_exception());
+            clogger.error("Failed to flush commits to disk: {:t}", std::current_exception());
             throw;
         }
 
@@ -1234,7 +1234,7 @@ public:
                     // TODO: retry/ignore/fail/stop - optional behaviour in origin.
                     // we fast-fail the whole commit.
                 } catch (...) {
-                    clogger.error("Failed to persist commits to disk for {}: {}", *this, std::current_exception());
+                    clogger.error("Failed to persist commits to disk for {}: {:t}", *this, std::current_exception());
                     throw;
                 }
             }
@@ -1294,7 +1294,7 @@ public:
     void background_cycle() {
         //FIXME: discarded future
         (void)cycle().discard_result().handle_exception([] (auto ex) {
-            clogger.error("Failed to flush commits to disk: {}", ex);
+            clogger.error("Failed to flush commits to disk: {:t}", ex);
         });
     }
 
@@ -2032,7 +2032,7 @@ future<> db::commitlog::segment_manager::replenish_reserve() {
         } catch (shutdown_marker&) {
             break;
         } catch (...) {
-            clogger.warn("Exception in segment reservation: {}", std::current_exception());
+            clogger.warn("Exception in segment reservation: {:t}", std::current_exception());
         }
         co_await sleep(100ms);
     }
@@ -2266,7 +2266,7 @@ void db::commitlog::segment_manager::flush_segments(uint64_t size_to_remove) {
             try {
                 f(id, hp);
             } catch (...) {
-                clogger.error("Exception during flush request {}/{}: {} ({})", id, hp, high, std::current_exception());
+                clogger.error("Exception during flush request {}/{}: {} ({:t})", id, hp, high, std::current_exception());
             }
         }
     }
@@ -2338,7 +2338,7 @@ void db::commitlog::segment_manager::check_no_data_older_than_allowed() {
                 try {
                     f(id, *high);
                 } catch (...) {
-                    clogger.error("Exception during flush request {}/{}: {}", id, *high, std::current_exception());
+                    clogger.error("Exception during flush request {}/{}: {:t}", id, *high, std::current_exception());
                 }
             }
         }
@@ -2495,7 +2495,7 @@ future<db::commitlog::segment_manager::sseg_ptr> db::commitlog::segment_manager:
             } catch (shutdown_marker&) {
                 throw;
             } catch (...) {
-                clogger.warn("Exception while waiting for segments {}. Will retry allocation...", std::current_exception());
+                clogger.warn("Exception while waiting for segments {:t}. Will retry allocation...", std::current_exception());
             }
             continue;
         }
@@ -2722,7 +2722,7 @@ future<> db::commitlog::segment_manager::shutdown() {
         try {
             co_await sync_all_segments();
         } catch (...) {
-            clogger.error("Syncing all segments failed during shutdown: {}. Aborting.", std::current_exception());
+            clogger.error("Syncing all segments failed during shutdown: {:t}. Aborting.", std::current_exception());
             abort();
         }
 
@@ -2752,7 +2752,7 @@ future<> db::commitlog::segment_manager::shutdown() {
             try {
                 co_await shutdown_all_segments();
             } catch (...) {
-                clogger.error("Shutting down all segments failed during shutdown: {}. Aborting.", std::current_exception());
+                clogger.error("Shutting down all segments failed during shutdown: {:t}. Aborting.", std::current_exception());
                 abort();
             }
         } catch (...) {
@@ -2915,7 +2915,7 @@ future<> db::commitlog::segment_manager::do_pending_deletes() {
                     SCYLLA_ASSERT(b); // we set this to max_size_t so...
                     continue;
                 } catch (...) {
-                    clogger.error("Could not recycle segment {}: {}", f.name(), std::current_exception());
+                    clogger.error("Could not recycle segment {}: {:t}", f.name(), std::current_exception());
                     recycle_error = std::current_exception();
                     // fallthrough
                 }
@@ -2925,7 +2925,7 @@ future<> db::commitlog::segment_manager::do_pending_deletes() {
             // last resort.
             co_await f.remove_file();
         } catch (...) {
-            clogger.error("Could not delete segment {}: {}", f.name(), std::current_exception());
+            clogger.error("Could not delete segment {}: {:t}", f.name(), std::current_exception());
         }
         // if we get here, we either successfully deleted the file,
         // or had such an exception that we consider the file dead

--- a/db/commitlog/commitlog_replayer.cc
+++ b/db/commitlog/commitlog_replayer.cc
@@ -319,7 +319,7 @@ future<> db::commitlog_replayer::impl::process(
                     } catch (...) {
                         s->invalid_mutations++;
                         // TODO: write mutation to file like origin.
-                        rlogger.warn("error replaying: {}", std::current_exception());
+                        rlogger.warn("error replaying: {:t}", std::current_exception());
                     }
                 });
             };
@@ -338,7 +338,7 @@ future<> db::commitlog_replayer::impl::process(
     } catch (...) {
         s->invalid_mutations++;
         // TODO: write mutation to file like origin.
-        rlogger.warn("error replaying: {}", std::current_exception());
+        rlogger.warn("error replaying: {:t}", std::current_exception());
     }
 }
 

--- a/db/consistency_level_type.hh
+++ b/db/consistency_level_type.hh
@@ -11,6 +11,7 @@
 #pragma once
 
 #include <fmt/core.h>
+#include <string_view>
 
 namespace db {
 

--- a/db/hints/internal/hint_endpoint_manager.cc
+++ b/db/hints/internal/hint_endpoint_manager.cc
@@ -99,8 +99,8 @@ bool hint_endpoint_manager::store_hint(schema_ptr s, lw_shared_ptr<const frozen_
             return do_store_hint(std::move(s), std::move(fm), tr_state);
         });
     } catch (...) {
-        manager_logger.trace("hint_endpoint_manager[{}]:store_hint: Failed to store a hint: {}", end_point_key(), std::current_exception());
-        tracing::trace(tr_state, "Failed to store a hint to {}: {}", end_point_key(), std::current_exception());
+        manager_logger.trace("hint_endpoint_manager[{}]:store_hint: Failed to store a hint: {:t}", end_point_key(), std::current_exception());
+        tracing::trace(tr_state, "Failed to store a hint to {}: {:t}", end_point_key(), std::current_exception());
 
         ++shard_stats().dropped;
         return false;

--- a/db/hints/internal/hint_sender.cc
+++ b/db/hints/internal/hint_sender.cc
@@ -238,7 +238,7 @@ void hint_sender::start() {
                 break;
             } catch (...) {
                 // log and keep on spinning
-                manager_logger.debug("hint_sender[{}]:start: Exception in the loop: {}", _ep_key, std::current_exception());
+                manager_logger.debug("hint_sender[{}]:start: Exception in the loop: {:t}", _ep_key, std::current_exception());
             }
         }
 
@@ -608,7 +608,7 @@ void hint_sender::send_hints_maybe() noexcept {
     // Ignore exceptions, we will retry sending this file from where we left off the next time.
     // Exceptions are not expected here during the regular operation, so just log them.
     } catch (...) {
-        manager_logger.debug("hint_sender[{}]:send_hints_maybe: Exception occurred while sending: {}", _ep_key, std::current_exception());
+        manager_logger.debug("hint_sender[{}]:send_hints_maybe: Exception occurred while sending: {:t}", _ep_key, std::current_exception());
     }
 
     if (have_segments()) {

--- a/db/hints/manager.cc
+++ b/db/hints/manager.cc
@@ -432,8 +432,8 @@ bool manager::store_hint(endpoint_id host_id, schema_ptr s, lw_shared_ptr<const 
 
         return get_ep_manager(host_id).store_hint(std::move(s), std::move(fm), tr_state);
     } catch (...) {
-        manager_logger.trace("Failed to store a hint to {}: {}", host_id, std::current_exception());
-        tracing::trace(tr_state, "Failed to store a hint to {}: {}", host_id, std::current_exception());
+        manager_logger.trace("Failed to store a hint to {}: {:t}", host_id, std::current_exception());
+        tracing::trace(tr_state, "Failed to store a hint to {}: {:t}", host_id, std::current_exception());
 
         ++_stats.errors;
         return false;
@@ -557,8 +557,8 @@ future<> manager::change_host_filter(host_filter filter) {
         });
     } catch (...) {
         const sstring exception_message = eptr
-                ? seastar::format("{} + {}", eptr, std::current_exception())
-                : seastar::format("{}", std::current_exception());
+                ? seastar::format("{} + {:t}", eptr, std::current_exception())
+                : seastar::format("{:t}", std::current_exception());
 
         manager_logger.warn("Changing the host filter has failed: {}", exception_message);
 

--- a/db/large_data_handler.cc
+++ b/db/large_data_handler.cc
@@ -484,7 +484,7 @@ void large_data_cache_tracker::on_collection_merged(const column_definition& cde
         // collection may slip past the guardrail until the next SSTable flush.
         large_data_logger.warn("Failed to record collection size for memtable-level "
             "large-collection cache; large collections may slip past the guardrail "
-            "until the next SSTable flush: {}", std::current_exception());
+            "until the next SSTable flush: {:t}", std::current_exception());
     }
 }
 

--- a/db/read_repair_decision.hh
+++ b/db/read_repair_decision.hh
@@ -11,6 +11,7 @@
 #pragma once
 
 #include <fmt/core.h>
+#include <string_view>
 
 namespace db {
 

--- a/db/row_cache.cc
+++ b/db/row_cache.cc
@@ -1477,7 +1477,7 @@ future<> row_cache::do_update(row_cache::external_updater eu, row_cache::interna
         } catch (...) {
             // Any error from execute is considered fatal
             // to enforce exception safety.
-            on_fatal_internal_error(clogger, fmt::format("Fatal error during cache update: {}", std::current_exception()));
+            on_fatal_internal_error(clogger, fmt::format("Fatal error during cache update: {:t}", std::current_exception()));
         }
         [&] () noexcept {
             _prev_snapshot_pos = dht::ring_position::min();

--- a/db/schema_applier.cc
+++ b/db/schema_applier.cc
@@ -1204,7 +1204,7 @@ static future<> execute_do_merge_schema(sharded<service::storage_proxy>& proxy, 
     } catch (...) {
         // We have no good way to recover from partial commit and continuing
         // would mean that schema is in inconsistent state.
-        on_fatal_internal_error(slogger, format("schema commit failed: {}", std::current_exception()));
+        on_fatal_internal_error(slogger, format("schema commit failed: {:t}", std::current_exception()));
     }
     co_await ap.post_commit();
 }

--- a/db/schema_tables.cc
+++ b/db/schema_tables.cc
@@ -2147,7 +2147,7 @@ static void prepare_builder_from_table_row(const schema_ctxt& ctxt, schema_build
                     }
                     continue;
                 } catch (...) {
-                    slogger.warn("Error parsing extension {}: {}", p.first, std::current_exception());
+                    slogger.warn("Error parsing extension {}: {:t}", p.first, std::current_exception());
                 }
             }
 

--- a/db/snapshot/backup_task.cc
+++ b/db/snapshot/backup_task.cc
@@ -90,7 +90,7 @@ future<> backup_task_impl::worker::upload_component(sstring name) {
         snap_log.info("Upload aborted per requested: {}", component_name.native());
         throw;
     } catch (...) {
-        snap_log.error("Error uploading {}: {}", component_name.native(), std::current_exception());
+        snap_log.error("Error uploading {}: {:t}", component_name.native(), std::current_exception());
         throw;
     }
 
@@ -107,7 +107,7 @@ future<> backup_task_impl::worker::upload_component(sstring name) {
         // If deletion of an uploaded file fails, the backup process will continue.
         // While this doesn't halt the backup, it may indicate filesystem permissions
         // issues or system constraints that should be investigated.
-        snap_log.warn("Failed to remove {}: {}", component_name, std::current_exception());
+        snap_log.warn("Failed to remove {}: {:t}", component_name, std::current_exception());
     }
 }
 
@@ -242,7 +242,7 @@ future<> backup_task_impl::worker::backup_file(sstring name, upload_permit permi
     try {
         co_await upload_component(name);
     } catch (...) {
-        snap_log.debug("backup_file {} failed: {}", name, std::current_exception());
+        snap_log.debug("backup_file {} failed: {:t}", name, std::current_exception());
         // keep the first exception
         if (!_ex) {
             _ex = std::current_exception();

--- a/db/snapshot/cluster_backup.cc
+++ b/db/snapshot/cluster_backup.cc
@@ -524,7 +524,7 @@ db::snapshot::backup_sstables(db::snapshot_ctl& snap, table_id table_id, std::st
                     }
                 } catch (...) {
                     error = true; // we might have written parts
-                    snap_log.error("Error uploading {}: {}", component_name.native(), std::current_exception());
+                    snap_log.error("Error uploading {}: {:t}", component_name.native(), std::current_exception());
                     if (!p) {
                         p = std::current_exception();
                     }
@@ -537,7 +537,7 @@ db::snapshot::backup_sstables(db::snapshot_ctl& snap, table_id table_id, std::st
                     try {
                         co_await remove_file(component_name.native());
                     } catch (...) {
-                        snap_log.warn("Failed to remove {}: {}", component_name, std::current_exception());
+                        snap_log.warn("Failed to remove {}: {:t}", component_name, std::current_exception());
                     }
                 }
                 co_await utils::get_local_injector().inject("backup_task_pause", utils::wait_for_message(std::chrono::minutes(2)));
@@ -558,7 +558,7 @@ db::snapshot::backup_sstables(db::snapshot_ctl& snap, table_id table_id, std::st
                 info.sstable.state = use_move ? db::snapshot_state::remote : db::snapshot_state::remote_and_local;
                 co_await sth.insert_snapshot_sstables(tag, ksname, cfname, local.dc, local.rack, { info.sstable });
             } catch (...) {
-                snap_log.error("Error marking {} as uploaded: {}", id, std::current_exception());
+                snap_log.error("Error marking {} as uploaded: {:t}", id, std::current_exception());
             }
         });
 

--- a/db/view/view.cc
+++ b/db/view/view.cc
@@ -2117,7 +2117,7 @@ future<> view_update_generator::mutate_MV(
                     ++cf_stats.total_view_updates_failed_local;
                     auto ep = f.get_exception();
                     tracing::trace(tr_state, "Failed to apply local view update for {}", my_address);
-                    vlogger.error("Error applying view update to {} (view: {}.{}, base token: {}, view token: {}): {}",
+                    vlogger.error("Error applying view update to {} (view: {}.{}, base token: {}, view token: {}): {:t}",
                             my_address, s->ks_name(), s->cf_name(), base_token, view_token, ep);
                     return make_exception_future<>(std::move(ep));
                 }
@@ -2160,7 +2160,7 @@ future<> view_update_generator::mutate_MV(
                     // Printing an error on every failed view mutation would cause log spam, so a rate limit is needed.
                     static thread_local logger::rate_limit view_update_error_rate_limit(std::chrono::seconds(4));
                     vlogger.log(log_level::warn, view_update_error_rate_limit,
-                        "Error applying view update to {} (view: {}.{}, base token: {}, view token: {}): {}",
+                        "Error applying view update to {} (view: {}.{}, base token: {}, view token: {}): {:t}",
                         *target_endpoint, s->ks_name(), s->cf_name(), base_token, view_token, ep);
                     return apply_update_synchronously ? make_exception_future<>(std::move(ep)) : make_ready_future<>();
                 }
@@ -2523,7 +2523,7 @@ future<> view_builder::calculate_shard_build_step(view_builder_init_state& vbi) 
     });
     auto bookkeeping_fut = co_await coroutine::as_future(seastar::when_all_succeed(vbi.bookkeeping_ops.begin(), vbi.bookkeeping_ops.end()));
     if (bookkeeping_fut.failed()) {
-        vlogger.warn("Failed to update materialized view bookkeeping while synchronizing view builds on all shards ({}), continuing anyway.", bookkeeping_fut.get_exception());
+        vlogger.warn("Failed to update materialized view bookkeeping while synchronizing view builds on all shards ({:t}), continuing anyway.", bookkeeping_fut.get_exception());
     }
 }
 
@@ -2695,7 +2695,7 @@ future<> view_builder::handle_create_view_local(const sstring& ks_name, const ss
     } catch (raft::request_aborted&) {
         vlogger.debug("Aborted while setting up view for building {}.{}", view->ks_name(), view->cf_name());
     } catch (...) {
-        vlogger.error("Error setting up view for building {}.{}: {}", view->ks_name(), view->cf_name(), std::current_exception());
+        vlogger.error("Error setting up view for building {}.{}: {:t}", view->ks_name(), view->cf_name(), std::current_exception());
     }
 
     _build_step.signal();
@@ -2800,7 +2800,7 @@ future<> view_builder::handle_drop_view_global_cleanup(const sstring& ks_name, c
             [this, &ks_name, &view_name] -> future<>  {
                 co_await remove_view_build_status(ks_name, view_name); });
     } catch (...) {
-        vlogger.warn("Failed to cleanup view {}.{}: {}", ks_name, view_name, std::current_exception());
+        vlogger.warn("Failed to cleanup view {}.{}: {:t}", ks_name, view_name, std::current_exception());
     }
 }
 
@@ -2837,7 +2837,7 @@ future<> view_builder::run_in_background() {
                 ++_current_step->second.base->cf_stats()->view_building_paused;
                 ++_stats.steps_failed;
                 auto base = _current_step->second.base->schema();
-                vlogger.warn("Error executing build step for base {}.{}: {}", base->ks_name(), base->cf_name(), std::current_exception());
+                vlogger.warn("Error executing build step for base {}.{}: {:t}", base->ks_name(), base->cf_name(), std::current_exception());
                 r.retry(_as).get();
                 initialize_reader_at_current_token(_current_step->second).get();
             }
@@ -3167,7 +3167,7 @@ void view_builder::execute(build_step& step, exponential_backoff_retry r) {
         }
     }
     seastar::when_all_succeed(bookkeeping_ops.begin(), bookkeeping_ops.end()).handle_exception([] (std::exception_ptr ep) {
-        vlogger.warn("Failed to update materialized view bookkeeping ({}), continuing anyway.", ep);
+        vlogger.warn("Failed to update materialized view bookkeeping ({:t}), continuing anyway.", ep);
     }).get();
     utils::get_local_injector().inject("delay_finishing_build_step", utils::wait_for_message(60s)).get();
 }
@@ -3366,7 +3366,7 @@ void view_updating_consumer::do_flush_buffer() {
         try {
             auto lock_holder = _view_update_pusher(std::move(_buffer.front())).get();
         } catch (...) {
-            vlogger.warn("Failed to push replica updates for table {}.{}: {}", _schema->ks_name(), _schema->cf_name(), std::current_exception());
+            vlogger.warn("Failed to push replica updates for table {}.{}: {:t}", _schema->ks_name(), _schema->cf_name(), std::current_exception());
         }
         _buffer.pop_front();
     }

--- a/db/view/view_building_coordinator.cc
+++ b/db/view/view_building_coordinator.cc
@@ -99,7 +99,7 @@ void view_building_coordinator::handle_coordinator_error(std::exception_ptr eptr
     } catch (raft::commit_status_unknown&) {
         vbc_logger.warn("view building coordinator got raft::commit_status_unknown");
     } catch (...) {
-        vbc_logger.error("view building coordinator got error: {}", std::current_exception());
+        vbc_logger.error("view building coordinator got error: {:t}", std::current_exception());
     }
 }
 
@@ -144,7 +144,7 @@ future<> view_building_coordinator::run() {
                 vbc_logger.debug("Sleeping after exception.");
                 co_await seastar::sleep_abortable(std::chrono::seconds(1), _as);
             } catch (...) {
-                vbc_logger.warn("sleep failed: {}", std::current_exception());
+                vbc_logger.warn("sleep failed: {:t}", std::current_exception());
             }
         }
     }
@@ -170,7 +170,7 @@ future<> view_building_coordinator::finished_task_gc_fiber() {
         } catch (raft::commit_status_unknown&) {
             vbc_logger.warn("view_building_coordinator::finished_task_gc_fiber got raft::commit_status_unknown");
         } catch (...) {
-            vbc_logger.error("view_building_coordinator::finished_task_gc_fiber got error: {}", std::current_exception());
+            vbc_logger.error("view_building_coordinator::finished_task_gc_fiber got error: {:t}", std::current_exception());
         }
     }
 }

--- a/db/view/view_building_worker.cc
+++ b/db/view/view_building_worker.cc
@@ -241,7 +241,7 @@ future<> view_building_worker::run_staging_sstables_registrator() {
         } catch (raft::request_aborted&) {
             vbw_logger.warn("Got raft::request_aborted while creating staging sstable tasks");
         } catch (...) {
-            vbw_logger.error("Exception while creating staging sstable tasks: {}", std::current_exception());
+            vbw_logger.error("Exception while creating staging sstable tasks: {:t}", std::current_exception());
             sleep = true;
         }
 
@@ -467,7 +467,7 @@ future<> view_building_worker::run_view_building_state_observer() {
         } catch (abort_requested_exception&) {
         } catch (broken_condition_variable&) {
         } catch (...) {
-            vbw_logger.warn("view_building_state_observer failed with: {}", std::current_exception());
+            vbw_logger.warn("view_building_state_observer failed with: {:t}", std::current_exception());
             sleep = true;
         }
 
@@ -476,7 +476,7 @@ future<> view_building_worker::run_view_building_state_observer() {
                 vbw_logger.debug("Sleeping after exception.");
                 co_await seastar::sleep_abortable(std::chrono::seconds(1), _as);
             } catch (...) {
-                vbw_logger.warn("view_building_state_observer sleep failed: {}", std::current_exception());
+                vbw_logger.warn("view_building_state_observer sleep failed: {:t}", std::current_exception());
             }
         }
     }

--- a/db/view/view_update_generator.cc
+++ b/db/view/view_update_generator.cc
@@ -145,7 +145,7 @@ future<> view_update_generator::start() {
                     }
                     input_size = result.second;
                 } catch (...) {
-                    vug_logger.warn("Processing {} failed for table {}:{}. Will retry...", s->ks_name(), s->cf_name(), std::current_exception());
+                    vug_logger.warn("Processing {} failed for table {}:{:t}. Will retry...", s->ks_name(), s->cf_name(), std::current_exception());
                     // Need to add sstables back to the set so we can retry later. By now it may
                     // have had other updates.
                     std::move(sstables.begin(), sstables.end(), std::back_inserter(_sstables_with_tables[t]));
@@ -161,7 +161,7 @@ future<> view_update_generator::start() {
                     std::move(sstables.begin(), sstables.end(), std::back_inserter(_sstables_to_move[t]));
                 } catch (...) {
                     // Move from staging will be retried upon restart.
-                    vug_logger.warn("Moving {} from staging failed: {}:{}. Ignoring...", s->ks_name(), s->cf_name(), std::current_exception());
+                    vug_logger.warn("Moving {} from staging failed: {}:{:t}. Ignoring...", s->ks_name(), s->cf_name(), std::current_exception());
                 }
                 _registration_sem.signal(num_sstables);
 
@@ -179,7 +179,7 @@ future<> view_update_generator::start() {
                     t->move_sstables_from_staging(sstables).get();
                 } catch (...) {
                     // Move from staging will be retried upon restart.
-                    vug_logger.warn("Moving some sstable from staging failed: {}. Ignoring...", std::current_exception());
+                    vug_logger.warn("Moving some sstable from staging failed: {:t}. Ignoring...", std::current_exception());
                 }
                 it = _sstables_to_move.erase(it);
             }

--- a/dht/boot_strapper.cc
+++ b/dht/boot_strapper.cc
@@ -60,7 +60,7 @@ future<> boot_strapper::bootstrap(streaming::stream_reason reason, gms::gossiper
         _abort_source.check();
         co_await streamer->stream_async();
     } catch (...) {
-        blogger.warn("Error during bootstrap: {}", std::current_exception());
+        blogger.warn("Error during bootstrap: {:t}", std::current_exception());
         throw;
     }
 }

--- a/dht/range_streamer.cc
+++ b/dht/range_streamer.cc
@@ -309,7 +309,7 @@ future<> range_streamer::stream_async() {
                     }
                 } catch (...) {
                     auto t = std::chrono::duration_cast<std::chrono::duration<float>>(lowres_clock::now() - start_time).count();
-                    logger.warn("{} with {} for keyspace={} failed, took {} seconds: {}", description, source, keyspace, t, std::current_exception());
+                    logger.warn("{} with {} for keyspace={} failed, took {} seconds: {:t}", description, source, keyspace, t, std::current_exception());
                     throw;
                 }
                 auto t = std::chrono::duration_cast<std::chrono::duration<float>>(lowres_clock::now() - start_time).count();

--- a/ent/encryption/azure_host.cc
+++ b/ent/encryption/azure_host.cc
@@ -192,7 +192,7 @@ static future<T> wrap_exceptions(const std::string& context, Callable&& func) {
     } catch (const rjson::malformed_value& e) {
         std::throw_with_nested(malformed_response_error(fmt::format("{}: {}", context, e.what())));
     } catch (...) {
-        std::throw_with_nested(service_error(fmt::format("{}: {}", context, std::current_exception())));
+        std::throw_with_nested(service_error(fmt::format("{}: {:t}", context, std::current_exception())));
     }
 }
 
@@ -438,7 +438,7 @@ future<azure_host::key_and_id_type> azure_host::impl::create_key(const attr_cach
     try {
         resp = co_await send_request_with_retry(host, port, scheme == "https", path, body, filter);
     } catch (...) {
-        azlog.error("[{}] Failed to wrap key {} with master_key={}: {}", _log_prefix, info, k.master_key, std::current_exception());
+        azlog.error("[{}] Failed to wrap key {} with master_key={}: {:t}", _log_prefix, info, k.master_key, std::current_exception());
         throw;
     }
     auto key_id = rjson::get<std::string>(resp, "kid");
@@ -497,7 +497,7 @@ future<bytes> azure_host::impl::find_key(const id_cache_key& k) {
     try {
         resp = co_await send_request_with_retry(host, port, scheme == "https", path, body, filter);
     } catch (...) {
-        azlog.error("[{}] Failed to unwrap key {}: {}", _log_prefix, k.id, std::current_exception());
+        azlog.error("[{}] Failed to unwrap key {}: {:t}", _log_prefix, k.id, std::current_exception());
         throw;
     }
     auto data = base64url_decode(rjson::get<std::string>(resp, "value"));

--- a/ent/encryption/encryption.cc
+++ b/ent/encryption/encryption.cc
@@ -571,7 +571,7 @@ public:
                 logg.warn("{}", problems);
             }
         } catch (...) {
-            std::throw_with_nested(exceptions::configuration_exception(fmt::format("Validation failed: {}", std::current_exception())));
+            std::throw_with_nested(exceptions::configuration_exception(fmt::format("Validation failed: {:t}", std::current_exception())));
         }
     }
 

--- a/ent/encryption/gcp_host.cc
+++ b/ent/encryption/gcp_host.cc
@@ -206,7 +206,7 @@ future<std::tuple<shared_ptr<encryption::symmetric_key>, encryption::gcp_host::i
     } catch (rjson::malformed_value& e) {
         std::throw_with_nested(malformed_response_error(fmt::format("get_or_create_key: {}", e.what())));
     } catch (...) {
-        std::throw_with_nested(service_error(fmt::format("get_or_create_key: {}", std::current_exception())));
+        std::throw_with_nested(service_error(fmt::format("get_or_create_key: {:t}", std::current_exception())));
     }
 }
 
@@ -232,7 +232,7 @@ future<shared_ptr<encryption::symmetric_key>> encryption::gcp_host::impl::get_ke
     } catch (rjson::malformed_value& e) {
         std::throw_with_nested(malformed_response_error(fmt::format("get_or_create_key: {}", e.what())));
     } catch (...) {
-        std::throw_with_nested(service_error(fmt::format("get_key_by_id: {}", std::current_exception())));
+        std::throw_with_nested(service_error(fmt::format("get_key_by_id: {:t}", std::current_exception())));
     }
 }
 
@@ -257,7 +257,7 @@ future<rjson::value> encryption::gcp_host::impl::gcp_auth_post_with_retry(std::s
             }
             i = _cached_credentials.emplace(src, std::move(c)).first;
         } catch (...) {
-            gcp_log.warn("Error resolving credentials for {}: {}", src, std::current_exception());
+            gcp_log.warn("Error resolving credentials for {}: {:t}", src, std::current_exception());
             throw;
         }
     }

--- a/ent/encryption/kmip_host.cc
+++ b/ent/encryption/kmip_host.cc
@@ -432,7 +432,7 @@ int kmip_host::impl::connection::io_callback(KMIP *kmip, void *cb_arg, int op, v
             return conn->recv(data, len, outlen);
         }
     } catch (...) {
-        kmip_log.warn("Error in KMIP IO: {}", std::current_exception());
+        kmip_log.warn("Error in KMIP IO: {:t}", std::current_exception());
         return KMIP_ERROR_IO;
     }
 }
@@ -1099,7 +1099,7 @@ future<std::tuple<shared_ptr<symmetric_key>, kmip_host::id_type>> kmip_host::imp
     } catch (std::invalid_argument& e) {
         std::throw_with_nested(configuration_error(fmt::format("get_or_create_key: {}", e.what())));
     } catch (...) {
-        std::throw_with_nested(service_error(fmt::format("get_or_create_key: {}", std::current_exception())));
+        std::throw_with_nested(service_error(fmt::format("get_or_create_key: {:t}", std::current_exception())));
     }
 }
 
@@ -1118,7 +1118,7 @@ future<shared_ptr<symmetric_key>> kmip_host::impl::get_key_by_id(const id_type& 
     } catch (std::invalid_argument& e) {
         std::throw_with_nested(configuration_error(fmt::format("get_key_by_id: {}", e.what())));
     } catch (...) {
-        std::throw_with_nested(service_error(fmt::format("get_key_by_id: {}", std::current_exception())));
+        std::throw_with_nested(service_error(fmt::format("get_key_by_id: {:t}", std::current_exception())));
     }
 }
 

--- a/ent/encryption/kms_host.cc
+++ b/ent/encryption/kms_host.cc
@@ -296,7 +296,7 @@ future<std::tuple<shared_ptr<encryption::symmetric_key>, encryption::kms_host::i
     } catch (rjson::malformed_value& e) {
         std::throw_with_nested(malformed_response_error(e.what()));
     } catch (...) {
-        std::throw_with_nested(service_error(fmt::format("get_key_by_id: {}", std::current_exception())));
+        std::throw_with_nested(service_error(fmt::format("get_key_by_id: {:t}", std::current_exception())));
     }
 }
 
@@ -322,7 +322,7 @@ future<shared_ptr<encryption::symmetric_key>> encryption::kms_host::impl::get_ke
     } catch (rjson::malformed_value& e) {
         std::throw_with_nested(malformed_response_error(e.what()));
     } catch (...) {
-        std::throw_with_nested(service_error(fmt::format("get_key_by_id: {}", std::current_exception())));
+        std::throw_with_nested(service_error(fmt::format("get_key_by_id: {:t}", std::current_exception())));
     }
 }
 
@@ -558,7 +558,7 @@ future<rjson::value> encryption::kms_host::impl::do_post(std::string_view target
                         , _options.aws_session_token.empty() ? "" : seastar::format(":{}[REDACTED]", _options.aws_session_token.substr(0, 2))
                     );
                 } catch (...) {
-                    kms_log.debug("Could not read credentials: {}", std::current_exception());
+                    kms_log.debug("Could not read credentials: {:t}", std::current_exception());
                 }
             }
         }

--- a/ent/encryption/local_file_provider.cc
+++ b/ent/encryption/local_file_provider.cc
@@ -217,7 +217,7 @@ future<> local_file_provider::read_key_file() {
             } catch (std::invalid_argument& e) {
                 std::throw_with_nested(configuration_error(fmt::format("read_key_file: {}", e.what())));
             } catch (...) {
-                std::throw_with_nested(service_error(fmt::format("read_key_file: {}", std::current_exception())));
+                std::throw_with_nested(service_error(fmt::format("read_key_file: {:t}", std::current_exception())));
             }
         });
     });

--- a/ent/encryption/replicated_key_provider.cc
+++ b/ent/encryption/replicated_key_provider.cc
@@ -259,14 +259,14 @@ future<std::tuple<key_ptr, opt_bytes>> replicated_key_provider::key(const key_in
                 } catch (exceptions::invalid_request_exception&) {
                 } catch (exceptions::read_failure_exception&) {
                 } catch (...) {
-                    std::throw_with_nested(service_error(fmt::format("key: {}", std::current_exception())));
+                    std::throw_with_nested(service_error(fmt::format("key: {:t}", std::current_exception())));
                 }
                 if (!id) {
                     try_local = true;
                 }
             }
             if (!try_local) {
-                std::throw_with_nested(service_error(fmt::format("key: {}", std::current_exception())));
+                std::throw_with_nested(service_error(fmt::format("key: {:t}", std::current_exception())));
             }
         }
     }

--- a/ent/ldap/ldap_connection.cc
+++ b/ent/ldap/ldap_connection.cc
@@ -257,7 +257,7 @@ ber_slen_t ldap_connection::sbi_read(Sockbuf_IO_Desc* sid, void* buffer, ber_len
     try {
         return connection(sid)->read(reinterpret_cast<char*>(buffer), size);
     } catch (...) {
-        mylog.error("Unexpected error while reading: {}", std::current_exception());
+        mylog.error("Unexpected error while reading: {:t}", std::current_exception());
         return failure_code;
     }
 }
@@ -267,7 +267,7 @@ ber_slen_t ldap_connection::sbi_write(Sockbuf_IO_Desc* sid, void* buffer, ber_le
     try {
         return connection(sid)->write(reinterpret_cast<const char*>(buffer), size);
     } catch (...) {
-        mylog.error("Unexpected error while writing: {}", std::current_exception());
+        mylog.error("Unexpected error while writing: {:t}", std::current_exception());
         return failure_code;
     }
 }

--- a/gms/gossiper.cc
+++ b/gms/gossiper.cc
@@ -449,7 +449,7 @@ future<> gossiper::handle_echo_msg(locator::host_id from_hid, seastar::rpc::opt_
                     co_await sleep_abortable(std::chrono::milliseconds(100), g._abort_source);
                 }
             } catch(...) {
-                logger.warn("handle_echo_msg: UP notification from {} failed with {}", from_hid, std::current_exception());
+                logger.warn("handle_echo_msg: UP notification from {} failed with {:t}", from_hid, std::current_exception());
             }
         });
     }
@@ -858,7 +858,7 @@ future<> gossiper::force_remove_endpoint(locator::host_id id, permit_id pid) {
             co_await gossiper.evict_from_membership(id, pid);
             logger.info("Finished to force remove node {}", id);
         } catch (...) {
-            logger.warn("Failed to force remove node {}: {}", id, std::current_exception());
+            logger.warn("Failed to force remove node {}: {:t}", id, std::current_exception());
         }
     });
 }
@@ -876,7 +876,7 @@ future<> gossiper::remove_endpoint(locator::host_id endpoint, permit_id pid) {
             return subscriber->on_remove(ip, endpoint, pid);
         });
     } catch (...) {
-        logger.warn("Fail to call on_remove callback: {}", std::current_exception());
+        logger.warn("Fail to call on_remove callback: {:t}", std::current_exception());
     }
 
     if (!state) {
@@ -907,7 +907,7 @@ future<> gossiper::remove_endpoint(locator::host_id endpoint, permit_id pid) {
             logger.info("InetAddress {}/{} is now DOWN, status = {}", host_id, ip, get_node_status(host_id));
             co_await do_on_dead_notifications(ip, std::move(state), pid);
         } catch (...) {
-            logger.warn("Fail to call on_dead callback: {}", std::current_exception());
+            logger.warn("Fail to call on_dead callback: {:t}", std::current_exception());
         }
     }
 }
@@ -1096,7 +1096,7 @@ future<> gossiper::failure_detector_loop_for_node(locator::host_id host_id, gene
             logger.debug("failure_detector_loop: Send echo to node {}/{}, status = ok", host_id, node);
         } catch (...) {
             failed = true;
-            logger.warn("failure_detector_loop: Send echo to node {}/{}, status = failed: {}", host_id, node, std::current_exception());
+            logger.warn("failure_detector_loop: Send echo to node {}/{}, status = failed: {:t}", host_id, node, std::current_exception());
         }
         auto now = gossiper::clk::now();
         diff = now - last;
@@ -1279,7 +1279,7 @@ void gossiper::run() {
             _nr_run++;
             logger.trace("=== Gossip round OK");
         } catch (...) {
-            logger.warn("=== Gossip round FAIL: {}", std::current_exception());
+            logger.warn("=== Gossip round FAIL: {:t}", std::current_exception());
         }
 
         if (logger.is_enabled(logging::log_level::trace)) {
@@ -1444,7 +1444,7 @@ future<> gossiper::replicate(endpoint_state es, permit_id pid) {
             g._endpoint_state_map[hid] = std::move(eps);
         });
     } catch (...) {
-        on_fatal_internal_error(logger, fmt::format("Failed to replicate endpoint_state: {}", std::current_exception()));
+        on_fatal_internal_error(logger, fmt::format("Failed to replicate endpoint_state: {:t}", std::current_exception()));
     }
 }
 
@@ -1677,7 +1677,7 @@ future<> gossiper::notify_nodes_on_up(std::unordered_set<locator::host_id> dsts)
                 auto generation = my_endpoint_state().get_heart_beat_state().get_generation();
                 co_await send_echo(dst, std::chrono::seconds(10), generation.value(), true);
             } catch (...) {
-                logger.warn("Failed to notify node {} that I am UP: {}", dst, std::current_exception());
+                logger.warn("Failed to notify node {} that I am UP: {:t}", dst, std::current_exception());
             }
         }
     });
@@ -1903,7 +1903,7 @@ future<> gossiper::apply_new_states(endpoint_state local_state, const endpoint_s
     try {
         co_await do_on_change_notifications(addr, host_id, changed, pid);
     } catch (...) {
-        auto msg = format("Gossip change listener failed: {}", std::current_exception());
+        auto msg = format("Gossip change listener failed: {:t}", std::current_exception());
         if (_abort_source.abort_requested()) {
             logger.warn("{}. Ignored", msg);
         } else {
@@ -2251,7 +2251,7 @@ future<> gossiper::add_local_application_state(application_state_map states) {
             co_await gossiper.do_on_change_notifications(ep_addr, gossiper.my_host_id(), states, permit.id());
         });
     } catch (...) {
-        logger.warn("Fail to apply application_state: {}", std::current_exception());
+        logger.warn("Fail to apply application_state: {:t}", std::current_exception());
     }
 }
 
@@ -2287,7 +2287,7 @@ future<> gossiper::do_stop_gossiping() {
                 co_await ser::gossip_rpc_verbs::send_gossip_shutdown(&_messaging, id, get_broadcast_address(), local_generation.value());
                 logger.trace("Got GossipShutdown Reply");
             } catch (...) {
-                logger.warn("Fail to send GossipShutdown to {}: {}", id, std::current_exception());
+                logger.warn("Fail to send GossipShutdown to {}: {:t}", id, std::current_exception());
             }
         });
         co_await sleep(std::chrono::milliseconds(_gcfg.shutdown_announce_ms));

--- a/gms/versioned_value.hh
+++ b/gms/versioned_value.hh
@@ -21,6 +21,7 @@
 #include "version.hh"
 #include <set>
 #include <unordered_set>
+#include <fmt/ranges.h>
 
 namespace gms {
 
@@ -71,7 +72,7 @@ public:
 
 private:
     static sstring version_string(const std::initializer_list<sstring>& args) {
-        return fmt::to_string(fmt::join(args, versioned_value::DELIMITER));
+        return fmt::to_string(fmt::join(std::span(args), versioned_value::DELIMITER));
     }
 
     static sstring make_token_string(const std::unordered_set<dht::token>& tokens);

--- a/index/secondary_index.cc
+++ b/index/secondary_index.cc
@@ -33,7 +33,7 @@ target_parser::target_info target_parser::parse(schema_ptr schema, const index_m
     try {
         return parse(schema, target);
     } catch (...) {
-        throw exceptions::configuration_exception(format("Unable to parse targets for index {} ({}): {}", im.name(), target, std::current_exception()));
+        throw exceptions::configuration_exception(format("Unable to parse targets for index {} ({}): {:t}", im.name(), target, std::current_exception()));
     }
 }
 

--- a/init.cc
+++ b/init.cc
@@ -34,7 +34,7 @@ std::set<gms::inet_address> get_seeds_from_db_config(const db::config& cfg,
                 seeds.emplace(gms::inet_address::lookup(seed, family, preferred).get());
             } catch (...) {
                 if (fail_on_lookup_error) {
-                    startlog.error("Bad configuration: invalid value in 'seeds': '{}': {}", seed, std::current_exception());
+                    startlog.error("Bad configuration: invalid value in 'seeds': '{}': {:t}", seed, std::current_exception());
                     throw bad_configuration_error();
                 }
                 startlog.warn("Bad configuration: invalid value in 'seeds': '{}': {}. Node will continue booting since already bootstrapped.",

--- a/main.cc
+++ b/main.cc
@@ -340,7 +340,7 @@ private:
                             _cfg.broadcast_to_all_shards().get();
                             startlog.info("completed re-reading configuration file");
                         } catch (...) {
-                            startlog.error("failed to re-read configuration file: {}", std::current_exception());
+                            startlog.error("failed to re-read configuration file: {:t}", std::current_exception());
                         }
                     }
                     return stop_iteration::no;
@@ -388,7 +388,7 @@ class sigquit_handler {
                     });
                 });
             } catch (...) {
-                diaglog.error("Failed to dump diagnostics: {}", std::current_exception());
+                diaglog.error("Failed to dump diagnostics: {:t}", std::current_exception());
             }
         }
     }
@@ -2130,7 +2130,7 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
                 if (!cfg->maintenance_mode()) {
                     throw;
                 }
-                startlog.error("Failed to load tablet metadata (ignoring due to maintenance mode): {}", std::current_exception());
+                startlog.error("Failed to load tablet metadata (ignoring due to maintenance mode): {:t}", std::current_exception());
             }
 
             // We do not support tablet re-sharding yet, see https://github.com/scylladb/scylladb/issues/16739.
@@ -2493,7 +2493,7 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
                             try {
                                 return gossiper.local().get_host_id(ip);
                             } catch (...) {
-                                startlog.debug("Could not resolve host id: {}, {}", ip, std::current_exception());
+                                startlog.debug("Could not resolve host id: {}, {:t}", ip, std::current_exception());
                                 return locator::host_id{};
                             }
                         });
@@ -2851,7 +2851,7 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
             _exit(0);
             return 0;
           } catch (...) {
-            startlog.error("Startup failed: {}", std::current_exception());
+            startlog.error("Startup failed: {:t}", std::current_exception());
             // We should be returning 1 here, but the system is not yet prepared for orderly rollback of main() objects
             // and thread_local variables.
             _exit(1);
@@ -2872,7 +2872,7 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
     });
   } catch (...) {
       // reactor may not have been initialized, so can't use logger
-      fmt::print(std::cerr, "FATAL: Exception during startup, aborting: {}\n", std::current_exception());
+      fmt::print(std::cerr, "FATAL: Exception during startup, aborting: {:t}\n", std::current_exception());
       return 7; // 1 has a special meaning for upstart
   }
 }

--- a/message/advanced_rpc_compressor.cc
+++ b/message/advanced_rpc_compressor.cc
@@ -378,7 +378,7 @@ rpc::snd_buf advanced_rpc_compressor::compress(size_t head_space, rpc::snd_buf d
         try {
             return compress_impl(head_space + 1 + checksum_size + protocol_header_size, std::move(data), get_compressor(algo), true, rpc::snd_buf::chunk_size);
         } catch (...) {
-            arc_logger.error("Error during compression with algorithm {}: {}. ", algo.name(), std::current_exception());
+            arc_logger.error("Error during compression with algorithm {}: {:t}. ", algo.name(), std::current_exception());
             throw;
         }
     });
@@ -489,7 +489,7 @@ rpc::rcv_buf advanced_rpc_compressor::decompress(rpc::rcv_buf data) {
         try {
             return decompress_impl(data, get_decompressor(algo), true, rpc::snd_buf::chunk_size);
          } catch (...) {
-            arc_logger.error("Error during decompression with algorithm {}: {}. ", algo.name(), std::current_exception());
+            arc_logger.error("Error during decompression with algorithm {}: {:t}. ", algo.name(), std::current_exception());
             throw;
         }
     });

--- a/message/dict_trainer.cc
+++ b/message/dict_trainer.cc
@@ -161,7 +161,7 @@ seastar::future<> dict_training_loop::start(
             } else if (_paused) {
                 dict_trainer_logger.debug("dict_training_loop: paused");
             } else  {
-                dict_trainer_logger.error("Failed to train a dictionary: {}.", std::current_exception());
+                dict_trainer_logger.error("Failed to train a dictionary: {:t}.", std::current_exception());
             }
         }
     }

--- a/raft/server.cc
+++ b/raft/server.cc
@@ -1076,7 +1076,7 @@ void server_impl::send_message(server_id id, Message m) {
                 try {
                     co_await server->_rpc->send_append_entries(id, m);
                 } catch(...) {
-                    logger.debug("[{}] io_fiber failed to send a message to {}: {}", server->_tag, id, std::current_exception());
+                    logger.debug("[{}] io_fiber failed to send a message to {}: {:t}", server->_tag, id, std::current_exception());
                 }
                 server->_append_request_status[id].count--;
                 if (server->_append_request_status[id].count == 0) {
@@ -1225,7 +1225,7 @@ future<> server_impl::process_fsm_output(index_t& last_stable, fsm_output&& batc
             send_message(m.first, std::move(m.second));
         } catch(...) {
             // Not being able to send a message is not a critical error
-            logger.debug("[{}] io_fiber failed to send a message to {}: {}", _tag, m.first, std::current_exception());
+            logger.debug("[{}] io_fiber failed to send a message to {}: {:t}", _tag, m.first, std::current_exception());
         }
     }
 
@@ -1414,7 +1414,7 @@ future<snapshot_reply> server_impl::apply_snapshot(server_id from, install_snaps
         try {
             reply = co_await _snapshot_application_done[from].get_future();
         } catch (...) {
-            logger.error("apply_snapshot[{}] failed with {}", _tag, std::current_exception());
+            logger.error("apply_snapshot[{}] failed with {:t}", _tag, std::current_exception());
         }
     }
     co_return reply;

--- a/reader_concurrency_semaphore.cc
+++ b/reader_concurrency_semaphore.cc
@@ -1277,7 +1277,7 @@ reader_concurrency_semaphore::inactive_read_handle reader_concurrency_semaphore:
         // due to lack of resources. Returning an empty
         // i_r_h here rather than throwing simplifies the caller's
         // error handling.
-        rcslog.warn("Registering inactive read failed: {}. Ignored as if it was evicted.", std::current_exception());
+        rcslog.warn("Registering inactive read failed: {:t}. Ignored as if it was evicted.", std::current_exception());
       }
     } else {
         permit->on_evicted();
@@ -1399,7 +1399,7 @@ void reader_concurrency_semaphore::do_detach_inactive_reader(reader_permit::impl
             ir.notify_handler(reason);
         }
     } catch (...) {
-        rcslog.error("[semaphore {}] evict(): notify handler failed for inactive read evicted due to {}: {}", _name, static_cast<int>(reason), std::current_exception());
+        rcslog.error("[semaphore {}] evict(): notify handler failed for inactive read evicted due to {}: {:t}", _name, static_cast<int>(reason), std::current_exception());
     }
     switch (reason) {
         case evict_reason::permit:

--- a/readers/multishard.cc
+++ b/readers/multishard.cc
@@ -812,7 +812,7 @@ future<> shard_reader::close() noexcept {
             });
         });
     } catch (...) {
-        mrlog.error("shard_reader::close(): failed to stop reader on shard {}: {}", _shard, std::current_exception());
+        mrlog.error("shard_reader::close(): failed to stop reader on shard {}: {:t}", _shard, std::current_exception());
     }
 }
 

--- a/repair/repair.cc
+++ b/repair/repair.cc
@@ -254,7 +254,7 @@ static const replica::column_family* find_column_family_if_exists(const replica:
         return &db.find_column_family(uuid);
     } catch (replica::no_such_column_family&) {
         if (warn) {
-            rlogger.warn("{}", std::current_exception());
+            rlogger.warn("{:t}", std::current_exception());
         }
         return nullptr;
     }
@@ -265,7 +265,7 @@ static const replica::column_family* find_column_family_if_exists(const replica:
         return &db.find_column_family(uuid);
     } catch (...) {
         if (warn) {
-            rlogger.warn("{}", std::current_exception());
+            rlogger.warn("{:t}", std::current_exception());
         }
         return nullptr;
     }
@@ -1271,9 +1271,14 @@ future<> repair::shard_repair_task_impl::run() {
     try {
         co_await do_repair_ranges();
     } catch (...) {
-        _failed_because.emplace(fmt::to_string(std::current_exception()));
+        // formattable(), not a plain "{}": do_repair_ranges() reports a rejected
+        // write as a seastar::nested_exception, and only formattable() descends
+        // into it. {fmt}'s own exception_ptr formatter recurses through
+        // std::nested_exception, which seastar::nested_exception is not, so it
+        // would print the bare type name and drop the reason for the failure.
+        _failed_because.emplace(fmt::to_string(seastar::formattable(std::current_exception())));
         rlogger.debug("repair[{}]: got error in do_repair_ranges: {}",
-            global_repair_id.uuid(), std::current_exception());
+            global_repair_id.uuid(), seastar::formattable(std::current_exception()));
     }
     check_failed_ranges();
     co_return;
@@ -1535,7 +1540,7 @@ future<> repair::user_requested_repair_task_impl::run() {
                 off_strategy_updater.get();
             } catch (const seastar::sleep_aborted& ignored) {
             } catch (...) {
-                rlogger.warn("repair[{}]: Found error in off-strategy compaction updater: {}", uuid, std::current_exception());
+                rlogger.warn("repair[{}]: Found error in off-strategy compaction updater: {:t}", uuid, std::current_exception());
             }
             rlogger.info("repair[{}]: Finished to shutdown off-strategy compaction updater", uuid);
         });
@@ -1544,7 +1549,7 @@ future<> repair::user_requested_repair_task_impl::run() {
             try {
                 rs.cleanup_history(tasks::task_id{uuid.uuid()}).get();
             } catch (...) {
-                rlogger.warn("repair[{}]: Failed to cleanup history: {}", uuid, std::current_exception());
+                rlogger.warn("repair[{}]: Failed to cleanup history: {:t}", uuid, std::current_exception());
             }
         });
 
@@ -2581,7 +2586,7 @@ future<> repair::tablet_repair_task_impl::run() {
                 off_strategy_updater.get();
             } catch (const seastar::sleep_aborted& ignored) {
             } catch (...) {
-                rlogger.warn("repair[{}]: Found error in off-strategy compaction updater: {}", uuid, std::current_exception());
+                rlogger.warn("repair[{}]: Found error in off-strategy compaction updater: {:t}", uuid, std::current_exception());
             }
             rlogger.info("repair[{}]: Finished to shutdown off-strategy compaction updater", uuid);
         });
@@ -2590,7 +2595,7 @@ future<> repair::tablet_repair_task_impl::run() {
             try {
                 rs.cleanup_history(tasks::task_id{uuid.uuid()}).get();
             } catch (...) {
-                rlogger.warn("repair[{}]: Failed to cleanup history: {}", uuid, std::current_exception());
+                rlogger.warn("repair[{}]: Failed to cleanup history: {:t}", uuid, std::current_exception());
             }
         });
 
@@ -2653,7 +2658,7 @@ future<> repair::tablet_repair_task_impl::run() {
                         ignore_msg = format("{} does not exist any more, ignoring it, ",
                                 rs.get_db().local().has_keyspace(m.keyspace_name) ? "table" : "keyspace");
                     }
-                    rlogger.warn("repair[{}]: Repair tablet for table={}.{} range={} status=failed: {}{}",
+                    rlogger.warn("repair[{}]: Repair tablet for table={}.{} range={} status=failed: {}{:t}",
                             id.uuid(), m.keyspace_name, m.table_name, m.range, ignore_msg, ep);
                     if (!ignore) {
                         error = std::move(ep);

--- a/repair/row_level.cc
+++ b/repair/row_level.cc
@@ -3516,7 +3516,7 @@ private:
                 (void)resp;  // nothing to do with the response yet
                 rlogger.debug("repair[{}]: Finished to update system.repair_history table of node {}", _shard_task.global_repair_id.uuid(), node);
             } catch (...) {
-                rlogger.warn("repair[{}]: Failed to update system.repair_history table of node {}: {}", _shard_task.global_repair_id.uuid(), node, std::current_exception());
+                rlogger.warn("repair[{}]: Failed to update system.repair_history table of node {}: {:t}", _shard_task.global_repair_id.uuid(), node, std::current_exception());
             }
         });
         co_return;
@@ -3736,7 +3736,7 @@ public:
             });
             rlogger.debug("Finished to remove row level repair on all shards for node {}", node);
         } catch(...) {
-            rlogger.warn("Failed to remove row level repair for node {}: {}", node, std::current_exception());
+            rlogger.warn("Failed to remove row level repair for node {}: {:t}", node, std::current_exception());
         }
     }
     virtual future<> on_dead(
@@ -3828,7 +3828,7 @@ future<> repair_service::stop() {
     _state = state::stopped;
     rlogger.info("Stopped repair_service");
   } catch (...) {
-    on_fatal_internal_error(rlogger, format("Failed stopping repair_service: {}", std::current_exception()));
+    on_fatal_internal_error(rlogger, format("Failed stopping repair_service: {:t}", std::current_exception()));
   }
 }
 
@@ -3927,7 +3927,7 @@ future<> repair_service::load_history() {
                     gc_state.batch_update_repair_time(table_uuid, updates);
                 });
             } catch (...) {
-                rlogger.warn("Failed to update repair history time for table_uuid={}: {}", table_uuid, std::current_exception());
+                rlogger.warn("Failed to update repair history time for table_uuid={}: {:t}", table_uuid, std::current_exception());
             }
             updates.clear();
         };
@@ -3951,7 +3951,7 @@ future<> repair_service::load_history() {
   } catch (const abort_requested_exception&) {
     // Ignore
   } catch (...) {
-    rlogger.warn("Failed to update repair history time: {}.  Ignored", std::current_exception());
+    rlogger.warn("Failed to update repair history time: {:t}.  Ignored", std::current_exception());
   }
 }
 

--- a/replica/cell_locking.hh
+++ b/replica/cell_locking.hh
@@ -248,7 +248,7 @@ private:
                     _cells.rehash(cells_type::bucket_traits(buckets.get(), new_bucket_count));
                     _buckets = std::move(buckets);
                 } catch (const std::bad_alloc&) {
-                    cell_locker_log.warn("Could not rehash cell_locker partition cells set: bucket_count={} new_bucket_count={}: {}", _cells.bucket_count(), new_bucket_count, std::current_exception());
+                    cell_locker_log.warn("Could not rehash cell_locker partition cells set: bucket_count={} new_bucket_count={}: {:t}", _cells.bucket_count(), new_bucket_count, std::current_exception());
                 }
                 // Attempt rehash at the new size in both success and failure paths.
                 // On failure, we don't want to retry too soon since it may take some time
@@ -349,7 +349,7 @@ private:
                 _partitions.rehash(partitions_type::bucket_traits(buckets.get(), new_bucket_count));
                 _buckets = std::move(buckets);
             } catch (const std::bad_alloc&) {
-                cell_locker_log.warn("Could not rehash cell_locker partitions set: bucket_count={} new_bucket_count={}: {}", _partitions.bucket_count(), new_bucket_count, std::current_exception());
+                cell_locker_log.warn("Could not rehash cell_locker partitions set: bucket_count={} new_bucket_count={}: {:t}", _partitions.bucket_count(), new_bucket_count, std::current_exception());
             }
             // Attempt rehash at the new size in both success and failure paths.
             // On failure, we don't want to retry too soon since it may take some time

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -821,7 +821,7 @@ do_parse_schema_tables(sharded<service::storage_proxy>& proxy, const sstring cf_
         try {
             co_await func(v);
         } catch (...) {
-            dblog.error("Skipping: {}. Exception occurred when loading system table {}: {}", v.first, cf_name, std::current_exception());
+            dblog.error("Skipping: {}. Exception occurred when loading system table {}: {:t}", v.first, cf_name, std::current_exception());
         }
     });
 }
@@ -3603,7 +3603,7 @@ void database::tables_metadata::remove_table(database& db, table& cf) noexcept {
         auto& ks = db.find_keyspace(s->ks_name());
         remove_table_helper(db, ks, cf, s);
     } catch (...) {
-        on_fatal_internal_error(dblog, format("tables_metadata::remove_cf: {}", std::current_exception()));
+        on_fatal_internal_error(dblog, format("tables_metadata::remove_cf: {:t}", std::current_exception()));
     }
 }
 

--- a/replica/distributed_loader.cc
+++ b/replica/distributed_loader.cc
@@ -505,7 +505,7 @@ future<> distributed_loader::populate_keyspace(sharded<replica::database>& db,
         } catch (...) {
             std::exception_ptr eptr = std::current_exception();
             std::string msg =
-                format("Exception while populating keyspace '{}' with column family '{}' from '{}': {}",
+                format("Exception while populating keyspace '{}' with column family '{}' from '{}': {:t}",
                         ks_name, cfname, cf.get_storage_options(), eptr);
             dblog.error("{}", msg);
             try {

--- a/replica/logstor/segment_manager.cc
+++ b/replica/logstor/segment_manager.cc
@@ -1409,7 +1409,7 @@ future<> segment_manager_impl::run_separator_fiber() {
             write_to_separator_failed.cancel();
         } catch (...) {
             ++_stats.separator_task_failures;
-            logstor_logger.debug("logstor separator task failure in separator fiber: {}", std::current_exception());
+            logstor_logger.debug("logstor separator task failure in separator fiber: {:t}", std::current_exception());
         }
     }
 }
@@ -1546,7 +1546,7 @@ void segment_manager_impl::on_free_record(log_location location) noexcept {
         try {
             desc.owner->update_segment(desc);
         } catch (...) {
-            logstor_logger.warn("Failed to update segments histogram: {}", std::current_exception());
+            logstor_logger.warn("Failed to update segments histogram: {:t}", std::current_exception());
         }
     }
     _stats.bytes_freed += location.size;
@@ -1606,7 +1606,7 @@ future<> segment_manager_impl::replenish_reserve() {
             break;
         } catch (...) {
             retry = true;
-            logstor_logger.warn("Exception in reserve replenisher: {}, will retry", std::current_exception());
+            logstor_logger.warn("Exception in reserve replenisher: {:t}, will retry", std::current_exception());
         }
 
         if (retry) {

--- a/replica/logstor/write_buffer.cc
+++ b/replica/logstor/write_buffer.cc
@@ -416,7 +416,7 @@ void write_buffer_pool::return_buffer(write_buffer* wb, seastar::semaphore_units
         buf->reset();
         _free.push_back(std::move(buf));
     } catch (...) {
-        logstor_logger.error("Failed to return a write buffer, dropping it from the pool: {}", std::current_exception());
+        logstor_logger.error("Failed to return a write buffer, dropping it from the pool: {:t}", std::current_exception());
         drop_buffer(std::move(buf), pool_units);
     }
 }
@@ -814,7 +814,7 @@ future<> buffered_writer::consumer_loop() {
             co_await coroutine::maybe_yield();
         }
     } catch (...) {
-        on_internal_error(logstor_logger, format("buffered_writer consumer loop aborted unexpectedly: {}", std::current_exception()));
+        on_internal_error(logstor_logger, format("buffered_writer consumer loop aborted unexpectedly: {:t}", std::current_exception()));
     }
 }
 

--- a/replica/multishard_query.cc
+++ b/replica/multishard_query.cc
@@ -562,7 +562,7 @@ future<> read_context::save_reader(shard_id shard, full_position_view last_pos) 
         } catch (...) {
             // We don't want to fail a read just because of a failure to
             // save any of the readers.
-            mq_log.debug("Failed to save reader: {}", std::current_exception());
+            mq_log.debug("Failed to save reader: {:t}", std::current_exception());
             ++db.get_stats().multishard_query_failed_reader_saves;
             return make_ready_future<>();
         }

--- a/replica/querier.cc
+++ b/replica/querier.cc
@@ -305,7 +305,7 @@ void querier_cache::insert_querier(
     // we're allowed to drop the reader upon registration
     // due to lack of resources - in which case we already
     // drop the querier.
-    qlogger.warn("Failed to insert querier into index: {}. Ignored as if it was evicted upon registration", std::current_exception());
+    qlogger.warn("Failed to insert querier into index: {:t}. Ignored as if it was evicted upon registration", std::current_exception());
   }
 }
 

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -1815,13 +1815,13 @@ table::add_new_sstable_and_update_cache(sstables::shared_sstable new_sst,
     if (ex) {
         // on failed split, input sstable is unlinked here.
         if (new_sst) {
-            tlogger.log(failure_log_level, "Failed to load SSTable {} of origin {} due to {}, it will be unlinked...", new_sst->get_filename(), new_sst->get_origin(), ex);
+            tlogger.log(failure_log_level, "Failed to load SSTable {} of origin {} due to {:t}, it will be unlinked...", new_sst->get_filename(), new_sst->get_origin(), ex);
             co_await new_sst->unlink();
         }
         // on failure after successful split, sstables not attached yet will be unlinked
         co_await coroutine::parallel_for_each(ssts, [&ex, failure_log_level] (sstables::shared_sstable sst) -> future<> {
             if (sst) {
-                tlogger.log(failure_log_level, "Failed to load SSTable {} of origin {} due to {}, it will be unlinked...", sst->get_filename(), sst->get_origin(), ex);
+                tlogger.log(failure_log_level, "Failed to load SSTable {} of origin {} due to {:t}, it will be unlinked...", sst->get_filename(), sst->get_origin(), ex);
                 co_await sst->unlink();
             }
         });
@@ -1855,7 +1855,7 @@ table::add_new_sstables_and_update_cache(std::vector<sstables::shared_sstable> n
     if (ex) {
         co_await coroutine::parallel_for_each(new_ssts, [&ex, failure_log_level] (sstables::shared_sstable sst) -> future<> {
             if (sst) {
-                tlogger.log(failure_log_level, "Failed to load SSTable {} of origin {} due to {}, it will be unlinked...", sst->get_filename(), sst->get_origin(), ex);
+                tlogger.log(failure_log_level, "Failed to load SSTable {} of origin {} due to {:t}, it will be unlinked...", sst->get_filename(), sst->get_origin(), ex);
                 co_await sst->unlink();
             }
         });
@@ -2468,7 +2468,7 @@ table::delete_sstables_atomically(const sstable_list_permit&, std::vector<sstabl
     } catch (...) {
         // There is nothing more we can do here.
         // Any remaining SSTables will eventually be re-compacted and re-deleted.
-        tlogger.error("SSTables deletion failed: {}. Ignored.", std::current_exception());
+        tlogger.error("SSTables deletion failed: {:t}. Ignored.", std::current_exception());
     }
 }
 
@@ -2781,7 +2781,7 @@ void table::try_trigger_compaction(compaction_group& cg) noexcept {
     try {
         cg.trigger_compaction();
     } catch (...) {
-        tlogger.error("Failed to trigger compaction: {}", std::current_exception());
+        tlogger.error("Failed to trigger compaction: {:t}", std::current_exception());
     }
 }
 
@@ -5350,7 +5350,7 @@ future<> table::move_sstables_from_staging(std::vector<sstables::shared_sstable>
                 add_sstable_to_backlog_tracker(cg.get_backlog_tracker(), sst);
             }
         } catch (...) {
-            tlogger.warn("Failed to move sstable {} from staging: {}", sst->get_filename(), std::current_exception());
+            tlogger.warn("Failed to move sstable {} from staging: {:t}", sst->get_filename(), std::current_exception());
             throw;
         }
     }

--- a/schema/schema_registry.cc
+++ b/schema/schema_registry.cc
@@ -47,7 +47,7 @@ schema_registry_entry::schema_registry_entry(table_schema_version v, schema_regi
         try {
             _registry._entries.erase(_version);
         } catch (...) {
-            slogger.error("Failed to erase schema version {}: {}", _version, std::current_exception());
+            slogger.error("Failed to erase schema version {}: {:t}", _version, std::current_exception());
         }
     });
 }
@@ -232,7 +232,7 @@ future<schema_ptr> schema_registry_entry::start_loading(async_schema_loader load
                 std::throw_with_nested(schema_version_loading_failed(_version));
             }
         } catch (...) {
-            slogger.debug("Loading of {} failed: {}", _version, std::current_exception());
+            slogger.debug("Loading of {} failed: {:t}", _version, std::current_exception());
             _schema_promise.set_exception(std::current_exception());
             _registry._entries.erase(_version);
         }

--- a/scripts/compare_build_systems.py
+++ b/scripts/compare_build_systems.py
@@ -130,7 +130,9 @@ _KNOWN_LIB_ASYMMETRIES = {
     "udev": "conf",
     "protobuf": "conf",
     "jsoncpp": "conf",
-    "fmt": "conf",
+    # NOTE: fmt is not listed here.  It is now built from the bundled submodule
+    # by both build systems (see configure_fmt() / add_subdirectory(fmt)), so
+    # it is auto-detected as an internal library and filtered symmetrically.
     # CMake resolves these transitively through Boost imported targets
     "boost_atomic": "cmake",
     # CMake links ssl explicitly for encryption targets
@@ -410,9 +412,15 @@ def normalize_linker_flag(tok):
 # ═══════════════════════════════════════════════════════════════════════════
 
 def _is_scylla_source(rel_path):
-    """True if this is a Scylla-owned source file (not seastar/abseil)."""
+    """True if this is a Scylla-owned source file (not seastar/abseil/fmt)."""
+    # fmt is a vendored submodule built by its own CMake project in both build
+    # systems: configure.py drives it as a separate sub-build (so its sources
+    # never appear in configure.py's build.ninja at all), while CMake pulls it
+    # in with add_subdirectory().  Its flags come from fmt's own CMakeLists in
+    # both cases, so there is nothing to compare here.
     return (not rel_path.startswith("seastar/")
             and not rel_path.startswith("abseil/")
+            and not rel_path.startswith("fmt/")
             and not rel_path.startswith("build")
             and not rel_path.startswith("..")
             and not os.path.isabs(rel_path)
@@ -1061,6 +1069,12 @@ def compare_link_settings(conf_targets, cmake_targets, internal_libs,
         target_base = target.rsplit("/", 1)[-1] if "/" in target else target
         if target_base in _CPP_APPS:
             only_cmake_flags.discard("-fno-lto")
+            # configure.py links fmt (and its rpath) into every target via
+            # $libs_<mode>; CMake adds fmt's rpath only to targets that
+            # actually link the shared fmt.  Standalone tools like patchelf
+            # don't link fmt in CMake, so the rpath shows up only on the
+            # configure.py side.
+            only_conf_flags.discard("-Wl,-rpath=<paths>")
 
         if only_conf_flags or only_cmake_flags:
             flag_diffs += 1

--- a/service/direct_failure_detector/failure_detector.cc
+++ b/service/direct_failure_detector/failure_detector.cc
@@ -232,7 +232,7 @@ future<> failure_detector::impl::update_endpoint_fiber(seastar::scheduling_group
 
             continue;
         } catch (...) {
-            logger.error("update_endpoint_fiber: failed to add/remove endpoint {}: {}", ep, std::current_exception());
+            logger.error("update_endpoint_fiber: failed to add/remove endpoint {}: {:t}", ep, std::current_exception());
         }
 
         // There was an exception.
@@ -348,7 +348,7 @@ future<> failure_detector::impl::destroy_worker(workers_map_t::iterator it) noex
         // Expected, ignore.
     } catch (...) {
         // Unexpected exception, log and continue.
-        logger.error("unexpected exception from ping_fiber when destroying worker for endpoint {}: {}", it->first, std::current_exception());
+        logger.error("unexpected exception from ping_fiber when destroying worker for endpoint {}: {:t}", it->first, std::current_exception());
     }
 
     // Mark the endpoint dead for all listeners which still consider it alive.
@@ -363,7 +363,7 @@ future<> failure_detector::impl::destroy_worker(workers_map_t::iterator it) noex
         co_await std::exchange(worker._notify_fiber, make_ready_future<>());
     } catch (...) {
         // Unexpected exception, log and continue.
-        logger.error("unexpected exception from notify_fiber when destroying worker for endpoint {}: {}", it->first, std::current_exception());
+        logger.error("unexpected exception from notify_fiber when destroying worker for endpoint {}: {:t}", it->first, std::current_exception());
     }
 
     for (auto& [_, l]: _listeners_liveness) {
@@ -428,7 +428,7 @@ subscription::~subscription() {
                 fd._impl->remove_listener(l);
             });
         } catch (...) {
-            logger.error("unexpected exception when deregistering listener {}: {}", fmt::ptr(l), std::current_exception());
+            logger.error("unexpected exception when deregistering listener {}: {:t}", fmt::ptr(l), std::current_exception());
         }
     });
 }
@@ -518,7 +518,7 @@ static future<bool> ping_with_timeout(pinger::endpoint_id id, clock::timepoint_t
     } catch (...) {
         // There should be no other exceptions, but just in case... log it and discard,
         // we want to propagate exceptions from `f`, not from sleep.
-        logger.error("unexpected exception from sleep_and_abort when pinging endpoint{}: {}", id, std::current_exception());
+        logger.error("unexpected exception from sleep_and_abort when pinging endpoint{}: {:t}", id, std::current_exception());
     }
 
     if (ep) {
@@ -564,7 +564,7 @@ future<> endpoint_worker::ping_fiber() noexcept {
                 logger.debug("ping to endpoint {} timed out after {} clock ticks", _id, clock.now() - start);
             } catch (...) {
                 // Unexpected exception, probably from `pinger.ping(...)`. Log and continue.
-                logger.warn("unexpected exception when pinging {}: {}", _id, std::current_exception());
+                logger.warn("unexpected exception when pinging {}: {:t}", _id, std::current_exception());
             }
         } else {
             // We have a listener which already timed out.
@@ -678,7 +678,7 @@ future<> failure_detector::stop() {
         // Expected.
     } catch (...) {
         // Unexpected exception, log and continue.
-        logger.error("unexpected exception when stopping update_endpoint_fiber: {}", std::current_exception());
+        logger.error("unexpected exception when stopping update_endpoint_fiber: {:t}", std::current_exception());
     }
 
     co_await container().invoke_on_all([] (failure_detector& fd) -> future<> {

--- a/service/migration_manager.cc
+++ b/service/migration_manager.cc
@@ -87,7 +87,7 @@ future<> migration_manager::stop() {
     try {
         co_await _schema_push.join();
     } catch (...) {
-        mlogger.error("schema_push failed: {}", std::current_exception());
+        mlogger.error("schema_push failed: {:t}", std::current_exception());
     }
 }
 

--- a/service/paxos/paxos_state.cc
+++ b/service/paxos/paxos_state.cc
@@ -167,7 +167,7 @@ future<prepare_response> paxos_state::prepare(storage_proxy& sp, paxos_store& pa
                         co_return make_foreign(std::move(result));
                     }
                 } catch(...) {
-                    logger.debug("Failed to get data or digest: {}. Ignored.", std::current_exception());
+                    logger.debug("Failed to get data or digest: {:t}. Ignored.", std::current_exception());
                     co_return std::nullopt;
                 }
             }

--- a/service/qos/qos_common.cc
+++ b/service/qos/qos_common.cc
@@ -233,7 +233,7 @@ future<qos::service_levels_info> get_service_levels(cql3::query_processor& qp, s
             };
             service_levels.emplace(service_level_name, slo);
         } catch (...) {
-            logger.warn("Failed to fetch data for service levels: {}", std::current_exception());
+            logger.warn("Failed to fetch data for service levels: {:t}", std::current_exception());
         }
     }
 
@@ -256,7 +256,7 @@ future<service_levels_info> get_service_level(cql3::query_processor& qp, std::st
             };
             service_levels.emplace(service_level_name, slo);
         } catch (...) {
-            logger.warn("Failed to fetch data for service level {}: {}", service_level_name, std::current_exception());
+            logger.warn("Failed to fetch data for service level {}: {:t}", service_level_name, std::current_exception());
         }
     }
     

--- a/service/qos/service_level_controller.cc
+++ b/service/qos/service_level_controller.cc
@@ -495,7 +495,7 @@ future<std::optional<service::group0_guard>> service_level_controller::migrate_t
         } catch (service::group0_concurrent_modification&) {
             throw; // Let caller handle `group0_concurrent_modification`
         } catch (...) {
-            sl_logger.error("Failed to create service level for driver: {}. Removal of user service levels below the limit is necessary to allow sl:driver creation.", std::current_exception());
+            sl_logger.error("Failed to create service level for driver: {:t}. Removal of user service levels below the limit is necessary to allow sl:driver creation.", std::current_exception());
             _last_unsuccessful_driver_sl_creation_attemp = seastar::lowres_clock::now();
         }
         co_return std::nullopt;
@@ -526,7 +526,7 @@ future<>  service_level_controller::notify_service_level_added(sstring name, ser
             try {
                 subscriber->on_before_service_level_add(sl_data.slo, sl_info).get();
             } catch (...) {
-                sl_logger.error("notify_service_level_added: exception occurred in one of the observers callbacks {}", std::current_exception());
+                sl_logger.error("notify_service_level_added: exception occurred in one of the observers callbacks {:t}", std::current_exception());
             }
         });
         auto result= _service_levels_db.emplace(name, sl_data);
@@ -558,7 +558,7 @@ future<> service_level_controller::notify_service_level_updated(sstring name, se
                 try {
                     subscriber->on_before_service_level_change(slo_before, slo, sl_info).get();
                 } catch (...) {
-                    sl_logger.error("notify_service_level_updated: exception occurred in one of the observers callbacks {}", std::current_exception());
+                    sl_logger.error("notify_service_level_updated: exception occurred in one of the observers callbacks {:t}", std::current_exception());
                 }
             });
             if (sl_it->second.slo.shares != slo.shares) {
@@ -598,7 +598,7 @@ future<> service_level_controller::notify_service_level_removed(sstring name) {
                 try {
                     subscriber->on_after_service_level_remove(sl_info).get();
                 } catch (...) {
-                    sl_logger.error("notify_service_level_removed: exception occurred in one of the observers callbacks {}", std::current_exception());
+                    sl_logger.error("notify_service_level_removed: exception occurred in one of the observers callbacks {:t}", std::current_exception());
                 }
             });
         });

--- a/service/raft/raft_group0.cc
+++ b/service/raft/raft_group0.cc
@@ -233,7 +233,7 @@ raft_server_for_group raft_group0::create_server_for_group0(raft::group_id gid, 
     auto config = raft::server::configuration {
         .on_background_error = [gid, this](std::exception_ptr e) {
             // The future will be waited indirectly in raft_group0::abort_and_drain.
-            (void)_raft_gr.abort_server(gid, fmt::format("background error, {}", e));
+            (void)_raft_gr.abort_server(gid, fmt::format("background error, {:t}", e));
             _status_for_monitoring = status_for_monitoring::aborted;
         }
     };
@@ -427,7 +427,7 @@ future<> raft_group0::do_abort_and_drain() {
 
         co_await std::move(_leadership_monitor);
     } catch (...) {
-        rslog.warn("Failed to abort raft group0: {}", std::current_exception());
+        rslog.warn("Failed to abort raft group0: {:t}", std::current_exception());
     }
 
     if (auto* group0_id = std::get_if<raft::group_id>(&_group0)) {
@@ -502,7 +502,7 @@ future<> raft_group0::leadership_monitor_fiber() {
             _leadership_observable.set(false);
         }
     } catch (...) {
-        group0_log.debug("leadership_monitor_fiber aborted with {}", std::current_exception());
+        group0_log.debug("leadership_monitor_fiber aborted with {:t}", std::current_exception());
     }
 }
 

--- a/service/raft/raft_group_registry.cc
+++ b/service/raft/raft_group_registry.cc
@@ -445,7 +445,7 @@ future<> raft_group_registry::do_abort_server(raft::group_id gid, raft_server_fo
         });
         co_await s.server->abort(std::move(reason));
     } catch (...) {
-        rslog.warn("Failed to abort raft group server {}: {}", gid, std::current_exception());
+        rslog.warn("Failed to abort raft group server {}: {:t}", gid, std::current_exception());
     }
 }
 

--- a/service/raft/raft_rpc.cc
+++ b/service/raft/raft_rpc.cc
@@ -54,7 +54,7 @@ raft_rpc::one_way_rpc(sloc loc, raft::server_id id,
                 } catch (seastar::rpc::timeout_error&) {
                 } catch (seastar::rpc::closed_error&) {
                 } catch (...) {
-                    rlogger.error("Failed to send {} to {}: {}", loc.function_name(), id, std::current_exception());
+                    rlogger.error("Failed to send {} to {}: {:t}", loc.function_name(), id, std::current_exception());
                 }
         });
     });

--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -655,7 +655,7 @@ private:
                             // database's total_writes_timedout, total_writes_rate_limited or total_writes_rejected_due_to_large_partition counter was incremented.
                             l = seastar::log_level::debug;
                         }
-                        slogger.log(l, "Failed to apply mutation from {}#{}: {}", reply_to_host_id, shard, eptr);
+                        slogger.log(l, "Failed to apply mutation from {}#{}: {:t}", reply_to_host_id, shard, eptr);
                     }
                 },
                 [&] {
@@ -2356,7 +2356,7 @@ paxos_response_handler::begin_and_repair_paxos(client_state& cs, unsigned& conte
             try {
                 co_await std::move(f);
             } catch(...) {
-                paxos::paxos_state::logger.debug("CAS[{}] Failure during commit repair {}", _id, std::current_exception());
+                paxos::paxos_state::logger.debug("CAS[{}] Failure during commit repair {:t}", _id, std::current_exception());
             }
             continue;
         }
@@ -2762,10 +2762,10 @@ void paxos_response_handler::prune(utils::UUID ballot) {
             tracing::trace(tr_state, "prune failed: connection closed");
         } catch (const mutation_write_timeout_exception& ex) {
             tracing::trace(tr_state, "prune failed: write timeout; received {:d} of {:d} required replies", ex.received, ex.block_for);
-            paxos::paxos_state::logger.debug("CAS[{}] prune: failed {}", h->_id, std::current_exception());
+            paxos::paxos_state::logger.debug("CAS[{}] prune: failed {:t}", h->_id, std::current_exception());
         } catch (...) {
-            tracing::trace(tr_state, "prune failed: {}", std::current_exception());
-            paxos::paxos_state::logger.error("CAS[{}] prune: failed {}", h->_id, std::current_exception());
+            tracing::trace(tr_state, "prune failed: {:t}", std::current_exception());
+            paxos::paxos_state::logger.error("CAS[{}] prune: failed {:t}", h->_id, std::current_exception());
         }
     });
 }
@@ -3279,7 +3279,7 @@ inline uint64_t& storage_proxy_stats::split_stats::get_ep_stat(const locator::to
         return _dc_stats[dc].val;
     } catch (...) {
         static thread_local uint64_t dummy_stat;
-        slogger.error("Failed to obtain stats ({}), fall-back to dummy", std::current_exception());
+        slogger.error("Failed to obtain stats ({:t}), fall-back to dummy", std::current_exception());
         return dummy_stat;
     }
 }
@@ -4854,7 +4854,7 @@ void storage_proxy::send_to_live_endpoints(storage_proxy::response_id_type respo
             } else if (auto* e = try_catch<replica::large_data_exception>(eptr)) {
                 msg = e->message();
             } else {
-                slogger.error("exception during mutation write to {}.{} on {}: {}",
+                slogger.error("exception during mutation write to {}.{} on {}: {:t}",
                     schema->ks_name(), schema->cf_name(), coordinator, eptr);
             }
             p->got_failure_response(response_id, coordinator, forward_size + 1, std::nullopt, err, std::move(msg));
@@ -4962,7 +4962,7 @@ public:
             // it.
             slogger.warn("Exception when communicating with {}, to read from {}.{}: {}", ep, _schema->ks_name(), _schema->cf_name(), ex->what());
         } else {
-            slogger.error("Exception when communicating with {}, to read from {}.{}: {}", ep, _schema->ks_name(), _schema->cf_name(), eptr);
+            slogger.error("Exception when communicating with {}, to read from {}.{}: {:t}", ep, _schema->ks_name(), _schema->cf_name(), eptr);
         }
 
         if (!_request_failed) { // request may fail only once.

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -158,7 +158,7 @@ namespace {
         try {
             resulting_node_list.emplace_back(n);
         } catch (...) {
-            throw std::runtime_error(::format("Failed to parse node list: {}: invalid node={}: {}", src_node_strings, n, std::current_exception()));
+            throw std::runtime_error(::format("Failed to parse node list: {}: invalid node={}: {:t}", src_node_strings, n, std::current_exception()));
         }
     }
     return resulting_node_list;
@@ -1095,7 +1095,7 @@ future<> storage_service::sstable_vnodes_cleanup_fiber(raft::server& server, gat
                         co_await task->done();
                         rtlogger.info("vnodes_cleanup {} finished", ks_name);
                     } catch (...) {
-                        rtlogger.error("vnodes_cleanup failed keyspace={} tables={} failed: {}", task->get_status().keyspace, table_infos, std::current_exception());
+                        rtlogger.error("vnodes_cleanup failed keyspace={} tables={} failed: {:t}", task->get_status().keyspace, table_infos, std::current_exception());
                         throw;
                     }
                 });
@@ -1130,7 +1130,7 @@ future<> storage_service::sstable_vnodes_cleanup_fiber(raft::server& server, gat
              rtlogger.info("vnodes_cleanup fiber aborted");
              break;
         } catch (...) {
-             rtlogger.error("vnodes_cleanup fiber got an error: {}", std::current_exception());
+             rtlogger.error("vnodes_cleanup fiber got an error: {:t}", std::current_exception());
              err = true;
         }
         if (err) {
@@ -1155,7 +1155,7 @@ future<> storage_service::raft_state_monitor_fiber(raft::server& raft, gate::hol
                     try {
                         _tablet_allocator.local().on_leadership_lost();
                     } catch (...) {
-                        rtlogger.error("tablet_allocator::on_leadership_lost() failed: {}", std::current_exception());
+                        rtlogger.error("tablet_allocator::on_leadership_lost() failed: {:t}", std::current_exception());
                     }
                 }
             }
@@ -1175,7 +1175,7 @@ future<> storage_service::raft_state_monitor_fiber(raft::server& raft, gate::hol
                     _topology_cmd_rpc_tracker);
         }
     } catch (...) {
-        rtlogger.info("raft_state_monitor_fiber aborted with {}", std::current_exception());
+        rtlogger.info("raft_state_monitor_fiber aborted with {:t}", std::current_exception());
     }
     if (as) {
         as->request_abort(); // abort current coordinator if running
@@ -2241,7 +2241,7 @@ future<token_metadata_change> storage_service::prepare_token_metadata_change(mut
                 co_await utils::clear_gently(view_erms);
             });
         } catch (...) {
-            slogger.warn("Failure to reset pending token_metadata in cleanup path: {}. Ignored.", std::current_exception());
+            slogger.warn("Failure to reset pending token_metadata in cleanup path: {:t}. Ignored.", std::current_exception());
         }
 
         std::rethrow_exception(std::move(ex));
@@ -2303,7 +2303,7 @@ void storage_service::commit_token_metadata_change(token_metadata_change& change
     } catch (...) {
         // applying the changes on all shards should never fail
         // it will end up in an inconsistent state that we can't recover from.
-        slogger.error("Failed to apply token_metadata changes: {}. Aborting.", std::current_exception());
+        slogger.error("Failed to apply token_metadata changes: {:t}. Aborting.", std::current_exception());
         abort();
     }
 }
@@ -2389,7 +2389,7 @@ future<> storage_service::remove_endpoint(inet_address endpoint, gms::permit_id 
     try {
         co_await _sys_ks.local().remove_endpoint(endpoint);
     } catch (...) {
-        slogger.error("fail to remove endpoint={}: {}", endpoint, std::current_exception());
+        slogger.error("fail to remove endpoint={}: {:t}", endpoint, std::current_exception());
     }
 }
 
@@ -3785,7 +3785,7 @@ future<> storage_service::unbootstrap() {
         try {
             co_await std::move(stream_success);
         } catch (...) {
-            slogger.warn("unbootstrap fails to stream : {}", std::current_exception());
+            slogger.warn("unbootstrap fails to stream : {:t}", std::current_exception());
             throw;
         }
         slogger.debug("stream acks all received.");
@@ -3838,7 +3838,7 @@ future<> storage_service::removenode_with_stream(locator::host_id leaving_node,
         try {
             streamer->stream_async().get();
         } catch (...) {
-            slogger.warn("removenode_with_stream: stream failed: {}", std::current_exception());
+            slogger.warn("removenode_with_stream: stream failed: {:t}", std::current_exception());
             throw;
         }
     });
@@ -4736,22 +4736,22 @@ future<> storage_service::process_tablet_split_candidate(table_id table) noexcep
                 co_await split_all_compaction_groups();
             }
         } catch (const locator::no_such_tablet_map& ex) {
-            slogger.warn("Failed to complete splitting of table {} due to {}", table, ex);
+            slogger.warn("Failed to complete splitting of table {} due to {:t}", table, ex);
             break;
         } catch (const replica::no_such_column_family& ex) {
-            slogger.warn("Failed to complete splitting of table {} due to {}", table, ex);
+            slogger.warn("Failed to complete splitting of table {} due to {:t}", table, ex);
             break;
         } catch (const seastar::abort_requested_exception& ex) {
-            slogger.warn("Failed to complete splitting of table {} due to {}", table, ex);
+            slogger.warn("Failed to complete splitting of table {} due to {:t}", table, ex);
             break;
         } catch (raft::request_aborted& ex) {
-            slogger.warn("Failed to complete splitting of table {} due to {}", table, ex);
+            slogger.warn("Failed to complete splitting of table {} due to {:t}", table, ex);
             break;
         } catch (seastar::gate_closed_exception& ex) {
-            slogger.warn("Failed to complete splitting of table {} due to {}", table, ex);
+            slogger.warn("Failed to complete splitting of table {} due to {:t}", table, ex);
             break;
         } catch (...) {
-            slogger.error("Failed to complete splitting of table {} due to {}, retrying after {} seconds",
+            slogger.error("Failed to complete splitting of table {} due to {:t}, retrying after {} seconds",
                           table, std::current_exception(), split_retry.sleep_time());
             sleep = true;
         }
@@ -4759,7 +4759,7 @@ future<> storage_service::process_tablet_split_candidate(table_id table) noexcep
             try {
                 co_await split_retry.retry(_group0_as);
             } catch (...) {
-                slogger.warn("Sleep in split monitor failed with {}", std::current_exception());
+                slogger.warn("Sleep in split monitor failed with {:t}", std::current_exception());
             }
         }
     }
@@ -4775,7 +4775,7 @@ void storage_service::register_tablet_split_candidate(table_id table) noexcept {
             _tablet_split_monitor_event.signal();
         }
     } catch (...) {
-        slogger.error("Unable to register table {} as candidate for tablet splitting, due to {}", table, std::current_exception());
+        slogger.error("Unable to register table {} as candidate for tablet splitting, due to {:t}", table, std::current_exception());
     }
 }
 
@@ -5246,13 +5246,13 @@ future<raft_topology_cmd_result> storage_service::raft_topology_cmd_handler(raft
             }
         }
     } catch (const raft::request_aborted& e) {
-        rtlogger.warn("raft_topology_cmd {} failed with: {}", cmd.cmd, e);
+        rtlogger.warn("raft_topology_cmd {} failed with: {:t}", cmd.cmd, e);
         result.error_message = e.what();
     } catch (const std::exception& e) {
-        rtlogger.error("raft_topology_cmd {} failed with: {}", cmd.cmd, e);
+        rtlogger.error("raft_topology_cmd {} failed with: {:t}", cmd.cmd, e);
         result.error_message = e.what();
     } catch (...) {
-        rtlogger.error("raft_topology_cmd {} failed with: {}", cmd.cmd, std::current_exception());
+        rtlogger.error("raft_topology_cmd {} failed with: {:t}", cmd.cmd, std::current_exception());
         result.error_message = "unknown error";
     }
 
@@ -5352,7 +5352,7 @@ future<tablet_operation_result> storage_service::do_tablet_operation(locator::gl
         co_return result;
     } catch (...) {
         p.set_exception(std::current_exception());
-        rtlogger.warn("{} for tablet migration of {} failed: {}", op_name, tablet, std::current_exception());
+        rtlogger.warn("{} for tablet migration of {} failed: {:t}", op_name, tablet, std::current_exception());
         throw;
     }
 }
@@ -5568,7 +5568,7 @@ future<> storage_service::stream_tablet(locator::global_tablet_id tablet) {
                     slogger.info("stream_sstables[{}] Streaming for tablet migration of {} finished table={}.{} range={} stream_bytes={} stream_time={} stream_bw={}",
                             ops_id, tablet, table.schema()->ks_name(), table.schema()->cf_name(), range, stream_bytes, duration, bw);
                 } catch (...) {
-                    slogger.warn("stream_sstables[{}] Streaming for tablet migration of {} from {} failed: {}", ops_id, tablet, leaving_replica, std::current_exception());
+                    slogger.warn("stream_sstables[{}] Streaming for tablet migration of {} from {} failed: {:t}", ops_id, tablet, leaving_replica, std::current_exception());
                     throw;
                 }
             }
@@ -7118,7 +7118,7 @@ static const char* disk_error_to_string(disk_error type) {
 void storage_service::do_isolate_on_error(disk_error type)
 {
     if (!std::exchange(_isolated, true)) {
-        slogger.error("Shutting down communications due to I/O errors until operator intervention: {} error: {}", disk_error_to_string(type), std::current_exception());
+        slogger.error("Shutting down communications due to I/O errors until operator intervention: {} error: {:t}", disk_error_to_string(type), std::current_exception());
         // isolated protect us against multiple stops on _this_ shard
         //FIXME: discarded future.
         (void)isolate();
@@ -7189,7 +7189,7 @@ future<> endpoint_lifecycle_notifier::notify_down(gms::inet_address endpoint, lo
             try {
                 subscriber->on_down(endpoint, hid);
             } catch (...) {
-                slogger.warn("Down notification failed {}/{}: {}", endpoint, hid, std::current_exception());
+                slogger.warn("Down notification failed {}/{}: {:t}", endpoint, hid, std::current_exception());
             }
         });
     });
@@ -7209,7 +7209,7 @@ future<> endpoint_lifecycle_notifier::notify_left(gms::inet_address endpoint, lo
             try {
                 subscriber->on_leave_cluster(endpoint, hid);
             } catch (...) {
-                slogger.warn("Leave cluster notification failed {}/{}: {}", endpoint, hid, std::current_exception());
+                slogger.warn("Leave cluster notification failed {}/{}: {:t}", endpoint, hid, std::current_exception());
             }
         });
     });
@@ -7221,7 +7221,7 @@ future<> endpoint_lifecycle_notifier::notify_released(locator::host_id hid) {
             try {
                 subscriber->on_released(hid);
             } catch (...) {
-                slogger.warn("Node released notification failed {}: {}", hid, std::current_exception());
+                slogger.warn("Node released notification failed {}: {:t}", hid, std::current_exception());
             }
         });
     });
@@ -7247,7 +7247,7 @@ future<> endpoint_lifecycle_notifier::notify_up(gms::inet_address endpoint, loca
             try {
                 subscriber->on_up(endpoint, hid);
             } catch (...) {
-                slogger.warn("Up notification failed {}/{}: {}", endpoint, hid, std::current_exception());
+                slogger.warn("Up notification failed {}/{}: {:t}", endpoint, hid, std::current_exception());
             }
         });
     });
@@ -7269,7 +7269,7 @@ future<> endpoint_lifecycle_notifier::notify_joined(gms::inet_address endpoint, 
             try {
                 subscriber->on_join_cluster(endpoint, hid);
             } catch (...) {
-                slogger.warn("Join cluster notification failed {}/{}: {}", endpoint, hid,std::current_exception());
+                slogger.warn("Join cluster notification failed {}/{}: {:t}", endpoint, hid,std::current_exception());
             }
         });
     });
@@ -7281,7 +7281,7 @@ future<> endpoint_lifecycle_notifier::notify_client_routes_change(const client_r
             try {
                 subscriber->on_client_routes_change(client_route_keys);
             } catch (...) {
-                slogger.warn("Client routes notification failed: {}", std::current_exception());
+                slogger.warn("Client routes notification failed: {:t}", std::current_exception());
             }
         });
     });

--- a/service/topology_coordinator.cc
+++ b/service/topology_coordinator.cc
@@ -482,7 +482,7 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
 
         if (f.failed()) {
             co_await coroutine::return_exception(std::runtime_error(
-                ::format("raft topology: exec_global_command({}) failed with {}",
+                ::format("raft topology: exec_global_command({}) failed with {:t}",
                     cmd.cmd, f.get_exception())));
         }
     };
@@ -595,7 +595,7 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
                     on_internal_error(rtlogger, ::format(
                         "make_new_cdc_generation_data: get_sharding_info:"
                         " can't get sharding info for node {}, owner of token {}."
-                        " Reason: {}", *ep, end, std::current_exception()));
+                        " Reason: {:t}", *ep, end, std::current_exception()));
                 }
             }
         };
@@ -818,14 +818,14 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
             } catch (term_changed_error&) {
                 rtlogger.debug("CDC generation publisher fiber notices term change {} -> {}", _term, _raft.get_current_term());
             } catch (...) {
-                rtlogger.error("CDC generation publisher fiber got error {}", std::current_exception());
+                rtlogger.error("CDC generation publisher fiber got error {:t}", std::current_exception());
                 sleep = true;
             }
             if (sleep) {
                 try {
                     co_await seastar::sleep_abortable(std::chrono::seconds(1), _as);
                 } catch (...) {
-                    rtlogger.debug("CDC generation publisher: sleep failed: {}", std::current_exception());
+                    rtlogger.debug("CDC generation publisher: sleep failed: {:t}", std::current_exception());
                 }
             }
             co_await coroutine::maybe_yield();
@@ -854,7 +854,7 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
                 rtlogger.debug("CDC streams GC fiber aborted");
                 sleep = false;
             } catch (...) {
-                rtlogger.warn("CDC streams GC fiber got error {}", std::current_exception());
+                rtlogger.warn("CDC streams GC fiber got error {:t}", std::current_exception());
             }
             auto refresh_interval = utils::get_local_injector().is_enabled("short_cdc_streams_gc_refresh_interval") ?
                     std::chrono::seconds(1) : cdc_streams_gc_refresh_interval;
@@ -862,7 +862,7 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
                 try {
                     co_await seastar::sleep_abortable(refresh_interval, _as);
                 } catch (...) {
-                    rtlogger.debug("CDC streams GC: sleep failed: {}", std::current_exception());
+                    rtlogger.debug("CDC streams GC: sleep failed: {:t}", std::current_exception());
                 }
             }
         }
@@ -925,12 +925,12 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
             } catch (term_changed_error&) {
                 rtlogger.debug("gossiper orphan remover fiber notices term change {} -> {}", _term, _raft.get_current_term());
             } catch (...) {
-                rtlogger.error("gossiper orphan remover fiber got error {}", std::current_exception());
+                rtlogger.error("gossiper orphan remover fiber got error {:t}", std::current_exception());
             }
             try {
                 co_await seastar::sleep_abortable(do_speedup_fiber ? std::chrono::milliseconds(1) : std::chrono::seconds(10), _as);
             } catch (...) {
-                rtlogger.debug("gossiper orphan remover: sleep failed: {}", std::current_exception());
+                rtlogger.debug("gossiper orphan remover: sleep failed: {:t}", std::current_exception());
             }
             co_await coroutine::maybe_yield();
         }
@@ -975,7 +975,7 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
                 rtlogger.debug("group0 voters refresh fiber notices term change {} -> {}", _term, _raft.get_current_term());
                 break; // exit the loop immediately (term change means we're not the coordinator anymore)
             } catch (...) {
-                rtlogger.error("group0 voters refresh fiber got error {}", std::current_exception());
+                rtlogger.error("group0 voters refresh fiber got error {:t}", std::current_exception());
             }
         }
     }
@@ -1274,7 +1274,7 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
                     }
                 }
             } catch (...) {
-                error = fmt::format("quiesce request failed: {}", std::current_exception());
+                error = fmt::format("quiesce request failed: {:t}", std::current_exception());
                 updates.clear();
             }
 
@@ -1505,7 +1505,7 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
                         .build());
             } catch (const std::exception& e) {
                 error = e.what();
-                rtlogger.error("Couldn't set up restore transitions for table {}: {}", tid, std::current_exception());
+                rtlogger.error("Couldn't set up restore transitions for table {}: {:t}", tid, std::current_exception());
                 updates.clear();
 
                 topology_mutation_builder builder(guard.write_timestamp());
@@ -1584,7 +1584,7 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
         try {
             guard = co_await exec_global_command(std::move(guard), raft_topology_cmd::command::barrier_and_drain, exclude_nodes, drop_guard_and_retake::yes);
         } catch (...) {
-            rtlogger.warn("drain rpc failed, proceed to fence old writes: {}", std::current_exception());
+            rtlogger.warn("drain rpc failed, proceed to fence old writes: {:t}", std::current_exception());
             if (drain_all_nodes) {
                 throw;
             }
@@ -1694,7 +1694,7 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
             holder = futurize_invoke(action).then_wrapped([this, gid, name] (future<> f) {
                 if (f.failed()) {
                     auto ep = f.get_exception();
-                    rtlogger.warn("{} for tablet {} failed: {}", name, gid, ep);
+                    rtlogger.warn("{} for tablet {} failed: {:t}", name, gid, ep);
                     return seastar::sleep_abortable(std::chrono::seconds(1), _as).then([ep] () mutable {
                         std::rethrow_exception(ep);
                     });
@@ -2555,7 +2555,7 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
                         if (auto it = restore_request_for_table.find(gid.table); it != restore_request_for_table.end()) {
                             updates.add(
                                 topology_request_tracking_mutation_builder(it->second)
-                                    .set("error", format("Restore failed for tablet {}: {}", gid, ep))
+                                    .set("error", format("Restore failed for tablet {}: {:t}", gid, ep))
                                     .build());
                         }
                         break;
@@ -3112,7 +3112,7 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
 
     void trigger_load_stats_refresh() {
         (void)_tablet_load_stats_refresh.trigger().handle_exception([] (auto ep) {
-            rtlogger.warn("Error during tablet load stats refresh: {}", ep);
+            rtlogger.warn("Error during tablet load stats refresh: {:t}", ep);
         });
     }
 
@@ -3158,7 +3158,7 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
                     try {
                         co_await wait_for_gossiper(id, _gossiper, _as);
                     } catch (...) {
-                        rtlogger.warn("wait_for_ip failed during cancellation: {}", std::current_exception());
+                        rtlogger.warn("wait_for_ip failed during cancellation: {:t}", std::current_exception());
                     }
                 }
                 break;
@@ -3322,7 +3322,7 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
                         try {
                             bootstrap_tokens = dht::boot_strapper::get_bootstrap_tokens(tmptr, tokens_string, num_tokens, dht::check_token_endpoint::yes);
                         } catch (...) {
-                            _rollback = fmt::format("Failed to assign tokens: {}", std::current_exception());
+                            _rollback = fmt::format("Failed to assign tokens: {:t}", std::current_exception());
                             break;
                         }
 
@@ -3430,8 +3430,8 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
                     throw;
                 } catch (...) {
                     rtlogger.error("transition_state::commit_cdc_generation, "
-                                    "raft_topology_cmd::command::barrier failed, error {}", std::current_exception());
-                    _rollback = fmt::format("Failed to commit cdc generation: {}", std::current_exception());
+                                    "raft_topology_cmd::command::barrier failed, error {:t}", std::current_exception());
+                    _rollback = fmt::format("Failed to commit cdc generation: {:t}", std::current_exception());
                 }
 
                 if (_rollback) {
@@ -3525,8 +3525,8 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
                 } catch (seastar::abort_requested_exception&) {
                     throw;
                 } catch (...) {
-                    rtlogger.error("tablets draining failed with {}. Aborting the topology operation", std::current_exception());
-                    _rollback = fmt::format("Failed to drain tablets: {}", std::current_exception());
+                    rtlogger.error("tablets draining failed with {:t}. Aborting the topology operation", std::current_exception());
+                    _rollback = fmt::format("Failed to drain tablets: {:t}", std::current_exception());
                 }
                 break;
             case topology::transition_state::write_both_read_old: {
@@ -3551,7 +3551,7 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
                     rtlogger.error("transition_state::write_both_read_old, "
                                     "global_token_metadata_barrier failed, error {}",
                                     std::current_exception());
-                    _rollback = fmt::format("global_token_metadata_barrier failed in write_both_read_old state {}", std::current_exception());
+                    _rollback = fmt::format("global_token_metadata_barrier failed in write_both_read_old state {:t}", std::current_exception());
                     break;
                 }
 
@@ -3612,8 +3612,8 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
                     throw;
                 } catch (...) {
                     rtlogger.error("send_raft_topology_cmd(stream_ranges) failed with exception"
-                                    " (node state is {}): {}", state, std::current_exception());
-                    _rollback = fmt::format("Failed stream ranges: {}", std::current_exception());
+                                    " (node state is {}): {:t}", state, std::current_exception());
+                    _rollback = fmt::format("Failed stream ranges: {:t}", std::current_exception());
                     break;
                 }
 
@@ -4205,12 +4205,12 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
                     throw;
                 } catch (const std::exception& e) {
                     rtlogger.error("send_raft_topology_cmd(stream_ranges) failed with exception"
-                                    " (node state is rebuilding): {}", e);
+                                    " (node state is rebuilding): {:t}", e);
                     rtbuilder.done(e.what());
                     retake = true;
                 } catch (...) {
                     rtlogger.error("send_raft_topology_cmd(stream_ranges) failed with exception"
-                                    " (node state is rebuilding): {}", std::current_exception());
+                                    " (node state is rebuilding): {:t}", std::current_exception());
                     rtbuilder.done("unknown error");
                     retake = true;
                 }
@@ -4461,7 +4461,7 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
         try {
             co_await _vb_coordinator->run();
         } catch (...) {
-            on_fatal_internal_error(rtlogger, format("unhandled exception in view_building_coordinator::run(): {}", std::current_exception()));
+            on_fatal_internal_error(rtlogger, format("unhandled exception in view_building_coordinator::run(): {:t}", std::current_exception()));
         }
         co_await _lifecycle_notifier.unregister_subscriber(_vb_coordinator.get());
     }
@@ -4874,14 +4874,14 @@ future<> topology_coordinator::start_tablet_load_stats_refresher() {
             rtlogger.debug("raft topology: Tablet load stats refresher aborted");
             sleep = false;
         } catch (...) {
-            rtlogger.warn("Found error while refreshing load stats for tablets: {}, retrying...", std::current_exception());
+            rtlogger.warn("Found error while refreshing load stats for tablets: {:t}, retrying...", std::current_exception());
         }
         auto refresh_interval = std::chrono::seconds(_tablet_load_stats_refresh_interval_in_seconds.get());
         if (sleep && can_proceed()) {
             try {
                 co_await seastar::sleep_abortable(refresh_interval, _as);
             } catch (...) {
-                rtlogger.debug("raft topology: Tablet load stats refresher: sleep failed: {}", std::current_exception());
+                rtlogger.debug("raft topology: Tablet load stats refresher: sleep failed: {:t}", std::current_exception());
             }
         }
     }
@@ -4919,7 +4919,7 @@ future<> topology_coordinator::fence_previous_coordinator() {
             rtlogger.debug("request to fence previous coordinator was aborted");
             break;
         } catch (...) {
-            rtlogger.error("failed to fence previous coordinator {}", std::current_exception());
+            rtlogger.error("failed to fence previous coordinator {:t}", std::current_exception());
         }
         try {
             co_await seastar::sleep_abortable(std::chrono::seconds(1), _as);
@@ -4927,7 +4927,7 @@ future<> topology_coordinator::fence_previous_coordinator() {
             // Abort was requested. Break the loop
             break;
         } catch (...) {
-            rtlogger.debug("sleep failed while fencing previous coordinator: {}", std::current_exception());
+            rtlogger.debug("sleep failed while fencing previous coordinator: {:t}", std::current_exception());
         }
     }
 }
@@ -4998,10 +4998,10 @@ bool topology_coordinator::handle_topology_coordinator_error(std::exception_ptr 
         // Term changed. We may no longer be a leader
         rtlogger.debug("topology change coordinator fiber notices term change {} -> {}", _term, _raft.get_current_term());
     } catch (seastar::rpc::remote_verb_error&) {
-        rtlogger.warn("topology change coordinator fiber got rpc::remote_verb_error {}", std::current_exception());
+        rtlogger.warn("topology change coordinator fiber got rpc::remote_verb_error {:t}", std::current_exception());
         return true;
     } catch (...) {
-        rtlogger.error("topology change coordinator fiber got error {}", std::current_exception());
+        rtlogger.error("topology change coordinator fiber got error {:t}", std::current_exception());
         return true;
     }
     return false;
@@ -5064,7 +5064,7 @@ future<> topology_coordinator::run() {
             try {
                 co_await seastar::sleep_abortable(std::chrono::seconds(1), _as);
             } catch (...) {
-                rtlogger.debug("sleep failed: {}", std::current_exception());
+                rtlogger.debug("sleep failed: {:t}", std::current_exception());
             }
         }
         co_await coroutine::maybe_yield();
@@ -5162,14 +5162,14 @@ future<> run_topology_coordinator(
     if (ex) {
         try {
             if (raft.is_leader()) {
-                rtlogger.warn("unhandled exception in topology_coordinator::run: {}; stepping down as a leader", ex);
+                rtlogger.warn("unhandled exception in topology_coordinator::run: {:t}; stepping down as a leader", ex);
                 const auto stepdown_timeout_ticks = std::chrono::seconds(5) / raft_tick_interval;
                 co_await raft.stepdown(raft::logical_clock::duration(stepdown_timeout_ticks));
             }
         } catch (...) {
-            rtlogger.error("failed to step down before aborting: {}", std::current_exception());
+            rtlogger.error("failed to step down before aborting: {:t}", std::current_exception());
         }
-        on_fatal_internal_error(rtlogger, format("unhandled exception in topology_coordinator::run: {}", ex));
+        on_fatal_internal_error(rtlogger, format("unhandled exception in topology_coordinator::run: {:t}", ex));
     }
     co_await utils::get_local_injector().inject("topology_coordinator_pause_before_stop", utils::wait_for_message(5min));
     co_await coordinator.stop();

--- a/sstable_dict_autotrainer.cc
+++ b/sstable_dict_autotrainer.cc
@@ -149,7 +149,7 @@ future<> sstable_dict_autotrainer::run() {
         } catch (const raft::stopped_error&) {
             alogger.debug("sstable_dict_autotrainer::run(): exiting via raft::stopped_error");
         } catch (...) {
-            alogger.debug("sstable_dict_autotrainer::run(): tick() failed with: {}", std::current_exception());
+            alogger.debug("sstable_dict_autotrainer::run(): tick() failed with: {:t}", std::current_exception());
         }
     }
 }

--- a/sstables/mx/reader.cc
+++ b/sstables/mx/reader.cc
@@ -2361,7 +2361,7 @@ future<uint64_t> validate(
             }
         }
     } catch (...) {
-        consumer.report_error(format("unexpected exception: {}", std::current_exception()));
+        consumer.report_error(format("unexpected exception: {:t}", std::current_exception()));
     }
 
     monitor.on_read_completed();

--- a/sstables/mx/writer.cc
+++ b/sstables/mx/writer.cc
@@ -925,7 +925,7 @@ writer::~writer() {
             try {
                 writer->close();
             } catch (...) {
-                sstlog.error("writer failed to close file: {}", std::current_exception());
+                sstlog.error("writer failed to close file: {:t}", std::current_exception());
             }
         }
     };
@@ -1584,7 +1584,7 @@ void writer::record_corrupt_row(clustering_row&& clustered_row) {
         corrupt_row_id = handler.record_corrupt_clustering_row(_schema, pk, std::move(clustered_row), "sstable-write", fmt::to_string(_sst.get_filename())).get();
         result = format("written corrupt row to {} with id {}", handler.storage_name(), corrupt_row_id);
     } catch (...) {
-        result = format("failed to write corrupt row to {}: {}", handler.storage_name(), std::current_exception());
+        result = format("failed to write corrupt row to {}: {:t}", handler.storage_name(), std::current_exception());
     }
 
     slogger.error("found non-full clustering key {} in partition {} while writing sstable {} for non-compact table {}.{}; {}",

--- a/sstables/sstable_directory.cc
+++ b/sstables/sstable_directory.cc
@@ -682,7 +682,7 @@ future<sstring> sstable_directory::create_pending_deletion_log(opened_directory&
             base_dir.sync(general_disk_error_handler).get();
             dirlog.debug("{} written successfully.", pending_delete_log);
         } catch (...) {
-            dirlog.warn("Error creating {}: {}.", pending_delete_log, std::current_exception());
+            dirlog.warn("Error creating {}: {:t}.", pending_delete_log, std::current_exception());
             throw;
         }
 
@@ -711,7 +711,7 @@ future<> sstable_directory::filesystem_components_lister::replay_pending_delete_
         dirlog.debug("Replayed {}, removing", pending_delete_log);
         co_await remove_file(pending_delete_log.native());
     } catch (...) {
-        dirlog.warn("Error replaying {}: {}. Ignoring.", pending_delete_log, std::current_exception());
+        dirlog.warn("Error replaying {}: {:t}. Ignoring.", pending_delete_log, std::current_exception());
     }
 }
 

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -729,7 +729,7 @@ future<> parse(const schema& schema, sstable_version_types v, random_access_read
     } catch (const malformed_sstable_exception&) {
         throw;
     } catch (...) {
-        throw_malformed_sstable_exception(fmt::format("Statistics file is malformed: {}", std::current_exception()));
+        throw_malformed_sstable_exception(fmt::format("Statistics file is malformed: {:t}", std::current_exception()));
     }
 }
 
@@ -1019,7 +1019,7 @@ file_writer::~file_writer() {
         // so auto-close the output_stream so it won't be destructed while open.
         _out.close().get();
     } catch (...) {
-        sstlog.warn("Error while auto-closing {}: {}. Ignored.", _component, std::current_exception());
+        sstlog.warn("Error while auto-closing {}: {:t}. Ignored.", _component, std::current_exception());
     }
 }
 
@@ -2016,7 +2016,7 @@ void sstable::maybe_rebuild_filter_from_index(uint64_t num_partitions) {
         try {
             index_file.close().get();
         } catch (...) {
-            sstlog.warn("sstable close index_file failed: {}", std::current_exception());
+            sstlog.warn("sstable close index_file failed: {:t}", std::current_exception());
             general_disk_error();
         }
     });
@@ -2036,7 +2036,7 @@ void sstable::maybe_rebuild_filter_from_index(uint64_t num_partitions) {
     try {
         consumer_ctx.consume_input().get();
     } catch (...) {
-        sstlog.warn("Failed to rebuild bloom filter {} : {}. Existing bloom filter will be written to disk.", filename(component_type::Filter), std::current_exception());
+        sstlog.warn("Failed to rebuild bloom filter {} : {:t}. Existing bloom filter will be written to disk.", filename(component_type::Filter), std::current_exception());
         return;
     }
 
@@ -2850,7 +2850,7 @@ future<> sstable::generate_summary() {
     try {
         co_await index_file.close();
     } catch (...) {
-        sstlog.warn("sstable close index_file failed: {}", std::current_exception());
+        sstlog.warn("sstable close index_file failed: {:t}", std::current_exception());
         general_disk_error();
     }
 
@@ -3724,7 +3724,7 @@ future<> sstable::close_files() {
                             }
                         }));
         } catch (...) {
-            sstlog.warn("Exception when deleting sstable file: {}", std::current_exception());
+            sstlog.warn("Exception when deleting sstable file: {:t}", std::current_exception());
         }
     }
 
@@ -3998,7 +3998,7 @@ sstable::unlink(const atomic_deletion* deletion) noexcept {
         memory::scoped_critical_alloc_section _;
         // Just log and ignore failures to delete large data entries.
         // They are not critical to the operation of the database.
-        sstlog.warn("Failed to delete large data entry for {}: {}. Ignoring.", toc_filename(), std::current_exception());
+        sstlog.warn("Failed to delete large data entry for {}: {:t}. Ignoring.", toc_filename(), std::current_exception());
     }
 
     co_await std::move(remove_fut);

--- a/sstables/sstables_manager.cc
+++ b/sstables/sstables_manager.cc
@@ -77,7 +77,7 @@ future<> atomic_deletion::execute() noexcept {
         co_await _impl->finalize();
     } catch (...) {
         // After commit(), the SSTables will be deleted even after a crash.
-        smlogger.warn("SSTables deletion failed after commit: {}. Will be retried on restart.", std::current_exception());
+        smlogger.warn("SSTables deletion failed after commit: {:t}. Will be retried on restart.", std::current_exception());
     }
 }
 
@@ -404,7 +404,7 @@ future<> sstables_manager::maybe_reload_components() {
             co_await sstable_ptr->reload_reclaimed_components();
         } catch (...) {
             // reload failed due to some reason
-            sstlog.warn("Failed to reload reclaimed SSTable components : {}", std::current_exception());
+            sstlog.warn("Failed to reload reclaimed SSTable components : {:t}", std::current_exception());
             // revert back changes made before the reload
             _total_reclaimable_memory -= reclaimed_memory;
             _reclaimed.insert(*sstable_to_reload);

--- a/sstables/storage.cc
+++ b/sstables/storage.cc
@@ -278,7 +278,7 @@ future<> filesystem_storage::remove_temp_dir() {
     try {
         co_await remove_file(_temp_dir->native());
     } catch (...) {
-        sstlog.error("Could not remove temporary directory: {}", std::current_exception());
+        sstlog.error("Could not remove temporary directory: {:t}", std::current_exception());
         throw;
     }
 
@@ -582,7 +582,7 @@ future<> filesystem_storage::wipe(sstable& sst, const atomic_deletion* deletion)
         // b. in the future sstables_manager is planned to handle sstables deletion.
         // c. Eventually we may want to record these failures in a system table
         //    and notify the administrator about that for manual handling (rather than aborting).
-        sstlog.warn("Failed to delete {}: {}. Ignoring.", name, std::current_exception());
+        sstlog.warn("Failed to delete {}: {:t}. Ignoring.", name, std::current_exception());
     }
 
     if (_temp_dir) {
@@ -590,7 +590,7 @@ future<> filesystem_storage::wipe(sstable& sst, const atomic_deletion* deletion)
             co_await recursive_remove_directory(*_temp_dir);
             _temp_dir.reset();
         } catch (...) {
-            sstlog.warn("Exception when deleting temporary sstable directory {}: {}", *_temp_dir, std::current_exception());
+            sstlog.warn("Exception when deleting temporary sstable directory {}: {:t}", *_temp_dir, std::current_exception());
         }
     }
 }
@@ -627,7 +627,7 @@ public:
             co_await remove_file(_pending_delete_log);
             sstlog.debug("{} removed.", _pending_delete_log);
         } catch (...) {
-            sstlog.warn("Error removing {}: {}. Ignoring.", _pending_delete_log, std::current_exception());
+            sstlog.warn("Error removing {}: {:t}. Ignoring.", _pending_delete_log, std::current_exception());
         }
     }
 };
@@ -661,7 +661,7 @@ future<> filesystem_storage::unlink_component(const sstable& sst, component_type
         // b. in the future sstables_manager is planned to handle sstables deletion.
         // c. Eventually we may want to record these failures in a system table
         //    and notify the administrator about that for manual handling (rather than aborting).
-        sstlog.warn("Failed to delete {}: {}. Ignoring.", name, std::current_exception());
+        sstlog.warn("Failed to delete {}: {:t}. Ignoring.", name, std::current_exception());
     }
 }
 
@@ -828,7 +828,7 @@ future<object_storage_reference_names> list_object_storage_references(object_sto
             return collect_lister_entries(lister, refs);
         });
     } catch (...) {
-        throw std::runtime_error(fmt::format("Failed to list references: prefix={} sstable_id={}: {}", prefix, sid, std::current_exception()));
+        throw std::runtime_error(fmt::format("Failed to list references: prefix={} sstable_id={}: {:t}", prefix, sid, std::current_exception()));
     }
     co_return refs;
 }
@@ -855,7 +855,7 @@ future<> object_storage_base::delete_components(sstable_version_types version, s
             if (!log_errors) {
                 throw;
             }
-            sstlog.warn("Failed to delete {} object {} for sstable_id={}: {}", _type, component, sid, std::current_exception());
+            sstlog.warn("Failed to delete {} object {} for sstable_id={}: {:t}", _type, component, sid, std::current_exception());
         }
     };
 
@@ -1066,7 +1066,7 @@ future<> object_storage_base::destroy(const sstable& sst) {
         }
         co_await sst.manager().sstables_registry().delete_entry(owner(), node_owner, sst.generation());
     } catch (...) {
-        sstlog.warn("Failed to delete registry entry for {}: {}", sst.toc_filename(), std::current_exception());
+        sstlog.warn("Failed to delete registry entry for {}: {:t}", sst.toc_filename(), std::current_exception());
     }
     sstlog.debug("Deleted reference {} remaining_refs={}", ref_name.str(), remaining_refs);
 }
@@ -1144,7 +1144,7 @@ future<> object_storage_base::unlink_component(const sstable& sst, component_typ
     try {
         co_await _client->delete_object(name);
     } catch (...) {
-        sstlog.warn("Failed to delete {}: {}. Ignoring.", name, std::current_exception());
+        sstlog.warn("Failed to delete {}: {:t}. Ignoring.", name, std::current_exception());
     }
 }
 

--- a/sstables_loader.cc
+++ b/sstables_loader.cc
@@ -1351,7 +1351,7 @@ protected:
         try {
             co_await loader._ss.local().restore_tablets(_tid, _snap_name);
         } catch (...) {
-            llog.error("Failed to restore tablets for table_id {}. Error: {}", _tid, std::current_exception());
+            llog.error("Failed to restore tablets for table_id {}. Error: {:t}", _tid, std::current_exception());
             eptr = std::current_exception();
         }
 
@@ -1359,7 +1359,7 @@ protected:
             llog.info("Restoring table with tid {} to the original schema", _tid);
             co_await loader._ss.local().alter_table_with_tablet_hints(_tid, min_tablet_count, max_tablet_count, false);
         } catch (...) {
-            llog.error("Failed to restore original schema for table_id {}. Error: {}", _tid, std::current_exception());
+            llog.error("Failed to restore original schema for table_id {}. Error: {:t}", _tid, std::current_exception());
         }
 
         if (eptr) {

--- a/sstables_loader_helpers.cc
+++ b/sstables_loader_helpers.cc
@@ -105,7 +105,7 @@ future<minimal_sst_info> download_sstable(replica::database& db, replica::table&
                 co_return minimal_sst_info{shards.front(), gen, descriptor.version, descriptor.format};
             }
         } catch (...) {
-            logger.info("Error downloading SSTable component {}. Reason: {}", it->first, std::current_exception());
+            logger.info("Error downloading SSTable component {}. Reason: {:t}", it->first, std::current_exception());
             throw;
         }
     }

--- a/streaming/stream_plan.cc
+++ b/streaming/stream_plan.cc
@@ -72,7 +72,7 @@ void stream_plan::abort() noexcept {
         do_abort();
     } catch (...) {
         try {
-            sslog.error("Failed to abort stream plan: {}", std::current_exception());
+            sslog.error("Failed to abort stream plan: {:t}", std::current_exception());
         } catch (...) {
             // Nothing else we can do.
         }

--- a/streaming/stream_session.cc
+++ b/streaming/stream_session.cc
@@ -240,8 +240,14 @@ void stream_manager::init_messaging_service_handler(abort_source& as) {
                         level = seastar::log_level::debug;
                         status = -2;
                     }
+                    // formattable(), not a plain "{}": ex is routinely a
+                    // seastar::nested_exception (see the try_catch above), and only
+                    // formattable() descends into it. {fmt}'s own exception_ptr
+                    // formatter recurses through std::nested_exception, which
+                    // seastar::nested_exception is not, so it would print the bare
+                    // type name and drop the reason the stream failed.
                     sslog.log(level, "[Stream #{}] Failed to handle STREAM_MUTATION_FRAGMENTS (receive and distribute phase) for ks={}, cf={}, peer={}: {}",
-                        plan_id, s->ks_name(), s->cf_name(), from, aborted?"Streaming aborted":format("{}",ex));
+                        plan_id, s->ks_name(), s->cf_name(), from, aborted?"Streaming aborted":format("{}",seastar::formattable(ex)));
                 } else {
                     received_partitions = f.get();
                 }
@@ -255,7 +261,7 @@ void stream_manager::init_messaging_service_handler(abort_source& as) {
                             co_await fail_stream_plan(plan_id);
                         }
                     } catch (...) {
-                        sslog.warn("[Stream #{}] Failed to abort the stream plan: {}", plan_id, std::current_exception());
+                        sslog.warn("[Stream #{}] Failed to abort the stream plan: {:t}", plan_id, std::current_exception());
                     }
                 }
                 co_await sink(status).finally([sink] () mutable {
@@ -273,8 +279,9 @@ void stream_manager::init_messaging_service_handler(abort_source& as) {
                     if (try_catch<seastar::rpc::closed_error>(ep)) {
                         level = seastar::log_level::debug;
                     }
+                    // formattable() for the same reason as the receive phase above.
                     sslog.log(level, "[Stream #{}] Failed to handle STREAM_MUTATION_FRAGMENTS (respond phase) for ks={}, cf={}, peer={}: {}",
-                            plan_id, s->ks_name(), s->cf_name(), from, ep);
+                            plan_id, s->ks_name(), s->cf_name(), from, seastar::formattable(ep));
                     co_await sink.close();
                 });
             });
@@ -357,7 +364,7 @@ future<> stream_session::on_initialization_complete() {
                 _stream_result->handle_session_prepared(this->shared_from_this());
             }
         } catch (...) {
-            sslog.warn("[Stream #{}] Fail to send PREPARE_MESSAGE to {}, {}", this->plan_id(), id, std::current_exception());
+            sslog.warn("[Stream #{}] Fail to send PREPARE_MESSAGE to {}, {:t}", this->plan_id(), id, std::current_exception());
             throw;
         }
         return make_ready_future<>();
@@ -550,7 +557,7 @@ std::vector<replica::column_family*> stream_session::get_column_family_stores(co
                 auto& x = db.find_column_family(keyspace, cf_name);
                 stores.push_back(&x);
             } catch (replica::no_such_column_family&) {
-                sslog.warn("stream_session: {}.{} does not exist: {}\n", keyspace, cf_name, std::current_exception());
+                sslog.warn("stream_session: {}.{} does not exist: {:t}\n", keyspace, cf_name, std::current_exception());
                 continue;
             }
         }

--- a/table_helper.cc
+++ b/table_helper.cc
@@ -132,7 +132,7 @@ future<> table_helper::cache_table_info(cql3::query_processor& qp, service::migr
             co_return co_await table_helper::setup_table(qp, mm.local(), create_cql);
         });
     } catch (...) {
-        tlogger.debug("Failed to create {}.{} table in best-effort recovery path: {}", _keyspace, _name, std::current_exception());
+        tlogger.debug("Failed to create {}.{} table in best-effort recovery path: {:t}", _keyspace, _name, std::current_exception());
     }
 
     // We throw the bad_column_family exception because the caller

--- a/tasks/task_manager.cc
+++ b/tasks/task_manager.cc
@@ -240,7 +240,7 @@ future<> task_manager::task::impl::maybe_fold_into_parent() const noexcept {
         }
     } catch (...) {
         // If folding fails, leave the subtree unfolded.
-        tasks::tmlogger.warn("Folding of task with id={} failed due to {}. Ignored", _status.id, std::current_exception());
+        tasks::tmlogger.warn("Folding of task with id={} failed due to {:t}. Ignored", _status.id, std::current_exception());
     }
 }
 
@@ -268,7 +268,7 @@ future<> task_manager::task::impl::finish_failed(std::exception_ptr ex, std::str
 future<> task_manager::task::impl::finish_failed(std::exception_ptr ex) noexcept {
     std::string error;
     try {
-        error = fmt::format("{}", ex);
+        error = fmt::format("{:t}", ex);
     } catch (...) {
         error = "Failed to get error message";
     }

--- a/test/boost/aws_errors_test.cc
+++ b/test/boost/aws_errors_test.cc
@@ -289,7 +289,7 @@ BOOST_AUTO_TEST_CASE(TestNestedException) {
     } catch (...) {
         auto error = aws::aws_error::from_exception_ptr(std::current_exception());
         BOOST_REQUIRE_EQUAL(aws::aws_error_type::UNKNOWN, error.get_error_type());
-        BOOST_REQUIRE_EQUAL("No error message was provided, exception content: char const*", error.get_error_message());
+        BOOST_REQUIRE_EQUAL("No error message was provided, exception content: unknown exception", error.get_error_message());
         BOOST_REQUIRE_EQUAL(error.is_retryable(), utils::http::retryable::no);
     }
 

--- a/test/boost/group0_test.cc
+++ b/test/boost/group0_test.cc
@@ -69,7 +69,7 @@ SEASTAR_TEST_CASE(test_abort_server_on_background_error) {
         };
 
         auto check_error = [](const raft::stopped_error& e) {
-            return e.what() == sstring("Raft instance is stopped, reason: \"background error, std::runtime_error (store_log_entries/test-failure)\"");
+            return e.what() == sstring("Raft instance is stopped, reason: \"background error, std::runtime_error: store_log_entries/test-failure\"");
         };
         BOOST_REQUIRE_EQUAL(get_status(), 1);
         BOOST_CHECK_EXCEPTION(co_await perform_schema_change(), raft::stopped_error, check_error);

--- a/test/boost/radix_tree_printer.hh
+++ b/test/boost/radix_tree_printer.hh
@@ -8,7 +8,7 @@
 
 #pragma once
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include "utils/compact-radix-tree.hh"
 
 namespace compact_radix_tree {

--- a/test/boost/tree_test_key.hh
+++ b/test/boost/tree_test_key.hh
@@ -11,6 +11,8 @@
 #include "utils/assert.hh"
 #include <fmt/core.h>
 #include <cassert>
+#include <compare>
+#include <concepts>
 
 /*
  * Helper class that helps to check that tree

--- a/test/cluster/dtest/commitlog_test.py
+++ b/test/cluster/dtest/commitlog_test.py
@@ -40,10 +40,10 @@ class TestCommitLog(Tester):
     @pytest.fixture(autouse=True)
     def fixture_add_additional_log_patterns(self, fixture_dtest_setup):
         fixture_dtest_setup.ignore_log_patterns += [
-            r"commitlog - Exception in segment reservation: storage_io_error \(Storage I/O error: 13: filesystem error: open failed",
+            r"commitlog - Exception in segment reservation: storage_io_error: Storage I/O error: 13: filesystem error: open failed",
             "Shutting down communications due to I/O errors until operator intervention",
-            r"commitlog - Failed to (flush|persist) commits to disk.*storage_io_error \(Storage I/O error: 28: No space left on device\)",
-            r"storage_proxy - .*\(Could not write mutation .* to commitlog\): storage_io_error \(Storage I/O error: 28: No space left on device\)",
+            r"commitlog - Failed to (flush|persist) commits to disk.*storage_io_error: Storage I/O error: 28: No space left on device",
+            r"storage_proxy - .*Could not write mutation .* to commitlog: storage_io_error: Storage I/O error: 28: No space left on device",
         ]
 
     @pytest.fixture(autouse=True)

--- a/test/cluster/object_store/test_backup.py
+++ b/test/cluster/object_store/test_backup.py
@@ -139,7 +139,7 @@ async def test_backup_with_non_existing_parameters(manager: ScyllaClusterManager
         assert status is not None
         assert status['state'] == 'failed'
         if ne_parameter == 'endpoint':
-            assert status['error'] == 'std::invalid_argument (endpoint no-such-endpoint not found)'
+            assert status['error'] == 'std::invalid_argument: endpoint no-such-endpoint not found'
 
 
 async def test_backup_endpoint_config_is_live_updateable(manager: ScyllaClusterManager, object_storage):
@@ -164,7 +164,7 @@ async def test_backup_endpoint_config_is_live_updateable(manager: ScyllaClusterM
         status = await manager.api.wait_task(server.ip_addr, tid)
         assert status is not None
         assert status['state'] == 'failed'
-        assert status['error'] == f'std::invalid_argument (endpoint {object_storage.address} not found)'
+        assert status['error'] == f'std::invalid_argument: endpoint {object_storage.address} not found'
 
         objconf = object_storage.create_endpoint_conf()
         await manager.server_update_config(server.server_id, 'object_storage_endpoints', objconf)
@@ -225,7 +225,7 @@ async def do_test_backup_abort(manager: ScyllaClusterManager, object_storage,
         status = await manager.api.wait_task(server.ip_addr, tid)
         print(f'Status: {status}')
         assert (status is not None) and (status['state'] == 'failed')
-        assert "seastar::abort_requested_exception (abort requested)" in status['error']
+        assert "seastar::abort_requested_exception: abort requested" in status['error']
 
         objects = set(o.key for o in object_storage.get_resource().Bucket(object_storage.bucket_name).objects.all())
         uploaded_count = 0

--- a/test/cluster/storage/test_out_of_space_prevention.py
+++ b/test/cluster/storage/test_out_of_space_prevention.py
@@ -543,7 +543,7 @@ async def test_repair_failure_on_split_rejection(manager: ScyllaClusterManager, 
 
                     # Expect repair to fail when splitting new sstables
                     await log.wait_for("Repair for tablet migration of .* failed", from_mark=mark)
-                    await log.wait_for(r"Failed to load SSTable.*\(critical disk utilization\)", from_mark=mark)
+                    await log.wait_for(r"Failed to load SSTable.*critical disk utilization", from_mark=mark)
 
                     assert await log.grep(f"compaction.*Split {cf}", from_mark=mark) == []
 

--- a/test/cluster/test_audit.py
+++ b/test/cluster/test_audit.py
@@ -1112,7 +1112,7 @@ class CQLAuditTester(AuditTester):
          check node not started
         """
         audit_settings = {"audit": "invalid", "audit_categories": "ADMIN,AUTH,QUERY,DML,DDL,DCL", "audit_keyspaces": "ks"}
-        expected_error = r"Startup failed: audit::audit_exception \(Bad configuration: invalid 'audit': invalid\)"
+        expected_error = r"Startup failed: audit::audit_exception: Bad configuration: invalid 'audit': invalid"
 
         servers = await self.manager.running_servers()
         if not servers:
@@ -1129,7 +1129,7 @@ class CQLAuditTester(AuditTester):
          check node not started
         """
         audit_settings = {"audit": "table,syslog,invalid", "audit_categories": "ADMIN,AUTH,QUERY,DML,DDL,DCL", "audit_keyspaces": "ks"}
-        expected_error = r"Startup failed: audit::audit_exception \(Bad configuration: invalid 'audit': invalid\)"
+        expected_error = r"Startup failed: audit::audit_exception: Bad configuration: invalid 'audit': invalid"
 
         servers = await self.manager.running_servers()
         if not servers:
@@ -1173,7 +1173,7 @@ class CQLAuditTester(AuditTester):
         check node not started
         """
         audit_settings = {"audit": "table", "audit_categories": "INVALID", "audit_keyspaces": "ks"}
-        expected_error = r"Startup failed: audit::audit_exception \(Bad configuration: invalid 'audit_categories': INVALID\)"
+        expected_error = r"Startup failed: audit::audit_exception: Bad configuration: invalid 'audit_categories': INVALID"
 
         servers = await self.manager.running_servers()
         if not servers:

--- a/test/cluster/test_major_compaction.py
+++ b/test/cluster/test_major_compaction.py
@@ -188,7 +188,7 @@ async def test_shutdown_drain_during_compaction(manager: ScyllaClusterManager):
         await stop_task
         # During shutdown, errors mentioning 'seastar::abort_requested_exception' is expected as we do abort the compaction midway.
         # Verify that the shutdown completed without any other unexpected errors
-        assert len(await log.grep(expr="ERROR .*", filter_expr=r".* seastar::abort_requested_exception \(abort requested\)", from_mark=mark)) == 0
+        assert len(await log.grep(expr="ERROR .*", filter_expr=r".* seastar::abort_requested_exception: abort requested", from_mark=mark)) == 0
 
         # For dropping the keyspace
         await manager.server_start(server.server_id)

--- a/test/cluster/test_tablets.py
+++ b/test/cluster/test_tablets.py
@@ -2551,7 +2551,7 @@ async def test_repair_with_invalid_session_id(manager: ScyllaClusterManager):
     [await manager.api.enable_injection(s.ip_addr, injection, one_shot=True) for s in servers]
     await manager.api.tablet_repair(servers[0].ip_addr, ks, "test", token)
 
-    matches = [await log.grep(r"std::runtime_error \(Session not found", from_mark=mark) for log, mark in zip(logs, marks)]
+    matches = [await log.grep(r"std::runtime_error: Session not found", from_mark=mark) for log, mark in zip(logs, marks)]
     assert sum(len(x) for x in matches) > 0
 
 async def test_moving_replica_to_replica(manager: ScyllaClusterManager):

--- a/test/cqlpy/test_tools.py
+++ b/test/cqlpy/test_tools.py
@@ -617,7 +617,7 @@ def test_scylla_sstable_write_temp_dir(cql, scylla_path, scylla_data_dir):
 
         assert res.returncode == 2
         assert res.stdout == ""
-        assert res.stderr.endswith(f"error running operation: std::filesystem::__cxx11::filesystem_error (error generic:20, filesystem error: temp_directory_path: Not a directory [{f.name}])\n")
+        assert res.stderr.endswith(f"error running operation: std::filesystem::filesystem_error: filesystem error: temp_directory_path: Not a directory [{f.name}]\n")
 
 
 @pytest.mark.parametrize("table_factory", [
@@ -1201,7 +1201,7 @@ class TestScyllaSsstableSchemaLoading(TestScyllaSsstableSchemaLoadingBase):
                 scylla_path,
                 ["--schema-tables", "--scylla-yaml-file", scylla_yaml_file, "--keyspace", "non-existent-keyspace", "--table", self.table],
                 ext_sstable,
-                error_msg="error processing arguments: could not load schema via schema-tables: std::runtime_error (Failed to find non-existent-keyspace.scylla_local in schema tables)")
+                error_msg="error processing arguments: could not load schema via schema-tables: std::runtime_error: Failed to find non-existent-keyspace.scylla_local in schema tables")
 
     def test_fail_nonexistent_table(self, scylla_path, system_scylla_local_sstable_prepared, temp_workdir, scylla_home_dir):
         ext_sstable = self.copy_sstable_to_external_dir(system_scylla_local_sstable_prepared, temp_workdir)
@@ -1210,7 +1210,7 @@ class TestScyllaSsstableSchemaLoading(TestScyllaSsstableSchemaLoadingBase):
                 scylla_path,
                 ["--schema-tables", "--scylla-yaml-file", scylla_yaml_file, "--keyspace", self.keyspace, "--table", "non-existent-table"],
                 ext_sstable,
-                error_msg="error processing arguments: could not load schema via schema-tables: std::runtime_error (Failed to find system.non-existent-table in schema tables)")
+                error_msg="error processing arguments: could not load schema via schema-tables: std::runtime_error: Failed to find system.non-existent-table in schema tables")
 
 
 @pytest.fixture(scope="class")
@@ -1490,7 +1490,7 @@ def test_scrub_abort_mode(scylla_path, scrub_workdir, scrub_schema_file, scrub_g
         check_scrub_output_dir(tmp_dir, 1)
 
     with tempfile.TemporaryDirectory(prefix="test_scrub_abort_mode", dir=scrub_workdir) as tmp_dir:
-        subprocess_check_error([scylla_path, "sstable", "scrub", "--schema-file", scrub_schema_file, "--scrub-mode", "abort", "--output-dir", tmp_dir, scrub_bad_sstable], "compaction_aborted_exception \\(Compaction for ks/tbl was aborted due to: scrub compaction found invalid data\\)")
+        subprocess_check_error([scylla_path, "sstable", "scrub", "--schema-file", scrub_schema_file, "--scrub-mode", "abort", "--output-dir", tmp_dir, scrub_bad_sstable], "compaction_aborted_exception: Compaction for ks/tbl was aborted due to: scrub compaction found invalid data")
         check_scrub_output_dir(tmp_dir, 0)
 
 
@@ -2079,7 +2079,7 @@ def test_scylla_sstable_query_temp_dir(cql, scylla_path, scylla_data_dir):
 
         assert res.returncode == 2
         assert res.stdout == ""
-        assert res.stderr.endswith(f"error running operation: std::filesystem::__cxx11::filesystem_error (error generic:20, filesystem error: temp_directory_path: Not a directory [{f.name}])\n")
+        assert res.stderr.endswith(f"error running operation: std::filesystem::filesystem_error: filesystem error: temp_directory_path: Not a directory [{f.name}]\n")
 
 
 def test_scylla_sstable_query_null_data(cql, test_keyspace, scylla_path, scylla_data_dir):

--- a/tools/json_mutation_stream_parser.cc
+++ b/tools/json_mutation_stream_parser.cc
@@ -193,7 +193,7 @@ private:
             auto raw = from_hex(*_string);
             _pkey.emplace(partition_key::from_bytes(raw));
         } catch (...) {
-            return error("failed to parse partition key from raw string: {}", std::current_exception());
+            return error("failed to parse partition key from raw string: {:t}", std::current_exception());
         }
         return true;
     }
@@ -203,7 +203,7 @@ private:
             auto raw = from_hex(*_string);
             _ckey.emplace(clustering_key::from_bytes(raw));
         } catch (...) {
-            return error("failed to parse clustering key from raw string: {}", std::current_exception());
+            return error("failed to parse clustering key from raw string: {:t}", std::current_exception());
         }
         return true;
     }
@@ -234,7 +234,7 @@ private:
             }
             return true;
         } catch (...) {
-            return error("failed to parse deletion_time: {}", std::current_exception());
+            return error("failed to parse deletion_time: {:t}", std::current_exception());
         }
     }
 
@@ -257,7 +257,7 @@ private:
         try {
             _expiry = gc_clock::time_point(gc_clock::duration(timestamp_from_string(*_string) / 1000));
         } catch (...) {
-            return error("failed to parse expiry: {}", std::current_exception());
+            return error("failed to parse expiry: {:t}", std::current_exception());
         }
         return true;
     }
@@ -333,7 +333,7 @@ private:
         try {
             _column->value.emplace(to_bytes(_column->def->type->from_string(*_string)));
         } catch (...) {
-            return error("failed to parse cell value: {}", std::current_exception());
+            return error("failed to parse cell value: {:t}", std::current_exception());
         }
         return true;
     }
@@ -872,7 +872,7 @@ public:
         try {
             _thread.join().get();
         } catch (...) {
-            _logger.warn("json_mutation_stream_parser: parser thread exited with exception: {}", std::current_exception());
+            _logger.warn("json_mutation_stream_parser: parser thread exited with exception: {:t}", std::current_exception());
         }
     }
     future<mutation_fragment_v2_opt> operator()() {

--- a/tools/schema_loader.cc
+++ b/tools/schema_loader.cc
@@ -293,7 +293,7 @@ std::vector<schema_ptr> do_load_schemas(const db::config& cfg, std::string_view 
     try {
         raw_statements = cql3::query_processor::parse_statements(schema_str, cql3::internal_dialect());
     } catch (...) {
-        throw std::runtime_error(format("tools:do_load_schemas(): failed to parse CQL statements: {}", std::current_exception()));
+        throw std::runtime_error(format("tools:do_load_schemas(): failed to parse CQL statements: {:t}", std::current_exception()));
     }
     for (auto& raw_statement : raw_statements) {
         if (raw_statement->get_prepare_context().bound_variables_size()) {

--- a/tools/scylla-nodetool.cc
+++ b/tools/scylla-nodetool.cc
@@ -5718,7 +5718,7 @@ For more information, see: {})";
             fmt::print(std::cerr, "error running operation: failed assert on JSON data: {}\nAPI requests: {}\n", e.what(), fmt::join(client->request_history(), "\n    "));
             return 2;
         } catch (...) {
-            fmt::print(std::cerr, "error running operation: {}\n", std::current_exception());
+            fmt::print(std::cerr, "error running operation: {:t}\n", std::current_exception());
             return 2;
         }
 

--- a/tools/scylla-sstable.cc
+++ b/tools/scylla-sstable.cc
@@ -261,7 +261,7 @@ std::optional<schema_with_source> try_load_schema_from_user_provided_source(cons
                 .obtained_from = "--sstable-schema parameter"};
         }
     } catch (...) {
-        fmt::print(std::cerr, "error processing arguments: could not load schema via {}: {}\n", schema_source_opt, std::current_exception());
+        fmt::print(std::cerr, "error processing arguments: could not load schema via {}: {:t}\n", schema_source_opt, std::current_exception());
         return {};
     }
     // Should not happen, but if it does (we all know it will), let's at least have a message printed.
@@ -277,7 +277,7 @@ std::optional<schema_with_source> try_load_schema_autodetect(const bpo::variable
             .path = schema_file_path,
             .obtained_from = "--schema-file parameters (default value)"};
     } catch (...) {
-        sst_log.debug("Trying to read schema file from default location failed: {}", std::current_exception());
+        sst_log.debug("Trying to read schema file from default location failed: {:t}", std::current_exception());
     }
 
     if (app_config.count("sstables")) {
@@ -288,7 +288,7 @@ std::optional<schema_with_source> try_load_schema_autodetect(const bpo::variable
                 .path = info.data_dir_path,
                 .obtained_from = format("sstable path ({})", info.sstable_path)};
         } catch (...) {
-            sst_log.debug("Trying to find scylla data dir based on the sstable path failed: {}", std::current_exception());
+            sst_log.debug("Trying to find scylla data dir based on the sstable path failed: {:t}", std::current_exception());
         }
     } else {
         sst_log.debug("Trying to find scylla data dir based on sstable path failed: no sstable argument provided");
@@ -302,7 +302,7 @@ std::optional<schema_with_source> try_load_schema_autodetect(const bpo::variable
             .path = data_dir_path,
             .obtained_from = "data dir"};
     } catch (...) {
-        sst_log.debug("Trying to locate data dir failed: {}", std::current_exception());
+        sst_log.debug("Trying to locate data dir failed: {:t}", std::current_exception());
     }
 
     try {
@@ -322,7 +322,7 @@ std::optional<schema_with_source> try_load_schema_autodetect(const bpo::variable
             .source = "sstable's serialization header",
             .obtained_from = sst_path};
     } catch (...) {
-        sst_log.debug("Trying to load schema from the sstable itself failed: {}", std::current_exception());
+        sst_log.debug("Trying to load schema from the sstable itself failed: {:t}", std::current_exception());
     }
 
     fmt::print(std::cerr, "Failed to autodetect and load schema, try again with --logger-log-level scylla-sstable=debug to learn more or provide the schema source manually\n");
@@ -388,7 +388,7 @@ const std::vector<sstables::shared_sstable> load_sstables(schema_ptr schema, sst
             // Print each individual error here since parallel_for_each
             // will propagate only one of them up the stack.
             auto msg = fmt::format("Could not load SSTable: {}", sst->get_filename());
-            fmt::print(std::cerr, "{}: {}\n", msg, std::current_exception());
+            fmt::print(std::cerr, "{}: {:t}\n", msg, std::current_exception());
             throw_with_nested(std::runtime_error(msg));
         }
 
@@ -1859,7 +1859,7 @@ validate_and_prepare_query(std::string_view query, std::string_view table_name, 
     try {
         raw_statements = cql3::query_processor::parse_statements(query, cql3::dialect{});
     } catch (...) {
-        throw std::invalid_argument(seastar::format("failed to parse query: {}", std::current_exception()));
+        throw std::invalid_argument(seastar::format("failed to parse query: {:t}", std::current_exception()));
     }
     if (raw_statements.size() != 1) {
         throw std::invalid_argument(seastar::format("expected exactly 1 query, got {}", raw_statements.size()));
@@ -1887,7 +1887,7 @@ validate_and_prepare_query(std::string_view query, std::string_view table_name, 
         auto prepared_statement = raw_statement->prepare(db, cql_stats, cql3::default_cql_config);
         return std::move(prepared_statement->statement);
     } catch (...) {
-        throw std::invalid_argument(seastar::format("failed to prepare query: {}", std::current_exception()));
+        throw std::invalid_argument(seastar::format("failed to prepare query: {:t}", std::current_exception()));
     }
 }
 
@@ -3199,7 +3199,7 @@ $ scylla sstable validate /path/to/md-123456-big-Data.db /path/to/md-123457-big-
             try {
                 sstables = load_sstables(schema, sst_man, sstm.local(), sstable_names);
             } catch (...) {
-                fmt::print(std::cerr, "error loading sstables: {}\n", std::current_exception());
+                fmt::print(std::cerr, "error loading sstables: {:t}\n", std::current_exception());
                 return 1;
             }
         }
@@ -3215,7 +3215,7 @@ $ scylla sstable validate /path/to/md-123456-big-Data.db /path/to/md-123457-big-
             fmt::print(std::cerr, "error processing arguments: {}\n", e.what());
             return 1;
         } catch (...) {
-            fmt::print(std::cerr, "error running operation: {}\n", std::current_exception());
+            fmt::print(std::cerr, "error running operation: {:t}\n", std::current_exception());
             return 2;
         }
 

--- a/tracing/traced_file.cc
+++ b/tracing/traced_file.cc
@@ -52,7 +52,7 @@ traced_file_impl::write_dma(uint64_t pos, const void* buf, size_t len, io_intent
             tracing::trace(_trace_state, "{} finished DMA write of {} bytes at position {}, successfully wrote {} bytes", _trace_prefix, len, pos, ret);
             return ret;
         } catch (...) {
-            tracing::trace(_trace_state, "{} failed DMA write of {} bytes at position {}: {}", _trace_prefix, len, pos, std::current_exception());
+            tracing::trace(_trace_state, "{} failed DMA write of {} bytes at position {}: {:t}", _trace_prefix, len, pos, std::current_exception());
             throw;
         }
     });
@@ -67,7 +67,7 @@ traced_file_impl::write_dma(uint64_t pos, std::vector<iovec> iov, io_intent* int
             tracing::trace(_trace_state, "{} finished DMA write at position {}, successfully wrote {} bytes", _trace_prefix, pos, ret);
             return ret;
         } catch (...) {
-            tracing::trace(_trace_state, "{} failed DMA write of at position {}: {}", _trace_prefix, pos, std::current_exception());
+            tracing::trace(_trace_state, "{} failed DMA write of at position {}: {:t}", _trace_prefix, pos, std::current_exception());
             throw;
         }
     });
@@ -82,7 +82,7 @@ traced_file_impl::read_dma(uint64_t pos, void* buf, size_t len, io_intent* inten
             tracing::trace(_trace_state, "{} finished DMA read of {} bytes at position {}, successfully read {} bytes", _trace_prefix, len, pos, ret);
             return ret;
         } catch (...) {
-            tracing::trace(_trace_state, "{} failed DMA read of {} bytes at position {}: {}", _trace_prefix, len, pos, std::current_exception());
+            tracing::trace(_trace_state, "{} failed DMA read of {} bytes at position {}: {:t}", _trace_prefix, len, pos, std::current_exception());
             throw;
         }
     });
@@ -97,7 +97,7 @@ traced_file_impl::read_dma(uint64_t pos, std::vector<iovec> iov, io_intent* inte
             tracing::trace(_trace_state, "{} finished DMA read at position {}, successfully read {} bytes", _trace_prefix, pos, ret);
             return ret;
         } catch (...) {
-            tracing::trace(_trace_state, "{} failed DMA read at position {}: {}", _trace_prefix, pos, std::current_exception());
+            tracing::trace(_trace_state, "{} failed DMA read at position {}: {:t}", _trace_prefix, pos, std::current_exception());
             throw;
         }
     });
@@ -111,7 +111,7 @@ traced_file_impl::flush(void) {
             f.get();
             tracing::trace(_trace_state, "{} finished flush", _trace_prefix);
         } catch (...) {
-            tracing::trace(_trace_state, "{} failed flush: {}", _trace_prefix, std::current_exception());
+            tracing::trace(_trace_state, "{} failed flush: {:t}", _trace_prefix, std::current_exception());
             throw;
         }
     });
@@ -126,7 +126,7 @@ traced_file_impl::stat(void) {
             tracing::trace(_trace_state, "{} finished file status retrieval", _trace_prefix);
             return s;
         } catch (...) {
-            tracing::trace(_trace_state, "{} failed to retrieve file status: {}", _trace_prefix, std::current_exception());
+            tracing::trace(_trace_state, "{} failed to retrieve file status: {:t}", _trace_prefix, std::current_exception());
             throw;
         }
     });
@@ -140,7 +140,7 @@ traced_file_impl::truncate(uint64_t length) {
             f.get();
             tracing::trace(_trace_state, "{} finished truncate to {} bytes", _trace_prefix, length);
         } catch (...) {
-            tracing::trace(_trace_state, "{} failed to truncate file to {} bytes: {}", _trace_prefix, length, std::current_exception());
+            tracing::trace(_trace_state, "{} failed to truncate file to {} bytes: {:t}", _trace_prefix, length, std::current_exception());
             throw;
         }
     });
@@ -154,7 +154,7 @@ traced_file_impl::discard(uint64_t offset, uint64_t length) {
             f.get();
             tracing::trace(_trace_state, "{} finished discard of {} bytes at offset {}", _trace_prefix, length, offset);
         } catch (...) {
-            tracing::trace(_trace_state, "{} failed to discard {} bytes at offset {}: {}", _trace_prefix, length, offset, std::current_exception());
+            tracing::trace(_trace_state, "{} failed to discard {} bytes at offset {}: {:t}", _trace_prefix, length, offset, std::current_exception());
             throw;
         }
     });
@@ -168,7 +168,7 @@ traced_file_impl::allocate(uint64_t position, uint64_t length) {
             f.get();
             tracing::trace(_trace_state, "{} finished allocation of {} bytes at position {}", _trace_prefix, length, position);
         } catch (...) {
-            tracing::trace(_trace_state, "{} failed to allocate {} bytes at position {}: {}", _trace_prefix, length, position, std::current_exception());
+            tracing::trace(_trace_state, "{} failed to allocate {} bytes at position {}: {:t}", _trace_prefix, length, position, std::current_exception());
             throw;
         }
     });
@@ -183,7 +183,7 @@ traced_file_impl::size(void) {
             tracing::trace(_trace_state, "{} retrieved size = {}", _trace_prefix, ret);
             return ret;
         } catch (...) {
-            tracing::trace(_trace_state, "{} failed to retrieve size: {}", _trace_prefix, std::current_exception());
+            tracing::trace(_trace_state, "{} failed to retrieve size: {:t}", _trace_prefix, std::current_exception());
             throw;
         }
     });
@@ -197,7 +197,7 @@ traced_file_impl::close() {
             f.get();
             tracing::trace(_trace_state, "{} closed file", _trace_prefix);
         } catch (...) {
-            tracing::trace(_trace_state, "{} failed to close: {}", _trace_prefix, std::current_exception());
+            tracing::trace(_trace_state, "{} failed to close: {:t}", _trace_prefix, std::current_exception());
             throw;
         }
     });

--- a/transport/generic_server.cc
+++ b/transport/generic_server.cc
@@ -216,7 +216,7 @@ bool connection::shutdown_input() {
     try {
         _fd.shutdown_input();
     } catch (...) {
-        _server._logger.warn("Error shutting down input side of connection {}->{}, exception: {}", _fd.remote_address(), _fd.local_address(), std::current_exception());
+        _server._logger.warn("Error shutting down input side of connection {}->{}, exception: {:t}", _fd.remote_address(), _fd.local_address(), std::current_exception());
         return false;
     }
     return true;
@@ -226,7 +226,7 @@ bool connection::shutdown_output() {
     try {
         _fd.shutdown_output();
     } catch (...) {
-        _server._logger.warn("Error shutting down output side of connection {}->{}, exception: {}", _fd.remote_address(), _fd.local_address(), std::current_exception());
+        _server._logger.warn("Error shutting down output side of connection {}->{}, exception: {:t}", _fd.remote_address(), _fd.local_address(), std::current_exception());
         return false;
     }
     return true;
@@ -356,7 +356,7 @@ server::listen(socket_address addr, std::shared_ptr<seastar::tls::credentials_bu
             ? is_tls = true, seastar::tls::listen(_credentials, addr, lo)
             : seastar::listen(addr, lo);
     } catch (...) {
-        throw std::runtime_error(format("{} error while listening on {} -> {}", _server_name, addr, std::current_exception()));
+        throw std::runtime_error(format("{} error while listening on {} -> {:t}", _server_name, addr, std::current_exception()));
     }
     _listeners.emplace_back(std::move(ss));
     // Each listener's do_accepts loop needs at least 1 unit to accept.
@@ -440,7 +440,7 @@ future<> server::do_accepts(int which, bool keepalive, socket_address server_add
                 });
             });
         } catch (...) {
-            _logger.debug("accept failed: {}", std::current_exception());
+            _logger.debug("accept failed: {:t}", std::current_exception());
         }
     }
 }

--- a/transport/server.cc
+++ b/transport/server.cc
@@ -960,7 +960,7 @@ std::unique_ptr<cql_server::response> cql_server::handle_exception(int16_t strea
         try {
             std::rethrow_if_nested(*exp);
         } catch (...) {
-            msg = seastar::format("{}: {}", msg, std::current_exception());
+            msg = seastar::format("{}: {:t}", msg, std::current_exception());
         }
         return make_error(stream, exceptions::exception_code::SERVER_ERROR, msg, trace_state);
     } else {

--- a/types/types.cc
+++ b/types/types.cc
@@ -324,7 +324,7 @@ int64_t timestamp_from_string(std::string_view s) {
         throw marshal_exception(
             seastar::format("unable to parse date '{}': {}", s, me.what()));
     } catch (...) {
-        throw marshal_exception(seastar::format("unable to parse date '{}': {}", s, std::current_exception()));
+        throw marshal_exception(seastar::format("unable to parse date '{}': {:t}", s, std::current_exception()));
     }
 }
 

--- a/utils/azure/identity/azure_cli_credentials.cc
+++ b/utils/azure/identity/azure_cli_credentials.cc
@@ -59,7 +59,7 @@ future<> azure_cli_credentials::refresh(const resource_type& resource_uri) {
     } catch (auth_error&) {
         throw;
     } catch (...) {
-        std::throw_with_nested(auth_error(fmt::format("{}", std::current_exception())));
+        std::throw_with_nested(auth_error(fmt::format("{:t}", std::current_exception())));
     }
 }
 

--- a/utils/directories.cc
+++ b/utils/directories.cc
@@ -24,7 +24,7 @@ static future<> disk_sanity(fs::path path, bool developer_mode) {
     try {
         co_await check_direct_io_support(path.native());
     } catch (...) {
-        startlog.error("Coould not access {}: {}", path, std::current_exception());
+        startlog.error("Coould not access {}: {:t}", path, std::current_exception());
         throw;
     }
 };
@@ -47,7 +47,7 @@ static future<file_lock> touch_and_lock(fs::path path) {
                 }
             });
         } catch (...) {
-            startlog.error("Directory '{}' cannot be initialized. Tried to do it but failed with: {}", path, std::current_exception());
+            startlog.error("Directory '{}' cannot be initialized. Tried to do it but failed with: {:t}", path, std::current_exception());
             throw;
         }
     });
@@ -89,7 +89,7 @@ future<> directories::create_and_verify(directories::set dir_set, recursive recu
         try {
             co_await directories::verify_owner_and_mode(path, recursive);
         } catch (...) {
-            startlog.error("Failed owner and mode verification: {}", std::current_exception());
+            startlog.error("Failed owner and mode verification: {:t}", std::current_exception());
             throw;
         }
     });

--- a/utils/disk_space_monitor.cc
+++ b/utils/disk_space_monitor.cc
@@ -126,7 +126,7 @@ future<> disk_space_monitor::poll() {
     } catch (const sleep_aborted&) {
     } catch (const abort_requested_exception&) {
     } catch (...) {
-        dsmlog.error("poll loop exited with error: {}", std::current_exception());
+        dsmlog.error("poll loop exited with error: {:t}", std::current_exception());
     }
 }
 

--- a/utils/gcp/object_storage.cc
+++ b/utils/gcp/object_storage.cc
@@ -626,7 +626,7 @@ utils::gcp::storage::client::impl::send_with_retry(const std::string& path, cons
 
             throw storage_io_error{EIO, format("GCP request failed with ({})", status)};
         } catch (...) {
-            throw storage_io_error{EIO, format("GCP error ({})", std::current_exception())};
+            throw storage_io_error{EIO, format("GCP error ({:t})", std::current_exception())};
         }
     }
 }

--- a/utils/http.cc
+++ b/utils/http.cc
@@ -109,7 +109,7 @@ future<connected_socket> utils::http::dns_connection_factory::make(abort_source*
         co_return co_await connect(address);
     } catch (...) {
         // On failure, forcefully renew address resolution and try again
-        _logger.debug("Connection failed, resetting address provider and retrying: {}", std::current_exception());
+        _logger.debug("Connection failed, resetting address provider and retrying: {:t}", std::current_exception());
     }
     _addr_list.reset();
     auto address = co_await get_address();

--- a/utils/logalloc.cc
+++ b/utils/logalloc.cc
@@ -272,7 +272,7 @@ private:
         try {
             fn();
         } catch (...) {
-            logger.error("Internal error, disabling the sanitizer: {}", std::current_exception());
+            logger.error("Internal error, disabling the sanitizer: {:t}", std::current_exception());
             _broken = true;
             _allocations.clear();
         }

--- a/utils/managed_string.hh
+++ b/utils/managed_string.hh
@@ -86,10 +86,11 @@ private:
 
 public:
     struct iter {
-        fragmented_ostringstream& stream;
+        iter(fragmented_ostringstream& s) : stream(&s) {}
+        fragmented_ostringstream* stream;
 
         iter& operator=(char c) {
-            stream.write(c);
+            stream->write(c);
             return *this;
         }
 

--- a/utils/s3/client.cc
+++ b/utils/s3/client.cc
@@ -143,7 +143,7 @@ void client::update_config_sync(std::string region, std::string ira) {
             _credentials = {};
             _creds_update_timer.rearm(lowres_clock::now());
         } catch (...) {
-            s3l.error("Failed to refresh credentials during config update: {}", std::current_exception());
+            s3l.error("Failed to refresh credentials during config update: {:t}", std::current_exception());
         }
     });
 }
@@ -411,7 +411,7 @@ future<> client::rebalance_connections() {
         throw storage_io_error {EIO, format("S3 request failed with ({})", status)};
     } catch (...) {
         auto e = std::current_exception();
-        throw storage_io_error {EIO, format("S3 error ({})", e)};
+        throw storage_io_error {EIO, format("S3 error ({:t})", e)};
     }
 }
 

--- a/utils/s3/credentials_providers/aws_credentials_provider_chain.cc
+++ b/utils/s3/credentials_providers/aws_credentials_provider_chain.cc
@@ -23,7 +23,7 @@ seastar::future<s3::aws_credentials> aws_credentials_provider_chain::get_aws_cre
             }
             cpc_logger.debug("Retrieving AWS credentials by credentials provider {} failed.", provider->get_name());
         } catch (...) {
-            cpc_logger.debug("Retrieving AWS credentials by credentials provider {} failed. Reason: {}", provider->get_name(), std::current_exception());
+            cpc_logger.debug("Retrieving AWS credentials by credentials provider {} failed. Reason: {:t}", provider->get_name(), std::current_exception());
         }
     }
     cpc_logger.error("Failed to retrieve AWS credentials from any provider.");


### PR DESCRIPTION
Fedora 44, the source of the frozen toolchain, carries fmt 11.2.0. Here, we
update to fmt 12.2.1 (prerelease). Since we depart from Fedora, we reinstate fmt as a sumodule,
as it was before Seastar dropped it [1].

The motivations for updating to 12.2.1 are:
 - support for C++26 [2]
 - built-in formatting for std::exception_ptr, avoiding the annoying deprecation warning
 - C++20 module support, as the Fedora packages don't carry fmt.cc and the build plumbing

The changes involve switching to a submodule without changing the version,
massaging the code to prepare it for new fmt, and the switch to 12.2.1. Because
formatting of exception_ptr:s is a little different, some minor changes have to be
made to formatting exceptions and matching messages.

I'll update to 12.2.1 (final) as soon as it's released.

[1] https://github.com/scylladb/seastar/commit/cd88bfecf2e6ea2f94426066b15bb344a96de30e
[2] https://github.com/fmtlib/fmt/issues/4760

This isn't fixing a bug, just preparing for future toolchain improvements, so not backporting.