### PR TITLE
utils: config_file: expose option status in system.config

### DIFF
--- a/db/virtual_tables.cc
+++ b/db/virtual_tables.cc
@@ -646,6 +646,7 @@ class db_config_table final : public streaming_virtual_table {
             .with_column("name", utf8_type, column_kind::partition_key)
             .with_column("type", utf8_type)
             .with_column("source", utf8_type)
+            .with_column("status", utf8_type)
             .with_column("value", utf8_type)
             .with_hash_version()
             .build();
@@ -656,6 +657,7 @@ class db_config_table final : public streaming_virtual_table {
             dht::decorated_key key;
             std::string_view type;
             sstring source;
+            std::string_view status;
             sstring value;
         };
 
@@ -664,7 +666,7 @@ class db_config_table final : public streaming_virtual_table {
             auto&& c = cfg_ref.get();
             dht::decorated_key dk = dht::decorate_key(*_s, partition_key::from_single_value(*_s, data_value(c.name()).serialize_nonnull()));
             if (this_shard_owns(dk)) {
-                cfg.emplace_back(config_entry{ std::move(dk), c.type_name(), c.source_name(), c.value_as_json()._res });
+                cfg.emplace_back(config_entry{ std::move(dk), c.type_name(), c.source_name(), c.status_name(), c.value_as_json()._res });
             }
         }
 
@@ -676,6 +678,7 @@ class db_config_table final : public streaming_virtual_table {
             clustering_row cr(clustering_key::make_empty());
             set_cell(cr.cells(), "type", c.type);
             set_cell(cr.cells(), "source", c.source);
+            set_cell(cr.cells(), "status", c.status);
             set_cell(cr.cells(), "value", c.value);
             co_await result.emit_row(std::move(cr));
             co_await result.emit_partition_end();
@@ -706,6 +709,10 @@ class db_config_table final : public streaming_virtual_table {
 
         if (rs.row(0).cells().contains("source")) {
             return make_exception_future<>(virtual_table_update_exception("option source is not updateable"));
+        }
+
+        if (rs.row(0).cells().contains("status")) {
+            return make_exception_future<>(virtual_table_update_exception("option status is not updateable"));
         }
 
         return smp::submit_to(0, [&cfg = _cfg, name = std::move(*name), value = std::move(*value)] () mutable -> future<> {

--- a/test/boost/virtual_table_test.cc
+++ b/test/boost/virtual_table_test.cc
@@ -69,8 +69,18 @@ SEASTAR_THREAD_TEST_CASE(test_system_config_table_read) {
         assert_that(res).is_rows().with_size(1).with_row({
             { utf8_type->decompose(sstring("partitioner")) },
             { utf8_type->decompose(sstring("default")) },
+            { utf8_type->decompose(sstring("used")) },
             { utf8_type->decompose(sstring("string")) },
             { utf8_type->decompose(format("\"{}\"", env.local_db().get_config().partitioner())) }
+        });
+    }).get();
+}
+
+SEASTAR_THREAD_TEST_CASE(test_system_config_table_status) {
+    do_with_cql_env_thread([] (cql_test_env& env) {
+        auto res = env.execute_cql("SELECT status FROM system.config WHERE name = 'commitlog_use_hard_size_limit';").get();
+        assert_that(res).is_rows().with_size(1).with_row({
+            { utf8_type->decompose(sstring("deprecated")) },
         });
     }).get();
 }

--- a/utils/config_file.cc
+++ b/utils/config_file.cc
@@ -447,3 +447,17 @@ sstring utils::config_file::config_src::source_name() const noexcept {
 
     __builtin_unreachable();
 }
+
+std::string_view utils::config_file::config_src::status_name() const noexcept {
+    switch (status()) {
+    case utils::config_file::value_status::Used:
+        return "used";
+    case utils::config_file::value_status::Unused:
+        return "unused";
+    case utils::config_file::value_status::Invalid:
+        return "invalid";
+    case utils::config_file::value_status::Deprecated:
+        return "deprecated";
+    }
+    __builtin_unreachable();
+}

--- a/utils/config_file.hh
+++ b/utils/config_file.hh
@@ -158,6 +158,7 @@ public:
         virtual value_status status() const noexcept = 0;
         virtual config_source source() const noexcept = 0;
         sstring source_name() const noexcept;
+        std::string_view status_name() const noexcept;
         json::json_return_type value_as_json() const;
     };
 


### PR DESCRIPTION
## What
`system.config`'s `source` column shows the plain `config_source` name (`default`, `config`, `cli`, ...) even for options whose `value_status` is `Deprecated` (or `Unused`/`Invalid`), so a deprecated option left at its default looks identical to any other default option. The only way to notice was grepping the boot log for the `Option is deprecated` warning.

Add a new `status` column to the `system.config` virtual table, populated from a new `config_src::status_name()` (`used`, `unused`, `invalid`, `deprecated`). `source_name()` is left unchanged, reporting only the plain source.

## Why
Scylla Doctor and users rely on `system.config` to inspect the effective configuration; deprecated (or otherwise non-standard-status) options should be identifiable there without cross-referencing logs. A dedicated `status` column is more explicit and extensible than encoding it into `source`.

Tests: unit (dev)

Fixes: https://scylladb.atlassian.net/browse/SCYLLADB-3904.