### PR TITLE
logstor: fix snapshots, destruction order, atomic apply, and counters

### DIFF
--- a/cql3/statements/create_table_statement.cc
+++ b/cql3/statements/create_table_statement.cc
@@ -271,8 +271,15 @@ std::unique_ptr<prepared_statement> create_table_statement::raw_statement::prepa
 
     if (_properties.properties()->has_property(cf_prop_defs::KW_STORAGE_ENGINE)) {
         auto storage_engine = _properties.properties()->get_string(cf_prop_defs::KW_STORAGE_ENGINE, "");
-        if (storage_engine == "logstor" && !_column_aliases.empty()) {
-            throw exceptions::configuration_exception("The 'logstor' storage engine cannot be used with tables that have clustering columns");
+        if (storage_engine == "logstor") {
+            if (!_column_aliases.empty()) {
+                throw exceptions::configuration_exception("The 'logstor' storage engine cannot be used with tables that have clustering columns");
+            }
+            for (auto&& [id, type] : stmt->_columns) {
+                if (type->is_counter()) {
+                    throw exceptions::configuration_exception("The 'logstor' storage engine cannot be used with counter columns");
+                }
+            }
         }
     }
 

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -2371,8 +2371,12 @@ future<> database::do_apply_many(const utils::chunked_vector<frozen_mutation>& m
         auto s = local_schema_registry().get(muts[i].schema_version());
         auto&& cf = find_column_family(muts[i].column_family_id());
 
-        if (cf.uses_logstor()) {
-            continue;
+        // Atomicity here comes from writing all the mutations to the commitlog as one batch, which
+        // a logstor table cannot take part in, having no commitlog. Skipping it instead would also
+        // desynchronize the handles below from the mutations they belong to.
+        if (cf.uses_logstor()) [[unlikely]] {
+            on_internal_error(dblog, format("Cannot apply atomically to a table using logstor: {}.{}",
+                              cf.schema()->ks_name(), cf.schema()->cf_name()));
         }
 
         if (!cl) {

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -1759,6 +1759,10 @@ private:
             db::per_partition_rate_limit::info,
             bool /* skip_large_data_guardrails */> _apply_stage;
 
+    // Declared ahead of the tables, since a logstor table holds a pointer to it and its compaction
+    // groups reach for its compaction manager as they are destroyed, so it has to outlive them.
+    std::unique_ptr<logstor::logstor> _logstor;
+
     flat_hash_map<sstring, keyspace> _keyspaces;
     tables_metadata _tables_metadata;
     std::unique_ptr<db::commitlog> _commitlog;
@@ -1773,8 +1777,6 @@ private:
     bool _shutdown = false;
     bool _enable_autocompaction_toggle = false;
     querier_cache _querier_cache;
-
-    std::unique_ptr<logstor::logstor> _logstor;
 
     std::unique_ptr<db::large_data_handler> _large_data_handler;
     std::unique_ptr<db::large_data_handler> _nop_large_data_handler;

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -1270,15 +1270,17 @@ future<utils::chunked_vector<logstor::segment_snapshot>> storage_group::take_log
         co_return co_await _main_cg->take_logstor_snapshot();
     }
     utils::chunked_vector<logstor::segment_snapshot> snp;
+    auto append = [&snp] (utils::chunked_vector<logstor::segment_snapshot> cg_snp) {
+        snp.insert(snp.end(), std::make_move_iterator(cg_snp.begin()), std::make_move_iterator(cg_snp.end()));
+    };
+    append(co_await _main_cg->take_logstor_snapshot());
     for (const auto& cg : _merging_groups) {
         if (!cg->empty()) {
-            auto cg_snp = co_await cg->take_logstor_snapshot();
-            snp.insert(snp.end(), std::make_move_iterator(cg_snp.begin()), std::make_move_iterator(cg_snp.end()));
+            append(co_await cg->take_logstor_snapshot());
         }
     }
     for (const auto& cg : _split_ready_groups) {
-        auto cg_snp = co_await cg->take_logstor_snapshot();
-        snp.insert(snp.end(), std::make_move_iterator(cg_snp.begin()), std::make_move_iterator(cg_snp.end()));
+        append(co_await cg->take_logstor_snapshot());
     }
     co_return std::move(snp);
 }

--- a/test/cqlpy/test_logstor.py
+++ b/test/cqlpy/test_logstor.py
@@ -156,6 +156,14 @@ def test_logstor_clustering_columns_disabled(cql, test_keyspace):
                             " WITH storage_engine = 'logstor'") as table:
             pass
 
+# Test that logstor tables can't be created with counter columns, since
+# counters are not supported currently with logstor.
+def test_logstor_counter_columns_disabled(cql, test_keyspace):
+    with pytest.raises(ConfigurationException, match="The 'logstor' storage engine cannot be used with counter columns"):
+        with new_test_table(cql, test_keyspace, "pk int PRIMARY KEY, c counter",
+                            " WITH storage_engine = 'logstor'") as table:
+            pass
+
 # Test frozen map column with logstor storage engine.
 def test_logstor_frozen_map(cql, test_keyspace):
     with new_test_table(cql, test_keyspace, "pk int PRIMARY KEY, v frozen<map<text, text>>",


### PR DESCRIPTION
miscellaneous small fixes for logstor.

* fix take_logstor_snapshot - it was missing the snapshot of the main compaction group in the case where there are also split ready or merging groups.
* reject atomic apply that has logstor tables with internal error - this works by writing all mutations to commitlog, and logstor doesn't use commitlog. this should not happen since it's only used for system tables.
* fix destruction order in db - destroy logstor after tables, since tables have a pointer to logstor.
* reject counter columns on logstor tables - Fixes [SCYLLADB-3487](https://scylladb.atlassian.net/browse/SCYLLADB-3487)

no backport - logstor is experimental

[SCYLLADB-3487]: https://scylladb.atlassian.net/browse/SCYLLADB-3487?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ