### PR TITLE
alternator: fix missing per-table operation counters

### DIFF
--- a/alternator/executor.cc
+++ b/alternator/executor.cc
@@ -2013,6 +2013,8 @@ future<executor::request_return_type> executor::update_table(client_state& clien
     _stats.api_operations.update_table++;
     elogger.trace("Updating table {}", request);
 
+    get_stats_from_schema(_proxy, *get_table(_proxy, request))->api_operations.update_table++;
+
     static const std::vector<sstring> unsupported = {
         "ProvisionedThroughput",
         "ReplicaUpdates",
@@ -3219,6 +3221,8 @@ future<executor::request_return_type> executor::put_item(client_state& client_st
     elogger.trace("put_item {}", request);
 
     auto op = make_shared<put_item_operation>(*_parsed_expression_cache, _proxy, std::move(request));
+    lw_shared_ptr<stats> per_table_stats = get_stats_from_schema(_proxy, *(op->schema()));
+    per_table_stats->api_operations.put_item++;
 
     if (!audit_info) {
         // On LWT shard bounce, audit_info is already set on the originating shard.
@@ -3238,6 +3242,7 @@ future<executor::request_return_type> executor::put_item(client_state& client_st
 
     if (cas_shard && !cas_shard->this_shard()) {
         _stats.api_operations.put_item--; // uncount on this shard, will be counted in other shard
+        per_table_stats->api_operations.put_item--; // same, for the per-table counter
         _stats.shard_bounce_for_lwt++;
         co_return co_await container().invoke_on(cas_shard->shard(), _ssg,
                 [request = std::move(*op).move_request(), cs = client_state.move_to_other_shard(), gt = tracing::global_trace_state_ptr(trace_state), permit = std::move(permit), &audit_info]
@@ -3251,8 +3256,6 @@ future<executor::request_return_type> executor::put_item(client_state& client_st
             });
         });
     }
-    lw_shared_ptr<stats> per_table_stats = get_stats_from_schema(_proxy, *(op->schema()));
-    per_table_stats->api_operations.put_item++;
     uint64_t wcu_total = 0;
     auto res = co_await op->execute(_proxy, std::move(cas_shard), client_state, trace_state, std::move(permit), needs_read_before_write, _stats, *per_table_stats, wcu_total);
     per_table_stats->operation_sizes.put_item_op_size_kb.add(bytes_to_kb_ceil(op->consumed_capacity()._total_bytes));
@@ -3343,6 +3346,7 @@ future<executor::request_return_type> executor::delete_item(client_state& client
     }
 
     lw_shared_ptr<stats> per_table_stats = get_stats_from_schema(_proxy, *(op->schema()));
+    per_table_stats->api_operations.delete_item++;
     tracing::add_alternator_table_name(trace_state, op->schema()->cf_name());
     const bool needs_read_before_write = _proxy.data_dictionary().get_config().alternator_force_read_before_write() || op->needs_read_before_write();
 
@@ -3352,6 +3356,7 @@ future<executor::request_return_type> executor::delete_item(client_state& client
 
     if (cas_shard && !cas_shard->this_shard()) {
         _stats.api_operations.delete_item--; // uncount on this shard, will be counted in other shard
+        per_table_stats->api_operations.delete_item--; // same, for the per-table counter
         _stats.shard_bounce_for_lwt++;
         per_table_stats->shard_bounce_for_lwt++;
         co_return co_await container().invoke_on(cas_shard->shard(), _ssg,
@@ -3366,7 +3371,6 @@ future<executor::request_return_type> executor::delete_item(client_state& client
             });
         });
     }
-    per_table_stats->api_operations.delete_item++;
     uint64_t wcu_total = 0;
     auto res = co_await op->execute(_proxy, std::move(cas_shard), client_state, trace_state, std::move(permit), needs_read_before_write, _stats, *per_table_stats, wcu_total);
     if (op->consumed_capacity()._total_bytes > 1) {
@@ -4523,6 +4527,8 @@ future<executor::request_return_type> executor::update_item(client_state& client
     elogger.trace("update_item {}", request);
 
     auto op = make_shared<update_item_operation>(*_parsed_expression_cache, _proxy, std::move(request));
+    lw_shared_ptr<stats> per_table_stats = get_stats_from_schema(_proxy, *(op->schema()));
+    per_table_stats->api_operations.update_item++;
 
     if (!audit_info) {
         // On LWT shard bounce, audit_info is already set on the originating shard.
@@ -4542,6 +4548,7 @@ future<executor::request_return_type> executor::update_item(client_state& client
 
     if (cas_shard && !cas_shard->this_shard()) {
         _stats.api_operations.update_item--; // uncount on this shard, will be counted in other shard
+        per_table_stats->api_operations.update_item--; // same, for the per-table counter
         _stats.shard_bounce_for_lwt++;
         co_return co_await container().invoke_on(cas_shard->shard(), _ssg,
                 [request = std::move(*op).move_request(), cs = client_state.move_to_other_shard(), gt = tracing::global_trace_state_ptr(trace_state), permit = std::move(permit), &audit_info]
@@ -4555,8 +4562,6 @@ future<executor::request_return_type> executor::update_item(client_state& client
             });
         });
     }
-    lw_shared_ptr<stats> per_table_stats = get_stats_from_schema(_proxy, *(op->schema()));
-    per_table_stats->api_operations.update_item++;
     uint64_t wcu_total = 0;
     auto res = co_await op->execute(_proxy, std::move(cas_shard), client_state, trace_state, std::move(permit), needs_read_before_write, _stats, *per_table_stats, wcu_total);
     per_table_stats->operation_sizes.update_item_op_size_kb.add(bytes_to_kb_ceil(op->consumed_capacity()._total_bytes));

--- a/alternator/ttl.cc
+++ b/alternator/ttl.cc
@@ -67,6 +67,7 @@ future<executor::request_return_type> executor::update_time_to_live(client_state
     }
 
     schema_ptr schema = get_table(_proxy, request);
+    get_stats_from_schema(_proxy, *schema)->api_operations.update_time_to_live++;
 
     maybe_audit(audit_info, audit::statement_category::DDL,
                 schema->ks_name(), schema->cf_name(), "UpdateTimeToLive", request);

--- a/test/alternator/test_metrics.py
+++ b/test/alternator/test_metrics.py
@@ -33,8 +33,8 @@ import pytest
 import requests
 from botocore.exceptions import ClientError
 
-from test.alternator.test_cql_rbac import new_dynamodb, new_role
-from test.alternator.util import random_string, new_test_table, is_aws, scylla_config_read, scylla_config_temporary, get_signed_request
+from test.alternator.test_cql_rbac import new_dynamodb, new_dynamodb_streams, new_role
+from test.alternator.util import random_string, new_test_table, is_aws, scylla_config_read, scylla_config_temporary, get_signed_request, unique_table_name
 from test.pylib.skip_types import skip_env
 from test.alternator.test_streams import wait_for_active_stream
 from test.alternator.test_vector import vs, needs_vector_store, wait_for_vector_index_active, table_vs
@@ -1621,6 +1621,96 @@ def test_metric_reads_before_write(dynamodb, metrics, write_isolation):
                 UpdateExpression='SET a = :val',
                 ConditionExpression='attribute_exists(p)',
                 ExpressionAttributeValues={':val': 'newval'})
+
+# Test that when the user is *unauthorized* to perform an operation, both
+# global and per-table operation-count metrics (scylla_alternator_operation
+# and scylla_alternator_table_operation) are still incremented for that
+# operation. We test this for every operation that can fail on
+# authorization.
+#
+# Note that this test is about authorization failures, NOT authentication
+# failures. If authentication failed, the request is not parsed at all,
+# so neither of the operation counters would be incremented.
+#
+# Two of the operations below (CreateTable, DeleteTable) don't have a
+# per-table metric to check at all: it's not a bug, it's a deliberate
+# choice (see the "Metrics that do not make sense to report per table"
+# comment in alternator/stats.cc). All the other operations below *do*
+# have a per-table metric.
+#
+# Reproduces issue #31261 where some operations were incrementing the global
+# metric but not the per-table metric on authorization failure, and issue
+# #30754 where some operations never incremented the per-table metric at
+# all (not even on success).
+def test_unauthorized_operation_counted(dynamodb, cql, dynamodbstreams, metrics):
+    # Since "GetRecords" is one of the operations we want to test, we need
+    # a table with a stream enabled to be able to get a shard iterator
+    # to pass to GetRecords.
+    with new_test_table(dynamodb,
+            KeySchema=[{'AttributeName': 'p', 'KeyType': 'HASH'}],
+            AttributeDefinitions=[{'AttributeName': 'p', 'AttributeType': 'S'}],
+            StreamSpecification={'StreamEnabled': True, 'StreamViewType': 'NEW_AND_OLD_IMAGES'}) as table:
+        # table_arn is for TagResource/UntagResource.
+        # stream_arn/shard_iterator are for GetRecords.
+        table_arn = dynamodb.meta.client.describe_table(TableName=table.name)['Table']['TableArn']
+        stream_arn, _ = wait_for_active_stream(dynamodbstreams, table)
+        shard_id = dynamodbstreams.describe_stream(StreamArn=stream_arn)['StreamDescription']['Shards'][0]['ShardId']
+        shard_iterator = dynamodbstreams.get_shard_iterator(
+            StreamArn=stream_arn, ShardId=shard_id, ShardIteratorType='TRIM_HORIZON')['ShardIterator']
+
+        # Each entry is (operation name, whether this operation has a
+        # per-table metric to check (all but CreateTable and DeleteTable do),
+        # and a function performing the operation given the unauthorized
+        # role's table resource and streams client).
+        ops = [
+            ('GetItem', True, lambda tab, streams: tab.get_item(Key={'p': random_string()}, ConsistentRead=True)),
+            ('PutItem', True, lambda tab, streams: tab.put_item(Item={'p': random_string()})),
+            ('UpdateItem', True, lambda tab, streams: tab.update_item(Key={'p': random_string()})),
+            ('DeleteItem', True, lambda tab, streams: tab.delete_item(Key={'p': random_string()})),
+            ('Query', True, lambda tab, streams: tab.query(KeyConditionExpression='p = :p',
+                ExpressionAttributeValues={':p': random_string()}, ConsistentRead=True)),
+            ('Scan', True, lambda tab, streams: tab.scan(ConsistentRead=True, Limit=1)),
+            ('BatchWriteItem', True, lambda tab, streams: tab.meta.client.batch_write_item(RequestItems={
+                tab.name: [{'PutRequest': {'Item': {'p': random_string()}}}]})),
+            ('BatchGetItem', True, lambda tab, streams: tab.meta.client.batch_get_item(RequestItems={
+                tab.name: {'Keys': [{'p': random_string()}], 'ConsistentRead': True}})),
+            ('TagResource', True, lambda tab, streams: tab.meta.client.tag_resource(
+                ResourceArn=table_arn, Tags=[{'Key': random_string(), 'Value': 'dog'}])),
+            ('UntagResource', True, lambda tab, streams: tab.meta.client.untag_resource(
+                ResourceArn=table_arn, TagKeys=[random_string()])),
+            ('UpdateTable', True, lambda tab, streams: tab.meta.client.update_table(
+                TableName=tab.name, BillingMode='PAY_PER_REQUEST')),
+            ('UpdateTimeToLive', True, lambda tab, streams: tab.meta.client.update_time_to_live(
+                TableName=tab.name, TimeToLiveSpecification={'AttributeName': 'expiration', 'Enabled': True})),
+            ('GetRecords', True, lambda tab, streams: streams.get_records(ShardIterator=shard_iterator)),
+            ('CreateTable', False, lambda tab, streams: tab.meta.client.create_table(TableName=unique_table_name(),
+                KeySchema=[{'AttributeName': 'p', 'KeyType': 'HASH'}],
+                AttributeDefinitions=[{'AttributeName': 'p', 'AttributeType': 'S'}],
+                BillingMode='PAY_PER_REQUEST')),
+            ('DeleteTable', False, lambda tab, streams: tab.meta.client.delete_table(TableName=tab.name)),
+        ]
+        with scylla_config_auth_temporary(dynamodb, True, False):
+            with new_role(cql) as (role, key):
+                with new_dynamodb(dynamodb, role, key) as d:
+                    with new_dynamodb_streams(dynamodb, role, key) as streams:
+                        tab = d.Table(table.name)
+                        # "tab" and "streams" both use a new role "role"
+                        # that has no permission to access the table, so all
+                        # operations that need authorization should fail with
+                        # AccessDeniedException.
+                        for op, per_table, do in ops:
+                            def run():
+                                try:
+                                    do(tab, streams)
+                                    pytest.fail(f"{op} unexpectedly succeeded for an unauthorized role")
+                                except ClientError as e:
+                                    assert e.response['Error']['Code'] == 'AccessDeniedException'
+                            with check_increases_operation(metrics, [op]):
+                                if per_table:
+                                    with check_table_increases_operation(metrics, [op], table.name):
+                                        run()
+                                else:
+                                    run()
 
 # TODO: there are additional metrics which we don't yet test here. At the
 # time of this writing they are:


### PR DESCRIPTION
This test fixes cases where we forgot to increment the *per-table* version of the operation counters for some of the operations:

1. For UpdateTable and UpdateTimeToLive, we forgot to update the per-table counter at all (we had the same bug in BatchGetItem but recently fixed it in pull request #30755).

2. For PutItem, DeleteItem and UpdateItem, we incremented the per-table counter but did it fairly late, so if a request was unauthorized, it would increment the global counter but not the per-table counter which is strange and inconsistent.

This patch fixes all five operations, and also adds a test, test_unauthorized_operation_counted, which verifies that for all operations that can be unauthorized - GetItem, PutItem, UpdateItem, DeleteItem, Query, Scan, BatchWriteItem, BatchGetItem, TagResource, UntagResource, UpdateTable, UpdateTImeToLive, GetRecords, CreateTable, DeleteTable - in all of those when the operation is unauthorized we still increment the global counter and also the per-table counter (except CreateTable and DeleteTable which deliberately don't have a per-table counter).

Refs #30754
Fixes #31261
