### PR TITLE
repair: fix repair over a range spanning several replica sets

### DIFF
--- a/repair/repair.cc
+++ b/repair/repair.cc
@@ -1331,7 +1331,46 @@ future<int> repair_service::do_repair_start(gms::gossip_address_map& addr_map, s
     // repair of each range is performed separately with repair_range().
     dht::token_range_vector ranges;
     if (options.ranges.size()) {
-        ranges = options.ranges;
+        // A requested range may span several vnode ranges with different
+        // replica sets, while repair_range() assumes each range has a single
+        // replica set (get_neighbors() resolves the replicas from the range's
+        // end token alone). Intersect the requested ranges with the local
+        // ranges, splitting them on vnode boundaries, so that each repaired
+        // range has a uniform replica set. Portions of the requested ranges
+        // this node is not a replica of are dropped, as the start_token and
+        // end_token options below already do.
+        auto local_ranges = co_await erm.get_ranges(my_host_id);
+        dht::token_range_vector dropped_ranges;
+        for (const auto& given_range : options.ranges) {
+            // The parts of given_range not replicated by this node are
+            // dropped; collect them to report the lost coverage below.
+            dht::token_range_vector remaining = {given_range};
+            for (const auto& local_range : local_ranges) {
+                if (auto intersection_opt = given_range.intersection(local_range, dht::token_comparator())) {
+                    dht::token_range_vector new_remaining;
+                    for (const auto& r : remaining) {
+                        auto subtracted = r.subtract(*intersection_opt, dht::token_comparator());
+                        new_remaining.insert(new_remaining.end(), subtracted.begin(), subtracted.end());
+                    }
+                    remaining = std::move(new_remaining);
+                    ranges.push_back(std::move(*intersection_opt));
+                }
+            }
+            dropped_ranges.insert(dropped_ranges.end(), remaining.begin(), remaining.end());
+            co_await coroutine::maybe_yield();
+        }
+        if (!dropped_ranges.empty()) {
+            constexpr size_t max_ranges_to_log = 100;
+            auto to_log = std::min(dropped_ranges.size(), max_ranges_to_log);
+            rlogger.warn("repair[{}]: {} sub-range(s) of the requested ranges are not replicated by this node and will not be repaired: {}{}",
+                    id.uuid(), dropped_ranges.size(),
+                    dht::token_range_vector(dropped_ranges.begin(), dropped_ranges.begin() + to_log),
+                    dropped_ranges.size() > max_ranges_to_log ? " and more" : "");
+        }
+        if (ranges.size() != options.ranges.size()) {
+            rlogger.info("repair[{}]: split the requested ranges on the local replica-set boundaries: {} requested ranges resulted in {} ranges to repair",
+                    id.uuid(), options.ranges.size(), ranges.size());
+        }
     } else if (options.primary_range) {
         rlogger.info("primary-range repair");
         // when "primary_range" option is on, neither data_centers nor hosts

--- a/repair/row_level.cc
+++ b/repair/row_level.cc
@@ -3007,6 +3007,55 @@ static void add_to_repair_meta_for_followers(repair_meta& rm) {
     debug::repair_meta_for_followers.add(rm);
 }
 
+// Ring tokens split the token ring into vnode ranges (t1, t2], each with its
+// own replica set. A token range therefore lies within a single vnode range,
+// and thus has a single replica set, iff no ring token splits it. A ring
+// token t splits a range iff the range covers tokens on both sides of the
+// boundary, i.e. some token <= t and some token > t.
+//
+// Returns the first ring token that splits the given non-wrapping range, or
+// std::nullopt if the range lies within a single vnode range.
+//
+// Example: with sorted ring tokens {10, 20, 30} the vnode ranges are
+// (10, 20], (20, 30] and the wrap-around one owning tokens above 30 and up
+// to 10. Then:
+//
+//   (10, 20] -> nullopt: exactly one vnode range. The first ring token the
+//              range covers is 20 and the range does not extend past it.
+//   (12, 18] -> nullopt: sub-range of (10, 20], ends before ring token 20.
+//   (10, 25] -> 20: covers tokens on both sides of 20 (e.g. 15 and 25), so
+//              the boundary splits it into (10, 20] and (20, 25], whose
+//              replica sets may differ.
+//   (5, 30]  -> 10: crosses 10 and 20; the first splitting token is
+//              returned.
+//   (30, max] -> nullopt: no ring token above 30, the whole range belongs
+//              to the wrap-around vnode range.
+//   [20, 25] -> 20: with an inclusive start the range covers token 20
+//              itself, which belongs to (10, 20], while the tokens after it
+//              belong to (20, 30].
+static std::optional<dht::token> ring_token_splitting_range(const dht::token_range& range, const utils::chunked_vector<dht::token>& sorted_tokens) {
+    // Find the first ring token t such that the range covers some token <= t:
+    // with an inclusive start s that is the first ring token >= s, with an
+    // exclusive start the first ring token > s, and with no start bound any
+    // ring token qualifies.
+    auto t = sorted_tokens.begin();
+    if (const auto& start = range.start()) {
+        t = start->is_inclusive()
+                ? std::lower_bound(sorted_tokens.begin(), sorted_tokens.end(), start->value())
+                : std::upper_bound(sorted_tokens.begin(), sorted_tokens.end(), start->value());
+    }
+    if (t == sorted_tokens.end()) {
+        return std::nullopt;
+    }
+    // The range covers tokens > *t iff it extends past *t. A range ending
+    // exactly on *t is the tail of the vnode range (previous_token, *t].
+    auto last_token = range.end() ? range.end()->value() : dht::maximum_token();
+    if (*t < last_token) {
+        return *t;
+    }
+    return std::nullopt;
+}
+
 class row_level_repair {
     repair::shard_repair_task_impl& _shard_task;
     sstring _cf_name;
@@ -3390,12 +3439,48 @@ private:
         if (_shard_task.reason() != streaming::stream_reason::repair) {
             co_return;
         }
-        auto my_address = get_erm()->get_topology().my_host_id();
-        // Update repair_history table only if all replicas have been repaired
-        size_t repaired_replicas = _all_live_peer_nodes.size() + 1;
-        if (_shard_task.get_total_rf() != repaired_replicas){
-            rlogger.debug("repair[{}]: Skipped to update system.repair_history total_rf={}, repaired_replicas={}, local={}, peers={}",
-                    _shard_task.global_repair_id.uuid(), _shard_task.get_total_rf(), repaired_replicas, my_address, _all_live_peer_nodes);
+        auto erm = get_erm();
+        auto my_address = erm->get_topology().my_host_id();
+        // Update repair_history table only if all replicas of the range have
+        // been repaired. Compare the participants against the range's
+        // replicas, not just their count: recording the range as repaired
+        // unlocks tombstone GC on it on the participants, so a wrong
+        // participant set of the right size could let them purge tombstones
+        // while a replica that did not participate still holds data the
+        // tombstones cover, resurrecting it.
+        auto end_token = _range.end() ? _range.end()->value() : dht::maximum_token();
+        std::unordered_set<locator::host_id> replicas;
+        if (_small_table_optimization) {
+            // With the small table optimization the repaired range is the
+            // whole ring and the required participants are all normal token
+            // owners, see get_neighbors().
+            replicas = erm->get_token_metadata().get_normal_token_owners();
+        } else {
+            // The replicas are resolved from the range's end token, which is
+            // correct only if the whole range has a single replica set. All
+            // callers uphold this: user-requested repair splits the requested
+            // ranges on the local replica-set boundaries, and tablet repair
+            // ranges never span tablets. Check this precondition, it is what
+            // makes the comparison below exact.
+            if (_is_tablet) {
+                const auto& tmap = erm->get_token_metadata_ptr()->tablets().get_tablet_map(_table_id);
+                auto tablet_range = tmap.get_token_range(tmap.get_tablet_id(end_token));
+                if (!tablet_range.contains(_range, dht::token_comparator())) {
+                    on_internal_error(rlogger, format("update_system_repair_table(): repair range {} spans multiple tablets, the end token's tablet range is {}",
+                            _range, tablet_range));
+                }
+            } else if (auto boundary = ring_token_splitting_range(_range, erm->get_token_metadata().sorted_tokens())) {
+                on_internal_error(rlogger, format("update_system_repair_table(): repair range {} spans multiple vnode ranges, it crosses the ring token {}",
+                        _range, *boundary));
+            }
+            auto natural_replicas = erm->get_natural_replicas(end_token);
+            replicas = std::unordered_set<locator::host_id>(natural_replicas.begin(), natural_replicas.end());
+        }
+        auto repaired_nodes = std::unordered_set<locator::host_id>(_all_live_peer_nodes.begin(), _all_live_peer_nodes.end());
+        repaired_nodes.insert(my_address);
+        if (replicas != repaired_nodes) {
+            rlogger.debug("repair[{}]: Skipped to update system.repair_history replicas={}, local={}, peers={}",
+                    _shard_task.global_repair_id.uuid(), replicas, my_address, _all_live_peer_nodes);
             co_return;
         }
         // Update repair_history table only if both hints and batchlog have been flushed.
@@ -3406,8 +3491,8 @@ private:
         // The tablet repair time for tombstone gc will be updated when the
         // system.tablet.repair_time is updated.
         if (_is_tablet && _shard_task.sched_info.sched_by_scheduler) {
-            rlogger.debug("repair[{}]: Skipped to update system.repair_history for tablet repair scheduled by scheduler total_rf={} repaired_replicas={} local={} peers={}",
-                    _shard_task.global_repair_id.uuid(), _shard_task.get_total_rf(), repaired_replicas, my_address, _all_live_peer_nodes);
+            rlogger.debug("repair[{}]: Skipped to update system.repair_history for tablet repair scheduled by scheduler replicas={} local={} peers={}",
+                    _shard_task.global_repair_id.uuid(), replicas, my_address, _all_live_peer_nodes);
             co_return;
         }
 

--- a/repair/task_manager_module.hh
+++ b/repair/task_manager_module.hh
@@ -235,10 +235,6 @@ public:
 
     locator::effective_replication_map_ptr get_erm();
 
-    size_t get_total_rf() {
-        return get_erm()->get_replication_factor();
-    }
-
     future<> repair_range(const dht::token_range& range, table_info table);
 
     size_t ranges_size() const noexcept;

--- a/test/cluster/test_repair.py
+++ b/test/cluster/test_repair.py
@@ -15,6 +15,7 @@ import uuid
 from cassandra.cluster import ConsistencyLevel
 from cassandra.query import SimpleStatement
 
+from test.pylib.internal_types import ServerInfo
 from test.pylib.scylla_cluster_manager import ScyllaClusterManager
 from test.pylib.rest_client import HTTPError
 from test.pylib.util import wait_for_cql_and_get_hosts
@@ -446,3 +447,282 @@ async def test_repair_rejects_equal_start_and_end_token(manager):
     with pytest.raises(HTTPError, match="Start and end tokens must be different"):
         await manager.api.client.post_json(f"/storage_service/repair_async/ks",
                                            host=servers[0].ip_addr, params=params)
+
+
+# ---------------------------------------------------------------------------
+# SCYLLADB-3944: repair of a token range that spans several vnode ranges with
+# different replica sets.
+#
+# get_neighbors() derives the participants of a repaired range from the range's
+# *end token* only, so a caller (e.g. Scylla Manager) that asked for a merged
+# range silently got the replica set of the last sub-range. The "all replicas
+# participated" guard before recording system.repair_history compared only a
+# participant *count* against RF, which the wrong-but-correctly-sized set
+# passed, so the whole merged range was recorded as repaired even though a
+# real replica of the first sub-range never took part. With tombstone_gc =
+# {'mode': 'repair'} that unlocked tombstone GC on a range that was never
+# actually repaired against all of its replicas -> data resurrection.
+#
+# Fixed by splitting user-requested ranges on the local replica-set boundaries
+# in repair_service::do_repair_start() (repair/repair.cc), and by recording
+# repair history only when the participant identities match the range's
+# replicas in update_system_repair_table() (repair/row_level.cc).
+# ---------------------------------------------------------------------------
+
+# Four single-token nodes, interleaving the two DCs, so that two adjacent vnode
+# ranges share their dc1 replicas but differ in their dc2 replica -- the same
+# shape as the customer cluster (FRA RF=3 identical, GRA RF=1 differing).
+_RING = [
+    # (dc, rack, token)
+    ("dc1", "rack1", -4611686018427387904),
+    ("dc2", "rack1", -2305843009213693952),
+    ("dc1", "rack2", 0),
+    ("dc2", "rack1", 2305843009213693952),
+]
+
+
+async def _add_ring(manager: ScyllaClusterManager, cmdline: list[str]) -> list[ServerInfo]:
+    """Bring up the fixed ring above and return the servers in ring-token order."""
+    servers = []
+    for dc, rack, token in _RING:
+        servers.append(await manager.server_add(
+            config={
+                "tablets_mode_for_new_keyspaces": "disabled",
+                "num_tokens": 1,
+                "initial_token": str(token),
+            },
+            property_file={"dc": dc, "rack": rack},
+            cmdline=cmdline))
+    return servers
+
+
+def _find_split_replica_set(ring) -> tuple[int, int, int, set[str], set[str]]:
+    """Find two adjacent, non-wrapping ranges (a, b] and (b, c] whose replica sets differ.
+
+    Returns (a, b, c, replicas_of_ab, replicas_of_bc).
+    """
+    entries = [(int(e["start_token"]), int(e["end_token"]), frozenset(e["endpoints"])) for e in ring]
+    entries = [e for e in entries if e[0] < e[1]]  # drop the wrapping range
+    entries.sort()
+    for (a, b, eps_ab), (b2, c, eps_bc) in zip(entries, entries[1:]):
+        if b == b2 and eps_ab != eps_bc:
+            return a, b, c, set(eps_ab), set(eps_bc)
+    pytest.fail(f"No two adjacent ranges with differing replica sets in {entries}")
+
+
+async def _repair_range(manager: ScyllaClusterManager, node_ip: str, ks: str, table: str, start: int, end: int):
+    await manager.api.repair(node_ip, ks, table, ranges=f"{start}:{end}")
+
+
+def _row_states(cql, host, table: str, pk: int) -> tuple[bool, bool]:
+    """Return (has_live_row, has_tombstone) for pk's clustering rows in the local
+    data of the given host, read via MUTATION_FRAGMENTS."""
+    has_live_row = False
+    has_tombstone = False
+    for row in cql.execute(f"SELECT * FROM MUTATION_FRAGMENTS({table}) WHERE pk = {pk}", host=host):
+        if row.partition_region != 2:  # only clustering rows
+            continue
+        metadata = json.loads(row.metadata)
+        tombstone = metadata.get("tombstone")
+        marker = metadata.get("marker")
+        if tombstone is None or (marker is not None and tombstone["timestamp"] < marker["timestamp"]):
+            has_live_row = True
+        if tombstone is not None:
+            has_tombstone = True
+    return has_live_row, has_tombstone
+
+
+async def _repair_history(cql, host, ks: str) -> list[tuple[int, int]]:
+    rows = list(cql.execute("SELECT keyspace_name, range_start, range_end FROM system.repair_history", host=host))
+    return sorted((r.range_start, r.range_end) for r in rows if r.keyspace_name == ks)
+
+
+async def test_repair_history_not_recorded_for_range_spanning_replica_sets(manager: ScyllaClusterManager):
+    """Repairing a range that spans two different replica sets must not claim the
+    whole range as repaired.
+
+    The ring is built so that two adjacent vnode ranges (a, b] and (b, c] have the
+    same dc1 replicas but a different dc2 replica. We ask for the merged range
+    (a, c]. Before the fix, its end token c selected the replica set of (b, c], so
+    the dc2 replica of (a, b] was left out of the repair -- yet system.repair_history
+    ended up claiming (a, c] was repaired on the nodes that did participate.
+
+    Asserted: the merged range is split on the vnode boundary and each sub-range is
+    repaired against its own replica set, so (a, b] is recorded on exactly the
+    replicas of (a, b] and (b, c] on exactly the replicas of (b, c] (the history is
+    broadcast to exactly the set of participants). Conversely, no node may record a
+    range covering (a, c], because no single replica set repaired all of it.
+    """
+    cmdline = ["--smp", "1", "--hinted-handoff-enabled", "0"]
+    servers = await _add_ring(manager, cmdline)
+    by_ip = {s.ip_addr: s for s in servers}
+
+    cql = manager.get_cql()
+    hosts = await wait_for_cql_and_get_hosts(cql, servers, time.time() + 60)
+    host_by_ip = {h.address: h for h in hosts}
+    assert set(by_ip) <= set(host_by_ip), f"driver hosts {sorted(host_by_ip)} != servers {sorted(by_ip)}"
+
+    async with new_test_keyspace(manager,
+            "WITH replication = {'class': 'NetworkTopologyStrategy', 'dc1': 2, 'dc2': 1} "
+            "AND tablets = {'enabled': false}") as ks:
+        cql.execute(f"CREATE TABLE {ks}.tbl (pk int, ck int, PRIMARY KEY (pk, ck)) "
+                    "WITH tombstone_gc = {'mode': 'repair', 'propagation_delay_in_seconds': '0'}")
+
+        ring = await manager.api.describe_ring(servers[0].ip_addr, ks)
+        a, b, c, eps_ab, eps_bc = _find_split_replica_set(ring)
+        logger.info(f"({a}, {b}] -> {sorted(eps_ab)}")
+        logger.info(f"({b}, {c}] -> {sorted(eps_bc)}")
+
+        # The replica that owns the first sub-range but not the second one.
+        excluded = eps_ab - eps_bc
+        assert len(excluded) == 1, f"expected exactly one differing replica, got {excluded}"
+        excluded_ip = excluded.pop()
+
+        # Repair must be driven by a node that replicates the whole merged range.
+        coordinator_ip = next(iter(eps_ab & eps_bc))
+        logger.info(f"Repairing merged range ({a}, {c}] from {coordinator_ip}; "
+                    f"{excluded_ip} is a replica of ({a}, {b}] only")
+
+        await _repair_range(manager, coordinator_ip, ks, "tbl", a, c)
+
+        history = {ip: await _repair_history(cql, host_by_ip[ip], ks) for ip in by_ip}
+        for ip, rows in history.items():
+            logger.info(f"repair_history on {ip}: {rows}")
+
+        # Nobody may claim to have repaired a range whose replicas did not all take part.
+        over_extended = [(ip, s, e) for ip, rows in history.items() for (s, e) in rows
+                         if s <= a and e >= c]
+        assert not over_extended, (
+            f"repair_history claims the merged range ({a}, {c}] was repaired on "
+            f"{[ip for ip, _, _ in over_extended]}, but replica {excluded_ip} of "
+            f"sub-range ({a}, {b}] did not participate (its history: {history[excluded_ip]})")
+
+        # The repair must not be a no-op either: the merged range is split on the
+        # vnode boundary and each sub-range is recorded on exactly its replicas.
+        for rng, replicas in [((a, b), eps_ab), ((b, c), eps_bc)]:
+            recorded_on = {ip for ip, rows in history.items() if rng in rows}
+            assert recorded_on == replicas, (
+                f"expected sub-range ({rng[0]}, {rng[1]}] to be recorded in "
+                f"repair_history on exactly its replicas {sorted(replicas)}, "
+                f"but it was recorded on {sorted(recorded_on)}")
+
+
+@pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
+async def test_data_resurrection_from_repair_range_spanning_replica_sets(manager: ScyllaClusterManager):
+    """End-to-end reproducer for the customer's data resurrection.
+
+    1. Insert a row whose token falls into the first of two adjacent vnode ranges
+       with differing replica sets.
+    2. Delete it while the dc2 replica of that sub-range rejects writes (database_apply
+       injection) and hints are off, so that replica keeps the live row and no tombstone.
+    3. Repair the *merged* range. Before the fix, that replica did not own the
+       merged range's end token, so it was not a participant and kept its live
+       row -- but repair_history was recorded for the whole merged range anyway.
+    4. tombstone_gc = repair then considered the tombstone collectable on the
+       nodes that did participate; a major compaction purged it.
+    5. The stale live row on the excluded replica was the only surviving version:
+       the deleted row came back.
+
+    With the fix, the merged range is split on the vnode boundary, the excluded
+    replica participates in the repair of its own sub-range (receiving the
+    tombstone), and the deleted row stays deleted.
+    """
+    # repair_hints_batchlog_flush_cache_time_in_ms defaults to 60s; with the cache on,
+    # repair records the batchlog manager's last_replay time instead of "now", which can
+    # be tens of seconds stale -- older than our tombstone, so nothing would ever be
+    # collectable. Disabling the cache makes the recorded repair time the actual repair time.
+    cmdline = ["--smp", "1", "--hinted-handoff-enabled", "0", "--enable-cache", "0",
+               "--repair-hints-batchlog-flush-cache-time-in-ms", "0"]
+    servers = await _add_ring(manager, cmdline)
+    by_ip = {s.ip_addr: s for s in servers}
+
+    cql = manager.get_cql()
+    hosts = await wait_for_cql_and_get_hosts(cql, servers, time.time() + 60)
+    host_by_ip = {h.address: h for h in hosts}
+
+    async with new_test_keyspace(manager,
+            "WITH replication = {'class': 'NetworkTopologyStrategy', 'dc1': 2, 'dc2': 1} "
+            "AND tablets = {'enabled': false}") as ks:
+        table = f"{ks}.tbl"
+        cql.execute(f"CREATE TABLE {table} (pk int, ck int, PRIMARY KEY (pk, ck)) "
+                    "WITH tombstone_gc = {'mode': 'repair', 'propagation_delay_in_seconds': '0'}")
+
+        ring = await manager.api.describe_ring(servers[0].ip_addr, ks)
+        a, b, c, eps_ab, eps_bc = _find_split_replica_set(ring)
+        excluded_ip = (eps_ab - eps_bc).pop()
+        coordinator_ip = next(iter(eps_ab & eps_bc))
+        participants = [by_ip[ip] for ip in eps_bc]
+
+        # Pick a key that lands in (a, b] -- the sub-range whose replica set is dropped.
+        # Probe by writing throw-away keys, reading their tokens, then wiping the table.
+        await asyncio.gather(*[cql.run_async(f"INSERT INTO {table} (pk, ck) VALUES ({k}, 0)")
+                               for k in range(200)])
+        pk = next((r[0] for r in cql.execute(f"SELECT pk, token(pk) FROM {table}")
+                   if a < r[1] <= b), None)
+        assert pk is not None, f"no key among the probes has a token in ({a}, {b}]"
+        cql.execute(f"TRUNCATE {table}")
+        logger.info(f"Using pk={pk}, excluded replica {excluded_ip}, coordinator {coordinator_ip}")
+
+        cql.execute(SimpleStatement(f"INSERT INTO {table} (pk, ck) VALUES ({pk}, 0)",
+                                    consistency_level=ConsistencyLevel.ALL))
+
+        # Make the excluded replica reject the delete, so it keeps the live row and never
+        # sees a tombstone. The other two replicas satisfy CL=TWO, so the delete succeeds.
+        await manager.api.enable_injection(excluded_ip, "database_apply", one_shot=False,
+                                           parameters={"ks_name": ks, "cf_name": "tbl", "what": "throw"})
+        cql.execute(SimpleStatement(f"DELETE FROM {table} WHERE pk = {pk} AND ck = 0",
+                                    consistency_level=ConsistencyLevel.TWO))
+        await manager.api.disable_injection(excluded_ip, "database_apply")
+
+        # Verify the injection produced the hazardous state: the excluded replica
+        # kept the live row and never saw the tombstone, while the other replicas
+        # of (a, b] did get it.
+        live, dead = _row_states(cql, host_by_ip[excluded_ip], table, pk)
+        assert live and not dead, (
+            f"expected {excluded_ip} to hold the live row and no tombstone, "
+            f"got has_live_row={live} has_tombstone={dead}")
+        for ip in eps_ab - {excluded_ip}:
+            live, dead = _row_states(cql, host_by_ip[ip], table, pk)
+            assert dead, f"expected the tombstone on replica {ip} of ({a}, {b}]"
+
+        # gc_before is derived from the repair time, at gc_clock's second
+        # granularity; wait out the granularity so the tombstone is strictly
+        # older than the repair. This is a fixed clock gap, not a condition that
+        # can be polled for, and USING TIMESTAMP would not help: tombstone GC
+        # compares the tombstone's deletion time, not its write timestamp.
+        await asyncio.sleep(2)
+
+        logger.info(f"Repairing merged range ({a}, {c}] from {coordinator_ip}")
+        await _repair_range(manager, coordinator_ip, ks, "tbl", a, c)
+
+        # The repair must not be a no-op: each sub-range of the split must be
+        # recorded on exactly its replicas, including the excluded one for (a, b].
+        history = {ip: await _repair_history(cql, host_by_ip[ip], ks) for ip in by_ip}
+        for rng, replicas in [((a, b), eps_ab), ((b, c), eps_bc)]:
+            recorded_on = {ip for ip, rows in history.items() if rng in rows}
+            assert recorded_on == replicas, (
+                f"expected sub-range ({rng[0]}, {rng[1]}] to be recorded in "
+                f"repair_history on exactly its replicas {sorted(replicas)}, "
+                f"but it was recorded on {sorted(recorded_on)}")
+
+        # Purge the tombstone on the nodes that consider the range repaired.
+        # consider_only_existing_data makes the major compaction skip the commitlog check
+        # (which would otherwise clamp gc_before to the age of the still-active segment);
+        # gc_before itself still comes from the repair history, which is what is under test.
+        for server in participants:
+            await manager.api.keyspace_flush(server.ip_addr, ks, "tbl")
+            await manager.api.keyspace_compaction(server.ip_addr, ks, "tbl",
+                                                  consider_only_existing_data=True)
+
+        # Diagnostics only -- deliberately not asserted. The repair was split into
+        # per-replica-set sub-ranges (asserted above), so the excluded replica got
+        # the tombstone; whether a given node has purged it by now is a compaction
+        # timing detail. Either way the row must stay deleted, asserted below.
+        for ip, host in host_by_ip.items():
+            frags = list(cql.execute(
+                f"SELECT * FROM MUTATION_FRAGMENTS({table}) WHERE pk = {pk}", host=host))
+            logger.info(f"mutation fragments on {ip}: {frags}")
+
+        rows = list(cql.execute(SimpleStatement(f"SELECT * FROM {table} WHERE pk = {pk}",
+                                                consistency_level=ConsistencyLevel.ALL)))
+        assert rows == [], f"deleted row was resurrected: {rows}"


### PR DESCRIPTION
repair_start() accepts explicit ranges and uses them verbatim, while get_neighbors() resolves the participants from a range's end token alone. A requested range spanning several vnode ranges with different replica sets is therefore repaired against the replica set of the last sub-range only: replicas owning only an earlier part never participate. The "all replicas participated" guard before recording system.repair_history compares a count against RF, so the wrong-but-correctly-sized participant set passes and the whole range is recorded as repaired on the nodes that did participate. Under tombstone_gc = {'mode': 'repair'} that entry unlocks tombstone GC on the participants, while the excluded replica may still hold live data covered by the tombstones they can now purge; a later read reaching that replica resurrects the deleted data. Seen in the field with repair automation that built the requested ranges from its own view of the ring.

This series fixes both defects independently:

- Intersect user-requested ranges with the node's local ranges, splitting them on vnode boundaries, so each repaired range has a uniform replica set and history is recorded per sub-range with the correct participants. Portions the node is not a replica of are dropped, matching the existing start_token/end_token semantics; the dropped sub-ranges are logged so the lost coverage is visible to the caller.
- Guard the system.repair_history update by comparing the participant identities against the range's replicas instead of comparing a count against RF. For small-table-optimization repairs the repaired range is the whole ring and the required participants are all normal token owners; otherwise the replicas come from the range's end token, backed by a checked precondition that the range does not cross a ring token (or a tablet boundary, for tablet tables). A mismatch skips the update, which only delays tombstone GC and is always safe.

Tests: two new cluster tests on a four-node, two-DC ring where adjacent vnode ranges differ in one replica: one asserts no node records history covering the merged range, and an end-to-end one asserts a deleted row stays deleted after repairing the merged range. Both fail without the fixes. Existing test_repair.py (including the small-table-optimization test), test_tombstone_gc.py and test_tablet_repair_scheduler.py pass.

Fixes SCYLLADB-3944

Backport to all active branches.