### PR TITLE
test: cluster: wait for CQL readiness after restart in remaining races

### DIFF
--- a/test/cluster/object_store/test_basic.py
+++ b/test/cluster/object_store/test_basic.py
@@ -15,7 +15,6 @@ from cassandra.protocol import ConfigurationException
 from cassandra.query import SimpleStatement, ConsistencyLevel
 from test.pylib.scylla_cluster_manager import ScyllaClusterManager
 from test.pylib.util import wait_for, wait_for_cql_and_get_hosts
-from test.cluster.util import reconnect_driver
 from test.pylib.object_storage import format_tuples, keyspace_options
 from test.cqlpy.rest_api import scylla_inject_error
 from test.cluster.test_config import wait_for_config
@@ -155,7 +154,7 @@ async def test_basic(manager: ScyllaClusterManager, object_storage, tmp_path, mo
         print('Restart scylla')
         for server in servers:
             await manager.server_restart(server.server_id)
-        cql = await reconnect_driver(manager)
+        cql, _ = await manager.get_ready_cql(servers)
 
         # Shouldn't be recreated by populator code
         assert not os.path.exists(os.path.join(workdir, f'data/{ks}')), "object storage backed keyspace has local directory resurrected"
@@ -195,7 +194,7 @@ async def test_garbage_collect(manager: ScyllaClusterManager, object_storage):
 
         print('Restart scylla')
         await manager.server_restart(server.server_id)
-        cql = await reconnect_driver(manager)
+        cql, _ = await manager.get_ready_cql([server])
 
         res = cql.execute(f"SELECT * FROM {ks}.test;")
         have_res = {x.name: x.value for x in res}
@@ -238,7 +237,7 @@ async def test_populate_from_quarantine(manager: ScyllaClusterManager, object_st
 
         print('Restart scylla')
         await manager.server_restart(server.server_id)
-        cql = await reconnect_driver(manager)
+        cql, _ = await manager.get_ready_cql([server])
 
         res = cql.execute(f"SELECT * FROM {ks}.test;")
         have_res = {x.name: x.value for x in res}
@@ -330,7 +329,7 @@ async def test_memtable_flush_retries(manager: ScyllaClusterManager, tmpdir, obj
 
         print('Restart scylla')
         await manager.server_restart(server.server_id)
-        cql = await reconnect_driver(manager)
+        cql, _ = await manager.get_ready_cql([server])
 
         res = cql.execute(f"SELECT * FROM {ks}.test;")
         have_res = { x.name: x.value for x in res }

--- a/test/cluster/test_audit.py
+++ b/test/cluster/test_audit.py
@@ -173,6 +173,7 @@ class AuditTester:
                 await self.manager.server_update_config(srv.server_id, config_options=full_cfg)
                 await self.manager.server_start(srv.server_id)
                 await self.manager.driver_connect(auth_provider=auth_provider)
+                await self.manager.get_ready_cql([srv])
             else:
                 # Server stays up — only push live-updatable keys.
                 live_cfg = {k: v for k, v in target_config.items() if k in LIVE_AUDIT_KEYS}
@@ -283,7 +284,8 @@ class AuditTester:
 
         self._prev_config_keys = set(target_config.keys())
 
-        cql = self.manager.get_cql()
+        current_servers = await self.manager.running_servers()
+        cql, _ = await self.manager.get_ready_cql(current_servers)
         cql.get_execution_profile(EXEC_PROFILE_DEFAULT).consistency_level = ConsistencyLevel.ONE
         audit_mode = target_config.get("audit") or ""
         if "table" not in audit_mode:

--- a/test/cluster/test_change_rpc_address.py
+++ b/test/cluster/test_change_rpc_address.py
@@ -62,6 +62,7 @@ async def test_change_rpc_address(two_nodes_cluster: list[ServerNum],
 
         # Connect the Python driver back with updated IP address.
         await manager.driver_connect()
+        await manager.get_ready_cql(await manager.running_servers())
 
         await table.add_column()
         await random_tables.verify_schema()
@@ -81,6 +82,7 @@ async def test_change_rpc_address(two_nodes_cluster: list[ServerNum],
 
     # Connect the Python driver back with updated IP addresses.
     await manager.driver_connect()
+    await manager.get_ready_cql(await manager.running_servers())
 
     await table.add_column()
     await random_tables.verify_schema()

--- a/test/cluster/test_mutation_schema_change.py
+++ b/test/cluster/test_mutation_schema_change.py
@@ -44,6 +44,7 @@ async def test_mutation_schema_change(manager, random_tables):
     logger.info("Stopping C %s", server_c)
     await manager.server_stop_gracefully(server_c.server_id)
     await manager.driver_connect()
+    await wait_for_cql_and_get_hosts(manager.cql, [server_a, server_b], time.time() + 60)
 
     async with inject_error(manager.api, server_b.ip_addr, 'paxos_error_before_learn'):
         await t.add_column()
@@ -104,6 +105,7 @@ async def test_mutation_schema_change_restart(manager, random_tables):
     logger.info("Stopping C %s", server_c)
     await manager.server_stop_gracefully(server_c.server_id)
     await manager.driver_connect()
+    await wait_for_cql_and_get_hosts(manager.cql, [server_a, server_b], time.time() + 60)
 
     await inject_error_one_shot(manager.api, server_a.ip_addr,
                                 'raft_server_reduce_threshold')

--- a/test/cluster/test_read_repair.py
+++ b/test/cluster/test_read_repair.py
@@ -221,8 +221,9 @@ async def test_incremental_read_repair(data_class: DataClass, manager: ScyllaClu
                 await manager.server_stop_gracefully(other_node.server_id)
 
             await manager.driver_connect(node)
+            cql, _ = await manager.get_ready_cql([node])
 
-            await data_class.write_data(manager.get_cql(), ks, total_rows, node_live_rows, all_live_rows)
+            await data_class.write_data(cql, ks, total_rows, node_live_rows, all_live_rows)
 
             for other_node in other_nodes:
                 await manager.server_start(other_node.server_id)

--- a/test/cluster/test_snapshot.py
+++ b/test/cluster/test_snapshot.py
@@ -49,6 +49,7 @@ async def test_snapshot(manager, random_tables):
 
     logger.info("Driver connecting to D %s", server_d)
     await manager.driver_connect()
+    await manager.get_ready_cql([server_d])
 
     await random_tables.verify_schema(do_read_barrier=False)
 

--- a/test/cluster/test_strong_consistency.py
+++ b/test/cluster/test_strong_consistency.py
@@ -10,7 +10,7 @@ from typing import Tuple
 
 from test.pylib.scylla_cluster_manager import ScyllaClusterManager
 from test.pylib.util import gather_safely, wait_for, Host
-from test.cluster.util import new_test_keyspace, new_test_table, reconnect_driver
+from test.cluster.util import new_test_keyspace, new_test_table
 from test.pylib.internal_types import HostID, ServerInfo
 from cassandra import InvalidRequest, ReadTimeout, WriteTimeout
 from cassandra.cluster import ConsistencyLevel
@@ -480,8 +480,7 @@ async def test_sc_persistence_restart_with_smp_increase(manager: ScyllaClusterMa
 
             await manager.server_update_cmdline(server.server_id, ['--smp=4'])
             await manager.server_restart(server.server_id)
-            await reconnect_driver(manager)
-            cql = manager.get_cql()
+            (cql, hosts) = await manager.get_ready_cql([server])
 
             # We can't read the internal raft state directly, so we perform extra writes
             # which should cause raft table updates based on the loaded state after restart.
@@ -532,8 +531,7 @@ async def test_sc_persistence_with_compaction(manager: ScyllaClusterManager):
 
             # Restart to verify compacted SSTables are correctly readable by raft server
             await manager.server_restart(server.server_id)
-            await reconnect_driver(manager)
-            cql = manager.get_cql()
+            (cql, hosts) = await manager.get_ready_cql([server])
 
             # We can't read the internal raft state directly, so we perform extra writes
             # which should cause raft table updates based on the loaded state after restart.
@@ -569,8 +567,7 @@ async def test_sc_persistence_after_crash(manager: ScyllaClusterManager):
             await manager.server_stop(server.server_id, convict=False)
 
             await manager.server_start(server.server_id)
-            await reconnect_driver(manager)
-            cql = manager.get_cql()
+            (cql, hosts) = await manager.get_ready_cql([server])
 
             # We can't read the internal raft state directly, so we perform extra writes
             # which should cause raft table updates based on the loaded state after restart.

--- a/test/cluster/test_strong_consistency_commitlog.py
+++ b/test/cluster/test_strong_consistency_commitlog.py
@@ -5,7 +5,7 @@
 #
 
 from test.pylib.scylla_cluster_manager import ScyllaClusterManager
-from test.cluster.util import new_test_keyspace, reconnect_driver
+from test.cluster.util import new_test_keyspace
 
 import pytest
 
@@ -37,8 +37,7 @@ async def test_data_survives_crash(manager: ScyllaClusterManager):
         # Crash the node (non-graceful stop — no flush)
         await manager.server_stop(server.server_id, convict=False)
         await manager.server_start(server.server_id)
-        await reconnect_driver(manager)
-        cql = manager.get_cql()
+        (cql, hosts) = await manager.get_ready_cql([server])
 
         for pk in range(5):
             rows = await cql.run_async(f"SELECT * FROM {ks}.test WHERE pk = {pk};")
@@ -94,8 +93,7 @@ async def test_schema_upgrade_during_replay(manager: ScyllaClusterManager):
         # Crash the node (non-graceful stop — no flush)
         await manager.server_stop(server.server_id, convict=False)
         await manager.server_start(server.server_id)
-        await reconnect_driver(manager)
-        cql = manager.get_cql()
+        (cql, hosts) = await manager.get_ready_cql([server])
 
         # Verify rows written under the old schema
         for pk in range(5):
@@ -140,8 +138,7 @@ async def test_double_crash_recovery(manager: ScyllaClusterManager):
         # First crash
         await manager.server_stop(server.server_id, convict=False)
         await manager.server_start(server.server_id)
-        await reconnect_driver(manager)
-        cql = manager.get_cql()
+        (cql, hosts) = await manager.get_ready_cql([server])
 
         # Verify phase 1 data survived
         for pk in range(10):
@@ -156,8 +153,7 @@ async def test_double_crash_recovery(manager: ScyllaClusterManager):
         # Second crash
         await manager.server_stop(server.server_id, convict=False)
         await manager.server_start(server.server_id)
-        await reconnect_driver(manager)
-        cql = manager.get_cql()
+        (cql, hosts) = await manager.get_ready_cql([server])
 
         # Verify all data (both phases) survived
         for pk in range(20):
@@ -200,8 +196,7 @@ async def test_crash_with_multiple_commitlog_segments(manager: ScyllaClusterMana
         # Crash
         await manager.server_stop(server.server_id, convict=False)
         await manager.server_start(server.server_id)
-        await reconnect_driver(manager)
-        cql = manager.get_cql()
+        (cql, hosts) = await manager.get_ready_cql([server])
 
         # Verify all rows survived
         rows_by_pk = {}
@@ -244,8 +239,7 @@ async def test_crash_recovery_multi_tablet(manager: ScyllaClusterManager):
         # Crash
         await manager.server_stop(server.server_id, convict=False)
         await manager.server_start(server.server_id)
-        await reconnect_driver(manager)
-        cql = manager.get_cql()
+        (cql, hosts) = await manager.get_ready_cql([server])
 
         # Verify all rows survived
         rows_by_pk = {}
@@ -293,8 +287,7 @@ async def test_crash_recovery_after_flush(manager: ScyllaClusterManager):
         # Crash (non-graceful — phase 2 data is only in commitlog)
         await manager.server_stop(server.server_id, convict=False)
         await manager.server_start(server.server_id)
-        await reconnect_driver(manager)
-        cql = manager.get_cql()
+        (cql, hosts) = await manager.get_ready_cql([server])
 
         # Verify all data: flushed (phase 1) + replayed from commitlog (phase 2)
         for pk in range(20):

--- a/test/cluster/test_tls.py
+++ b/test/cluster/test_tls.py
@@ -57,7 +57,8 @@ async def test_upgrade_to_ssl(manager: ScyllaClusterManager) -> None:
         async def reconnect():
             manager.driver_close()
             await manager.driver_connect()
-            return manager.get_cql()
+            cql, _ = await manager.get_ready_cql(servers)
+            return cql
 
         async def run_retry_async(stmt : str):
             lcql = cql

--- a/test/cluster/test_truncate_with_drop.py
+++ b/test/cluster/test_truncate_with_drop.py
@@ -45,9 +45,8 @@ async def test_truncation_records_pruned_on_dirty_restart(manager: ScyllaCluster
     async def restart():
         await manager.server_stop(server.server_id, convict=False)
         await manager.server_start(server.server_id)
-        manager.driver_close()
-        await manager.driver_connect()
-        return manager.cql
+        cql, _ = await manager.get_ready_cql([server])
+        return cql
     
     # Create a keyspace
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1}") as ks:


### PR DESCRIPTION
## Summary

Follow-up to #31265 (SCYLLADB-3908). That PR fixed a race in `test_commitlog_segment_data_resurrection.py` where a test reused `manager.cql`/called `driver_connect()` and immediately queried right after a node restart, without waiting for full CQL readiness — `driver_connect()` alone doesn't guarantee the driver's control connection is actually usable yet, causing an intermittent `DriverException("Reconnecting during shutdown") -> NoHostAvailable`.

An AI-assisted audit of `test/cluster` (see #31265 discussion) found the same anti-pattern in several other files. Root cause: `reconnect_driver()` in `test/cluster/util.py` only does `driver_close()` + `driver_connect()` — it never waits for CQL readiness like `get_ready_cql()` does. This PR replaces the unsafe pattern with `get_ready_cql()` at each site found:

- `test/cluster/test_strong_consistency_commitlog.py` (6 test functions)
- `test/cluster/test_strong_consistency.py` (3 test functions)
- `test/cluster/object_store/test_basic.py` (4 test functions)
- `test/cluster/test_truncate_with_drop.py`
- `test/cluster/test_audit.py`
- `test/cluster/test_mutation_schema_change.py`
- `test/cluster/test_tls.py`
- `test/cluster/test_snapshot.py`
- `test/cluster/test_change_rpc_address.py`
- `test/cluster/test_read_repair.py`

Fixes: SCYLLADB-3957

## Test plan

- [x] All touched files compile (`py_compile`)
- [x] CI run on this PR