### PR TITLE
test: Check that the API server's swagger docs are usable

### DIFF
--- a/test/cqlpy/run.py
+++ b/test/cqlpy/run.py
@@ -272,6 +272,11 @@ def run_scylla_cmd(pid, dir):
     }
     return ([scylla_link,
         '--options-file',  source_path + '/conf/scylla.yaml',
+        # api_doc_dir defaults to a path relative to the current directory,
+        # which is wherever this script happened to be started from, so spell
+        # it out - the same way install.sh points it at the installed copy.
+        # Without it every /api-doc record the server advertises is unusable.
+        '--api-doc-dir', source_path + '/api/api-doc/',
         '--developer-mode', '1',
         '--ring-delay-ms', '0',
         '--collectd', '0',

--- a/test/pylib/scylla_server.py
+++ b/test/pylib/scylla_server.py
@@ -365,9 +365,14 @@ class ScyllaServer:
 
         # The basic server configuration (the workdir and the maintenance
         # socket are the server's own) topped by the caller-assembled options.
+        # api_doc_dir defaults to a path relative to the current directory,
+        # which is the server's workdir here, so point it at the source tree -
+        # the same way install.sh points it at the installed copy. Without it
+        # every /api-doc record the server advertises is unusable.
         self.config = {
             'workdir': str(self.workdir.resolve()),
             'maintenance_socket': self.maintenance_socket_path,
+            'api_doc_dir': f"{TOP_SRC_DIR / 'api/api-doc'}/",
         } | config_options
         self.property_file = property_file
         self.append_env = append_env

--- a/test/rest_api/test_api_doc.py
+++ b/test/rest_api/test_api_doc.py
@@ -1,0 +1,58 @@
+# Copyright 2026-present ScyllaDB
+#
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
+
+import json
+
+
+def get_json(rest_api, path):
+    resp = rest_api.send("GET", path)
+    resp.raise_for_status()
+    # Reading the body is the part that matters here. The api-doc records are
+    # served by a file_handler that streams the file only after the 200 status
+    # line and the headers have been sent, so a missing file does not turn into
+    # an error status - the connection is just closed mid-body. requests
+    # reports that as a ChunkedEncodingError while reading .content.
+    return json.loads(resp.content)
+
+
+def test_api_doc_index(rest_api):
+    """The /api-doc index itself must be valid JSON in the swagger 1.2 shape."""
+    doc = get_json(rest_api, "api-doc")
+    assert doc["swaggerVersion"] == "1.2"
+    assert doc["apis"], "the /api-doc index lists no APIs"
+    for api in doc["apis"]:
+        assert api["path"].startswith("/"), f"malformed api-doc record {api}"
+        assert api["description"], f"api-doc record without description {api}"
+
+
+def test_api_doc_records_resolve(rest_api):
+    """Every record advertised by /api-doc must resolve to a valid swagger file.
+
+    Registering an API module (api_registry::reg(), reached via
+    api_registry_builder::register_function()) does two things at once: it adds
+    a {path, description} record to the /api-doc index and it routes
+    /api-doc/<name> to <api_doc_dir>/<name>.json. Nothing checks that the file
+    is actually there, and when it isn't the server answers 200 and truncates
+    the body, without even a log message. Walk the index the way a swagger
+    client would, so that a module registered without its .json file is caught.
+    """
+    index = get_json(rest_api, "api-doc")
+    broken = {}
+    for api in index["apis"]:
+        path = api["path"]
+        try:
+            doc = get_json(rest_api, "api-doc" + path)
+            assert doc["swaggerVersion"] == "1.2", f"unexpected swaggerVersion {doc.get('swaggerVersion')}"
+            assert "apis" in doc, "no 'apis' section"
+        except Exception as e:
+            broken[path] = f"{type(e).__name__}: {e}"
+    assert not broken, f"unusable /api-doc records: {broken}"
+
+
+def test_api_doc_v2(rest_api):
+    """The v2 doc is concatenated from several files, so it is easy to break."""
+    doc = get_json(rest_api, "v2")
+    assert doc["swagger"] == "2.0"
+    assert doc["paths"], "the v2 swagger doc lists no paths"
+    assert doc["definitions"], "the v2 swagger doc lists no definitions"


### PR DESCRIPTION
Registering an API module adds a record to the /api-doc index and routes /api-doc/<name> to the module's .json file in one and the same call, so it is easy to register a module whose file does not exist. Nothing notices when that happens: the doc handler sends the 200 and the headers before it opens the file, so a missing file cannot turn into an error status - the server answers 200 and then closes the connection mid-body, without even a log line. A dangling record is therefore invisible to anything short of actually fetching it, and spotting one costs a careful reviewer.

Walk the index the way a swagger client would and fetch every record it advertises. Cover /v2 separately - it is served by a different registry, is not reachable from the /api-doc index at all, and is concatenated from several files, so any one of them going missing truncates the whole document.

Servers started by the test harness could not answer any of this, because api_doc_dir defaults to a path relative to the current directory, which is the server's own workdir here. Point it at the source tree, the way install.sh points it at the installed copy.

New test, not backporting