### PR TITLE
utils/s3: drain in-flight requests before closing the http clients

### DIFF
--- a/utils/s3/client.cc
+++ b/utils/s3/client.cc
@@ -500,6 +500,9 @@ future<> client::make_request(http::request req,
                               error_handler err_handler,
                               std::optional<http::reply::status_type> expected,
                               seastar::abort_source* as) {
+    // Held for the whole request. close() waits for the gate before closing
+    // the http clients, so no http connection can outlive them.
+    auto holder = _requests_gate.hold();
     auto request = std::move(req);
     auto handler = wrap_handler(request, std::move(handle), expected);
     co_await authorize(request);
@@ -516,6 +519,9 @@ future<> client::make_request(http::request req,
                               error_handler err_handler,
                               std::optional<http::reply::status_type> expected,
                               seastar::abort_source* as) {
+    // Held across the lookup as well: find_or_create_client() can suspend and
+    // insert into _https, which close() must not drain in that window.
+    auto holder = _requests_gate.hold();
     auto& gc = co_await find_or_create_client();
     auto handle = [&gc, handle = std::move(handle_ex)] (const http::reply& rep, input_stream<char>&& in) {
         return handle(gc, rep, std::move(in));
@@ -2016,6 +2022,7 @@ future<> client::close() noexcept {
     s3l.info("Closing S3 client...");
 
     co_await _config_update_gate.close();
+    co_await _requests_gate.close();
     {
         auto units = co_await get_units(_creds_sem, 1);
         _creds_invalidation_timer.cancel();

--- a/utils/s3/client.hh
+++ b/utils/s3/client.hh
@@ -121,6 +121,7 @@ class client : public enable_shared_from_this<client> {
     aws_credentials _credentials;
     aws::aws_credentials_provider_chain _creds_provider_chain;
     seastar::gate _config_update_gate;
+    seastar::gate _requests_gate;
 
     struct group_client {
         seastar::http::client http;


### PR DESCRIPTION
### Problem

`seastar::http::client::close()` drains only the connection pool. A connection checked out for an in-flight request is not in the pool, so `close()` returns while that connection is still alive, and `http::client` declares no destructor that waits for it. The S3 client hands a `shared_ptr<client>` to every `readable_file`, data source and data sink, and the `http::client` instances live in the client's `_https` map, so an open file keeps them alive past `close()`. Were a `close()` to run with a connection checked out, the last holder to drop would destroy the `http::client`, and that connection's `client_ref` destructor would then dereference freed memory.

This is reachable by construction, not observed — there is no production or CI failure behind it. Nothing closes an S3 client while files are still open on it today: `s3_client_wrapper::update_config_sync()` reconfigures the live client in place rather than swapping it, so S3 only closes at shutdown, by which point the files are closed. The guard is absent, not unnecessary; adding a swap-based reconfigure path would arm it.

### Changes

`client` gets a gate that every request holds for its duration, and `client::close()` closes that gate before closing the `_https` entries' http clients. After `close()` returns no request is in flight and every connection is back in the pool, so the pool drain is complete and destroying the client later has nothing left to dangle.

All four `make_request()` overloads funnel through the one that calls `group_client::http.make_request()`, and that is the only place a request touches an http client, so one hold there covers every request — including `chunked_download_source`'s filling fiber. The `reply_handler_ext` overload takes a second hold across its own `find_or_create_client()` call, because that can suspend on `_rebalance_sem` and then insert into `_https`, which `close()` must not miss in its drain. The gate closes before the `_creds_sem` block in `close()` deliberately: a request holding the gate can still be inside `authorize()` waiting on that semaphore, and the reverse order would have `close()` hold the semaphore while waiting for a request that needs it.

### Follow-up to #31164

#31164 fixed this same ownership shape for GCS and deliberately left S3 alone, filing SCYLLADB-3844 for it. This is that follow-up, and it is the same change.

Unlike the GCS case there is no test to add or re-enable. The test commit in #31164 only removed a `skip_bug()` from `test_create_keyspace_after_config_update`, which had been disabled because the GCS close race made it flaky. The `[s3]` flavor of that same test already runs, already pushes a config update at a live client, and passes with or without this commit — because S3 reconfigures in place and never closes. A test that fails on revert would need a new error-injection point in the S3 request path to stall a request while `close()` runs, which is more than the GCS fix carried.

The alternative of making `seastar::http::client::close()` await `_nr_connections == 0` — which `~client_ref` already broadcasts for — is closed as Won't Fix (SCYLLADB-3845), so the per-caller gate is the remaining option.

Tested in dev mode: `test/boost/s3_test.cc` 45/45, and `test_create_keyspace_after_config_update` passes in both the `[s3]` and `[gs]` flavors.

Fixes: https://scylladb.atlassian.net/browse/SCYLLADB-3844

No backport needed. The fault cannot fire on the release branches either — nothing there closes an S3 client while files are open on it — so this only removes the latent hazard on master. #31164 was backported because the GCS path had a live trigger and a reproducing test; this one has neither.
