### PR TITLE
Fix data race on service::client_state between shards

### DIFF
--- a/alternator/executor.cc
+++ b/alternator/executor.cc
@@ -1935,6 +1935,9 @@ future<executor::request_return_type> executor::update_table(client_state& clien
     co_return co_await _mm.container().invoke_on(0, [&p = _proxy.container(), request = std::move(request), gt = tracing::global_trace_state_ptr(std::move(trace_state)), enforce_authorization = bool(_enforce_authorization),
                 warn_authorization = bool(_warn_authorization), client_state_other_shard = client_state.move_to_other_shard(), empty_request, &e = this->container(), &audit_info]
                                                 (service::migration_manager& mm) mutable -> future<executor::request_return_type> {
+        // Materialize the shard-local copy once; every get() creates a whole
+        // new client_state.
+        const service::client_state local_client_state = client_state_other_shard.get();
         schema_ptr schema;
         size_t retries = mm.get_concurrent_ddl_retries();
         for (;;) {
@@ -2267,7 +2270,7 @@ future<executor::request_return_type> executor::update_table(client_state& clien
                 co_return api_error::validation("UpdateTable requires one of GlobalSecondaryIndexUpdates, VectorIndexUpdates, StreamSpecification or BillingMode to be specified");
             }
 
-            co_await verify_permission(enforce_authorization, warn_authorization, client_state_other_shard.get(), schema, auth::permission::ALTER, e.local()._stats);
+            co_await verify_permission(enforce_authorization, warn_authorization, local_client_state, schema, auth::permission::ALTER, e.local()._stats);
             auto m = co_await service::prepare_column_family_update_announcement(p.local(), schema, std::vector<view_ptr>(), group0_guard.write_timestamp());
             for (view_ptr view : new_views) {
                 auto m2 = co_await service::prepare_new_view_announcement(p.local(), view, group0_guard.write_timestamp());
@@ -2282,17 +2285,17 @@ future<executor::request_return_type> executor::update_table(client_state& clien
             // Also, when we delete a GSI we should revoke any permissions set on
             // it - so if it's ever created again the old permissions wouldn't be
             // remembered for the new GSI. This is known as "auto-revoke"
-            if (client_state_other_shard.get().user() && (!new_views.empty() || !dropped_views.empty())) {
+            if (local_client_state.user() && (!new_views.empty() || !dropped_views.empty())) {
                 service::group0_batch mc(std::move(group0_guard));
                 mc.add_mutations(std::move(m));
                 for (view_ptr view : new_views) {
                     auto resource = auth::make_data_resource(view->ks_name(), view->cf_name());
                     co_await auth::grant_applicable_permissions(
-                        *client_state_other_shard.get().get_auth_service(), *client_state_other_shard.get().user(), resource, mc);
+                        *local_client_state.get_auth_service(), *local_client_state.user(), resource, mc);
                 }
                 for (const auto& view_name : dropped_views) {
                     auto resource = auth::make_data_resource(schema->ks_name(), view_name);
-                    co_await auth::revoke_all(*client_state_other_shard.get().get_auth_service(), resource, mc);
+                    co_await auth::revoke_all(*local_client_state.get_auth_service(), resource, mc);
                 }
                 std::tie(m, group0_guard) = co_await std::move(mc).extract();
             }

--- a/configure.py
+++ b/configure.py
@@ -1703,6 +1703,7 @@ deps['test/boost/combined_tests'] += [
     'test/boost/aggregate_fcts_test.cc',
     'test/boost/auth_cache_test.cc',
     'test/boost/auth_test.cc',
+    'test/boost/client_state_test.cc',
     'test/boost/batchlog_manager_test.cc',
     'test/boost/table_helper_test.cc',
     'test/boost/cache_algorithm_test.cc',

--- a/service/client_state.hh
+++ b/service/client_state.hh
@@ -63,6 +63,8 @@ public:
 
     class client_state_for_another_shard;
 private:
+    // Copies the client_state fields from `cs`. Must be called on the shard
+    // owning `cs`, unless `cs` is a private snapshot which is not modified.
     client_state(const client_state* cs,
         seastar::sharded<auth::service>* auth_service,
         seastar::sharded<qos::service_level_controller>* sl_controller,
@@ -480,7 +482,9 @@ public:
         return _user;
     }
 
-    client_state_for_another_shard move_to_other_shard();
+    // Takes a snapshot of this client_state which can be safely passed to
+    // other shards.
+    client_state_for_another_shard move_to_other_shard() const;
 
 #if 0
     public static SemanticVersion[] getCQLSupportedVersion()
@@ -536,23 +540,32 @@ public:
 // It is created on a shard that owns client_state than passed
 // to a target shard where client_state_for_another_shard::get()
 // can be called to obtain a shard local copy.
+//
+// The relevant fields are copied eagerly, on the owning shard, when
+// this object is constructed. The original client_state must not be
+// referenced from another shard because it can be concurrently
+// modified by the owning shard (e.g. by a USE statement changing
+// _keyspace) while the other shard reads it, which is a data race.
 class client_state::client_state_for_another_shard {
 private:
-    const client_state* _cs;
+    client_state _snapshot;
     seastar::sharded<auth::service>* _auth_service;
     seastar::sharded<qos::service_level_controller>* _sl_controller;
     client_state_for_another_shard(const client_state* cs,
         seastar::sharded<auth::service>* auth_service,
         seastar::sharded<qos::service_level_controller>* sl_controller)
-        : _cs(cs), _auth_service(auth_service), _sl_controller(sl_controller) {}
+        : _snapshot(cs, nullptr, nullptr, nullptr), _auth_service(auth_service), _sl_controller(sl_controller) {}
     friend client_state;
 public:
+    client_state_for_another_shard(const client_state_for_another_shard& o)
+        : _snapshot(&o._snapshot, nullptr, nullptr, nullptr), _auth_service(o._auth_service), _sl_controller(o._sl_controller) {}
+    client_state_for_another_shard(client_state_for_another_shard&&) = default;
     client_state get(abort_source* as = nullptr) const {
-        return client_state(_cs, _auth_service, _sl_controller, as);
+        return client_state(&_snapshot, _auth_service, _sl_controller, as);
     }
 };
 
-inline client_state::client_state_for_another_shard client_state::move_to_other_shard() {
+inline client_state::client_state_for_another_shard client_state::move_to_other_shard() const {
     return client_state_for_another_shard(this,
         _auth_service ? &_auth_service->container() : nullptr,
         _sl_controller ? &_sl_controller->container() : nullptr);

--- a/service/client_state.hh
+++ b/service/client_state.hh
@@ -61,25 +61,7 @@ public:
     };
     using workload_type = qos::service_level_options::workload_type;
 
-    // This class is used to move client_state between shards
-    // It is created on a shard that owns client_state than passed
-    // to a target shard where client_state_for_another_shard::get()
-    // can be called to obtain a shard local copy.
-    class client_state_for_another_shard {
-    private:
-        const client_state* _cs;
-        seastar::sharded<auth::service>* _auth_service;
-        seastar::sharded<qos::service_level_controller>* _sl_controller;
-        client_state_for_another_shard(const client_state* cs,
-            seastar::sharded<auth::service>* auth_service,
-            seastar::sharded<qos::service_level_controller>* sl_controller)
-            : _cs(cs), _auth_service(auth_service), _sl_controller(sl_controller) {}
-        friend client_state;
-    public:
-        client_state get(abort_source* as = nullptr) const {
-            return client_state(_cs, _auth_service, _sl_controller, as);
-        }
-    };
+    class client_state_for_another_shard;
 private:
     client_state(const client_state* cs,
         seastar::sharded<auth::service>* auth_service,
@@ -498,11 +480,7 @@ public:
         return _user;
     }
 
-    client_state_for_another_shard move_to_other_shard() {
-        return client_state_for_another_shard(this,
-            _auth_service ? &_auth_service->container() : nullptr,
-            _sl_controller ? &_sl_controller->container() : nullptr);
-    }
+    client_state_for_another_shard move_to_other_shard();
 
 #if 0
     public static SemanticVersion[] getCQLSupportedVersion()
@@ -553,6 +531,32 @@ public:
         return _original_shard;
     }
 };
+
+// This class is used to move client_state between shards
+// It is created on a shard that owns client_state than passed
+// to a target shard where client_state_for_another_shard::get()
+// can be called to obtain a shard local copy.
+class client_state::client_state_for_another_shard {
+private:
+    const client_state* _cs;
+    seastar::sharded<auth::service>* _auth_service;
+    seastar::sharded<qos::service_level_controller>* _sl_controller;
+    client_state_for_another_shard(const client_state* cs,
+        seastar::sharded<auth::service>* auth_service,
+        seastar::sharded<qos::service_level_controller>* sl_controller)
+        : _cs(cs), _auth_service(auth_service), _sl_controller(sl_controller) {}
+    friend client_state;
+public:
+    client_state get(abort_source* as = nullptr) const {
+        return client_state(_cs, _auth_service, _sl_controller, as);
+    }
+};
+
+inline client_state::client_state_for_another_shard client_state::move_to_other_shard() {
+    return client_state_for_another_shard(this,
+        _auth_service ? &_auth_service->container() : nullptr,
+        _sl_controller ? &_sl_controller->container() : nullptr);
+}
 
 }
 

--- a/test/boost/CMakeLists.txt
+++ b/test/boost/CMakeLists.txt
@@ -345,6 +345,7 @@ add_scylla_test(combined_tests
     aggregate_fcts_test.cc
     auth_cache_test.cc
     auth_test.cc
+    client_state_test.cc
     batchlog_manager_test.cc
     table_helper_test.cc
     cache_algorithm_test.cc

--- a/test/boost/client_state_test.cc
+++ b/test/boost/client_state_test.cc
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2026-present ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
+ */
+
+#include <boost/test/unit_test.hpp>
+#include <seastar/core/smp.hh>
+#undef SEASTAR_TESTING_MAIN
+#include <seastar/testing/test_case.hh>
+
+#include "service/client_state.hh"
+#include "test/lib/cql_test_env.hh"
+
+BOOST_AUTO_TEST_SUITE(client_state_test)
+
+// Reproducer for SCYLLADB-3951: a client_state passed to another shard via
+// move_to_other_shard() used to hold a reference to the original object, so
+// the other shard read client_state::_keyspace while the owning shard could
+// concurrently modify it with a USE statement. The snapshot must be taken
+// eagerly on the owning shard, so later modifications of the original are
+// not observed (and not raced with) by the receiving shard.
+SEASTAR_TEST_CASE(test_client_state_for_another_shard_is_a_snapshot) {
+    co_await do_with_cql_env([] (cql_test_env& env) -> future<> {
+        auto& cs = env.local_client_state();
+        cs.set_raw_keyspace("ks_before");
+
+        auto snapshot = cs.move_to_other_shard();
+
+        // Simulates a concurrent USE statement on the owning shard.
+        cs.set_raw_keyspace("ks_after");
+
+        // A copy of the snapshot (e.g. when a lambda capturing it is copied
+        // per target shard) must also carry the original value.
+        auto snapshot_copy = snapshot;
+
+        co_await smp::invoke_on_all([&snapshot, &snapshot_copy] {
+            auto local_cs = snapshot.get();
+            BOOST_REQUIRE_EQUAL(local_cs.get_raw_keyspace(), "ks_before");
+            auto local_cs2 = snapshot_copy.get();
+            BOOST_REQUIRE_EQUAL(local_cs2.get_raw_keyspace(), "ks_before");
+        });
+
+        BOOST_REQUIRE_EQUAL(cs.get_raw_keyspace(), "ks_after");
+    });
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/test/cqlpy/rest_api.py
+++ b/test/cqlpy/rest_api.py
@@ -9,6 +9,8 @@
 import requests
 from . import nodetool
 import pytest
+import threading
+import time
 from contextlib import contextmanager
 
 from test.pylib.skip_types import skip_env
@@ -78,3 +80,17 @@ def scylla_inject_error(cql, err, one_shot=False):
     finally:
         print("Disabling error injection", err)
         delete_request(cql, f'v2/error_injection/injection/{err}')
+
+# Waits until a fiber reaches the given error injection. The injection's enter
+# count is bumped before the fiber parks, so once it is non-zero the injected
+# code is paused.
+def wait_for_injection_enter(cql, err, timeout=60):
+    tick = threading.Event()
+    deadline = time.monotonic() + timeout
+    while get_request(cql, f'v2/error_injection/injection/{err}/enters') == 0:
+        assert time.monotonic() < deadline, f'timed out waiting for injection {err}'
+        tick.wait(0.01)
+
+# Sends a message to a fiber paused on the given error injection, resuming it.
+def message_injection(cql, err):
+    post_request(cql, f'v2/error_injection/injection/{err}/message')

--- a/test/cqlpy/test_prepare_use_race.py
+++ b/test/cqlpy/test_prepare_use_race.py
@@ -1,0 +1,54 @@
+# Copyright 2026-present ScyllaDB
+#
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
+
+#############################################################################
+# Test that a PREPARE racing with a USE on the same connection prepares the
+# statement under one keyspace on all shards. PREPARE used to hand the other
+# shards a reference to the connection's client_state, which the owning shard
+# could modify at the same time (SCYLLADB-3951).
+#############################################################################
+
+from concurrent.futures import ThreadPoolExecutor
+
+from .util import new_test_keyspace, new_cql, unique_name
+from .rest_api import scylla_inject_error, wait_for_injection_enter, message_injection
+
+INJECTION = "cql_server_process_prepare_before_local_prepare"
+
+
+def test_prepare_concurrent_with_use(cql, scylla_only):
+    ks_opts = "WITH REPLICATION = { 'class' : 'NetworkTopologyStrategy', 'replication_factor' : 1 }"
+    with new_test_keyspace(cql, ks_opts) as ks1, new_test_keyspace(cql, ks_opts) as ks2:
+        # The same table name in both keyspaces, so the unqualified name in the
+        # prepared statement resolves to a different table under each of them.
+        table = unique_name()
+        for ks in (ks1, ks2):
+            cql.execute(f"CREATE TABLE {ks}.{table} (pk int PRIMARY KEY, v int)")
+        try:
+            # Rows exist only in ks1's table.
+            for pk in range(32):
+                cql.execute(f"INSERT INTO {ks1}.{table} (pk, v) VALUES ({pk}, {pk + 100})")
+            with new_cql(cql) as ncql:
+                ncql.execute(f"USE {ks1}")
+                with scylla_inject_error(ncql, INJECTION, one_shot=True), \
+                     ThreadPoolExecutor(max_workers=1) as executor:
+                    prepare = executor.submit(ncql.prepare, f"SELECT v FROM {table} WHERE pk = ?")
+                    # PREPARE is now paused after the other shards prepared the
+                    # statement, before the local shard does.
+                    wait_for_injection_enter(ncql, INJECTION)
+                    assert not prepare.done()
+                    # Change the keyspace while PREPARE is in flight. This is
+                    # what used to race with the other shards' reads.
+                    ncql.execute(f"USE {ks2}")
+                    message_injection(ncql, INJECTION)
+                    stmt = prepare.result()
+                # The statement was prepared while ks1 was the keyspace, so the
+                # bind metadata the server returned must name ks1, and the
+                # statement must read ks1's table on every shard.
+                assert stmt.column_metadata[0].keyspace_name == ks1
+                for pk in range(32):
+                    assert [(pk + 100,)] == [tuple(r) for r in ncql.execute(stmt, [pk])]
+        finally:
+            for ks in (ks1, ks2):
+                cql.execute(f"DROP TABLE {ks}.{table}")

--- a/transport/server.cc
+++ b/transport/server.cc
@@ -36,6 +36,7 @@
 #include <seastar/core/seastar.hh>
 #include <seastar/core/lowres_clock.hh>
 #include <seastar/coroutine/as_future.hh>
+#include <seastar/coroutine/exception.hh>
 #include <seastar/coroutine/try_future.hh>
 #include <seastar/net/byteorder.hh>
 #include <seastar/core/metrics.hh>
@@ -1682,7 +1683,7 @@ future<std::unique_ptr<cql_server::response>> cql_server::connection::process_pr
 
     utils::result_with_exception_ptr<utils::chunked_string> query_result = in.read_long_chunked_string();
     if (!query_result) {
-        return make_exception_future<std::unique_ptr<cql_server::response>>(std::move(query_result).assume_error());
+        co_return coroutine::exception(std::move(query_result).assume_error());
     }
     auto query = std::move(query_result).assume_value();
     auto dialect = get_dialect();
@@ -1690,20 +1691,19 @@ future<std::unique_ptr<cql_server::response>> cql_server::connection::process_pr
     tracing::add_query(trace_state, query);
     tracing::begin(trace_state, "Preparing CQL3 query", client_state.get_client_address());
 
-    return _server._query_processor.invoke_on_others([query, &client_state, dialect] (auto& qp) mutable {
+    co_await _server._query_processor.invoke_on_others([query, &client_state, dialect] (auto& qp) mutable {
             return qp.prepare(std::move(query), client_state, dialect).discard_result();
-    }).then([this, query, stream, &client_state, trace_state, dialect] () mutable {
-        tracing::trace(trace_state, "Done preparing on remote shards");
-        return _server._query_processor.local().prepare(std::move(query), client_state, dialect).then([this, stream, &client_state, trace_state] (auto msg) {
-            tracing::trace(trace_state, "Done preparing on a local shard - preparing a result. ID is [{}]", seastar::value_of([&msg] {
-                return messages::result_message::prepared::cql::get_id(msg);
-            }));
-            cql_metadata_id_wrapper metadata_id = is_metadata_id_supported(client_state)
-                ? cql_metadata_id_wrapper(msg->get_metadata_id())
-                : cql_metadata_id_wrapper();
-            return make_result(stream, *msg, trace_state, _version, std::move(metadata_id));
-        });
     });
+    tracing::trace(trace_state, "Done preparing on remote shards");
+
+    auto msg = co_await _server._query_processor.local().prepare(std::move(query), client_state, dialect);
+    tracing::trace(trace_state, "Done preparing on a local shard - preparing a result. ID is [{}]", seastar::value_of([&msg] {
+        return messages::result_message::prepared::cql::get_id(msg);
+    }));
+    cql_metadata_id_wrapper metadata_id = is_metadata_id_supported(client_state)
+        ? cql_metadata_id_wrapper(msg->get_metadata_id())
+        : cql_metadata_id_wrapper();
+    co_return make_result(stream, *msg, trace_state, _version, std::move(metadata_id));
 }
 
 static future<cql_server::process_fn_return_type>

--- a/transport/server.cc
+++ b/transport/server.cc
@@ -1691,12 +1691,23 @@ future<std::unique_ptr<cql_server::response>> cql_server::connection::process_pr
     tracing::add_query(trace_state, query);
     tracing::begin(trace_state, "Preparing CQL3 query", client_state.get_client_address());
 
-    co_await _server._query_processor.invoke_on_others([query, &client_state, dialect] (auto& qp) mutable {
-            return qp.prepare(std::move(query), client_state, dialect).discard_result();
+    // The statement is prepared on all shards, so client_state has to be passed
+    // to the other shards. It must not be passed by reference, because the
+    // owning shard can modify it concurrently (a USE statement reassigns
+    // _keyspace) while another shard reads it.
+    auto cs_snapshot = client_state.move_to_other_shard();
+
+    co_await _server._query_processor.invoke_on_others([query, cs_snapshot, dialect] (cql3::query_processor& qp) mutable -> future<> {
+        auto local_client_state = cs_snapshot.get();
+        co_await qp.prepare(std::move(query), local_client_state, dialect);
     });
     tracing::trace(trace_state, "Done preparing on remote shards");
 
-    auto msg = co_await _server._query_processor.local().prepare(std::move(query), client_state, dialect);
+    // Prepare on the local shard with the same snapshot: the statement id is
+    // derived from the keyspace, so a USE arriving in the middle of a PREPARE
+    // would otherwise make this shard return an id the others don't have.
+    auto local_client_state = cs_snapshot.get(&_server._abort_source);
+    auto msg = co_await _server._query_processor.local().prepare(std::move(query), local_client_state, dialect);
     tracing::trace(trace_state, "Done preparing on a local shard - preparing a result. ID is [{}]", seastar::value_of([&msg] {
         return messages::result_message::prepared::cql::get_id(msg);
     }));

--- a/transport/server.cc
+++ b/transport/server.cc
@@ -1703,6 +1703,9 @@ future<std::unique_ptr<cql_server::response>> cql_server::connection::process_pr
     });
     tracing::trace(trace_state, "Done preparing on remote shards");
 
+    co_await utils::get_local_injector().inject("cql_server_process_prepare_before_local_prepare",
+            utils::wait_for_message(std::chrono::seconds(60)));
+
     // Prepare on the local shard with the same snapshot: the statement id is
     // derived from the keyspace, so a USE arriving in the middle of a PREPARE
     // would otherwise make this shard return an id the others don't have.


### PR DESCRIPTION
cql_server::connection::process_prepare() passed the connection's client_state
to every other shard by reference, while USE statements reassign
client_state::_keyspace on the shard that owns the connection. A PREPARE racing
with a USE on the same connection let remote shards read an sstring that was
being rewritten under them: in the reported crash a short, internally stored
keyspace name was read as an externally stored one, with a bogus multi-megabyte
length, which gave an oversized-allocation warning and then a SIGSEGV in
cql3::hash_target().

client_state_for_another_shard had the same flaw - it kept a pointer to the
original and copied the fields in get(), i.e. on the target shard - so the CQL
shard bounce path raced the same way.

Both are fixed by taking the snapshot on the owning shard. process_prepare()
uses that single snapshot on all shards, including the local one, so a USE
landing mid-PREPARE can no longer make the local shard cache the statement
under a different keyspace, and id, than the other shards.

Fixes: SCYLLADB-3951

Backport: yes, to all supported branches - 2025.1, 2026.1, 2026.2 and 2026.3.
Both racy patterns are present in all of them, the crash was hit in the field
on 2025.1.7.