### PR TITLE
logstor: support SELECT ... FROM MUTATION_FRAGMENTS()

### DIFF
--- a/docs/dev/logstor.md
+++ b/docs/dev/logstor.md
@@ -124,6 +124,21 @@ SELECT * FROM keyspace.table_name;
 DELETE FROM keyspace.table_name WHERE pk = 1;
 ```
 
+### Inspecting a Table
+
+`SELECT ... FROM MUTATION_FRAGMENTS()` dumps the raw mutations of a logstor table as the
+node they are read on stores them, bypassing the storage proxy. A logstor table has two
+mutation sources:
+
+| Source | Content |
+|--------|---------|
+| `logstor-cache` | The partition as held in the logstor cache, if it is cached |
+| `logstor-log:${file path}:${segment}` | The log record, named after the segment holding it |
+
+```cql
+SELECT * FROM MUTATION_FRAGMENTS(keyspace.table_name) WHERE pk = 1;
+```
+
 ## On-Disk Format
 
 ### Files

--- a/docs/operating-scylla/admin-tools/select-from-mutation-fragments.rst
+++ b/docs/operating-scylla/admin-tools/select-from-mutation-fragments.rst
@@ -87,6 +87,8 @@ Where ``mutation_source_kind`` is one of:
 * ``memtable``
 * ``row-cache``
 * ``sstable``
+* ``logstor-cache``
+* ``logstor-log``
 
 
 And the ``mutation_source_id`` is used to distinguish individual mutation sources of the same kind, where applicable:
@@ -94,6 +96,8 @@ And the ``mutation_source_id`` is used to distinguish individual mutation source
 * ``memtable`` - a numeric id, starting from ``0``
 * ``row-cache`` - N/A, there is only a single cache per table
 * ``sstable`` - the path of the sstable
+* ``logstor-cache`` - N/A, there is only a single cache per table
+* ``logstor-log`` - the path of the log file, followed by the id of the segment holding the record
 
 
 partition_region

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -898,6 +898,12 @@ public:
         return _logstor != nullptr;
     }
 
+    // The mutation sources of this table for SELECT ... FROM MUTATION_FRAGMENTS(), see
+    // logstor::make_mutation_sources_for_dump(). Only valid when uses_logstor().
+    std::map<sstring, mutation_source> make_logstor_mutation_sources_for_dump(schema_ptr s, const dht::decorated_key& dk, reader_permit permit) {
+        return _logstor->make_mutation_sources_for_dump(std::move(s), *_logstor_index, dk, std::move(permit));
+    }
+
     logstor::primary_index& logstor_index() noexcept {
         return *_logstor_index;
     }

--- a/replica/logstor/cache.cc
+++ b/replica/logstor/cache.cc
@@ -76,6 +76,21 @@ std::optional<mutation> cache_tracker::lookup(const primary_index_entry& pie, sc
     return cached_mut;
 }
 
+std::optional<mutation> cache_tracker::peek(const primary_index_entry& pie, schema_ptr target_schema) {
+    std::optional<mutation> cached_mut;
+    _read_section(region(), [&] {
+        if (pie._cached_entry) {
+            cached_mut = mutation(pie._cached_entry->schema(), dht::decorated_key(pie.key()), pie._cached_entry->partition());
+        }
+    });
+
+    if (cached_mut && cached_mut->schema() != target_schema) {
+        cached_mut->upgrade(target_schema);
+    }
+
+    return cached_mut;
+}
+
 void cache_tracker::populate(const primary_index_entry& pie, const mutation& m) {
     _populate_section(region(), [&] {
         with_allocator(allocator(), [&] {

--- a/replica/logstor/cache.hh
+++ b/replica/logstor/cache.hh
@@ -121,6 +121,11 @@ public:
 
     std::optional<mutation> lookup(const primary_index_entry&, schema_ptr);
 
+    // Like lookup(), but for introspection: returns a snapshot of the cached mutation
+    // without touching the LRU, without counting a hit or a miss and without upgrading
+    // the cached entry in place.
+    std::optional<mutation> peek(const primary_index_entry&, schema_ptr);
+
     void populate(const primary_index_entry&, const mutation&);
 
     logalloc::region& region() noexcept {

--- a/replica/logstor/index.hh
+++ b/replica/logstor/index.hh
@@ -201,6 +201,28 @@ public:
         return std::nullopt;
     }
 
+    struct dump_lookup_result {
+        index_entry entry;
+        std::optional<mutation> cached_mutation;
+    };
+
+    // Looks up a key for MUTATION_FRAGMENTS(): returns its index entry and, when the key
+    // is cached, a snapshot of the cached mutation. Unlike the read path this neither
+    // touches the cache's LRU nor counts a cache hit or miss, so that inspecting a table
+    // does not perturb its cache.
+    std::optional<dump_lookup_result> lookup_for_dump(const dht::decorated_key& dk, schema_ptr target_schema) const {
+        auto it = find(dk);
+        if (it == _partitions.end()) {
+            return std::nullopt;
+        }
+
+        dump_lookup_result result{.entry = it->entry()};
+        if (_cache_tracker) {
+            result.cached_mutation = _cache_tracker->peek(*it, std::move(target_schema));
+        }
+        return result;
+    }
+
     bool is_record_alive(const primary_index_key& key, log_location location) {
         auto it = _partitions.find(key.dk, dht::ring_position_comparator(*_schema));
         if (it != _partitions.end()) {

--- a/replica/logstor/logstor.cc
+++ b/replica/logstor/logstor.cc
@@ -200,6 +200,69 @@ future<std::optional<mutation>> logstor::read(const schema& s, const primary_ind
     co_return std::move(m);
 }
 
+std::map<sstring, mutation_source> logstor::make_mutation_sources_for_dump(schema_ptr s, const primary_index& index,
+        const dht::decorated_key& dk, reader_permit permit) {
+    // The snapshot of the cached mutation, held until the dump is done with its source.
+    // The source is copyable, so the snapshot and the memory it is accounted with are
+    // shared between its copies.
+    struct cache_snapshot {
+        mutation mut;
+        reader_permit::resource_units memory;
+    };
+
+    std::map<sstring, mutation_source> sources;
+
+    auto lookup = index.lookup_for_dump(dk, s);
+    if (!lookup) {
+        return sources;
+    }
+
+    // The cached mutation is snapshotted by the lookup above; the cache entry may be
+    // evicted by the time the source is read from.
+    if (lookup->cached_mutation) {
+        auto memory = permit.consume_memory(lookup->cached_mutation->memory_usage(*s));
+        auto snapshot = make_lw_shared<cache_snapshot>(cache_snapshot{std::move(*lookup->cached_mutation), std::move(memory)});
+        sources.emplace("logstor-cache", mutation_source([snapshot = std::move(snapshot)] (
+                schema_ptr s,
+                reader_permit permit,
+                const dht::partition_range&,
+                const query::partition_slice& slice,
+                tracing::trace_state_ptr,
+                streamed_mutation::forwarding fwd,
+                mutation_reader::forwarding) {
+            return make_mutation_reader_from_mutations(std::move(s), std::move(permit), mutation(snapshot->mut), slice, fwd);
+        }));
+    }
+
+    // The name identifies the segment holding the record, the way an sstable source is
+    // named after the sstable holding the row, and not the record's position inside it.
+    // All the records of a segment therefore share one source name, so that a dump can be
+    // restricted to the contents of a single segment. The name changes when compaction or
+    // an overwrite moves the record to another segment.
+    const auto location = lookup->entry.location;
+    auto name = format("logstor-log:{}:{}", _segment_manager.get_segment_file_path(location.segment), location.segment.value);
+
+    // The record is read through the regular read path, with the cache bypassed so that
+    // inspecting a table neither reads from nor populates it. The read happens on the
+    // first fill_buffer() call and resolves the record location from the index again, so
+    // a compaction which moved the record in the meantime is followed (in which case the
+    // source name, computed above, names the record's old location).
+    sources.emplace(std::move(name), mutation_source([this, &index] (
+            schema_ptr s,
+            reader_permit permit,
+            const dht::partition_range& pr,
+            const query::partition_slice& slice,
+            tracing::trace_state_ptr trace_state,
+            streamed_mutation::forwarding,   // The dump consumes whole partitions and never
+            mutation_reader::forwarding) {   // forwards the readers it creates.
+        auto dump_slice = slice;
+        dump_slice.options.set<query::partition_slice::option::bypass_cache>();
+        return make_reader(std::move(s), index, std::move(permit), pr, dump_slice, std::move(trace_state));
+    }));
+
+    return sources;
+}
+
 mutation_reader logstor::make_reader(schema_ptr schema, const primary_index& index, reader_permit permit, const dht::partition_range& pr,
         const query::partition_slice& slice, tracing::trace_state_ptr trace_state) {
 

--- a/replica/logstor/logstor.hh
+++ b/replica/logstor/logstor.hh
@@ -9,11 +9,13 @@
 
 #include <seastar/core/future.hh>
 #include <seastar/core/temporary_buffer.hh>
+#include <map>
 #include <optional>
 #include <seastar/core/scheduling.hh>
 #include "db/cache_tracker.hh"
 #include "readers/mutation_reader.hh"
 #include "replica/logstor/compaction.hh"
+#include "readers/mutation_source.hh"
 #include "types.hh"
 #include "index.hh"
 #include "segment_manager.hh"
@@ -76,6 +78,15 @@ public:
     future<> write(const mutation&, write_target target, db::timeout_clock::time_point timeout);
 
     future<std::optional<mutation>> read(const schema&, const primary_index&, const dht::decorated_key&, const query::partition_slice&);
+
+    // Debug introspection for SELECT * FROM MUTATION_FRAGMENTS(): returns one
+    // mutation source per place the key's data currently lives in - the
+    // in-memory logstor cache (if cached) and the log record - keyed by a name
+    // identifying the source. Returns an empty map when the key is not in the
+    // index. Neither source reads, populates or otherwise perturbs the cache.
+    // The cached mutation is snapshotted here and charged to the given permit,
+    // since the cache entry may be evicted before the source is read from.
+    std::map<sstring, mutation_source> make_mutation_sources_for_dump(schema_ptr, const primary_index&, const dht::decorated_key&, reader_permit);
 
     /// Create a mutation reader for a specific key
     mutation_reader make_reader(schema_ptr schema,

--- a/replica/logstor/segment_manager.cc
+++ b/replica/logstor/segment_manager.cc
@@ -987,6 +987,10 @@ public:
         return _cfg.segment_size;
     }
 
+    sstring get_segment_file_path(log_segment_id segment_id) const {
+        return sstring(_file_mgr.get_file_path(segment_id_to_file_location(segment_id).file_id).native());
+    }
+
     future<> discard_segments(logstor_group&);
 
     size_t get_memory_usage() const {
@@ -2738,6 +2742,10 @@ const compaction_manager& segment_manager::get_compaction_manager() const noexce
 
 uint64_t segment_manager::get_segment_size() const noexcept {
     return _impl->get_segment_size();
+}
+
+sstring segment_manager::get_segment_file_path(log_segment_id segment_id) const {
+    return _impl->get_segment_file_path(segment_id);
 }
 
 future<> segment_manager::discard_segments(logstor_group& cg) {

--- a/replica/logstor/segment_manager.hh
+++ b/replica/logstor/segment_manager.hh
@@ -135,6 +135,12 @@ public:
 
     uint64_t get_segment_size() const noexcept;
 
+    // Returns the path of the file holding the given segment (for debug/introspection).
+    // The path is computed from the segment id, the segment is not looked up, so the file
+    // does not have to hold a live segment. The file names are shard local, so this has to
+    // be called on the shard owning the segment.
+    sstring get_segment_file_path(log_segment_id) const;
+
     // Removes all the segments of the group and frees them. Waits for an ongoing compaction of
     // the group and keeps compaction disabled while discarding, so the caller doesn't have to.
     // The index must be cleared first, so that no record of the group is reachable.

--- a/replica/mutation_dump.cc
+++ b/replica/mutation_dump.cc
@@ -65,6 +65,9 @@ private:
             all_mutation_sources.emplace("virtual-table", tbl.as_mutation_source());
             return all_mutation_sources;
         }
+        if (tbl.uses_logstor()) {
+            return tbl.make_logstor_mutation_sources_for_dump(_underlying_schema, _dk, _permit);
+        }
         {
             auto mss = tbl.select_memtables_as_mutation_sources(_dk.token());
             for (size_t i = 0; i < mss.size(); ++i) {

--- a/replica/mutation_dump.cc
+++ b/replica/mutation_dump.cc
@@ -147,6 +147,31 @@ private:
         return query::clustering_range(transform_range_bound(cr.start(), false), transform_range_bound(cr.end(), true));
     }
 
+    // Each output row's clustering key starts with the mutation source name, e.g.
+    // ("row-cache", region, ck..., weight) or ("sstable:/some/path", region, ck..., weight).
+    // So a clustering range can span several sources at once, like from
+    // ("row-cache", pos) to ("sstable:/some/path", end) - but its start and end bounds
+    // only mean something for the sources they name. A source that just happens to sit
+    // between the two bounds should be read in full, not cut down to `pos`.
+    //
+    // This function takes such a range plus one `source` from that span, and hands back
+    // the range with whichever bound doesn't belong to `source` removed, e.g. asking for
+    // "sstable:/some/path" above drops the row-cache start bound and keeps only `end`.
+    static exploded_clustering_range narrow_to_source(const exploded_clustering_range& cr,
+            const interval<sstring>& ms_int, const sstring& source) {
+        auto start = cr.start();
+        auto end = cr.end();
+        // A bound naming no source at all (a fully-open range) constrains nothing,
+        // so leaving it alone here changes nothing either.
+        if (!ms_int.start() || ms_int.start()->value() != source) {
+            start = std::nullopt;
+        }
+        if (!ms_int.end() || ms_int.end()->value() != source) {
+            end = std::nullopt;
+        }
+        return exploded_clustering_range(std::move(start), std::move(end));
+    }
+
     void create_underlying_mutation_sources() {
         const auto all_mutation_sources = create_all_mutation_sources();
         const auto ms_end = all_mutation_sources.end();
@@ -183,13 +208,13 @@ private:
                 continue;
             }
 
-            const auto region_int = transform_range<int8_t>(exploded_cr, 1).transform([] (int8_t v) { return partition_region(v); });
-            const auto transformed_cr = transform_to_underlying_cr(exploded_cr);
             while (ms_it != ms_end && ms_int.contains(ms_it->first,  std::compare_three_way{})) {
+                const auto source_cr = narrow_to_source(exploded_cr, ms_int, ms_it->first);
+                const auto region_int = transform_range<int8_t>(source_cr, 1).transform([] (int8_t v) { return partition_region(v); });
                 auto& e = prepared_mutation_sources[ms_it->first];
                 e.ms = ms_it->second;
                 maybe_push(e.region_intervals, region_int, std::compare_three_way{});
-                maybe_push(e.underlying_crs, transformed_cr, clustering_key_view::tri_compare(*_underlying_schema));
+                maybe_push(e.underlying_crs, transform_to_underlying_cr(source_cr), clustering_key_view::tri_compare(*_underlying_schema));
                 ++ms_it;
             }
         }

--- a/test/cqlpy/test_logstor.py
+++ b/test/cqlpy/test_logstor.py
@@ -7,8 +7,11 @@
 # involving multiple nodes, reboots, etc., in test/cluster/test_logstor.py.
 #############################################################################
 
+import json
+
 import pytest
 from cassandra.protocol import ConfigurationException
+from cassandra.query import SimpleStatement
 from .util import new_test_table
 
 # All tests in this file are Scylla-only (logstor is not available on Cassandra).
@@ -212,6 +215,173 @@ def test_logstor_describe(cql, test_keyspace):
         result = cql.execute(f"DESCRIBE TABLE {table}")
         create_statement = result.one().create_statement
         assert "storage_engine = 'logstor'" not in create_statement
+
+# Test SELECT * FROM MUTATION_FRAGMENTS() on a logstor table. Freshly written
+# keys live only in the log, so each partition should consist of a partition
+# start, a single clustering row and a partition end, all coming from a single
+# "logstor-log:" mutation source naming the log file and segment holding the
+# record.
+def test_logstor_mutation_fragments(cql, test_keyspace):
+    with new_test_table(cql, test_keyspace, "pk int PRIMARY KEY, v int",
+                        " WITH storage_engine = 'logstor'") as table:
+        for i in range(3):
+            cql.execute(f"INSERT INTO {table} (pk, v) VALUES ({i}, {i*10})")
+
+        by_pk = {}
+        for row in cql.execute(f"SELECT * FROM MUTATION_FRAGMENTS({table})"):
+            by_pk.setdefault(row.pk, []).append(row)
+        assert set(by_pk.keys()) == {0, 1, 2}
+
+        for pk, frags in by_pk.items():
+            kinds = [f.mutation_fragment_kind for f in frags]
+            assert kinds == ['partition start', 'clustering row', 'partition end']
+            # Nothing was read yet, so the data is not cached and all fragments
+            # come from a single log record.
+            assert len({f.mutation_source for f in frags}) == 1
+            assert frags[0].mutation_source.startswith('logstor-log:')
+            # A freshly written partition has no tombstone.
+            assert json.loads(frags[0].metadata)['tombstone'] == {}
+            assert json.loads(frags[1].value) == {'v': str(pk*10)}
+
+        # Single-partition query returns only that partition's fragments.
+        rows = list(cql.execute(f"SELECT * FROM MUTATION_FRAGMENTS({table}) WHERE pk = 1"))
+        assert [r.pk for r in rows] == [1, 1, 1]
+        assert [r.mutation_fragment_kind for r in rows] == ['partition start', 'clustering row', 'partition end']
+
+# Test that after a key is read (and thus cached), MUTATION_FRAGMENTS() shows
+# it in both the logstor cache and the on-disk log, with the same value.
+def test_logstor_mutation_fragments_cache(cql, test_keyspace):
+    with new_test_table(cql, test_keyspace, "pk int PRIMARY KEY, v int",
+                        " WITH storage_engine = 'logstor'") as table:
+        cql.execute(f"INSERT INTO {table} (pk, v) VALUES (1, 100)")
+        cql.execute(f"INSERT INTO {table} (pk, v) VALUES (2, 200)")
+
+        # Read pk=1 to populate the logstor cache with it.
+        assert cql.execute(f"SELECT v FROM {table} WHERE pk = 1").one().v == 100
+
+        rows = list(cql.execute(f"SELECT * FROM MUTATION_FRAGMENTS({table}) WHERE pk = 1"))
+        sources = {r.mutation_source for r in rows}
+        assert 'logstor-cache' in sources
+        log_sources = {s for s in sources if s.startswith('logstor-log:')}
+        assert len(log_sources) == 1
+        # Both sources hold the same row value.
+        for r in rows:
+            if r.mutation_fragment_kind == 'clustering row':
+                assert json.loads(r.value) == {'v': '100'}
+        assert len([r for r in rows if r.mutation_fragment_kind == 'clustering row']) == 2
+
+        # The unread pk=2 is not cached, so only the log source shows up.
+        rows = list(cql.execute(f"SELECT * FROM MUTATION_FRAGMENTS({table}) WHERE pk = 2"))
+        assert len(rows) == 3
+        assert all(r.mutation_source.startswith('logstor-log:') for r in rows)
+
+        # Restricting the mutation_source clustering column works.
+        rows = list(cql.execute(f"SELECT * FROM MUTATION_FRAGMENTS({table}) WHERE pk = 1 AND mutation_source = 'logstor-cache'"))
+        assert len(rows) == 3
+        assert all(r.mutation_source == 'logstor-cache' for r in rows)
+
+# Test that a deleted key shows up in MUTATION_FRAGMENTS() as a partition
+# tombstone (with no rows), as logstor stores deletions as tombstone records.
+def test_logstor_mutation_fragments_tombstone(cql, test_keyspace):
+    with new_test_table(cql, test_keyspace, "pk int PRIMARY KEY, v int",
+                        " WITH storage_engine = 'logstor'"
+                        " AND tombstone_gc = {'mode': 'disabled'}") as table:
+        cql.execute(f"INSERT INTO {table} (pk, v) VALUES (1, 100) USING TIMESTAMP 1000")
+        cql.execute(f"DELETE FROM {table} USING TIMESTAMP 2000 WHERE pk = 1")
+
+        rows = list(cql.execute(f"SELECT * FROM MUTATION_FRAGMENTS({table}) WHERE pk = 1"))
+        kinds = [r.mutation_fragment_kind for r in rows]
+        assert kinds == ['partition start', 'partition end']
+        assert rows[0].mutation_source.startswith('logstor-log:')
+        tombstone = json.loads(rows[0].metadata)['tombstone']
+        assert tombstone['timestamp'] == 2000
+
+# Test that overwriting a key leaves a single log record visible in
+# MUTATION_FRAGMENTS(), holding the latest value (logstor replaces the old
+# record on overwrite rather than accumulating versions).
+def test_logstor_mutation_fragments_overwrite(cql, test_keyspace):
+    with new_test_table(cql, test_keyspace, "pk int PRIMARY KEY, v int",
+                        " WITH storage_engine = 'logstor'") as table:
+        cql.execute(f"INSERT INTO {table} (pk, v) VALUES (1, 100)")
+        cql.execute(f"INSERT INTO {table} (pk, v) VALUES (1, 200)")
+
+        rows = list(cql.execute(f"SELECT * FROM MUTATION_FRAGMENTS({table}) WHERE pk = 1"))
+        assert len({r.mutation_source for r in rows}) == 1
+        row_frags = [r for r in rows if r.mutation_fragment_kind == 'clustering row']
+        assert len(row_frags) == 1
+        assert json.loads(row_frags[0].value) == {'v': '200'}
+
+# Test that MUTATION_FRAGMENTS() reports nothing at all - not even an empty
+# partition - for a key which is not in the index, and likewise when the query
+# is restricted to a source the key does not have.
+def test_logstor_mutation_fragments_no_source(cql, test_keyspace):
+    with new_test_table(cql, test_keyspace, "pk int PRIMARY KEY, v int",
+                        " WITH storage_engine = 'logstor'") as table:
+        cql.execute(f"INSERT INTO {table} (pk, v) VALUES (1, 100)")
+
+        assert list(cql.execute(f"SELECT * FROM MUTATION_FRAGMENTS({table}) WHERE pk = 2")) == []
+        # pk=1 was never read, so it is not in the logstor cache.
+        assert list(cql.execute(f"SELECT * FROM MUTATION_FRAGMENTS({table}) WHERE pk = 1 AND mutation_source = 'logstor-cache'")) == []
+
+# Test that dumping a key does not populate the logstor cache: the dump reads
+# the log record with the cache bypassed, so an uncached key stays uncached no
+# matter how often it is dumped.
+def test_logstor_mutation_fragments_do_not_populate_cache(cql, test_keyspace):
+    with new_test_table(cql, test_keyspace, "pk int PRIMARY KEY, v int",
+                        " WITH storage_engine = 'logstor'") as table:
+        cql.execute(f"INSERT INTO {table} (pk, v) VALUES (1, 100)")
+
+        for _ in range(2):
+            rows = list(cql.execute(f"SELECT * FROM MUTATION_FRAGMENTS({table}) WHERE pk = 1"))
+            assert len(rows) == 3
+            assert all(r.mutation_source.startswith('logstor-log:') for r in rows)
+
+# Test that a logstor table with caching disabled never reports a cache source,
+# not even for a key which was read.
+def test_logstor_mutation_fragments_caching_disabled(cql, test_keyspace):
+    with new_test_table(cql, test_keyspace, "pk int PRIMARY KEY, v int",
+                        " WITH storage_engine = 'logstor'"
+                        " AND caching = {'enabled': 'false'}") as table:
+        cql.execute(f"INSERT INTO {table} (pk, v) VALUES (1, 100)")
+        assert cql.execute(f"SELECT v FROM {table} WHERE pk = 1").one().v == 100
+
+        rows = list(cql.execute(f"SELECT * FROM MUTATION_FRAGMENTS({table}) WHERE pk = 1"))
+        assert len(rows) == 3
+        assert all(r.mutation_source.startswith('logstor-log:') for r in rows)
+
+# Test that the log source name identifies the segment holding the record, and
+# is therefore shared by all the partitions stored in that segment - the way an
+# sstable source is shared by the partitions of one sstable. A dump can be
+# restricted to a single source, or to the log sources of all the partitions.
+def test_logstor_mutation_fragments_source_restriction(cql, test_keyspace):
+    with new_test_table(cql, test_keyspace, "pk int PRIMARY KEY, v text",
+                        " WITH storage_engine = 'logstor'") as table:
+        # 50KB values, 8 of them: bigger than a whole 128KB segment (the
+        # default segment size), so they are spread across several segments,
+        # and therefore several log sources.
+        large_value = 'x' * (50 * 1024)
+        for i in range(8):
+            cql.execute(f"INSERT INTO {table} (pk, v) VALUES ({i}, '{i}-{large_value}')")
+
+        # Group the partitions by the log source holding them.
+        pks_by_source = {}
+        for row in cql.execute(f"SELECT * FROM MUTATION_FRAGMENTS({table})"):
+            assert row.mutation_source.startswith('logstor-log:')
+            pks_by_source.setdefault(row.mutation_source, set()).add(row.pk)
+        assert set().union(*pks_by_source.values()) == set(range(8))
+        assert len(pks_by_source) > 1
+
+        # Restricting the query to one source returns exactly the partitions
+        # stored in it, with all their fragments.
+        for source, pks in pks_by_source.items():
+            rows = list(cql.execute(f"SELECT * FROM MUTATION_FRAGMENTS({table}) WHERE mutation_source = '{source}' ALLOW FILTERING"))
+            assert {r.pk for r in rows} == pks
+            assert len(rows) == 3 * len(pks)
+
+        # A range over the source kind returns all the log sources.
+        rows = list(cql.execute(f"SELECT * FROM MUTATION_FRAGMENTS({table})"
+                                f" WHERE mutation_source > 'logstor-log' AND mutation_source < 'logstor-log;' ALLOW FILTERING"))
+        assert len(rows) == 24
 
 # Test large text values to verify segment switching in logstor.
 def test_logstor_large_values(cql, test_keyspace):

--- a/test/cqlpy/test_select_from_mutation_fragments.py
+++ b/test/cqlpy/test_select_from_mutation_fragments.py
@@ -371,6 +371,39 @@ def test_paging(cql, test_table, scylla_only):
 
 
 @pytest.mark.parametrize("test_keyspace", ["tablets", "vnodes"], indirect=True)
+def test_paging_across_mutation_sources(cql, test_keyspace, scylla_only):
+    """ Test that a page ending inside one mutation source doesn't chop up the next ones.
+
+    MUTATION_FRAGMENTS() output rows are ordered by mutation source first (e.g.
+    all "row-cache" rows, then all "sstable:..." rows). A page resumes where the
+    previous one stopped, e.g. mid-way through "row-cache", so that becomes the
+    starting point of the next page's query. That starting point only makes sense
+    for "row-cache" - the "sstable:..." source comes after it and was never reached
+    by the previous page, so it should be read from its own beginning, not from
+    wherever "row-cache" happened to stop.
+    """
+    with util.new_test_table(cql, test_keyspace, 'pk int, ck int, v int, s int static, PRIMARY KEY (pk, ck)') as test_table:
+        cql.execute(f"UPDATE {test_table} SET s = 0 WHERE pk = 0")
+        cql.execute(f"INSERT INTO {test_table} (pk, ck, v) VALUES (0, 0, 0)")
+        cql.execute(f"INSERT INTO {test_table} (pk, ck, v) VALUES (0, 1, 1)")
+        nodetool.flush(cql, f"{test_table}")
+        # Read the partition, so that it is in the row cache as well as in the sstable.
+        assert len(list(cql.execute(f"SELECT v FROM {test_table} WHERE pk = 0"))) == 2
+
+        query = f"SELECT * FROM MUTATION_FRAGMENTS({test_table}) WHERE pk = 0"
+        expected = list(cql.execute(query))
+        # A partition start, a static row, two rows and a partition end, in the
+        # row cache and in the sstable.
+        assert len(expected) == 10
+
+        # Every page size puts the page boundary somewhere else, including
+        # inside the row-cache source, which is what loses the sstable source.
+        for page_size in range(1, len(expected)):
+            statement = cassandra.query.SimpleStatement(query, fetch_size=page_size)
+            assert list(cql.execute(statement)) == expected, f"fetch_size={page_size} lost fragments"
+
+
+@pytest.mark.parametrize("test_keyspace", ["tablets", "vnodes"], indirect=True)
 def test_slicing_rows(cql, test_table, scylla_only):
     """ Test that slicing rows from underlying works. """
     pk1 = util.unique_key_int()


### PR DESCRIPTION
implement SELECT ... FROM MUTATION_FRAGMENTS() for logstor tables.

MUTATION_FRAGMENTS() is answered from the coordinator's own storage and
never goes through the storage proxy, so it shows what a specific node
really stores. That makes it the natural tool for inspecting a logstor
table, and for tests that need to compare what each replica holds.

A logstor table has no memtables and no sstables, and its reads do not go
through the row cache, so the sources the dump collects for a normal table
are replaced by one source per place a key's data really lives in:

- "logstor-log:file_path:segment" - the log record. The name identifies
  the segment holding the record, the way an sstable source is named after
  the sstable holding the row and not after the row's position in it, so
  all the records of a segment share one source name and a dump can be
  restricted to the contents of a single segment. The record is read
  through the regular single-key read path on the first fill_buffer(),
  which resolves its location from the index again, so a compaction that
  moved the record since the source was created is followed - in which case
  the name, taken when the source was created, names the segment the record
  was in before.
- "logstor-cache" - the partition as held in the logstor cache, if it is
  cached. It is snapshotted when the source is created, because the entry
  may be evicted before it is read from, and charged to the reader permit
  for as long as the source holds it.

Neither source perturbs the cache. The record is read with the cache
bypassed, so the dump neither reads from nor populates it, and the cached
partition is snapshotted through primary_index::lookup_for_dump(), which
unlike the read path does not touch the LRU, does not count a cache hit or
a miss and does not upgrade the cached entry in place - the same care
row_cache::make_nonpopulating_reader() takes on the sstable side of the
dump.

We also fix a pre-existing issue we encountered in mutation_dump where it resumes and calculates wrong bounds for later sources. We add a new test that reproduces the issue and fails before the fix, and passes after the fix.

Fixes [SCYLLADB-3494](https://scylladb.atlassian.net/browse/SCYLLADB-3494)

no backport - new feature

[SCYLLADB-3494]: https://scylladb.atlassian.net/browse/SCYLLADB-3494?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ