### PR TITLE
transport: audit certificate-based logins

### DIFF
--- a/auth/authenticator.cc
+++ b/auth/authenticator.cc
@@ -17,6 +17,6 @@ const sstring auth::authenticator::PASSWORD_KEY("password");
 const sstring auth::authenticator::SERVICE_KEY("service");
 const sstring auth::authenticator::REALM_KEY("realm");
 
-future<std::optional<auth::authenticated_user>> auth::authenticator::authenticate(session_dn_func) const {
-    return make_ready_future<std::optional<auth::authenticated_user>>(std::nullopt);
+future<std::optional<sstring>> auth::authenticator::authenticate(session_dn_func) const {
+    return make_ready_future<std::optional<sstring>>(std::nullopt);
 }

--- a/auth/authenticator.hh
+++ b/auth/authenticator.hh
@@ -108,9 +108,9 @@ public:
     ///
     /// Authenticate (early) using transport info
     ///
-    /// \returns nullopt if not supported/required. exceptional future if failed
+    /// \returns the name of the authenticated role, nullopt if not supported/required, exceptional future if failed
     ///
-    virtual future<std::optional<authenticated_user>> authenticate(session_dn_func) const;
+    virtual future<std::optional<sstring>> authenticate(session_dn_func) const;
 
     ///
     /// Create an authentication record for a new user. This is required before the user can log-in.

--- a/auth/certificate_authenticator.cc
+++ b/auth/certificate_authenticator.cc
@@ -104,9 +104,9 @@ auth::authentication_option_set auth::certificate_authenticator::alterable_optio
     return {};
 }
 
-future<std::optional<auth::authenticated_user>> auth::certificate_authenticator::authenticate(session_dn_func f) const {
+future<std::optional<sstring>> auth::certificate_authenticator::authenticate(session_dn_func f) const {
     if (auto user = utils::get_local_injector().inject_parameter("transport_early_auth_bypass")) {
-        co_return auth::authenticated_user{sstring(*user)};
+        co_return sstring(*user);
     }
     if (!f) {
         co_return std::nullopt;

--- a/auth/certificate_authenticator.hh
+++ b/auth/certificate_authenticator.hh
@@ -46,7 +46,7 @@ public:
     authentication_option_set alterable_options() const override;
 
     future<authenticated_user> authenticate(const credentials_map& credentials) const override;
-    future<std::optional<authenticated_user>> authenticate(session_dn_func) const override;
+    future<std::optional<sstring>> authenticate(session_dn_func) const override;
 
     future<> create(std::string_view role_name, const authentication_options& options, ::service::group0_batch& mc) override;
     future<> alter(std::string_view role_name, const authentication_options& options, ::service::group0_batch&) override;

--- a/auth/certificate_or_password_authenticator.cc
+++ b/auth/certificate_or_password_authenticator.cc
@@ -54,7 +54,7 @@ authentication_option_set certificate_or_password_authenticator::alterable_optio
     return _pwd_auth->alterable_options();
 }
 
-future<std::optional<authenticated_user>>
+future<std::optional<sstring>>
 certificate_or_password_authenticator::authenticate(session_dn_func f) const {
     if (!f) {
         // No TLS on this connection (e.g. plain-text port or maintenance

--- a/auth/certificate_or_password_authenticator.hh
+++ b/auth/certificate_or_password_authenticator.hh
@@ -76,10 +76,10 @@ public:
 
     // If a client certificate is present, extract the role from its subject
     // and/or ALTNAME (SAN) fields (as configured via auth_certificate_role_queries)
-    // and return the user without issuing a SASL challenge. If no client
+    // and return the role name without issuing a SASL challenge. If no client
     // certificate is present, return std::nullopt so process_startup falls
     // back to SASL (password path).
-    future<std::optional<authenticated_user>> authenticate(session_dn_func) const override;
+    future<std::optional<sstring>> authenticate(session_dn_func) const override;
 
     // Password path (SASL AUTH_RESPONSE): delegate to password_authenticator.
     future<authenticated_user> authenticate(const credentials_map&) const override;

--- a/docs/operating-scylla/security/auditing.rst
+++ b/docs/operating-scylla/security/auditing.rst
@@ -223,6 +223,13 @@ alternation ``@(a|b)``, and quantifiers ``+(…)``, ``*(…)``, ``?(…)``. For
 example, ``"prod_ks.*"`` or ``"!(system).*"`` for tables and ``"admin_*"`` for
 roles.
 
+.. note::
+
+   A login attempt that establishes no role name, such as one whose client
+   certificate was rejected, is audited with an empty user name. ``roles: ["*"]``
+   and ``roles: [""]`` match it; a rule listing only specific patterns, such as
+   ``["admin_*"]``, does not record such attempts.
+
 ``audit_rules`` is a live-updatable parameter. To apply changes at runtime, edit
 ``scylla.yaml`` and send ``SIGHUP`` to the ScyllaDB process. See
 :doc:`/reference/configuration-parameters` for details on live updates and

--- a/test/boost/audit_rule_test.cc
+++ b/test/boost/audit_rule_test.cc
@@ -262,6 +262,12 @@ BOOST_AUTO_TEST_CASE(test_matching_primitives) {
     BOOST_CHECK(!role_matches("!(guest)", "guest"));
     // Trailing backslash: incomplete escape.
     BOOST_CHECK(!role_matches("admin\\", "admin"));
+
+    BOOST_CHECK(role_matches("", ""));
+    BOOST_CHECK(role_matches("*", ""));
+    BOOST_CHECK(!role_matches("admin_*", ""));
+    BOOST_CHECK(!role_matches("?", ""));
+    BOOST_CHECK(!role_matches("", "admin"));
 }
 
 BOOST_AUTO_TEST_CASE(test_rule_matching_and_sinks) {

--- a/test/cluster/test_auth_certificate_or_password.py
+++ b/test/cluster/test_auth_certificate_or_password.py
@@ -123,45 +123,43 @@ def _gen_certs(tmp_path):
            f'-out "{tmp_path}/client3.crt" 2>/dev/null')
 
 
-async def _start_server(manager, tmp_path):
-    """Start a Scylla node with CertificateOrPasswordAuthenticator and TLS settings.
+def _server_config(tmp_path, extra_config=None):
+    """Build the node config the tests in this file share.
 
     native_transport_port_ssl adds the TLS port (9143) while keeping the default
     plain port (9042), which the test framework's manager requires since it connects
     without TLS.  All four ports (9042, 9143, 19042, 19142) must be set explicitly:
     without that, the shard-aware port (19042) inherits the encryption setting and
     becomes TLS-only, which makes the manager's plain driver hang on connection.
-    On the plain port, CertificateOrPasswordAuthenticator sees no
-    client certificate and falls back to SASL; we supply cassandra/cassandra
-    credentials via driver_connect_opts.
+
+    extra_config, when given, is merged over the defaults, so a test needing a
+    node configured differently - a different authenticator, or auditing turned
+    on - can say so without affecting the other tests in this file.
     """
-    servers = await manager.servers_add(1,
-        config={
-            'authenticator': 'CertificateOrPasswordAuthenticator',
-            'authorizer': 'CassandraAuthorizer',
-            'auth_certificate_role_queries': [
-                {'source': 'SUBJECT', 'query': 'CN=([^,]+)'},
-            ],
-            # Set explicit non-SSL and SSL ports so the driver can connect to unencrypted port.
-            # Without this, native_shard_aware_transport_port (19042) gets encrypted
-            # (np=0, nps=0, ceo=1 → encrypted), which prevents the manager's plain driver
-            # from connecting and causes servers_add to hang.
-            'native_transport_port': 9042,
-            'native_shard_aware_transport_port': 19042,
-            'native_transport_port_ssl': _TLS_PORT,
-            'native_shard_aware_transport_port_ssl': 19142,
-            'client_encryption_options': {
-                'enabled': True,
-                'certificate': 'conf/scylla.crt',
-                'keyfile': 'conf/scylla.key',
-                'truststore': f'{tmp_path}/ca.crt',
-                'require_client_auth': 'optional',
-            },
+    config = {
+        'authenticator': 'CertificateOrPasswordAuthenticator',
+        'authorizer': 'CassandraAuthorizer',
+        'auth_certificate_role_queries': [
+            {'source': 'SUBJECT', 'query': 'CN=([^,]+)'},
+        ],
+        # Set explicit non-SSL and SSL ports so the driver can connect to unencrypted port.
+        # Without this, native_shard_aware_transport_port (19042) gets encrypted
+        # (np=0, nps=0, ceo=1 → encrypted), which prevents the manager's plain driver
+        # from connecting and causes servers_add to hang.
+        'native_transport_port': 9042,
+        'native_shard_aware_transport_port': 19042,
+        'native_transport_port_ssl': _TLS_PORT,
+        'native_shard_aware_transport_port_ssl': 19142,
+        'client_encryption_options': {
+            'enabled': True,
+            'certificate': 'conf/scylla.crt',
+            'keyfile': 'conf/scylla.key',
+            'truststore': f'{tmp_path}/ca.crt',
+            'require_client_auth': 'optional',
         },
-        driver_connect_opts={
-            'auth_provider': PlainTextAuthProvider(username='cassandra', password='cassandra'),
-        })
-    return servers[0]
+    }
+    config.update(extra_config or {})
+    return config
 
 
 async def test_cql_optional_client_cert(manager: ScyllaClusterManager, tmp_path):
@@ -182,7 +180,11 @@ async def test_cql_optional_client_cert(manager: ScyllaClusterManager, tmp_path)
             and there is no fallback to password auth.
     """
     _gen_certs(tmp_path)
-    host = (await _start_server(manager, tmp_path)).ip_addr
+    servers = await manager.servers_add(1, config=_server_config(tmp_path),
+        driver_connect_opts={
+            'auth_provider': PlainTextAuthProvider(username='cassandra', password='cassandra'),
+        })
+    host = servers[0].ip_addr
 
     # Test 1: cert-bearing client authenticates via cert CN, no SASL needed.
     logger.info("Test 1: cert client should authenticate via cert CN")
@@ -291,7 +293,10 @@ async def test_cql_plain_port(manager: ScyllaClusterManager, tmp_path):
     correct credentials succeed, and incorrect credentials fail.
     """
     _gen_certs(tmp_path)
-    server = await _start_server(manager, tmp_path)
+    server = (await manager.servers_add(1, config=_server_config(tmp_path),
+        driver_connect_opts={
+            'auth_provider': PlainTextAuthProvider(username='cassandra', password='cassandra'),
+        }))[0]
 
     # Correct password authenticates successfully via SASL.
     logger.info("Correct password should succeed on the plain port")

--- a/test/cluster/test_auth_certificate_or_password.py
+++ b/test/cluster/test_auth_certificate_or_password.py
@@ -24,15 +24,22 @@ authentication succeeds or fails as expected in each case.
 """
 
 import os
+import socket
 import ssl
+import struct
 import logging
 import pytest
 
+from contextlib import asynccontextmanager
+
+from cassandra import ConsistencyLevel, InvalidRequest        # type: ignore
 from cassandra.cluster import Cluster, NoHostAvailable       # type: ignore
 from cassandra.auth import PlainTextAuthProvider             # type: ignore
 from cassandra.cluster import ExecutionProfile, EXEC_PROFILE_DEFAULT  # type: ignore
 from cassandra.policies import WhiteListRoundRobinPolicy     # type: ignore
+from cassandra.query import SimpleStatement                  # type: ignore
 
+from test.cluster.dtest.dtest_class import wait_for
 from test.pylib.scylla_cluster_manager import ScyllaClusterManager
 from test.pylib.driver_utils import safe_driver_shutdown
 
@@ -46,6 +53,62 @@ def system(cmd):
 # on 9042 because the test framework's manager connects without TLS and needs
 # a plain port to reach the server.
 _TLS_PORT = 9143
+
+
+_CQL_OPCODE_ERROR = 0x00
+_CQL_OPCODE_STARTUP = 0x01
+_CQL_FRAME_HEADER_LEN = 9
+
+
+def _cql_startup_frame(stream: int = 0) -> bytes:
+    """Build a raw protocol v4 STARTUP frame.
+
+    The driver closes the connection as soon as a login is refused, so a test
+    that has to send a second STARTUP on the same socket cannot use it.  This
+    follows the frame building in test/cqlpy/test_protocol_exceptions.py.
+    """
+    def short_string(value: str) -> bytes:
+        encoded = value.encode()
+        return struct.pack('!H', len(encoded)) + encoded
+
+    body = struct.pack('!H', 1) + short_string('CQL_VERSION') + short_string('3.0.0')
+    return (struct.pack('!B', 0x04)
+            + struct.pack('!B', 0x00)
+            + struct.pack('!H', stream)
+            + struct.pack('!B', _CQL_OPCODE_STARTUP)
+            + struct.pack('!I', len(body))
+            + body)
+
+
+def _recv_exactly(sock, count: int) -> bytes:
+    buf = b''
+    while len(buf) < count:
+        chunk = sock.recv(count - len(buf))
+        assert chunk, f'connection closed after {len(buf)} of {count} bytes'
+        buf += chunk
+    return buf
+
+
+def _recv_cql_opcode(sock) -> int:
+    """Read one whole frame off the socket and return its opcode."""
+    header = _recv_exactly(sock, _CQL_FRAME_HEADER_LEN)
+    opcode = header[4]
+    (body_len,) = struct.unpack('!I', header[5:9])
+    _recv_exactly(sock, body_len)
+    return opcode
+
+
+def _tls_socket(host: str, port: int, certfile: str, keyfile: str):
+    """A raw TLS socket presenting a client certificate.
+
+    The server's certificate is not verified: these tests generate their own CA
+    and are only interested in what the server does with the client's.
+    """
+    context = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+    context.check_hostname = False
+    context.verify_mode = ssl.CERT_NONE
+    context.load_cert_chain(certfile=certfile, keyfile=keyfile)
+    return context.wrap_socket(socket.create_connection((host, port), timeout=30))
 
 
 def _make_tls_cluster(host: str, port: int,
@@ -81,11 +144,15 @@ def _make_tls_cluster(host: str, port: int,
 
 
 def _gen_certs(tmp_path):
-    """Generate a self-signed CA and a client certificate with CN=cassandra.
+    """Generate a self-signed CA and the client certificates the tests connect with.
 
-    Also generates a second CA (ca2) that is *not* trusted by the server, and
-    a client certificate signed by it (client2.crt / client2.key).  Used to
-    simulate a client presenting an untrusted certificate.
+    client.crt   trusted, CN=cassandra - the happy path.
+    client2.crt  signed by a second CA (ca2) that the server does *not* trust,
+                 to simulate a client presenting an untrusted certificate.
+    client3.crt  trusted, but its subject has no CN, so the role query cannot
+                 extract a role name from it.
+    client4.crt  trusted, CN=certuser - a role that exists and may log in.
+    client5.crt  trusted, CN=certghost - a role that is never created.
     """
     system(f'openssl genrsa 2048 > "{tmp_path}/ca.key" 2>/dev/null')
     system(f'openssl req -new -x509 -nodes -sha256 -days 365 '
@@ -121,6 +188,22 @@ def _gen_certs(tmp_path):
            f'-in "{tmp_path}/client3.csr" '
            f'-CA "{tmp_path}/ca.crt" -CAkey "{tmp_path}/ca.key" -CAcreateserial '
            f'-out "{tmp_path}/client3.crt" 2>/dev/null')
+
+    system(f'openssl genrsa 2048 > "{tmp_path}/client4.key" 2>/dev/null')
+    system(f'openssl req -new -sha256 -subj "/CN=certuser" '
+           f'-key "{tmp_path}/client4.key" -out "{tmp_path}/client4.csr" 2>/dev/null')
+    system(f'openssl x509 -req -sha256 -days 365 '
+           f'-in "{tmp_path}/client4.csr" '
+           f'-CA "{tmp_path}/ca.crt" -CAkey "{tmp_path}/ca.key" -CAcreateserial '
+           f'-out "{tmp_path}/client4.crt" 2>/dev/null')
+
+    system(f'openssl genrsa 2048 > "{tmp_path}/client5.key" 2>/dev/null')
+    system(f'openssl req -new -sha256 -subj "/CN=certghost" '
+           f'-key "{tmp_path}/client5.key" -out "{tmp_path}/client5.csr" 2>/dev/null')
+    system(f'openssl x509 -req -sha256 -days 365 '
+           f'-in "{tmp_path}/client5.csr" '
+           f'-CA "{tmp_path}/ca.crt" -CAkey "{tmp_path}/ca.key" -CAcreateserial '
+           f'-out "{tmp_path}/client5.crt" 2>/dev/null')
 
 
 def _server_config(tmp_path, extra_config=None):
@@ -315,3 +398,233 @@ async def test_cql_plain_port(manager: ScyllaClusterManager, tmp_path):
     error_texts = [str(e) for e in exc_info.value.errors.values()]
     assert any('Bad credentials' in t for t in error_texts), \
         f"Expected a CQL authentication failure, got: {error_texts}"
+
+
+@asynccontextmanager
+async def _audit_login_node(manager, tmp_path):
+    """A node auditing AUTH, yielding its address and an admin session.
+
+    audit_categories is narrowed to AUTH so the DCL rows for the CREATE ROLE
+    statements below stay out of audit.audit_log.
+    """
+    _gen_certs(tmp_path)
+    server = (await manager.servers_add(1,
+        config=_server_config(tmp_path, extra_config={
+            'audit': 'table',
+            'audit_categories': 'AUTH',
+        }),
+        driver_connect_opts={
+            'auth_provider': PlainTextAuthProvider(username='cassandra', password='cassandra'),
+        }))[0]
+    admin = await manager.get_cql_exclusive(
+        server, auth_provider=PlainTextAuthProvider(username='cassandra', password='cassandra'))
+    admin.execute("CREATE ROLE certuser WITH LOGIN = true")
+    admin.execute("CREATE ROLE pwduser WITH PASSWORD = 'pwduser' AND LOGIN = true")
+    yield server.ip_addr, admin
+
+
+def _login_records(session):
+    """The AUTH/LOGIN records in the audit log."""
+    try:
+        rows = session.execute(SimpleStatement('SELECT * FROM audit.audit_log',
+                                               consistency_level=ConsistencyLevel.ONE))
+    except InvalidRequest:
+        return []
+    return [r for r in rows if r.category == 'AUTH' and r.operation == 'LOGIN']
+
+
+def _await_login_record(admin, host, username, error, description):
+    """Wait for an AUTH/LOGIN record for username, and check the columns it shares.
+
+    Matched by presence, not by count: a driver opens more than one connection per
+    cluster, so one logical login can legitimately produce several rows.
+    """
+    found = []
+
+    def appeared():
+        nonlocal found
+        found = [r for r in _login_records(admin)
+                 if r.username == username and r.error == error]
+        return bool(found)
+
+    wait_for(appeared, timeout=60, text=f'audit login record for {description}')
+    for row in found:
+        assert row.node == host
+        assert row.source
+        assert row.keyspace_name == ''
+        assert row.table_name == ''
+    return found
+
+
+def _attempt_cert_login(host, tmp_path, cert, refused):
+    """Open a TLS connection presenting cert, expecting it to be accepted or refused."""
+    cluster = _make_tls_cluster(host, _TLS_PORT,
+                                certfile=f'{tmp_path}/{cert}.crt',
+                                keyfile=f'{tmp_path}/{cert}.key')
+    try:
+        if refused:
+            with pytest.raises(NoHostAvailable):
+                cluster.connect()
+        else:
+            cluster.connect()
+    finally:
+        safe_driver_shutdown(cluster)
+
+
+async def test_audit_accepted_certificate_login(manager: ScyllaClusterManager, tmp_path):
+    """An accepted certificate login is audited under the role it names (SCYLLADB-3926)."""
+    async with _audit_login_node(manager, tmp_path) as (host, admin):
+        assert not [r for r in _login_records(admin) if r.username == 'certuser'], \
+            'certuser login records exist before certuser has connected'
+        _attempt_cert_login(host, tmp_path, 'client4', refused=False)
+        _await_login_record(admin, host, 'certuser', error=False,
+                            description='certuser certificate login')
+
+
+async def test_audit_rejected_certificate_login(manager: ScyllaClusterManager, tmp_path):
+    """A certificate the role query cannot match is audited under an empty name (SCYLLADB-3926)."""
+    async with _audit_login_node(manager, tmp_path) as (host, admin):
+        assert not [r for r in _login_records(admin) if r.username == '' and r.error], \
+            'an identity-less login failure was recorded before one was attempted'
+        _attempt_cert_login(host, tmp_path, 'client3', refused=True)
+        _await_login_record(admin, host, '', error=True, description='rejected certificate')
+
+
+async def test_audit_certificate_for_missing_role(manager: ScyllaClusterManager, tmp_path):
+    """A certificate naming a role that does not exist is audited as an error (SCYLLADB-3926).
+
+    authenticate() resolves a name from the certificate without checking that the
+    role exists, so the record has to state the outcome of the whole login.
+    """
+    async with _audit_login_node(manager, tmp_path) as (host, admin):
+        assert not [r for r in _login_records(admin) if r.username == 'certghost'], \
+            'certghost login records exist before certghost has connected'
+        _attempt_cert_login(host, tmp_path, 'client5', refused=True)
+        _await_login_record(admin, host, 'certghost', error=True,
+                            description='certghost refused login')
+        assert not [r for r in _login_records(admin)
+                    if r.username == 'certghost' and not r.error], \
+            'a refused certificate login must not also produce a success record'
+
+
+async def test_audit_password_login_on_tls_port(manager: ScyllaClusterManager, tmp_path):
+    """A password login on the TLS port keeps producing its SASL-path record (SCYLLADB-3926)."""
+    async with _audit_login_node(manager, tmp_path) as (host, admin):
+        cluster = _make_tls_cluster(
+            host, _TLS_PORT,
+            auth_provider=PlainTextAuthProvider(username='pwduser', password='pwduser'))
+        try:
+            cluster.connect()
+        finally:
+            safe_driver_shutdown(cluster)
+        _await_login_record(admin, host, 'pwduser', error=False,
+                            description='pwduser password login')
+
+
+@asynccontextmanager
+async def _certificate_authenticator_node(manager, tmp_path):
+    """A CertificateAuthenticator node, yielding its address and an admin session.
+
+    CertificateOrPasswordAuthenticator falls back to SASL rather than refusing, so
+    a test for a refused login needs this authenticator instead.  The manager's own
+    driver cannot log into it on the plain port, hence connect_driver=False and an
+    admin connection over TLS retried until the listener answers.
+    """
+    _gen_certs(tmp_path)
+    server = await manager.server_add(
+        config=_server_config(tmp_path, extra_config={
+            'authenticator': 'CertificateAuthenticator',
+            'audit': 'table',
+            'audit_categories': 'AUTH',
+        }),
+        connect_driver=False)
+
+    def connect_admin():
+        cluster = _make_tls_cluster(
+            server.ip_addr, _TLS_PORT,
+            certfile=f'{tmp_path}/client.crt',
+            keyfile=f'{tmp_path}/client.key',
+        )
+        try:
+            return cluster, cluster.connect()
+        except NoHostAvailable:
+            safe_driver_shutdown(cluster)
+            return None
+
+    admin_cluster, admin = wait_for(connect_admin, timeout=60,
+                                    text='the TLS port to accept a certificate login')
+    try:
+        yield server.ip_addr, admin
+    finally:
+        safe_driver_shutdown(admin_cluster)
+
+
+def _refused_login_records(session):
+    """Audit records for a login refused before any role name existed."""
+    return [r for r in _login_records(session) if r.username == '' and r.error]
+
+
+async def test_audit_login_without_certificate(manager: ScyllaClusterManager, tmp_path):
+    """A client presenting no certificate at all must be audited (SCYLLADB-3926).
+
+    Such a login is refused before any name exists, so it is recorded under an
+    empty user name: the client address and the node are what the attempt has to
+    say for itself.
+    """
+    async with _certificate_authenticator_node(manager, tmp_path) as (host, admin):
+        assert not _refused_login_records(admin), \
+            'an identity-less login failure was recorded before one was attempted'
+
+        cluster_no_cert = _make_tls_cluster(host, _TLS_PORT)
+        try:
+            with pytest.raises(NoHostAvailable):
+                cluster_no_cert.connect()
+        finally:
+            safe_driver_shutdown(cluster_no_cert)
+
+        found = []
+
+        def appeared():
+            nonlocal found
+            found = _refused_login_records(admin)
+            return bool(found)
+
+        wait_for(appeared, timeout=60, text='audit login record for a certificate-less client')
+        for row in found:
+            assert row.node == host
+            assert row.source
+            assert row.keyspace_name == ''
+            assert row.table_name == ''
+
+
+async def test_audit_repeated_refused_startup(manager: ScyllaClusterManager, tmp_path):
+    """Every rejected STARTUP on one connection must be audited (SCYLLADB-3926).
+
+    A refused STARTUP is answered with an ERROR but leaves the connection in
+    UNINITIALIZED, which accepts STARTUP again, so one socket can repeat the
+    attempt.  The driver closes as soon as a login is refused and cannot send the
+    second one, which is why this test - alone in this file - speaks CQL frames
+    directly.
+    """
+    async with _certificate_authenticator_node(manager, tmp_path) as (host, admin):
+        assert not _refused_login_records(admin), \
+            'an identity-less login failure was recorded before one was attempted'
+
+        sock = _tls_socket(host, _TLS_PORT,
+                           certfile=f'{tmp_path}/client3.crt',
+                           keyfile=f'{tmp_path}/client3.key')
+        try:
+            for attempt in range(2):
+                sock.sendall(_cql_startup_frame(stream=attempt))
+                opcode = _recv_cql_opcode(sock)
+                assert opcode == _CQL_OPCODE_ERROR, \
+                    f'attempt {attempt} answered with opcode {opcode:#x}, expected ERROR'
+        finally:
+            sock.close()
+
+        def both_appeared():
+            return len(_refused_login_records(admin)) >= 2
+
+        wait_for(both_appeared, timeout=60, text='an audit record for each rejected STARTUP')
+        assert len(_refused_login_records(admin)) == 2, \
+            'two rejected STARTUPs produced more than two audit records'

--- a/transport/server.cc
+++ b/transport/server.cc
@@ -1498,9 +1498,9 @@ future<std::unique_ptr<cql_server::response>> cql_server::connection::process_st
                 co_return std::nullopt;
             };
         }
-        auto opt_user = co_await a.authenticate(std::move(dn_func));
-        if (opt_user) {
-            client_state.set_login(std::move(*opt_user));
+        auto role_name = co_await a.authenticate(std::move(dn_func));
+        if (role_name) {
+            client_state.set_login(auth::authenticated_user(*role_name));
             co_await client_state.check_user_can_login();
             client_state.maybe_update_per_service_level_params();
             update_scheduling_group();

--- a/transport/server.cc
+++ b/transport/server.cc
@@ -1498,10 +1498,22 @@ future<std::unique_ptr<cql_server::response>> cql_server::connection::process_st
                 co_return std::nullopt;
             };
         }
-        auto role_name = co_await a.authenticate(std::move(dn_func));
+        auto auth_fut = co_await coroutine::as_future(a.authenticate(std::move(dn_func)));
+        if (auth_fut.failed()) {
+            auto ex = auth_fut.get_exception();
+            co_await audit::inspect_login(sstring(), client_state.get_client_address().addr(), true);
+            co_return coroutine::exception(std::move(ex));
+        }
+        auto role_name = auth_fut.get();
         if (role_name) {
             client_state.set_login(auth::authenticated_user(*role_name));
-            co_await client_state.check_user_can_login();
+            auto login_fut = co_await coroutine::as_future(client_state.check_user_can_login());
+            if (login_fut.failed()) {
+                auto login_ex = login_fut.get_exception();
+                co_await audit::inspect_login(*role_name, client_state.get_client_address().addr(), true);
+                co_return coroutine::exception(std::move(login_ex));
+            }
+            co_await audit::inspect_login(*role_name, client_state.get_client_address().addr(), false);
             client_state.maybe_update_per_service_level_params();
             update_scheduling_group();
             _authenticating = false;


### PR DESCRIPTION
Before this patch series audit::inspect_login() was called only from the SASL branch
in process_auth_response(), so a client that authenticates with a TLS client
certificate leaves no AUTH/LOGIN record at all - neither when the certificate is
accepted nor when it is rejected. Certificate authentication happens earlier, in
process_startup(), which never audited anything.

Audit both outcomes there, under the role name the certificate names, whether or not
that role exists. A rejected certificate names no role, and neither does a client
that presented none, so those records carry an empty user name; the certificate
subject is deliberately not put there, since any string can be a role name and a
subject in that column would be indistinguishable from a role named that. Rules match
role patterns against the user name, so an AUTH rule listing specific patterns records
none of those attempts - the roles field description now says what an empty name
matches.

Fixes: SCYLLADB-3926
Backport: no backport, a minor bugfix