### PR TITLE
utils: disambiguate cycle-detection error in topological_sort

### DIFF
--- a/cql3/statements/describe_statement.cc
+++ b/cql3/statements/describe_statement.cc
@@ -149,7 +149,7 @@ future<std::vector<user_type>> get_sorted_types(const lw_shared_ptr<keyspace_met
         }
     }
 
-    co_return co_await utils::topological_sort(all_udts, adjacency);
+    co_return co_await utils::topological_sort(all_udts, adjacency, "user defined types for DESCRIBE");
 }
 
 future<utils::chunked_vector<description>> types(replica::database& db, const lw_shared_ptr<keyspace_metadata>& ks, with_create_statement with_stmt) {

--- a/db/cql_type_parser.cc
+++ b/db/cql_type_parser.cc
@@ -87,7 +87,7 @@ public:
     }
 
     // See cassandra Types.java
-    future<std::vector<user_type>> build() {
+    future<std::vector<user_type>> build(std::string_view description) {
         struct entry_comparator {
             inline bool operator()(const entry* a, const entry* b) const {
                 return a->name < b->name;
@@ -119,7 +119,7 @@ public:
         replica::user_types_metadata types = _ks.user_types();
         const auto &ks_name = _ks.name();
 
-        auto sorted = co_await utils::topological_sort(all_definitions, adjacency);
+        auto sorted = co_await utils::topological_sort(all_definitions, adjacency, fmt::format("user defined types ({})", description));
         std::vector<user_type> created;
         created.reserve(sorted.size());
 
@@ -145,6 +145,6 @@ void db::cql_type_parser::raw_builder::add(sstring name, std::vector<sstring> fi
     _impl->add(std::move(name), std::move(field_names), std::move(field_types));
 }
 
-future<std::vector<user_type>> db::cql_type_parser::raw_builder::build() {
-    return _impl->build();
+future<std::vector<user_type>> db::cql_type_parser::raw_builder::build(std::string_view description) {
+    return _impl->build(description);
 }

--- a/db/cql_type_parser.hh
+++ b/db/cql_type_parser.hh
@@ -9,6 +9,7 @@
 
 #pragma once
 
+#include <string_view>
 #include <vector>
 #include <seastar/core/sstring.hh>
 
@@ -36,7 +37,9 @@ public:
     ~raw_builder();
 
     void add(sstring name, std::vector<sstring> field_names, std::vector<sstring> field_types);
-    future<std::vector<user_type>> build();
+    // description identifies the caller's context (e.g. "schema merge"), and is used to
+    // disambiguate the error thrown if the user defined types form a dependency cycle.
+    future<std::vector<user_type>> build(std::string_view description);
 private:
     class impl;
     std::unique_ptr<impl>

--- a/db/schema_applier.cc
+++ b/db/schema_applier.cc
@@ -436,9 +436,9 @@ future<> schema_applier::merge_types()
             new_keyspaces_per_shard.emplace(ks->metadata()->name(), std::ref(*ks));
         }
 
-        af.created = co_await create_types(db, diff.created, new_keyspaces_per_shard);
-        af.altered = co_await create_types(db, diff.altered, new_keyspaces_per_shard);
-        af.dropped = co_await create_types(db, diff.dropped, new_keyspaces_per_shard);
+        af.created = co_await create_types(db, diff.created, new_keyspaces_per_shard, "schema merge: created types");
+        af.altered = co_await create_types(db, diff.altered, new_keyspaces_per_shard, "schema merge: altered types");
+        af.dropped = co_await create_types(db, diff.dropped, new_keyspaces_per_shard, "schema merge: dropped types");
     });
 
     co_await _types_storage.init(_proxy.local().get_db(), _affected_keyspaces, _affected_user_types);

--- a/db/schema_tables.cc
+++ b/db/schema_tables.cc
@@ -936,7 +936,7 @@ template<typename V>
 static std::vector<V> get_list(const query::result_set_row& row, const sstring& name);
 
 // Create types for a given keyspace. This takes care of topologically sorting user defined types.
-template <typename T> static future<std::vector<user_type>> create_types(keyspace_metadata& ks, T&& range) {
+template <typename T> static future<std::vector<user_type>> create_types(keyspace_metadata& ks, T&& range, std::string_view description) {
     cql_type_parser::raw_builder builder(ks);
     std::unordered_set<bytes> names;
     for (const query::result_set_row& row : range) {
@@ -964,7 +964,7 @@ template <typename T> static future<std::vector<user_type>> create_types(keyspac
             }
         }
     }
-    co_return co_await builder.build();
+    co_return co_await builder.build(description);
 }
 
 static lw_shared_ptr<keyspace_metadata> find_keyspace_metadata(std::string_view name, replica::database& db,
@@ -976,7 +976,7 @@ static lw_shared_ptr<keyspace_metadata> find_keyspace_metadata(std::string_view 
     return db.find_keyspace(name).metadata();
 }
 
-future<std::vector<user_type>> create_types(replica::database& db, const std::vector<const query::result_set_row*>& rows, std::map<sstring, std::reference_wrapper<replica::keyspace>>& new_keyspaces) {
+future<std::vector<user_type>> create_types(replica::database& db, const std::vector<const query::result_set_row*>& rows, std::map<sstring, std::reference_wrapper<replica::keyspace>>& new_keyspaces, std::string_view description) {
     std::vector<user_type> ret;
     for (auto i = rows.begin(), e = rows.end(); i != e;) {
         const auto &row = *i;
@@ -985,7 +985,7 @@ future<std::vector<user_type>> create_types(replica::database& db, const std::ve
             return r->get_nonnull<sstring>("keyspace_name") != keyspace;
         });
         auto ks = find_keyspace_metadata(keyspace, db, new_keyspaces);
-        auto v = co_await create_types(*ks, std::ranges::subrange(i, next) | std::views::transform([] (auto&& r) -> auto& { return *r; }));
+        auto v = co_await create_types(*ks, std::ranges::subrange(i, next) | std::views::transform([] (auto&& r) -> auto& { return *r; }), description);
         std::ranges::move(v, std::back_inserter(ret));
         i = next;
     }
@@ -1315,8 +1315,8 @@ static std::vector<V> get_list(const query::result_set_row& row, const sstring& 
 }
 
 future<std::vector<user_type>> create_types_from_schema_partition(
-        keyspace_metadata& ks, lw_shared_ptr<query::result_set> result) {
-    co_return co_await create_types(ks, result->rows());
+        keyspace_metadata& ks, lw_shared_ptr<query::result_set> result, std::string_view description) {
+    co_return co_await create_types(ks, result->rows(), description);
 }
 
 seastar::future<std::vector<shared_ptr<cql3::functions::user_function>>> create_functions_from_schema_partition(

--- a/db/schema_tables.hh
+++ b/db/schema_tables.hh
@@ -24,6 +24,7 @@
 
 #include <vector>
 #include <map>
+#include <string_view>
 
 namespace data_dictionary {
 class keyspace_metadata;
@@ -212,9 +213,11 @@ utils::chunked_vector<mutation> make_create_type_mutations(lw_shared_ptr<keyspac
 // Given a set of rows that is sorted by keyspace, create types for each keyspace.
 // The topological sort in each keyspace is necessary when creating types, since we can only create a type when the
 // types it reference have already been created.
-future<std::vector<user_type>> create_types(replica::database& db, const std::vector<const query::result_set_row*>& rows, std::map<sstring, std::reference_wrapper<replica::keyspace>>& new_keyspaces);
+// description identifies the caller's context (e.g. "schema merge"), and is used to disambiguate
+// the error thrown if the user defined types form a dependency cycle.
+future<std::vector<user_type>> create_types(replica::database& db, const std::vector<const query::result_set_row*>& rows, std::map<sstring, std::reference_wrapper<replica::keyspace>>& new_keyspaces, std::string_view description);
 
-future<std::vector<user_type>> create_types_from_schema_partition(keyspace_metadata& ks, lw_shared_ptr<query::result_set> result);
+future<std::vector<user_type>> create_types_from_schema_partition(keyspace_metadata& ks, lw_shared_ptr<query::result_set> result, std::string_view description);
 
 std::vector<data_type> read_arg_types(const query::result_set_row& row, const sstring& keyspace, const data_dictionary::user_types_storage& user_types);
 

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -858,7 +858,7 @@ future<> database::parse_system_tables(sharded<service::storage_proxy>& proxy, s
     }));
     co_await do_parse_schema_tables(proxy, db::schema_tables::TYPES, coroutine::lambda([&] (schema_result_value_type &v) -> future<> {
         auto& ks = this->find_keyspace(v.first);
-        auto&& user_types = co_await create_types_from_schema_partition(*ks.metadata(), v.second);
+        auto&& user_types = co_await create_types_from_schema_partition(*ks.metadata(), v.second, "loading types at startup");
         for (auto&& type : user_types) {
             ks.add_user_type(type);
         }

--- a/test/boost/sorting_test.cc
+++ b/test/boost/sorting_test.cc
@@ -79,9 +79,9 @@ SEASTAR_TEST_CASE(test_topological_sorting) {
         for (size_t i = 0; i < tests.size(); i++) {
             testlog.info("Testing case index: {}", i);
             if (tests[i].expect_error) {
-                BOOST_REQUIRE_THROW(utils::topological_sort(all_nodes, tests[i].adjacent_map).get(), std::runtime_error);
+                BOOST_REQUIRE_THROW(utils::topological_sort(all_nodes, tests[i].adjacent_map, "test nodes").get(), std::runtime_error);
             } else {
-                auto result = utils::topological_sort(all_nodes, tests[i].adjacent_map).get();
+                auto result = utils::topological_sort(all_nodes, tests[i].adjacent_map, "test nodes").get();
                 BOOST_REQUIRE_EQUAL_COLLECTIONS(result.begin(), result.end(), tests[i].expected_result.begin(), tests[i].expected_result.end());
             }
         }

--- a/tools/schema_loader.cc
+++ b/tools/schema_loader.cc
@@ -471,7 +471,7 @@ schema_ptr do_load_schema_from_schema_tables(const db::config& dbcfg, std::files
             ut_builder.add(name, field_names, field_types);
         }
 
-        auto user_types = ut_builder.build().get();
+        auto user_types = ut_builder.build("offline schema loading").get();
         for (auto&& ut : user_types) {
             utm.add_type(std::move(ut));
         }

--- a/utils/sorting.hh
+++ b/utils/sorting.hh
@@ -9,10 +9,12 @@
 #pragma once
 
 #include <stdexcept>
+#include <string_view>
 #include <vector>
 #include <map>
 #include <seastar/core/future.hh>
 #include <seastar/coroutine/maybe_yield.hh>
+#include <fmt/core.h>
 #include "utils/stall_free.hh"
 
 namespace utils {
@@ -29,13 +31,16 @@ concept VerticiesContainer = requires(const Container& c) {
  *
  * @param vertices      Contains all vertices of the graph
  * @param adjacency_map Entry {k, v} means there is an k->v edge in the graph
- * @return a vector of topologically sorted vertices. 
+ * @param description   Describes what is being sorted and why, used to disambiguate the
+ *                       cycle-detected error between call sites (e.g. "user defined types
+ *                       during schema merge").
+ * @return a vector of topologically sorted vertices.
         If there is an edge k->v, then vertex k will be before vertex v.
  * @throws std::runtime_error when a graph has any cycle.
  */
 template<typename T, typename Compare = std::less<T>, typename Container>
 requires VerticiesContainer<Container, T>
-seastar::future<std::vector<T>> topological_sort(const Container& vertices, const std::multimap<T, T, Compare>& adjacency_map) {
+seastar::future<std::vector<T>> topological_sort(const Container& vertices, const std::multimap<T, T, Compare>& adjacency_map, std::string_view description) {
     std::map<T, size_t, Compare> ref_count_map; // Contains counters how many edges point (reference) to a vertex
     std::vector<T> sorted;
     sorted.reserve(vertices.size());
@@ -69,7 +74,7 @@ seastar::future<std::vector<T>> topological_sort(const Container& vertices, cons
     co_await utils::clear_gently(ref_count_map);
 
     if (sorted.size() != vertices.size()) {
-        throw std::runtime_error("Detected cycle in the graph.");
+        throw std::runtime_error(fmt::format("Detected cycle in the graph while sorting {}.", description));
     }
     co_return sorted;
 }


### PR DESCRIPTION
utils::topological_sort() threw a generic "Detected cycle in the graph." on a cycle, with no indication of which caller's graph had the cycle. Add a required description parameter identifying what is being sorted, and thread it through every caller so each names its own context.

raw_builder::build() (used to build user defined types) is shared by several unrelated callers, so the description is threaded through it and through schema_tables::create_types() /
create_types_from_schema_partition() rather than hardcoded once.

Fixes SCYLLADB-2309

backport not needed - small improvement for future debugging