### PR TITLE
storage_proxy: use chunked_fifo for _throttled_writes

### DIFF
--- a/service/storage_proxy.hh
+++ b/service/storage_proxy.hh
@@ -33,7 +33,7 @@
 #include "utils/phased_barrier.hh"
 #include "utils/small_vector.hh"
 #include "service/endpoint_lifecycle_subscriber.hh"
-#include <seastar/core/circular_buffer.hh>
+#include <seastar/core/chunked_fifo.hh>
 #include "exceptions/coordinator_result.hh"
 #include "replica/exceptions.hh"
 #include "locator/host_id.hh"
@@ -302,7 +302,7 @@ private:
     // be already completed by the point they tried to be unthrottled (request completion does
     // not remove request from the buffer), but this is fine since request ids are unique, so we
     // just skip an entry if request no longer exists.
-    circular_buffer<response_id_type> _throttled_writes;
+    chunked_fifo<response_id_type> _throttled_writes;
     db::hints::resource_manager _hints_resource_manager;
     db::hints::manager _hints_manager;
     db::hints::directory_initializer _hints_directory_initializer;


### PR DESCRIPTION
_throttled_writes is a circular_buffer, which keeps all of its elements in a single contiguous array that it reallocates by doubling. Under a write or view-update backlog the queue legitimately grows to tens of thousands of entries, and the corresponding allocation trips seastar's large-allocation warning:

  seastar_memory - oversized allocation: 262144 bytes. This is non-fatal,
  but could lead to latency and/or fragmentation issues.

  seastar::circular_buffer<unsigned long, ...>::expand()
  service::abstract_write_response_handler::signal(unsigned long)::'lambda'(...)
  void service::abstract_write_response_handler::delay<...>(...)

Unbounded growth of the queue was already addressed by c19f980802a ("storage_proxy: avoid infinite growth of _throttled_writes"), which garbage-collects stale ids from the front. That bounds the queue logically, but a queue that is legitimately deep still needs one huge contiguous block, which is bad for fragmentation.

Switch to chunked_fifo, which stores the elements in fixed-size chunks held on a linked list, so the largest single allocation is O(1) rather than O(N) - about 1 KiB with the default 128 items per chunk.

_throttled_writes is a pure FIFO: the only operations used are push_back(), front(), pop_front(), empty() and size(), all of which chunked_fifo provides with the same semantics and the same complexity, so no other code has to change.

Fixes SCYLLADB-3788.
Fixes scylladb/scylladb#28035.
Fixes scylladb/scylladb#25793.

No need to backport. Mostly cosmetic problem.