### PR TITLE
alternator: use current timestamp in stream event IDs

### DIFF
--- a/alternator/streams.cc
+++ b/alternator/streams.cc
@@ -1449,6 +1449,7 @@ future<executor::request_return_type> executor::get_records(client_state& client
             break;
         }
         if (eor) {
+            timestamp = ts;
             size_t index = 0;
             for (auto& [_, rec] : records_map) {
                 rjson::add(rec.record, "awsRegion", rjson::from_string(dc_name));
@@ -1461,7 +1462,6 @@ future<executor::request_return_type> executor::get_records(client_state& client
             }
 
             records_map.clear();
-            timestamp = ts;
             if (records.Size() >= limit) {
                 // Note: we might have more than limit rows here - BatchWriteItem will emit multiple items
                 // with the same timestamp and we have no way of resume iteration midway through those,

--- a/test/alternator/test_streams.py
+++ b/test/alternator/test_streams.py
@@ -7,6 +7,7 @@
 
 import time
 import urllib.request
+import uuid
 from contextlib import contextmanager, ExitStack
 from urllib.error import URLError
 
@@ -1019,6 +1020,13 @@ def compare_events(expected_events, output, mode, expected_region):
             # some libraries rely on this. This reproduces issue #7158:
             assert 'SequenceNumber' in record
             assert record['SequenceNumber'].isdecimal()
+            if event['eventSource'] == 'scylladb:alternator':
+                # The event ID and sequence number must identify the same CDC
+                # timestamp. This reproduces issue #31294.
+                sequence_number = int(record['SequenceNumber'])
+                event_uuid = uuid.UUID(event['eventID'].rsplit(':', 2)[1])
+                assert event_uuid.time == sequence_number >> 64
+                assert event_uuid.int & ((1 << 64) - 1) == sequence_number & ((1 << 64) - 1)
             # Alternator doesn't set the SizeBytes member. Issue #6931.
             #assert 'SizeBytes' in record
             if mode == 'KEYS_ONLY':


### PR DESCRIPTION
GetRecords dereferenced the timestamp before initializing it for the first event and used the preceding timestamp for later event IDs.

Set the timestamp before emitting each CDC batch so event IDs and paging state use the current value.

Fixes #31294