### PR TITLE
alternator: account for decompressed request memory

### DIFF
--- a/alternator/controller.cc
+++ b/alternator/controller.cc
@@ -162,7 +162,7 @@ future<> controller::start_server() {
                     _config.alternator_enforce_authorization,
                     _config.alternator_warn_authorization,
                     _config.alternator_max_users_query_size_in_trace_output,
-                    &_memory_limiter.local().get_semaphore(),
+                    &_memory_limiter.local(),
                     _config.max_concurrent_requests_per_shard);
         }).handle_exception([this, addr, alternator_port, alternator_https_port, alternator_port_proxy_protocol, alternator_https_port_proxy_protocol] (std::exception_ptr ep) {
             logger.error("Failed to set up Alternator HTTP server on {} port {}, TLS port {}, proxy-protocol port {}, TLS proxy-protocol port {}: {}",

--- a/alternator/server.cc
+++ b/alternator/server.cc
@@ -23,6 +23,7 @@
 #include "seastarx.hh"
 #include "error.hh"
 #include "service/client_state.hh"
+#include "service/memory_limiter.hh"
 #include "service/qos/service_level_controller.hh"
 #include "utils/assert.hh"
 #include "timeout_config.hh"
@@ -765,6 +766,8 @@ future<executor::request_return_type> server::handle_api_request(std::unique_ptr
         // for such a size.
         co_return api_error::payload_too_large(fmt::format("Request content length limit of {} bytes exceeded", request_content_length_limit));
     }
+    sstring content_encoding = req->get_header("Content-Encoding");
+    const bool content_is_compressed = content_encoding == "gzip" || content_encoding == "deflate";
     // Check the concurrency limit early, before acquiring memory and
     // reading the request body, to avoid piling up memory from excess
     // requests that will be rejected anyway. This mirrors the CQL
@@ -778,25 +781,32 @@ future<executor::request_return_type> server::handle_api_request(std::unique_ptr
     auto leave = defer([this] () noexcept { _pending_requests.leave(); });
     // JSON parsing can allocate up to roughly 2x the size of the raw
     // document, + a couple of bytes for maintenance.
-    // If the Content-Length of the request is not available, we assume
+    // If the uncompressed length of the request is not available, we assume
     // the largest possible request (request_content_length_limit, i.e., 16 MB)
-    // and after reading the request we return_units() the excess.
-    size_t mem_estimate = (req->content_length ? req->content_length : request_content_length_limit) * 2 + 8000;
-    auto units_fut = get_units(*_memory_limiter, mem_estimate);
-    if (_memory_limiter->waiters()) {
+    // and return the excess after learning the actual length. For compressed
+    // requests this also covers the compressed and uncompressed bodies while
+    // both are alive during decompression.
+    const size_t estimated_content_length = content_is_compressed || !req->content_length
+            ? request_content_length_limit
+            : req->content_length;
+    // A semaphore request larger than its total capacity can never complete.
+    const size_t mem_estimate = std::min(estimated_content_length * 2 + 8000, _memory_limiter->total_memory());
+    auto& memory_limiter = _memory_limiter->get_semaphore();
+    auto units_fut = get_units(memory_limiter, mem_estimate);
+    if (memory_limiter.waiters()) {
         ++_executor._stats.requests_blocked_memory;
     }
     auto units = co_await std::move(units_fut);
     throwing_assert(req->content_stream);
     chunked_content content = co_await read_entire_stream(*req->content_stream, request_content_length_limit);
-    // If the request had no Content-Length, we reserved too many units
-    // so need to return some
-    if (req->content_length == 0) {
+    // If the uncompressed request had no Content-Length, we reserved too many
+    // units, so return the excess now.
+    if (req->content_length == 0 && !content_is_compressed) {
         size_t content_length = 0;
         for (const auto& chunk : content) {
             content_length += chunk.size();
         }
-        size_t new_mem_estimate = content_length * 2 + 8000;
+        const size_t new_mem_estimate = std::min(content_length * 2 + 8000, mem_estimate);
         units.return_units(mem_estimate - new_mem_estimate);
     }
     auto username = co_await verify_signature(*req, content);
@@ -805,7 +815,6 @@ future<executor::request_return_type> server::handle_api_request(std::unique_ptr
     // We apply the request_content_length_limit again to the uncompressed
     // content - we don't want to allow a tiny compressed request to
     // expand to a huge uncompressed request.
-    sstring content_encoding = req->get_header("Content-Encoding");
     if (content_encoding == "gzip") {
         content = co_await ungzip(std::move(content), request_content_length_limit);
     } else if (content_encoding == "deflate") {
@@ -815,6 +824,14 @@ future<executor::request_return_type> server::handle_api_request(std::unique_ptr
         // I'm not sure if this is the best error code, but let's do it too.
         // See the test test_garbage_content_encoding confirming this case.
         co_return api_error::internal("Unsupported Content-Encoding");
+    }
+    if (content_is_compressed) {
+        size_t content_length = 0;
+        for (const auto& chunk : content) {
+            content_length += chunk.size();
+        }
+        const size_t new_mem_estimate = std::min(content_length * 2 + 8000, mem_estimate);
+        units.return_units(mem_estimate - new_mem_estimate);
     }
 
     // As long as the system_clients_entry object is alive, this request will
@@ -1050,7 +1067,7 @@ future<> server::init(net::inet_address addr, std::optional<uint16_t> port, std:
         std::optional<uint16_t> port_proxy_protocol, std::optional<uint16_t> https_port_proxy_protocol,
         std::optional<tls::credentials_builder> creds,
         utils::updateable_value<bool> enforce_authorization, utils::updateable_value<bool> warn_authorization, utils::updateable_value<uint64_t> max_users_query_size_in_trace_output,
-        semaphore* memory_limiter, utils::updateable_value<uint32_t> max_concurrent_requests) {
+        service::memory_limiter* memory_limiter, utils::updateable_value<uint32_t> max_concurrent_requests) {
     _memory_limiter = memory_limiter;
     _enforce_authorization = std::move(enforce_authorization);
     _warn_authorization = std::move(warn_authorization);

--- a/alternator/server.hh
+++ b/alternator/server.hh
@@ -25,6 +25,10 @@
 
 struct client_data;
 
+namespace service {
+class memory_limiter;
+}
+
 namespace alternator {
 
 using chunked_content = rjson::chunked_content;
@@ -72,7 +76,7 @@ class server : public peering_sharded_service<server> {
 
     alternator_callbacks_map _callbacks;
 
-    semaphore* _memory_limiter;
+    service::memory_limiter* _memory_limiter;
     utils::updateable_value<uint32_t> _max_concurrent_requests;
 
     ::shared_ptr<seastar::tls::server_credentials> _credentials;
@@ -121,7 +125,7 @@ public:
             std::optional<uint16_t> port_proxy_protocol, std::optional<uint16_t> https_port_proxy_protocol,
             std::optional<tls::credentials_builder> creds,
             utils::updateable_value<bool> enforce_authorization, utils::updateable_value<bool> warn_authorization, utils::updateable_value<uint64_t> max_users_query_size_in_trace_output,
-            semaphore* memory_limiter, utils::updateable_value<uint32_t> max_concurrent_requests);
+            service::memory_limiter* memory_limiter, utils::updateable_value<uint32_t> max_concurrent_requests);
     future<> stop();
     // get_client_data() is called (on each shard separately) when the virtual
     // table "system.clients" is read. It is expected to generate a list of
@@ -146,4 +150,3 @@ private:
 };
 
 }
-

--- a/test/alternator/test_compressed_request.py
+++ b/test/alternator/test_compressed_request.py
@@ -28,16 +28,21 @@
 # and the server returning a compressed response - is a separate issue and
 # not tested here.
 
+import concurrent.futures
+import gzip
+import threading
+import time
+import zlib
+
 import boto3
 import botocore
-import gzip
-import zlib
 import requests
 import pytest
 from botocore import UNSIGNED
 
 from .util import random_string, get_cert
 from .test_manual_requests import get_signed_request
+from .test_metrics import get_metric, metrics
 
 # The compressed_req fixture is like the dynamodb fixture - providing a
 # connection to a DynamDB-API server. But the unique feature of compressed_req
@@ -115,6 +120,56 @@ def test_long_compressed_request(test_table_s, compressed_req):
     tab.put_item(Item=item)
     got_item = tab.get_item(Key={'p': p}, ConsistentRead=True)['Item']
     assert got_item == item
+
+class _DelayedBody:
+    def __init__(self, body, started, release):
+        self.body = body
+        self.started = started
+        self.release = release
+
+    def __len__(self):
+        return len(self.body)
+
+    def __iter__(self):
+        yield self.body[:1]
+        self.started.set()
+        if not self.release.wait(timeout=30):
+            raise RuntimeError('timed out waiting to send compressed request body')
+        yield self.body[1:]
+
+# A highly compressible request must reserve enough memory admission units for
+# its uncompressed body. Three requests are enough to exceed the limiter on at
+# least one of the two shards used by the test server. This reproduces issue
+# #31296: before the fix, each request reserved only its small compressed size,
+# so none of them blocked on the memory limiter.
+def test_large_compressed_request_accounted(dynamodb, test_table, metrics):
+    p = random_string()
+    payload = '{"TableName": "' + test_table.name + '", "Item": {"p": {"S": "' + p + '"}, "c": {"S": "x"}}}'
+    payload = payload[:-1] + ' ' * (1024 * 1024) + payload[-1]
+    payload = gzip.compress(payload.encode('utf-8'))
+    assert len(payload) < 16 * 1024
+    req = get_signed_request(dynamodb, 'PutItem', payload)
+    headers = dict(req.headers)
+    headers.update({'Content-Encoding': 'gzip'})
+
+    blocked_before = get_metric(metrics, 'scylla_alternator_requests_blocked_memory')
+    release = threading.Event()
+    started = [threading.Event() for _ in range(3)]
+    with concurrent.futures.ThreadPoolExecutor(max_workers=len(started)) as executor:
+        responses = [executor.submit(requests.post, req.url, headers=headers,
+                data=_DelayedBody(req.body, event, release), verify=False, cert=req.cert, timeout=30)
+                for event in started]
+        try:
+            assert all(event.wait(timeout=10) for event in started)
+            deadline = time.monotonic() + 10
+            while get_metric(metrics, 'scylla_alternator_requests_blocked_memory') == blocked_before:
+                assert time.monotonic() < deadline, 'compressed requests did not reserve their uncompressed size'
+                time.sleep(0.05)
+        finally:
+            release.set()
+        assert all(response.result().status_code == 200 for response in responses)
+
+    assert test_table.get_item(Key={'p': p, 'c': 'x'}, ConsistentRead=True)['Item'] == {'p': p, 'c': 'x'}
 
 # The tests above configured boto3 to compress its requests so we could
 # test them. We now want to test unusual scenarios - including corrupt


### PR DESCRIPTION
Compressed requests acquired admission units from their wire size even though decompression could retain a much larger body.

Reserve for the maximum uncompressed request before reading compressed content, cap the reservation to the shared service memory limiter's capacity, and return excess units after decompression.

Regression coverage pauses concurrent known-length compressed requests and verifies that they block on memory admission. This fails with wire-size accounting while avoiding an OOM-based test.

Testing:
- `./tools/toolchain/dbuild ninja build/dev/scylla`
- focused test collection
- delayed request body preserves `Content-Length`

Full focused test execution is currently blocked during test-environment startup because local `slapadd` exits unsuccessfully, before the test runs.

Fixes scylladb/scylladb#31296
