### PR TITLE
test: cluster: reconnect robustly after node restart in commitlog resurrection tests

### DIFF
--- a/test/cluster/test_commitlog_segment_data_resurrection.py
+++ b/test/cluster/test_commitlog_segment_data_resurrection.py
@@ -132,7 +132,9 @@ async def test_pinned_cl_segment_doesnt_resurrect_data(manager: ScyllaClusterMan
 
         manager.driver_close()
         await manager.driver_connect()
-        cql = manager.cql
+        # driver_connect() alone doesn't guarantee full CQL availability right
+        # after a restart, so wait for it explicitly (see SCYLLADB-3908).
+        cql, _ = await manager.get_ready_cql([server])
 
         assert len(list(cql.execute(f"SELECT * FROM {tbl2} WHERE pk = {pk1}"))) == 0
 
@@ -293,6 +295,8 @@ async def test_pinned_cl_segment_doesnt_resurrect_data_but_repair_ensures_tombst
 
         manager.driver_close()
         await manager.driver_connect()
-        cql = manager.cql
+        # driver_connect() alone doesn't guarantee full CQL availability right
+        # after a restart, so wait for it explicitly (see SCYLLADB-3908).
+        cql, _ = await manager.get_ready_cql(servers)
 
         assert len(list(cql.execute(f"SELECT * FROM {tbl2} WHERE pk = {pk1}"))) == 0


### PR DESCRIPTION
driver_connect() alone doesn't guarantee full CQL availability right after
a cluster restart, causing an intermittent DriverException("Reconnecting
during shutdown") -> NoHostAvailable race. Wait for CQL availability via
get_ready_cql() instead, matching the fix already applied for the same
race in test_sstable_compression_dictionaries_basic.

Fixes: SCYLLADB-3908

## Backport
No backport needed. Both the failing test
(`test_pinned_cl_segment_doesnt_resurrect_data_but_repair_ensures_tombstone_gc`,
added by 43cab2a3321 on 2026-05-19) and the helper this fix relies on
(`get_ready_cql()`, added by 69b69886454 on 2026-08-16) are master-only —
neither exists on any maintained release branch (branch-2025.2 through
branch-2026.2), so there is nothing to backport.