### PR TITLE
service: session: reduce verbosity of session closing logging

### DIFF
--- a/service/session.cc
+++ b/service/session.cc
@@ -59,7 +59,7 @@ void session_manager::initiate_close_of_sessions_except(const std::unordered_set
 }
 
 future<> session_manager::drain_closing_sessions() {
-    slogger.info("drain_closing_sessions: waiting for lock");
+    slogger.debug("drain_closing_sessions: waiting for lock");
     seastar::timer<lowres_clock> lock_timer([this] {
         slogger.warn("drain_closing_sessions: still waiting for lock, available units {}",
                      _session_drain_sem.available_units());
@@ -68,13 +68,13 @@ future<> session_manager::drain_closing_sessions() {
     auto lock = co_await get_units(_session_drain_sem, 1);
     lock_timer.cancel();
     auto n = std::distance(_closing_sessions.begin(), _closing_sessions.end());
-    slogger.info("drain_closing_sessions: acquired lock, {} sessions to drain", n);
+    slogger.debug("drain_closing_sessions: acquired lock, {} sessions to drain", n);
     auto i = _closing_sessions.begin();
     while (i != _closing_sessions.end()) {
         session& s = *i;
         ++i;
         auto id = s.id();
-        slogger.info("drain_closing_sessions: waiting for session {} to close, gate count {}", id, s.gate_count());
+        slogger.debug("drain_closing_sessions: waiting for session {} to close, gate count {}", id, s.gate_count());
         std::optional<seastar::timer<lowres_clock>> warn_timer;
         warn_timer.emplace([&s, id] {
             slogger.warn("drain_closing_sessions: session {} still not closed, gate count {}",
@@ -87,7 +87,7 @@ future<> session_manager::drain_closing_sessions() {
             slogger.info("drain_closing_sessions: session {} closed", id);
         }
     }
-    slogger.info("drain_closing_sessions: done");
+    slogger.debug("drain_closing_sessions: done");
 }
 
 } // namespace service


### PR DESCRIPTION
The log was with high priority because we chased a bug in this area. But now the bug is fixed and we still have warning logged if session is not closed for 5 minutes, so we can reduce the verbosity of the logging in the normal flow.

Fixes SCYLLADB-3905

Backport to all supported version that has the logs enabled.