### PR TITLE
logstor: add logstor_sparse_files, and enable it in tests

### DIFF
--- a/db/config.cc
+++ b/db/config.cc
@@ -983,6 +983,9 @@ db::config::config(std::shared_ptr<db::extensions> exts)
     , logstor_format_on_startup(this, "logstor_format_on_startup", value_status::Used, true,
         "Controls when logstor data files are formatted. When enabled, all logstor files are formatted during node startup, which increases startup time but ensures optimal write performance immediately after startup. "
         "When disabled, logstor files are formatted lazily on first write, which reduces startup time but may cause slightly degraded write performance on first access to each file.")
+    , logstor_sparse_files(this, "logstor_sparse_files", value_status::Used, false,
+        "Create logstor data files as sparse files. When disabled, each file is preallocated and fully written with zeros, guaranteeing space is available and avoiding fragmentation. "
+        "When enabled, the file is only extended to its nominal size, so unwritten regions consume no disk space. Useful for tests, where the disk space and I/O of formatting files is wasteful.")
     , logstor_compaction_trigger_threshold(this, "logstor_compaction_trigger_threshold", liveness::LiveUpdate, value_status::Used, 0.05,
         "Trigger automatic logstor compaction when the number of available segments drops below this fraction of the total number of logstor segments. A value of 0 disables the trigger threshold.")
     , logstor_compaction_max_shares(this, "logstor_compaction_max_shares", liveness::LiveUpdate, value_status::Used, 2000,

--- a/db/config.hh
+++ b/db/config.hh
@@ -278,6 +278,7 @@ public:
     named_value<uint32_t> logstor_disk_size_in_mb;
     named_value<uint32_t> logstor_file_size_in_mb;
     named_value<bool> logstor_format_on_startup;
+    named_value<bool> logstor_sparse_files;
     named_value<double> logstor_compaction_trigger_threshold;
     named_value<float> logstor_compaction_max_shares;
     named_value<uint32_t> file_cache_size_in_mb;

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -966,6 +966,7 @@ database::init_logstor() {
             .file_size = _cfg.logstor_file_size_in_mb() * 1024ull * 1024ull,
             .disk_size = _cfg.logstor_disk_size_in_mb() * 1024ull * 1024ull,
             .format_on_startup = _cfg.logstor_format_on_startup(),
+            .sparse_files = _cfg.logstor_sparse_files(),
             .trigger_compaction_threshold = _cfg.logstor_compaction_trigger_threshold,
             .compaction_sg = _dbcfg.logstor_compaction_scheduling_group,
             .compaction_static_shares = _cfg.compaction_static_shares,

--- a/replica/logstor/segment_manager.cc
+++ b/replica/logstor/segment_manager.cc
@@ -281,6 +281,7 @@ class file_manager {
     std::filesystem::path _base_dir;
     seastar::scheduling_group _sched_group;
     bool _format_on_startup;
+    bool _sparse_files;
 
     file_id_t _next_file_id{0};
 
@@ -300,6 +301,7 @@ public:
         , _base_dir(cfg.base_dir)
         , _sched_group(cfg.compaction_sg)
         , _format_on_startup(cfg.format_on_startup)
+        , _sparse_files(cfg.sparse_files)
         , _open_read_files(static_cast<size_t>(_max_files.actual))
     {}
 
@@ -359,8 +361,14 @@ future<> file_manager::format_file(file_id_t file_id) {
         auto tmp_path = file_path + ".tmp";
         auto tmp_file = co_await seastar::open_file_dma(tmp_path,
                 seastar::open_flags::rw | seastar::open_flags::create | seastar::open_flags::truncate | seastar::open_flags::dsync);
-        co_await tmp_file.allocate(0, _file_size);
-        co_await format_file_region(tmp_file, 0, _file_size);
+        if (_sparse_files) {
+            // Reading a hole yields zeros, so the file is already formatted as
+            // far as the reader is concerned.
+            co_await tmp_file.truncate(_file_size);
+        } else {
+            co_await tmp_file.allocate(0, _file_size);
+            co_await format_file_region(tmp_file, 0, _file_size);
+        }
         co_await tmp_file.close();
 
         // move the temp file to the final location

--- a/replica/logstor/segment_manager.hh
+++ b/replica/logstor/segment_manager.hh
@@ -45,6 +45,10 @@ struct segment_manager_config {
     uint64_t file_size = default_file_size;
     uint64_t disk_size;
     bool format_on_startup = true;
+    // Create files sparse: extend them to their nominal size without
+    // preallocating or zero-filling. Saves disk space and I/O, at the cost of
+    // fragmentation and of not reserving space up front.
+    bool sparse_files = false;
     bool compaction_enabled = true;
     size_t max_segments_per_compaction = 32;
     utils::updateable_value<double> trigger_compaction_threshold{0.05};

--- a/test/boost/logstor_test.cc
+++ b/test/boost/logstor_test.cc
@@ -329,6 +329,7 @@ logstor_config make_test_logstor_config(const std::filesystem::path& base_dir) {
             .segment_size = segment_size,
             .file_size = file_size,
             .disk_size = 4 * file_size,
+            .sparse_files = true,
             .compaction_enabled = true,
             .max_segments_per_compaction = 8,
             .compaction_sg = seastar::current_scheduling_group(),

--- a/test/cqlpy/run.py
+++ b/test/cqlpy/run.py
@@ -343,6 +343,8 @@ def run_scylla_cmd(pid, dir):
         '--alternator-ttl-period-in-seconds=0.5',
         '--logstor-disk-size-in-mb=8',
         '--logstor-file-size-in-mb=4',
+        # Don't waste disk space and I/O on formatting logstor files
+        '--logstor-sparse-files=true',
         ], env)
 
 # Same as run_scylla_cmd, just use SSL encryption for the CQL port (same
@@ -415,6 +417,7 @@ def run_precompiled_scylla_cmd(exe, pid, dir):
         cmd.remove('--logstor-disk-size-in-mb=8')
         cmd.remove('--logstor-file-size-in-mb=4')
         cmd.remove('--logstor-separator-max-memory-in-mb=8')
+        cmd.remove('--logstor-sparse-files=true')
     return (cmd, env)
 
 # Get a Cluster object to connect to CQL at the given IP address (and with

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -125,6 +125,10 @@ cql_test_config::cql_test_config(shared_ptr<db::config> cfg)
     db_config->commitlog_use_o_dsync(false);
 
     db_config->rf_rack_valid_keyspaces(true);
+
+    // Preallocating and zero-filling logstor files wastes disk space and I/O
+    // for data that is thrown away when the test ends.
+    db_config->logstor_sparse_files(true);
 }
 
 cql_test_config::cql_test_config(const cql_test_config&) = default;

--- a/test/pylib/scylla_server.py
+++ b/test/pylib/scylla_server.py
@@ -134,6 +134,10 @@ def make_scylla_conf(mode: str, host_addr: str, seed_addrs: List[str], cluster_n
         'alternator_allow_system_table_write': True,
         'alternator_ttl_period_in_seconds': 0.5,
         'sstable_format': 'mt',
+
+        # Tests create many small clusters; preallocating and zero-filling
+        # logstor files wastes disk space and I/O.
+        'logstor_sparse_files': True,
     }
 
 # Seastar options can not be passed through scylla.yaml, use command line


### PR DESCRIPTION
Formatting a logstor file preallocates it and writes zeros over its entire length. That guarantees the space is there and avoids fragmentation, but for tests it is pure waste: every cluster created by test.py writes megabytes of zeros to disk and throws them away when the test ends.

Add a logstor_sparse_files option (default off, like commitlog_use_o_dsync) that instead just extends the file to its nominal size. Reading a hole yields zeros, so the file looks identically formatted to the reader and recovery is unaffected.

Enable it for tests: test.py clusters, cqlpy, and the C++ unit test harnesses.

Measured on a 2-shard node with the test config (logstor_disk_size_in_mb=8, logstor_file_size_in_mb=4, i.e. 2 files of 4MB per shard): logstor disk usage after startup drops from 16MB to 0, and the 16MB of zero-fill writes per node disappear. Multiply by the number of servers in a cluster test.

Test improvement, so not backporting, even though it can affect overall stability.