### PR TITLE
sstable: allow recovery from failed component rewrite

### DIFF
--- a/compaction/compaction_manager.cc
+++ b/compaction/compaction_manager.cc
@@ -1473,7 +1473,10 @@ future<stop_iteration> compaction_task_executor::maybe_retry(std::exception_ptr 
             cmlog.error("{}: failed: {}. Will retry in {} seconds", *this, std::current_exception(),
                     std::chrono::duration_cast<std::chrono::seconds>(_compaction_retry.sleep_time()).count());
             switch_state(state::pending);
-            return _compaction_retry.retry(_compaction_data.abort).handle_exception_type([this] (sleep_aborted&) {
+            auto retry_future = utils::get_local_injector().enter("compaction_task_executor_compaction_retry_sleep_aborted")
+                ? make_exception_future(sleep_aborted{})
+                : _compaction_retry.retry(_compaction_data.abort);
+            return retry_future.handle_exception_type([this] (sleep_aborted&) {
                 return make_exception_future<>(make_compaction_stopped_exception());
             }).then([] {
                 return make_ready_future<stop_iteration>(false);

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -2585,6 +2585,10 @@ compaction_group::do_update_sstable_sets_on_compaction_completion(compaction::co
     // if the deletion fails (note deletion of shared sstables can take
     // unbounded time, because all shards must agree on the deletion).
 
+    utils::get_local_injector().inject("update_sstable_sets_on_compaction_completion_fail", [] {
+        throw std::runtime_error{"update_sstable_sets_on_compaction_completion_fail error injection"};
+    });
+
     // make sure all old sstables belong *ONLY* to current shard before we proceed to their deletion.
     for (auto& sst : desc.old_sstables) {
         auto shards = sst->get_shards_for_this_sstable();

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -1645,14 +1645,14 @@ bool sstable::should_update_repaired_at(int64_t repaired_at) const {
 // This efficiently creates a modified SSTable without copying all files.
 // 1. Create a new SSTable object with a new generation number
 //    - The creator function determines the new generation
-// 2. Hard-link all components EXCEPT the one being rewritten and Scylla metadata
+// 2. Copy in-memory Statistics, Digest and Checksum components from the source SSTable
+// 3. Hard-link all components EXCEPT the one being rewritten and Scylla metadata
 //    - The component being rewritten will be written fresh (not linked)
 //    - Scylla metadata must be rewritten to include the new component's digest
-// 3. Copy in-memory component metadata from the source SSTable
-//    - This doesn't deep copy _components, just copies the foreign_ptr
-// 4. Apply the modifier function to the new SSTable's components
-// 5. Re-read the Scylla metadata from disk
-//    - Ensures we have the latest on-disk metadata (not potentially modified in-memory state)
+// 4. Read the Scylla, Compression, Filter and Summary components from disk
+//    - This is done in order to have a deep copy of in-memory components, not just a shallow-copy of the _components pointer.
+//    - Reading the Scylla component form disk ensures we have the latest on-disk metadata (not potentially modified in-memory state)
+// 5. Apply the modifier function to the new SSTable's components
 // 6. If update_sstable_id is true, update the Scylla metadata's sstable identifier to a new value
 // 7. Write the component with updated Scylla metadata
 //    - Uses write_component_with_metadata() which handles digest calculation and metadata updates
@@ -1708,8 +1708,42 @@ future<shared_sstable> sstable::link_with_rewritten_component(std::function<shar
         new_sst->mark_created_by_component_rewrite();
 
         std::unordered_set<component_type> excluded_components = {component, component_type::Scylla};
+
+        new_sst->_recognized_components = _recognized_components;
+        new_sst->_features = _components->scylla_metadata ? _components->scylla_metadata->get_features() : sstable_enabled_features{};
+
+        if (new_sst->_marked_for_deletion == mark_for_deletion::none) {
+            new_sst->_marked_for_deletion = mark_for_deletion::implicit;
+        }
+
+        new_sst->_components->statistics = _components->statistics;
+        new_sst->_components->digest = _components->digest;
+        new_sst->_components->checksum = _components->checksum;
+
         _storage->link_with_excluded_components(*this, generation, excluded_components, *sid).get();
-        new_sst->copy_components(*this).get();
+
+        // FIXME: Optimize by re-reading metadata only if _components->scylla_metadata was modified after loading.
+        // If unchanged, reuse the existing _components->scylla_metadata instead.
+        new_sst->_components->scylla_metadata.emplace();
+        auto metadata_size = _metadata_size_on_disk;
+        std::exception_ptr ex;
+
+        try {
+            read_simple<component_type::Scylla>(*new_sst->_components->scylla_metadata).get();
+        } catch (...) {
+            ex = std::current_exception();
+        }
+
+        _metadata_size_on_disk = metadata_size;
+        if (ex) {
+            std::rethrow_exception(ex);
+        }
+
+        when_all_succeed(
+            [&] { return new_sst->read_compression(); },
+            [&] { return new_sst->read_filter(); },
+            [&] { return new_sst->read_summary(); }
+        ).get();
 
         new_sst->_metadata_size_on_disk = _metadata_size_on_disk;
         parallel_for_each(excluded_components, coroutine::lambda([this, new_sst] (component_type type) -> future<> {
@@ -1718,18 +1752,25 @@ future<shared_sstable> sstable::link_with_rewritten_component(std::function<shar
 
         modifier(*new_sst);
 
-        // FIXME: Optimize by re-reading metadata only if _components->scylla_metadata was modified after loading.
-        // If unchanged, reuse the existing _components->scylla_metadata instead.
-        scylla_metadata metadata;
-        read_simple<component_type::Scylla>(metadata).get();
-
-        new_sst->write_component_with_metadata(component, std::move(metadata));
+        new_sst->write_component_with_metadata(component);
 
         new_sst->_shards = this->_shards;
-        new_sst->seal_sstable(false).get();
-        new_sst->open_data().get();
 
-        _cloned_to_sstable_filename = new_sst->component_basename(component_type::Data);
+        ex = nullptr;
+        try {
+            new_sst->seal_sstable(false).get();
+            new_sst->open_data().get();
+
+            _cloned_to_sstable_filename = new_sst->component_basename(component_type::Data);
+        } catch (...) {
+            ex = std::current_exception();
+        }
+
+        if (ex) {
+            new_sst->unlink().get();
+            std::rethrow_exception(ex);
+        }
+
         return new_sst;
     });
 }
@@ -1741,11 +1782,15 @@ future<shared_sstable> sstable::link_with_rewritten_component(std::function<shar
 // 2. Update the Scylla metadata's ComponentsDigests map with the new component digest
 // 3. Calculate the Scylla metadata's own digest based on its updated data
 // 4. Write the Scylla metadata component file
-// 5. Set the in-memory Scylla metadata to the new metadata
-void sstable::write_component_with_metadata(component_type type, scylla_metadata metadata) {
+void sstable::write_component_with_metadata(component_type type) {
     if (!is_component_rewrite_supported(type)) {
         on_internal_error(sstlog, "Only Statistics component can be rewritten.");
     }
+    if (!_components->scylla_metadata) {
+        on_internal_error(sstlog, "SSTable must have Scylla component to rewrite Statistics component.");
+    }
+
+    auto& metadata = *_components->scylla_metadata;
 
     write_component(type);
 
@@ -1763,7 +1808,6 @@ void sstable::write_component_with_metadata(component_type type, scylla_metadata
 
     write_simple<component_type::Scylla>(metadata);
 
-    _components->scylla_metadata = std::move(metadata);
     // Keep the cached _features in sync with the metadata we just wrote,
     // mirroring read_scylla_metadata(). Otherwise a rewritten sstable would
     // report zeroed features (e.g. losing ShadowableTombstones).

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -1756,6 +1756,10 @@ future<shared_sstable> sstable::link_with_rewritten_component(std::function<shar
 
         new_sst->_shards = this->_shards;
 
+        utils::get_local_injector().inject("link_with_rewritten_component_fail", [] {
+            throw std::runtime_error{"link_with_rewritten_component_fail error injection"};
+        });
+
         ex = nullptr;
         try {
             new_sst->seal_sstable(false).get();

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -1271,7 +1271,7 @@ public:
             std::function<void(sstable&)> modifier,
             update_sstable_id);
     // Must be called in a seastar thread
-    void write_component_with_metadata(component_type type, scylla_metadata metadata);
+    void write_component_with_metadata(component_type type);
 private:
     future<uint64_t> component_filesize(component_type type) const noexcept;
 };

--- a/sstables/types.hh
+++ b/sstables/types.hh
@@ -248,6 +248,7 @@ struct metadata {
     virtual ~metadata() {}
     virtual uint64_t serialized_size(sstable_version_types v) const = 0;
     virtual void write(sstable_version_types v, file_writer& write) const = 0;
+    virtual std::unique_ptr<metadata> clone() const = 0;
 };
 
 template <typename T>
@@ -266,6 +267,9 @@ public:
     }
     virtual void write(sstable_version_types v, file_writer& writer) const override {
         return sstables::write(v, writer, static_cast<const Component&>(*this));
+    }
+    virtual std::unique_ptr<metadata> clone() const final {
+        return std::make_unique<Component>(static_cast<const Component&>(*this));
     }
 };
 
@@ -814,6 +818,27 @@ inline int32_t adjusted_local_deletion_time(gc_clock::time_point local_deletion_
 struct statistics {
     disk_array<uint32_t, std::pair<metadata_type, uint32_t>> offsets; // ordered by metadata_type
     std::unordered_map<metadata_type, std::unique_ptr<metadata>> contents;
+private:
+    std::unordered_map<metadata_type, std::unique_ptr<metadata>> clone_contents() const {
+        std::unordered_map<metadata_type, std::unique_ptr<metadata>> result;
+        for (const auto& [type, md] : contents) {
+            result[type] = md->clone();
+        }
+        return result;
+    }
+public:
+    statistics() = default;
+    ~statistics() = default;
+    statistics(statistics&&) = default;
+    statistics(const statistics& other)
+        : offsets{other.offsets}
+        , contents{other.clone_contents()} {}
+    statistics& operator=(statistics&&) = default;
+    statistics& operator=(const statistics& other) {
+        offsets = other.offsets;
+        contents = other.clone_contents();
+        return *this;
+    }
 };
 
 enum class column_mask : uint8_t {

--- a/test/boost/sstable_compaction_test.cc
+++ b/test/boost/sstable_compaction_test.cc
@@ -6436,6 +6436,63 @@ SEASTAR_TEST_CASE(test_perform_component_rewrite_single_sstable_without_backup) 
     return test_perform_component_rewrite_single_sstable(sstables::update_sstable_id::no);
 }
 
+void do_test_component_rewrite_failure(test_env& env) {
+    simple_schema ss;
+    auto s = ss.schema();
+    auto pk = ss.make_pkey();
+
+    auto mut1 = mutation(s, pk);
+    mut1.partition().apply_insert(*s, ss.make_ckey(0), ss.new_timestamp());
+    auto sst = make_sstable_containing(env.make_sstable(s), {mut1}).get();
+
+    auto table = env.make_table_for_tests(s);
+    auto close_table = deferred_stop(table);
+
+    table->add_sstable_and_update_cache(sst).get();
+
+    auto all_sstables = table->get_sstables();
+    BOOST_REQUIRE(all_sstables->size() == 1);
+    BOOST_REQUIRE(all_sstables->contains(sst));
+
+    auto modifier = [] (sstables::sstable& sst) {
+        sst.update_repaired_at(1);
+    };
+
+    scoped_error_injection abort_retry_wait{"compaction_task_executor_compaction_retry_sleep_aborted"};
+    table->perform_component_rewrite(
+        dht::token_range::make_open_ended_both_sides(),
+        tasks::make_empty_task_info(),
+        [] (const auto&) { return true; },
+        sstables::component_type::Statistics,
+        std::move(modifier)
+    ).get();
+
+    auto res = sstables::validate_checksums_and_digests(sst, env.make_reader_permit()).get();
+    BOOST_REQUIRE(res.status == sstables::validate_checksums_status::valid);
+}
+
+SEASTAR_TEST_CASE(test_component_rewrite_replacer_failure) {
+#ifndef SCYLLA_ENABLE_ERROR_INJECTION
+    fmt::print("Skipping test as it depends on error injection. Please run in mode where it's enabled (debug,dev).\n");
+    return make_ready_future();
+#endif
+    return test_env::do_with_async([] (test_env& env) {
+        scoped_error_injection replacer_error{"update_sstable_sets_on_compaction_completion_fail"};
+        do_test_component_rewrite_failure(env);
+    });
+}
+
+SEASTAR_TEST_CASE(test_component_rewrite_failure) {
+#ifndef SCYLLA_ENABLE_ERROR_INJECTION
+    fmt::print("Skipping test as it depends on error injection. Please run in mode where it's enabled (debug,dev).\n");
+    return make_ready_future();
+#endif
+    return test_env::do_with_async([] (test_env& env) {
+        scoped_error_injection rewrite_error{"link_with_rewritten_component_fail"};
+        do_test_component_rewrite_failure(env);
+    });
+}
+
 static void object_storage_perform_component_rewrite_single_sstable_fn(test_env& env) {
     // Regression test for SCYLLADB-3420.
     //

--- a/test/boost/sstable_test.cc
+++ b/test/boost/sstable_test.cc
@@ -495,6 +495,71 @@ SEASTAR_TEST_CASE(test_link_with_rewritten_component_bytes_on_disk) {
     return test_env::do_with_async(do_test_link_with_rewritten_component_size);
 }
 
+static void do_test_link_with_rewritten_component(test_env& env, sstable_version_types version) {
+    auto random_spec = tests::make_random_schema_specification(
+        "ks",
+        std::uniform_int_distribution<size_t>(1, 4),
+        std::uniform_int_distribution<size_t>(2, 4),
+        std::uniform_int_distribution<size_t>(2, 8),
+        std::uniform_int_distribution<size_t>(2, 8));
+    auto random_schema = tests::random_schema{tests::random::get_int<uint32_t>(), *random_spec};
+    auto schema = random_schema.schema();
+
+    const auto muts = tests::generate_random_mutations(random_schema, 2).get();
+    auto sst = make_sstable_containing(env.make_sstable(schema, version), muts).get();
+
+    const auto orig_components = sst->all_components();
+    const auto orig_offsets = sstables::test(sst)._statistics().offsets.elements;
+    const auto orig_features = sst->features().enabled_features;
+    const auto orig_run_id = sst->run_identifier();
+    const auto orig_sid = sst->sstable_identifier();
+    const auto orig_shards = sst->get_shards_for_this_sstable();
+    const auto orig_has_summary = bool{sst->get_summary()};
+    const auto orig_generation = sst->generation();
+
+    auto new_sst = mutate_sstable(env, sst, std::identity{}).get();
+
+    BOOST_REQUIRE(new_sst->get_version() == version);
+    BOOST_REQUIRE(new_sst->generation() != orig_generation);
+    BOOST_REQUIRE(new_sst->sstable_identifier() == orig_sid);
+    BOOST_REQUIRE(new_sst->all_components() == orig_components);
+    BOOST_REQUIRE(new_sst->features().enabled_features == orig_features);
+    BOOST_REQUIRE(new_sst->run_identifier() == orig_run_id);
+    BOOST_REQUIRE(new_sst->get_shards_for_this_sstable() == orig_shards);
+    BOOST_REQUIRE(sstables::test(new_sst)._statistics().offsets.elements == orig_offsets);
+    BOOST_REQUIRE(orig_has_summary == bool{new_sst->get_summary()});
+}
+
+SEASTAR_TEST_CASE(test_link_with_rewritten_component_mt) {
+    return test_env::do_with_async([] (test_env& env) {
+        do_test_link_with_rewritten_component(env, sstable_version_types::mt);
+    });
+}
+
+SEASTAR_TEST_CASE(test_link_with_rewritten_component_ms) {
+    return test_env::do_with_async([] (test_env& env) {
+        do_test_link_with_rewritten_component(env, sstable_version_types::ms);
+    });
+}
+
+SEASTAR_TEST_CASE(test_link_with_rewritten_component_me) {
+    return test_env::do_with_async([] (test_env& env) {
+        do_test_link_with_rewritten_component(env, sstable_version_types::me);
+    });
+}
+
+SEASTAR_TEST_CASE(test_link_with_rewritten_component_md) {
+    return test_env::do_with_async([] (test_env& env) {
+        do_test_link_with_rewritten_component(env, sstable_version_types::md);
+    });
+}
+
+SEASTAR_TEST_CASE(test_link_with_rewritten_component_mc) {
+    return test_env::do_with_async([] (test_env& env) {
+        do_test_link_with_rewritten_component(env, sstable_version_types::mc);
+    });
+}
+
 // Tests for reading a large partition for which the index contains a
 // "promoted index", i.e., a sample of the column names inside the partition,
 // with which we can avoid reading the entire partition when we look only


### PR DESCRIPTION
Currently, `link_with_rewritten_component` modifies the in-memory component state of the original sstable. 
Normally, shortly after, the original sstable gets replaced by the cloned one and unlinked, so this does not matter.
However, if `link_with_rewritten_component` fails after mutating the state, or the rewrite component compaction doesn't correctly replace the original sstable (e.g. if `do_update_sstable_sets_on_compaction_completion` throws), the original sstable may be left in an invalid state.
When done with the `rewrite_sstables_component` compaction, this is usually masked by the retry. But, if the retry doesn't happen (e.g. it is aborted), the sstable will continue to have an invalid state. In particular, the digests will not match.

As the automatic scrub feature #31024 will rely on component rewrite to update scrub time, this path will be called much more often and will not be masked by compaction retry, as scrub in validate mode does not retry.
Additionally, mutating the original sstable's in memory state can impact concurrent operations like file streaming.

To fix this issue, create a new `shareable_components` instance, by copying in-memory Statistics, Digest and Checksum and reading the remaining components from file. Add a copy constructor for the Statistics component.
Add a test, which shows how the bug can be triggered. It only passes after the changes in this PR.

Fixes: https://scylladb.atlassian.net/browse/SCYLLADB-3943

backport to versions with the component rewrite mechanism that updates component digests