### PR TITLE
build: make header checks cacheable by sccache

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -2664,7 +2664,7 @@ def write_build_file(f,
                         $builddir/{mode}/gen/${{stem}}Parser.cpp
                 description = ANTLR3 $in
             rule checkhh.{mode}
-              command = $cxx -MD -MT $out -MF $out.d {seastar_cflags} $cxxflags $cxxflags_{mode} $obj_cxxflags --include $in -c -o $out $builddir/{mode}/gen/empty.cc -USCYLLA_USE_PRECOMPILED_HEADER
+              command = $cxx -MD -MT $out -MF $out.d {seastar_cflags} $cxxflags $cxxflags_{mode} $obj_cxxflags -include $in -c -o $out $builddir/{mode}/gen/empty.cc -USCYLLA_USE_PRECOMPILED_HEADER
               description = CHECKHH $in
               depfile = $out.d
             rule test.{mode}


### PR DESCRIPTION
The checkhh rule force-includes the header being checked with clang's "--include" alias. sccache does not recognize that spelling, so it takes the header for a second input file and refuses to cache the compilation, reporting "multiple input files". Since configure.py prefers sccache over ccache, this means every header check is a full recompile on every build, in CI and locally.

Use the canonical "-include" spelling, which both gcc and clang accept and sccache understands. Building five header checks (replica/database.hh, mutation/mutation.hh, utils/UUID.hh, schema/schema.hh, dht/token.hh) with sccache 0.17.0, cold then warm:

  --include:  cold 9.96s, warm 10.26s  (0 hits, 10 non-cacheable)
  -include:   cold 10.88s, warm  0.14s (5 hits,  0 non-cacheable)

ccache is unaffected: it handles "--include" correctly, which is why this went unnoticed on setups without sccache installed.

Tiny build-time improvement, so not backporting.