### PR TITLE
alternator: keep canonical header values stable

### DIFF
--- a/alternator/server.cc
+++ b/alternator/server.cc
@@ -396,6 +396,8 @@ future<std::string> server::verify_signature(const request& req, const chunked_c
         signed_headers_map.emplace(header, std::string_view());
     }
     std::vector<std::string> modified_values;
+    // The map values below point into this vector, so its elements must not move.
+    modified_values.reserve(signed_headers_map.size());
     for (auto& header : req._headers) {
         std::string header_str;
         header_str.resize(header.first.size());

--- a/test/alternator/test_authorization.py
+++ b/test/alternator/test_authorization.py
@@ -174,6 +174,22 @@ def test_canonization_middle_whitespace(dynamodb, test_table):
     response = requests.post(req.url, headers=req.headers, data=req.body, verify=False)
     assert response.ok
 
+# Canonizing several short header values must keep all normalized values alive
+# while calculating the signature. This reproduces issue #31293.
+def test_canonization_middle_whitespace_multiple_headers(dynamodb, test_table):
+    payload = '{"TableName": "' + test_table.name + '", "Item": {"p": {"S": "x"}, "c": {"S": "x"}}}'
+    custom_headers = {
+        'Meerkat': 'one two',
+        'Capybara': 'three four',
+        'Wombat': 'five six',
+    }
+    req = get_signed_request(dynamodb, 'PutItem', payload, custom_headers)
+    for name in custom_headers:
+        assert name.lower() in req.headers['Authorization']
+        req.headers[name] = req.headers[name].replace(' ', '   ', 1)
+    response = requests.post(req.url, headers=req.headers, data=req.body, verify=False)
+    assert response.ok
+
 # Test that the case of the header name is canonized before signing
 def test_canonization_header_name_capitalization(dynamodb, test_table):
     payload = '{"TableName": "' + test_table.name + '", "Item": {"p": {"S": "x"}, "c": {"S": "x"}}}'


### PR DESCRIPTION
SigV4 verification stored string views into a vector whose reallocation could invalidate short canonicalized header values.

Reserve one slot per signed header so normalized strings remain stable until signature calculation.

Fixes #31293