### PR TITLE
test.py: fix coverage mode

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -124,23 +124,6 @@ else()
         set(BUILD_SHARED_LIBS OFF CACHE BOOL "" FORCE)
     endif()
     add_subdirectory(seastar)
-
-    # Coverage mode sets cmake_build_type='Debug' for Seastar
-    # (configure.py:515), so Seastar's pkg-config output includes sanitizer
-    # link flags in seastar_libs_coverage (configure.py:2514,2649).
-    # Seastar's own CMake only activates sanitizer targets for Debug/Sanitize
-    # configs, so we inject link options on the seastar target for Coverage.
-    # Using PUBLIC ensures they propagate to all targets linking Seastar
-    # (but not standalone tools like patchelf), matching configure.py's
-    # behavior.  Compile-time flags and defines are handled globally in
-    # cmake/mode.Coverage.cmake.
-    if(CMAKE_BUILD_TYPE STREQUAL "Coverage")
-        target_link_options(seastar
-            PUBLIC
-                -fsanitize=address
-                -fsanitize=undefined
-                -fsanitize=vptr)
-    endif()
 endif()
 
 set(ABSL_PROPAGATE_CXX_STD ON CACHE BOOL "" FORCE)

--- a/cmake/mode.Coverage.cmake
+++ b/cmake/mode.Coverage.cmake
@@ -10,10 +10,10 @@ update_build_flags(Coverage
 set(scylla_build_mode_Coverage "coverage")
 
 # Coverage mode sets cmake_build_type='Debug' for Seastar
-# (configure.py:515), so Seastar's pkg-config --cflags output
-# (configure.py:2252-2267, queried at configure.py:3039) includes debug
-# defines, sanitizer compile flags, and -fstack-clash-protection.
-# Seastar's CMake generator expressions only activate these for
+# (configure.py:515) with Seastar_SANITIZE=OFF, so Seastar's pkg-config
+# --cflags output (configure.py:2252-2267, queried at configure.py:3039)
+# includes debug defines and -fstack-clash-protection, but no sanitizer
+# flags.  Seastar's CMake generator expressions only activate these for
 # Debug/Sanitize configs, so we add them explicitly for Coverage.
 set(Seastar_DEFINITIONS_COVERAGE
   SCYLLA_BUILD_MODE=${scylla_build_mode_Coverage}
@@ -22,16 +22,14 @@ set(Seastar_DEFINITIONS_COVERAGE
   SEASTAR_SHUFFLE_TASK_QUEUE
   SEASTAR_DEBUG_SHARED_PTR
   SEASTAR_DEBUG_PROMISE
-  SEASTAR_TYPE_ERASE_MORE)
+  SEASTAR_TYPE_ERASE_MORE
+  SCYLLA_ENABLE_ERROR_INJECTION)
 foreach(definition ${Seastar_DEFINITIONS_COVERAGE})
   add_compile_definitions(
     $<$<CONFIG:Coverage>:${definition}>)
 endforeach()
 
 add_compile_options(
-  $<$<CONFIG:Coverage>:-fsanitize=address>
-  $<$<CONFIG:Coverage>:-fsanitize=undefined>
-  $<$<CONFIG:Coverage>:-fsanitize=vptr>
   $<$<CONFIG:Coverage>:-fstack-clash-protection>)
 
 set(CMAKE_EXE_LINKER_FLAGS_COVERAGE

--- a/configure.py
+++ b/configure.py
@@ -505,7 +505,7 @@ modes = {
         'advanced_optimizations': False,
     },
     'coverage': {
-        'cxxflags': '-fprofile-instr-generate -fcoverage-mapping -g -gz',
+        'cxxflags': '-DSCYLLA_ENABLE_ERROR_INJECTION -fprofile-instr-generate -fcoverage-mapping -g -gz',
         'cxx_ld_flags': '-fprofile-instr-generate -fcoverage-mapping',
         'stack-usage-threshold': 1024*40,
         'optimization-level': 'g',
@@ -2254,6 +2254,12 @@ def configure_seastar(build_dir, mode, mode_config, compiler_cache=None):
         seastar_cmake_args += ['-DSeastar_DEBUG_ALLOCATIONS=ON']
     if mode_config['build_seastar_shared_libs']:
         seastar_cmake_args += ['-DBUILD_SHARED_LIBS=ON']
+
+    # The coverage mode uses cmake_build_type='Debug', which by default enables sanitizers
+    # in Seastar. Since coverage mode doesn't link against sanitizer runtime libraries,
+    # we must explicitly disable them to avoid linker errors for __asan_* / __ubsan_* symbols.
+    if '-DSANITIZE' not in mode_config['cxxflags']:
+        seastar_cmake_args += ['-DSeastar_SANITIZE=OFF']
 
     cmake_args = seastar_cmake_args[:]
     seastar_cmd = ['cmake', '-G', 'Ninja', real_relpath(args.seastar_path, seastar_build_dir)] + cmake_args

--- a/scripts/coverage.py
+++ b/scripts/coverage.py
@@ -130,8 +130,8 @@ def generate_coverage_report(path="testlog/coverage/coverage", build_path="build
         profraw_files = []
         # Cluster-based suites (topology, cql, alternator, ...) exercise the
         # scylla server binary itself rather than a per-suite binary under
-        # build_path, and name their raw profiles after the LLVM %m pool
-        # token (see runner.py:create_cluster_factory), not a test name.
+        # build_path, and name their raw profiles after LLVM_PROFILE_FILE's
+        # "%m" placeholder (a value unique to the binary), not a test name.
         scylla_exe = os.path.join(os.path.dirname(os.path.normpath(build_path)), "scylla")
         # Walk the raw-profile tree itself (one subdirectory per suite that
         # actually ran), not build_path: a suite with no dedicated binary
@@ -169,7 +169,11 @@ def generate_coverage_report(path="testlog/coverage/coverage", build_path="build
         maybe_print(f"Found {len(profraw_files)} input files")
 
     if not profraw_files:
-        sys.exit("Error: couldn't find any raw profiling data files, can't generate coverage report")
+        # Not a fatal error: test.py calls this in-process after every
+        # coverage-mode run, and a run may legitimately produce no raw
+        # profiles (e.g. only cluster-based suites ran without --coverage).
+        print("Warning: couldn't find any raw profiling data files, skipping coverage report generation")
+        return
 
     test_executables = list(dict.fromkeys(test_executables))  # de-dup, preserve order
 

--- a/scripts/coverage.py
+++ b/scripts/coverage.py
@@ -67,32 +67,35 @@ def run(args, executable=None, distinct_id=None):
         pass # allow process to be shut down with ^C
 
 
-def generate_coverage_report(path="build/coverage/test", name="tests", input_files=None, verbose=0):
+def generate_coverage_report(path="testlog/coverage/coverage", build_path="build/coverage/test", name="tests", input_files=None, verbose=0):
     """Generate a html coverage report from the given profiling data
 
     Arguments:
-    * PATH - path to the directory where the raw profiling output as well as
-      the test executables producing them can be found. Raw profiling output will
-      be automatically picked up and merged to provide the combined output.
-      Profiling output files are expected to have names that matches that of the
-      test executable that generated them, plus the compiler specific extension.
-      E.g. for clang and a test executable named 'querier_cache_test', the
-      matching profiling output should be 'querier_cache_test.profraw'.
-      For clang, this can be achieved by setting the LLVM_PROFILE_FILE env
-      variable to the appropriate value when running the test. This is
-      automatically done by test.py.
-      The PATH is typically 'build/coverage/test' when the script is ran from
-      the scylla repository root.
+    * PATH - path to the directory where test.py collects raw profiling
+      output for a test run, and where the merged output (profdata, lcov and
+      html report) will be written. This mirrors the layout test.py already
+      uses for a Scylla cluster's own coverage
+      (`<tmpdir>/<mode>/coverage/<suite>/`): raw profiles for the unit-test
+      suites under BUILD_PATH are expected at PATH/<suite>/*.profraw.
+    * BUILD_PATH - path to the directory containing the test executables, one
+      subdirectory per suite (e.g. 'boost', 'raft', 'ldap', 'unit'). Used only
+      by the automatic search (see INPUT_FILES below) to enumerate suites and
+      map a raw profile back to the executable that produced it.
+      The BUILD_PATH is typically 'build/coverage/test' when the script is
+      ran from the scylla repository root.
     * NAME - the name of the generated report. This will be the name of the
       directory containing the generated html report, as well as the name of any
       intermediate files generated in the process (with the appropriate
       extensions).
     * INPUT_FILES (optional) - the list of raw profiling data to generate the
       report from. When provided, this overrides the automatic search for
-      profiling data found in PATH and the profiling report will only include
-      the files provided herein.
+      profiling data found under PATH/BUILD_PATH and the profiling report
+      will only include the files provided herein. Each input file's
+      executable is inferred from its own name, matching the raw profiling
+      data's name minus its extension (e.g. 'querier_cache_test.profraw' next
+      to executable 'querier_cache_test').
       If not provided, the input files are located with the automatic search
-      described in PATH instead.
+      described above instead.
       Note that even if provided, PATH is still used to store intermediate
       files, as well as the final result.
     * VERBOSE (optional) - set verbosity level:
@@ -123,19 +126,54 @@ def generate_coverage_report(path="build/coverage/test", name="tests", input_fil
 
             test_executables.append(os.path.join(dirname, match.group(1)))
     else:
-        maybe_print(f"Scanning {path} for input files matching {input_file_re_str}")
+        maybe_print(f"Scanning {path} for input files matching {input_file_re_str}, using executables from {build_path}")
         profraw_files = []
-        for root, dirs, files in os.walk(path):
-            for file in files:
-                match = re.fullmatch(input_file_re, file)
-                if match is not None:
+        # Cluster-based suites (topology, cql, alternator, ...) exercise the
+        # scylla server binary itself rather than a per-suite binary under
+        # build_path, and name their raw profiles after the LLVM %m pool
+        # token (see runner.py:create_cluster_factory), not a test name.
+        scylla_exe = os.path.join(os.path.dirname(os.path.normpath(build_path)), "scylla")
+        # Walk the raw-profile tree itself (one subdirectory per suite that
+        # actually ran), not build_path: a suite with no dedicated binary
+        # directory there (e.g. cql, cqlpy, alternator, cluster, rest_api)
+        # would otherwise be skipped entirely, silently dropping most of the
+        # project's coverage.
+        suite_dirs = sorted(os.scandir(path), key=lambda e: e.name) if os.path.isdir(path) else []
+        for suite_dir in suite_dirs:
+            if not suite_dir.is_dir():
+                continue
+            build_suite_dir = os.path.join(build_path, suite_dir.name)
+            for root, dirs, files in os.walk(suite_dir.path):
+                for file in files:
+                    match = re.fullmatch(input_file_re, file)
+                    if match is None:
+                        continue
                     profraw_files.append(os.path.join(root, file))
-                    test_executables.append(os.path.join(root, match.group(1)))
+                    if os.path.isdir(build_suite_dir):
+                        # unit-test raw profiles are named
+                        # `<test_name>.<case>.<run_id>.profraw` (see
+                        # test/pylib/cpp/base.py); the executable lives under
+                        # build_path, not next to the profile itself. Some
+                        # boost tests have no binary of their own and are
+                        # built into a suite-wide `combined_tests` executable
+                        # instead (see COMBINED_TESTS in
+                        # test/pylib/cpp/boost.py), so fall back to that when
+                        # <test_name> doesn't exist as its own executable.
+                        test_name = match.group(1).split(".")[0]
+                        exe_path = os.path.join(build_suite_dir, test_name)
+                        if not os.path.isfile(exe_path):
+                            exe_path = os.path.join(build_suite_dir, "combined_tests")
+                    else:
+                        exe_path = scylla_exe
+                    test_executables.append(exe_path)
         maybe_print(f"Found {len(profraw_files)} input files")
 
     if not profraw_files:
         sys.exit("Error: couldn't find any raw profiling data files, can't generate coverage report")
 
+    test_executables = list(dict.fromkeys(test_executables))  # de-dup, preserve order
+
+    os.makedirs(path, exist_ok=True)
     profdata_path = os.path.join(path, f"{name}.profdata")
 
     maybe_print(f"Merging raw profiling data {profraw_files}")
@@ -159,7 +197,11 @@ def generate_coverage_report(path="build/coverage/test", name="tests", input_fil
         genhtml_cmd = ["genhtml"]
     else:
         genhtml_cmd = ["genhtml", "-q"]
-    subprocess.check_call(genhtml_cmd + ["-o", html_report_path, info_path])
+    # Coverage data merged across independently-built subprojects (e.g. abseil,
+    # built as its own CMake subproject) can reference source paths genhtml
+    # can't resolve from this checkout; skip annotating those instead of
+    # failing the whole report.
+    subprocess.check_call(genhtml_cmd + ["--ignore-errors", "source", "--synthesize-missing", "-o", html_report_path, info_path])
 
     print(f"Coverage report written to {html_report_path}, url: file://{html_report_url}")
 
@@ -201,7 +243,8 @@ def main(argv):
     arg_parser = argparse.ArgumentParser(description=inspect.getdoc(generate_coverage_report), formatter_class=argparse.RawDescriptionHelpFormatter,
             epilog=inspect.getdoc(main))
 
-    arg_parser.add_argument("--path", dest="path", action="store", type=str, required=False, default="build/coverage/test", help="defaults to 'build/coverage/test'")
+    arg_parser.add_argument("--path", dest="path", action="store", type=str, required=False, default="testlog/coverage/coverage", help="defaults to 'testlog/coverage/coverage'")
+    arg_parser.add_argument("--build-path", dest="build_path", action="store", type=str, required=False, default="build/coverage/test", help="defaults to 'build/coverage/test'; only used for the automatic search (no --run/--input-files)")
     arg_parser.add_argument("--name", dest="name", action="store", type=Value, required=False, default=Value("tests", is_default=True), help="defaults to 'tests', with --run it defaults to the name of the provided executable")
     arg_parser.add_argument("--input-files", dest="input_files", nargs='+', action="extend", type=str, required=False)
     arg_parser.add_argument("--verbose", "-v", dest="verbose", action="count", required=False, default=0, help="defaults to not verbose")
@@ -224,8 +267,8 @@ def main(argv):
 
     args = arg_parser.parse_args(argv_head)
 
-    if not os.path.isdir(args.path):
-        arg_parser.exit(2, f"Error: invalid value for `--path`: path '{args.path}' doesn't exists or is not a directory\n")
+    if os.path.exists(args.path) and not os.path.isdir(args.path):
+        arg_parser.exit(2, f"Error: invalid value for `--path`: '{args.path}' exists and is not a directory\n")
 
     if args.run:
         run(argv_tail, args.executable, args.distinct_id)
@@ -244,7 +287,7 @@ def main(argv):
         else:
             print("Ignoring --no-coverage-report as --run was not provided")
 
-    generate_coverage_report(args.path, args.name.val, input_files, args.verbose)
+    generate_coverage_report(args.path, args.build_path, args.name.val, input_files, args.verbose)
 
 
 if __name__ == "__main__":

--- a/test.py
+++ b/test.py
@@ -233,13 +233,9 @@ def parse_cmd_line() -> argparse.Namespace:
 
     if not args.coverage_modes and args.coverage:
         args.coverage_modes = list(args.modes)
-        if "coverage" in args.coverage_modes:
-            args.coverage_modes.remove("coverage")
         if not args.coverage_modes:
             args.coverage = False
     elif args.coverage_modes:
-        if "coverage" in args.coverage_modes:
-            raise RuntimeError("'coverage' mode is not allowed in --coverage-mode")
         missing_coverage_modes = set(args.coverage_modes).difference(set(args.modes))
         if len(missing_coverage_modes) > 0:
             raise RuntimeError(f"The following modes weren't built or ran (using the '--mode' option): {missing_coverage_modes}")
@@ -358,6 +354,9 @@ def run_pytest(options: argparse.Namespace) -> int:
         args.append(f'--random-seed={options.random_seed}')
     if options.gather_metrics:
         args.append('--gather-metrics')
+    if options.coverage:
+        args.append('--coverage')
+        args.extend(f'--coverage-mode={mode}' for mode in options.coverage_modes)
     if options.artifacts_dir_url:
         args.append(f'--artifacts_dir_url={options.artifacts_dir_url}')
     if options.timeout:
@@ -418,7 +417,10 @@ async def main() -> int:
                            "the test markers if you used the '--markers' option."
                            "Alternatively you can check with --list option if there any errors."))
     if 'coverage' in options.modes:
-        coverage.generate_coverage_report(path_to("coverage", "tests"))
+        coverage.generate_coverage_report(
+            str(coverage_utils.coverage_dir(pathlib.Path(options.tmpdir) / "coverage")),
+            path_to("coverage", "test"),
+        )
 
     if options.coverage:
         await process_coverage(options)
@@ -445,13 +447,18 @@ async def process_coverage(options):
                                                                logger = logger)
     logger.debug(f"Binary ids map is: {files_to_ids_map}")
     logger.info("Done getting binary ids for coverage conversion")
-    # get the suits that have actually been ran
-    suits_to_exclude = ["pylib_test", "dist_test", "nodetool"]
     sources_to_exclude = [line for line in open("coverage_excludes.txt", 'r').read().split('\n') if line and not line.startswith('#')]
-    ran_suites = list({test.suite for test in TestSuite.all_tests() if test.suite.need_coverage()})
 
-    def suite_coverage_path(suite) -> pathlib.Path:
-        return pathlib.Path(suite.options.tmpdir) / suite.mode / 'coverage' / suite.name
+    # The retired TestSuite registry used to hand out the suites that ran; the
+    # pytest runner instead writes per-suite raw profiles to
+    # `<tmpdir>/<mode>/coverage/<suite>/*.profraw`, so discover them from disk.
+    ran_suites = []
+    for mode in modes_for_coverage:
+        coverage_root = coverage_utils.coverage_dir(pathlib.Path(options.tmpdir) / mode)
+        if not coverage_root.is_dir():
+            continue
+        for suite_dir in sorted(p for p in coverage_root.iterdir() if p.is_dir()):
+            ran_suites.append((suite_dir.name, mode, suite_dir))
 
     def pathsize(path : pathlib.Path):
         if path.is_file():
@@ -496,28 +503,21 @@ async def process_coverage(options):
                                   identifier = "root",
                                   data = Stats("Coverage Processing Stats", 0, 0))
 
-    for suite in list(ran_suites):
-        coverage_path = suite_coverage_path(suite)
-        if not coverage_path.exists():
-            logger.warning(f"Coverage dir for suite '{suite.name}' in mode '{suite.mode}' wasn't found, common reasons:\n\t"
-                "1. The suite doesn't use any instrumented binaries.\n\t"
-                "2. The binaries weren't compiled with coverage instrumentation.")
-            continue
-
+    for name, mode, coverage_path in ran_suites:
         # 1. Transform every suite raw profiles into indexed profiles
         raw_profiles = list(coverage_path.glob("*.profraw"))
         if len(raw_profiles) == 0:
-            logger.warning(f"Couldn't find any raw profiles for suite '{suite.name}' in mode '{suite.mode}' ({coverage_path}):\n\t"
+            logger.warning(f"Couldn't find any raw profiles for suite '{name}' in mode '{mode}' ({coverage_path}):\n\t"
                 "1. The binaries are killed instead of terminating which bypasses profile dump.\n\t"
                 "2. The suite tempres with the LLVM_PROFILE_FILE which causes the profile to be dumped\n\t"
                 "   to somewhere else.")
             continue
-        mode_stats = stats.get_node(suite.mode)
+        mode_stats = stats.get_node(mode)
         if not mode_stats:
             mode_stats = stats.create_node(tag = time.time(),
-                                           identifier = suite.mode,
+                                           identifier = mode,
                                            parent = ROOT_NODE,
-                                           data = Stats(f"{suite.mode} mode processing stats", 0, 0))
+                                           data = Stats(f"{mode} mode processing stats", 0, 0))
 
         raw_stats_node = stats.get_node(mode_stats.identifier + RAW_PROFILE_STATS)
         if not raw_stats_node:
@@ -526,15 +526,15 @@ async def process_coverage(options):
                                                parent = mode_stats,
                                                data = Stats(RAW_PROFILE_STATS, 0, 0))
         stat = stats.create_node(tag = time.time(),
-                                 identifier = raw_stats_node.identifier + suite.name,
+                                 identifier = raw_stats_node.identifier + name,
                                  parent = raw_stats_node,
-                                 data = Stats(suite.name, pathsize(coverage_path), 0))
+                                 data = Stats(name, pathsize(coverage_path), 0))
         raw_stats_node.data += stat.data
         mode_stats.data.time += stat.data.time
         mode_stats.data.size = max(mode_stats.data.size, raw_stats_node.data.size)
 
 
-        logger.info(f"{suite.name}: Converting raw profiles into indexed profiles - {stat.data}.")
+        logger.info(f"{name}: Converting raw profiles into indexed profiles - {stat.data}.")
         start_time = time.time()
         merge_result = await coverage_utils.merge_profiles(profiles = raw_profiles,
                                             path_for_merged = coverage_path,
@@ -548,21 +548,21 @@ async def process_coverage(options):
                                                    parent = mode_stats,
                                                    data = Stats(INDEXED_PROFILE_STATS, 0, 0))
         stat = stats.create_node(tag = time.time(),
-                                 identifier = indexed_stats_node.identifier + suite.name,
+                                 identifier = indexed_stats_node.identifier + name,
                                  parent = indexed_stats_node,
-                                 data = Stats(suite.name, pathsize(coverage_path), time.time() - start_time))
+                                 data = Stats(name, pathsize(coverage_path), time.time() - start_time))
         indexed_stats_node.data += stat.data
         mode_stats.data.time += stat.data.time
         mode_stats.data.size = max(mode_stats.data.size, indexed_stats_node.data.size)
 
-        logger.info(f"{suite.name}: Done converting raw profiles into indexed profiles - {humanfriendly.format_timespan(stat.data.time)}.")
+        logger.info(f"{name}: Done converting raw profiles into indexed profiles - {humanfriendly.format_timespan(stat.data.time)}.")
 
         # 2. Transform every indexed profile into an lcov trace file,
         #    after this step, the dependency upon the build artifacts
         #    ends and processing of the files can be done using the source
         #    code only.
 
-        logger.info(f"{suite.name}: Converting indexed profiles into lcov trace files.")
+        logger.info(f"{name}: Converting indexed profiles into lcov trace files.")
         start_time = time.time()
         if len(merge_result.errors) > 0:
             raise RuntimeError(merge_result.errors)
@@ -580,22 +580,23 @@ async def process_coverage(options):
                                                            parent = mode_stats,
                                                            data = Stats(LCOV_CONVERSION_STATS, 0, 0))
         stat = stats.create_node(tag = time.time(),
-                                 identifier = lcov_conversion_stats_node.identifier + suite.name,
+                                 identifier = lcov_conversion_stats_node.identifier + name,
                                  parent = lcov_conversion_stats_node,
-                                 data = Stats(suite.name, pathsize(coverage_path), time.time() - start_time))
+                                 data = Stats(name, pathsize(coverage_path), time.time() - start_time))
         lcov_conversion_stats_node.data += stat.data
         mode_stats.data.time += stat.data.time
         mode_stats.data.size = max(mode_stats.data.size, lcov_conversion_stats_node.data.size)
 
-        logger.info(f"{suite.name}: Done converting indexed profiles into lcov trace files - {humanfriendly.format_timespan(stat.data.time)}.")
+        logger.info(f"{name}: Done converting indexed profiles into lcov trace files - {humanfriendly.format_timespan(stat.data.time)}.")
 
         # 3. combine all tracefiles
-        logger.info(f"{suite.name} in mode {suite.mode}: Combinig lcov trace files.")
+        logger.info(f"{name} in mode {mode}: Combinig lcov trace files.")
         start_time = time.time()
         trace_files = list(coverage_path.glob("**/*.info"))
-        target_trace_file = coverage_path / (suite.name + ".info")
+        target_trace_file = coverage_path / (name + ".info")
         if len(trace_files) == 0: # No coverage data, can skip
-            logger.warning(f"{suite.name} in mode  {suite.mode}: No coverage tracefiles found")
+            logger.warning(f"{name} in mode  {mode}: No coverage tracefiles found")
+            continue
         elif len(trace_files) == 1: # No need to merge, we can just rename the file
             trace_files[0].rename(str(target_trace_file))
         else:
@@ -612,21 +613,21 @@ async def process_coverage(options):
                                                       parent = mode_stats,
                                                       data = Stats(LCOV_SUITES_MEREGE_STATS, 0, 0))
         stat = stats.create_node(tag = time.time(),
-                                 identifier = lcov_merge_stats_node.identifier + suite.name,
+                                 identifier = lcov_merge_stats_node.identifier + name,
                                  parent = lcov_merge_stats_node,
-                                 data = Stats(suite.name, pathsize(coverage_path), time.time() - start_time))
+                                 data = Stats(name, pathsize(coverage_path), time.time() - start_time))
         lcov_merge_stats_node.data += stat.data
         mode_stats.data.time += stat.data.time
         mode_stats.data.size = max(mode_stats.data.size, lcov_merge_stats_node.data.size)
 
-        suits_trace_files.setdefault(suite.mode, {})[suite.name] = target_trace_file
-        logger.info(f"{suite.name}: Done combinig lcov trace files - {humanfriendly.format_timespan(stat.data.time)}")
+        suits_trace_files.setdefault(mode, {})[name] = target_trace_file
+        logger.info(f"{name}: Done combinig lcov trace files - {humanfriendly.format_timespan(stat.data.time)}")
 
     #4. combine the suite lcovs into per mode trace files
     modes_trace_files  = {}
     for mode, suite_traces in suits_trace_files.items():
 
-        target_trace_file = pathlib.Path(options.tmpdir) / mode / "coverage" / f"{mode}_coverage.info"
+        target_trace_file = coverage_utils.coverage_dir(pathlib.Path(options.tmpdir) / mode) / f"{mode}_coverage.info"
         start_time = time.time()
         logger.info(f"Consolidating trace files for mode {mode}.")
         await coverage_utils.lcov_combine_traces(lcovs = suite_traces.values(),

--- a/test.py
+++ b/test.py
@@ -35,7 +35,7 @@ import humanfriendly
 import treelib
 
 from scripts import coverage
-from test import ALL_MODES, HOST_ID, TOP_SRC_DIR, path_to
+from test import ALL_MODES, HOST_ID, TOP_SRC_DIR, path_to, DEBUG_MODES
 from test.pylib import coverage_utils
 from test.pylib.util import LogPrefixAdapter, get_configured_modes, palette
 
@@ -67,7 +67,7 @@ class ThreadsCalculator:
             max_system_memory_reserve,
         ))
         available_mem = max(0, sys_mem - system_memory_reserve)
-        is_debug = "debug" in modes
+        is_debug = set(DEBUG_MODES) & set(modes)
         test_mem = min(
             sys_mem / test_memory_fraction,
             max_test_memory if is_debug else non_debug_max_test_memory,

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -27,8 +27,8 @@ ALL_MODES = {
     "coverage": "Coverage",
 }
 
-DEBUG_MODES = {"debug", "sanitize"}
-MODES_TIMEOUT_FACTOR = {"release": 1, "sanitize": 3, "debug": 3, "dev": 2, "coverage": 1}
+DEBUG_MODES = {"debug", "sanitize", "coverage"}
+MODES_TIMEOUT_FACTOR = {"release": 1, "sanitize": 3, "debug": 3, "dev": 2, "coverage": 3}
 
 HOST_ID = os.environ.get("SCYLLA_TEST_HOST_ID")
 if HOST_ID is None:

--- a/test/pylib/coverage_utils.py
+++ b/test/pylib/coverage_utils.py
@@ -49,6 +49,17 @@ from urllib.parse import quote, unquote
 
 # Type definitions for annotation
 PathLike = Union[Path, str]
+
+
+def coverage_dir(mode_log_dir: PathLike) -> Path:
+    """Root of the raw-profile tree for one mode's log dir (<tmpdir>/<mode>).
+
+    Every writer (test/pylib/runner.py, test/pylib/cpp/base.py) and reader
+    (test.py, scripts/coverage.py callers) must build the path through this
+    helper so they can never disagree on the layout:
+    <tmpdir>/<mode>/coverage/<suite>/*.profraw
+    """
+    return Path(mode_log_dir) / "coverage"
 ConcurrencyParam = Optional[Union[int, Semaphore]]
 LoggerType = Union[logging.Logger, logging.LoggerAdapter]
 

--- a/test/pylib/cpp/base.py
+++ b/test/pylib/cpp/base.py
@@ -20,6 +20,7 @@ from _pytest._code.code import ReprFileLocation
 
 from scripts import coverage as coverage_script
 from test import DEBUG_MODES, TEST_DIR, TOP_SRC_DIR, path_to
+from test.pylib.coverage_utils import coverage_dir
 from test.pylib.runner import BUILD_MODE, RUN_ID, TEST_SUITE
 from test.pylib.scylla_server import merge_cmdline_options
 
@@ -107,7 +108,15 @@ class CppFile(pytest.File, ABC):
             "TMPDIR": str(self.log_dir),
         }
         if self.build_mode == "coverage":
-            variables.update(coverage_script.env(self.exe_path))
+            # "%m" in LLVM_PROFILE_FILE expands to a value unique to this
+            # binary and makes the profile runtime merge counters into the
+            # resulting file (under a file lock) rather than overwrite it.
+            # The binary is invoked once per test case, so all cases
+            # accumulate into a single profile instead of each dumping a
+            # full separate one -- for a large multi-object boost binary
+            # that would balloon disk usage by the number of cases.
+            profile_base = coverage_dir(self.log_dir) / self.stash[TEST_SUITE].name / f"{self.test_name}.%m"
+            variables.update(coverage_script.env(profile_base))
         return variables
 
     @cached_property

--- a/test/pylib/lcov_utils.py
+++ b/test/pylib/lcov_utils.py
@@ -195,8 +195,24 @@ class LcovRecord(metaclass = MakeLcovRouter):
 
     def add_end_of_record(self, fields: List[str]) -> bool:
         self.sealed = True
-        self.validate_integrity()
+        # llvm-cov can emit FN/BRDA entries for lines that have no DA record
+        # (e.g. branches inside macro expansions) -- a known family of
+        # lcov-export line-attribution bugs, see e.g.
+        #   https://github.com/llvm/llvm-project/issues/120071
+        #   https://github.com/llvm/llvm-project/issues/78751
+        # genhtml likewise rejects such records ("branch on non-executable
+        # line") unless run with --filter branch, which drops them. Do the
+        # same here so the record satisfies the line-based invariant
+        # validate_integrity() checks; line coverage is unaffected.
+        lines = set(self.line_hits.keys())
+        self.function_hits = {
+            key: hits for key, hits in self.function_hits.items() if key[0] in lines
+        }
+        self.branch_hits = {
+            key: hits for key, hits in self.branch_hits.items() if key[0] in lines
+        }
         self._refresh_functions_to_lines()
+        self.validate_integrity()
         return True
 
     def remove_lines(self, line_numbers: List[int]):

--- a/test/pylib/runner.py
+++ b/test/pylib/runner.py
@@ -33,6 +33,7 @@ from _pytest.junitxml import xml_key
 
 from test import ALL_MODES, DEBUG_MODES, TOP_SRC_DIR, HOST_ID, path_to
 from test.pylib.artifact_registry import ArtifactRegistry as artifacts
+from test.pylib.coverage_utils import coverage_dir
 from test.pylib.ldap_server import start_ldap
 from test.pylib.minio_server import MinioServer
 from test.pylib.resource_gather import setup_cgroup, setup_worker_cgroup, get_resource_gather, SystemResourceMonitor, \
@@ -323,7 +324,7 @@ def testpy_cluster_factory(request: pytest.FixtureRequest,
         # this way is that the storage will not be bloated with coverage files (each can weigh 10s of MBs so for several
         # thousands of tests it can easily reach 10 of GBs)
         # ref: https://clang.llvm.org/docs/SourceBasedCodeCoverage.html#running-the-instrumented-program
-        base_env["LLVM_PROFILE_FILE"] = str(suite_log_dir / "coverage" / suite_config.name / "%m.profraw")
+        base_env["LLVM_PROFILE_FILE"] = str(coverage_dir(suite_log_dir) / suite_config.name / "%m.profraw")
 
     cluster_size = suite_config.cfg.get("cluster", {}).get("initial_size", 1)
 

--- a/test/pylib/util.py
+++ b/test/pylib/util.py
@@ -401,7 +401,7 @@ def get_modes_to_run(config) -> list[str]:
 
 def scale_timeout_by_mode(mode: str, timeout: int | float) -> int | float:
     """Scale timeout according to test.py mode semantics.
-    Each mode has a different scale: debug and sanitize modes are multiplied by 3, dev by 2.
+    Each mode has a different scale: debug, coverage, and sanitize modes are multiplied by 3, dev by 2.
     Unknown modes are left unchanged.
     """
     return MODES_TIMEOUT_FACTOR.get(mode, 1) * timeout

--- a/test/pylib_test/test_util.py
+++ b/test/pylib_test/test_util.py
@@ -36,7 +36,7 @@ def test_read_last_line():
         ("sanitize", 10, 30),
         ("release", 10, 10),
         ("dev", 10, 20),
-        ("coverage", 10, 10),
+        ("coverage", 10, 30),
         ("custom_exe", 10, 10),
     ],
 )

--- a/test/scylla_gdb/test_basic_commands.py
+++ b/test/scylla_gdb/test_basic_commands.py
@@ -12,7 +12,7 @@ from test.scylla_gdb.conftest import execute_gdb_command
 
 pytestmark = [
     pytest.mark.skip_mode(
-        mode=["dev", "debug"],
+        mode=["dev", "debug", "coverage"],
         reason="Scylla was built without debug symbols; use release mode",
     ),
 ]

--- a/test/scylla_gdb/test_schema_commands.py
+++ b/test/scylla_gdb/test_schema_commands.py
@@ -12,7 +12,7 @@ from test.scylla_gdb.conftest import execute_gdb_command
 
 pytestmark = [
     pytest.mark.skip_mode(
-        mode=["dev", "debug"],
+        mode=["dev", "debug", "coverage"],
         reason="Scylla was built without debug symbols; use release mode",
     ),
 ]

--- a/test/scylla_gdb/test_sstable_commands.py
+++ b/test/scylla_gdb/test_sstable_commands.py
@@ -11,7 +11,7 @@ from test.scylla_gdb.conftest import execute_gdb_command
 
 pytestmark = [
     pytest.mark.skip_mode(
-        mode=["dev", "debug"],
+        mode=["dev", "debug", "coverage"],
         reason="Scylla was built without debug symbols; use release mode",
     ),
 ]

--- a/test/scylla_gdb/test_task_commands.py
+++ b/test/scylla_gdb/test_task_commands.py
@@ -13,7 +13,7 @@ from test.scylla_gdb.conftest import execute_gdb_command
 
 pytestmark = [
     pytest.mark.skip_mode(
-        mode=["dev", "debug"],
+        mode=["dev", "debug", "coverage"],
         reason="Scylla was built without debug symbols; use release mode",
     ),
 ]


### PR DESCRIPTION
The coverage build mode bit-rotted after the test harness moved to the
pytest-based runner and was broken at every stage: the mode no longer
linked, because its Debug cmake type implicitly enabled sanitizers in
Seastar that nothing was built against, and a --coverage run crashed
before processing a single profile, because suite discovery still
relied on the retired TestSuite registry.

Make coverage mode work end to end again:

- build without the implicit sanitizer instrumentation while keeping
  the debug-friendly configuration, and enable error injection so the
  same tests run as in the other debug-like modes;

- treat coverage as a debug-like mode for timeouts and resource-heavy
  tests, since instrumented binaries are considerably slower;

- write raw profiles in the per-suite layout the post-processing
  expects, merged in place so that binaries invoked once per test case
  don't bloat storage, and discover the suites to process from that
  layout instead of the removed registry;

- tolerate records llvm-cov is known to emit inconsistently instead of
  failing the whole post-processing run.

No backport, no need to coount lcov for older versions.

Related: https://scylladb.atlassian.net/browse/SCYLLADB-3534