### PR TITLE
test: migrate database_metrics_test.py from scylla-dtest

### DIFF
--- a/test/cqlpy/test_metrics.py
+++ b/test/cqlpy/test_metrics.py
@@ -2,7 +2,15 @@
 #
 # SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
 
+import logging
+import math
+
+import cassandra.concurrent
+
 from .util import new_test_table, ScyllaMetrics
+
+logger = logging.getLogger(__name__)
+
 
 # Test that executing CQL requests with client-provided timestamps
 # updates the client timestamp drift histogram metric.
@@ -29,3 +37,82 @@ def test_client_timestamp_drift_metric(cql, test_keyspace, scylla_only):
         after = count_after if count_after is not None else 0
         assert after >= before + 10, \
             f"Expected at least 10 new samples, got {after - before}"
+
+
+# Run read_func() and check that the number of reads it reports is reflected in
+# the scylla_database_total_reads metric of the user-facing read classes.
+# read_func() is expected to perform the reads and return how many it issued.
+def check_reads_counted(cql, read_func):
+    # A user connection starts in the sl:driver scheduling group and only migrates to
+    # sl:default once the server detects it as a user connection, so reads issued by the
+    # session may be accounted under either class. get() sums both for us.
+    classes = {"sl:default", "sl:driver"}
+
+    initial_reads = ScyllaMetrics.query(cql).get("scylla_database_total_reads", labels={"class": classes})
+    if initial_reads is None:
+        # Versions before 2025.1 merge these metrics into the "user" class
+        classes = {"user"}
+        initial_reads = ScyllaMetrics.query(cql).get("scylla_database_total_reads", labels={"class": classes})
+
+    total_count = read_func()
+
+    final_reads = ScyllaMetrics.query(cql).get("scylla_database_total_reads", labels={"class": classes})
+
+    added = final_reads - initial_reads
+    min_count = total_count
+    # The driver itself issues side-reads that get counted in the same metric classes: the
+    # control connection polls system.local/system.peers for schema agreement, and a schema
+    # change makes it re-read the system_schema tables. Their number depends on timing, not on
+    # how many reads the test issued, so `added` can exceed total_count by a few tens of reads.
+    # A 10% overshoot window absorbs that as long as total_count is large enough - which is why
+    # the callers below issue well over a thousand reads. An upper bound is still worth keeping
+    # so a regression that causes far more reads than expected doesn't go unnoticed.
+    max_count = total_count * 1.1
+    assert min_count <= added <= max_count, \
+        f"Expected additional reads to be in the [{min_count}, {max_count}] range, but metrics show {added} reads"
+
+
+# Following scylladb/scylla:0c6bbc8 queries are now classified by its initiator, so here is a
+# small test that aims to ensure that when a user runs queries, they will be marked as user
+# initiated (here we are checking the `scylla_database_total_reads` metric under class="user"
+# or the sl:default/sl:driver scheduling group classes).
+def test_total_reads_user(cql, test_keyspace, scylla_only):
+    schema = "c1 int, c2 int, primary key (c1)"
+    with new_test_table(cql, test_keyspace, schema) as table:
+        keys = range(100)
+        cassandra.concurrent.execute_concurrent_with_args(
+            cql, cql.prepare(f"INSERT INTO {table} (c1, c2) VALUES (?, ?)"),
+            [(k, k) for k in keys], concurrency=32)
+
+        select_stmt = cql.prepare(f"SELECT * FROM {table} WHERE c1=?")
+        # Read every key several times: the 10% overshoot allowed by check_reads_counted() has
+        # to stay comfortably above the driver's own background reads, whose number doesn't
+        # shrink with the number of reads the test issues.
+        reads_per_key = 16
+        params = [(k,) for k in keys for _ in range(reads_per_key)]
+
+        def read_func():
+            cassandra.concurrent.execute_concurrent_with_args(cql, select_stmt, params, concurrency=32)
+            return len(params)
+
+        check_reads_counted(cql, read_func)
+
+
+# Same principle as test_total_reads_user, but read a system table instead,
+# and check that the reads are still classified as "user" reads.
+def test_total_reads_system(cql, scylla_only):
+    all_rows = list(cql.execute("SELECT keyspace_name, table_name, column_name FROM system_schema.columns"))
+
+    # As in test_total_reads_user, issue plenty of reads so that the 10% overshoot allowed by
+    # check_reads_counted() stays well above the driver's own background reads.
+    rounds = math.ceil(1000 / len(all_rows))
+    params = [(r.keyspace_name, r.table_name, r.column_name) for _ in range(rounds) for r in all_rows]
+
+    select_stmt = cql.prepare(
+        "SELECT * FROM system_schema.columns WHERE keyspace_name=? AND table_name=? AND column_name=?")
+
+    def read_func():
+        cassandra.concurrent.execute_concurrent_with_args(cql, select_stmt, params, concurrency=32)
+        return len(params)
+
+    check_reads_counted(cql, read_func)

--- a/test/cqlpy/test_metrics.py
+++ b/test/cqlpy/test_metrics.py
@@ -2,14 +2,11 @@
 #
 # SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
 
-import logging
 import math
 
 import cassandra.concurrent
 
 from .util import new_test_table, ScyllaMetrics
-
-logger = logging.getLogger(__name__)
 
 
 # Test that executing CQL requests with client-provided timestamps

--- a/test/cqlpy/util.py
+++ b/test/cqlpy/util.py
@@ -366,8 +366,16 @@ class ScyllaMetrics:
             def match_kv(kv):
                 key, val = kv.split('=')
                 val = val.strip('"')
-                return shard == 'total' or val == shard if key == 'shard' \
-                    else labels is None or labels.get(key, None) == val
+                if key == 'shard':
+                    return shard == 'total' or val == shard
+                if labels is None:
+                    return True
+                expected = labels.get(key, None)
+                # A label may be given a collection of accepted values, in which case
+                # all of the matching series are summed up by the loop below.
+                if isinstance(expected, (list, tuple, set, frozenset)):
+                    return val in expected
+                return expected == val
             match = all(match_kv(kv) for kv in l[labels_start + 1:labels_finish].split(','))
             if match:
                 value = float(l[labels_finish + 2:])

--- a/test/cqlpy/util.py
+++ b/test/cqlpy/util.py
@@ -357,7 +357,7 @@ class ScyllaMetrics:
     def get(self, name, labels = None, shard='total'):
         result = None
         for l in self._lines:
-            if not l.startswith(name):
+            if not l.startswith(name) or l[len(name):len(name) + 1] not in ('{', ' '):
                 continue
             labels_start = l.find('{')
             labels_finish = l.find('}')

--- a/test/cqlpy/util.py
+++ b/test/cqlpy/util.py
@@ -355,7 +355,29 @@ class ScyllaMetrics:
         url = f'http://{cql.cluster.contact_points[0]}:9180/metrics'
         return ScyllaMetrics(requests.get(url).text.split('\n'))
     def get(self, name, labels = None, shard='total'):
+        """Return the value of the metric `name`, or None if it doesn't exist.
+
+        `labels` restricts which series of the metric are matched, and can express
+        both AND and OR conditions:
+          - Different keys in `labels` are ANDed together, e.g.
+            labels={'class': 'user', 'ks': 'ks1'} matches series with both
+            class="user" and ks="ks1".
+          - A single key may be given a collection of accepted values (list, tuple,
+            set or frozenset) to OR across them, e.g. labels={'class': {'sl:default',
+            'sl:driver'}} matches series with class="sl:default" OR class="sl:driver".
+        All matching series (across shards, and across OR'ed label values) are
+        summed up and returned as a single value.
+
+        `shard` restricts the result to a specific shard instead of the 'total'
+        (all-shards sum) pseudo-shard that Scylla itself reports.
+        """
         result = None
+        # An OR'ed label means more than one series per shard can match, so the
+        # early-exit-after-first-match optimization below (for shard != 'total')
+        # must be disabled in that case, or it would silently drop the other
+        # OR'ed series.
+        has_or_label = labels is not None and any(
+            isinstance(v, (list, tuple, set, frozenset)) for v in labels.values())
         for l in self._lines:
             if not l.startswith(name) or l[len(name):len(name) + 1] not in ('{', ' '):
                 continue
@@ -371,8 +393,6 @@ class ScyllaMetrics:
                 if labels is None:
                     return True
                 expected = labels.get(key, None)
-                # A label may be given a collection of accepted values, in which case
-                # all of the matching series are summed up by the loop below.
                 if isinstance(expected, (list, tuple, set, frozenset)):
                     return val in expected
                 return expected == val
@@ -383,6 +403,6 @@ class ScyllaMetrics:
                     result = value
                 else:
                     result += value
-                if shard != 'total':
+                if shard != 'total' and not has_or_label:
                     break
         return result


### PR DESCRIPTION
## Summary

Ports `database_metrics_test.py` from scylla-dtest into `test/cqlpy`, so it runs as part of the in-tree cqlpy suite.

The test verifies that queries issued directly by a client are correctly accounted as user-initiated reads in the `scylla_database_total_reads` metric — checked under the `"user"` class for versions before 2025.1, and under the `sl:default`/`sl:driver` scheduling-group classes since queries started being classified by initiator (scylladb/scylla:0c6bbc8). Two scenarios are covered:

- `test_total_reads_user`: concurrent inserts + selects against a user table
- `test_total_reads_system`: selects against a system table (`system_schema.columns`)

Migration from dtest, no production code changes.

## Backport

No backport needed: this only adds test coverage in the current in-tree cqlpy suite, it does not change or add any production behavior.
