### PR TITLE
alternator: account for audit request memory

### DIFF
--- a/alternator/executor.cc
+++ b/alternator/executor.cc
@@ -196,9 +196,7 @@ void executor::maybe_audit(
         if (alternator_batch_tables) {
             audit_info->set_alternator_batch_tables(std::move(*alternator_batch_tables));
         }
-        // FIXME: rjson::print(request) serializes the entire JSON request body, which
-        // can be up to 16 MB for BatchWriteItem.
-        audit_info->set_query_string(sstring(rjson::print(request)), sstring(operation_name));
+        audit_info->set_query_string(rjson::print(request), operation_name);
     }
 }
 

--- a/alternator/server.cc
+++ b/alternator/server.cc
@@ -781,7 +781,8 @@ future<executor::request_return_type> server::handle_api_request(std::unique_ptr
     // If the Content-Length of the request is not available, we assume
     // the largest possible request (request_content_length_limit, i.e., 16 MB)
     // and after reading the request we return_units() the excess.
-    size_t mem_estimate = (req->content_length ? req->content_length : request_content_length_limit) * 2 + 8000;
+    const size_t memory_multiplier = audit::audit::audit_instance().local_is_initialized() ? 4 : 2;
+    const size_t mem_estimate = (req->content_length ? req->content_length : request_content_length_limit) * memory_multiplier + 8000;
     auto units_fut = get_units(*_memory_limiter, mem_estimate);
     if (_memory_limiter->waiters()) {
         ++_executor._stats.requests_blocked_memory;
@@ -796,7 +797,7 @@ future<executor::request_return_type> server::handle_api_request(std::unique_ptr
         for (const auto& chunk : content) {
             content_length += chunk.size();
         }
-        size_t new_mem_estimate = content_length * 2 + 8000;
+        const size_t new_mem_estimate = content_length * memory_multiplier + 8000;
         units.return_units(mem_estimate - new_mem_estimate);
     }
     auto username = co_await verify_signature(*req, content);
@@ -856,6 +857,7 @@ future<executor::request_return_type> server::handle_api_request(std::unique_ptr
             co_return api_error::validation("Request content must be an object");
         }
         std::unique_ptr<audit::audit_info_alternator> audit_info;
+        auto request_permit = make_service_permit(std::move(units));
 
         // We need to futurize here as `callback` might be a normal function returning a future and
         // if that function throws `as_future` won't catch it - the exception will be propagated to the caller and
@@ -863,7 +865,7 @@ future<executor::request_return_type> server::handle_api_request(std::unique_ptr
         auto ret_fut = co_await seastar::coroutine::as_future(
             seastar::futurize_invoke(
                 callback,
-                _executor, client_state, trace_state, make_service_permit(std::move(units)), std::move(json_request), std::move(req), audit_info
+                _executor, client_state, trace_state, request_permit, std::move(json_request), std::move(req), audit_info
             )
         );
         auto ret = ret_fut.failed() ? convert_exception_ptr_to_api_error(ret_fut.get_exception()) : ret_fut.get();

--- a/audit/audit.hh
+++ b/audit/audit.hh
@@ -21,10 +21,13 @@
 
 #include "enum_set.hh"
 
+#include <algorithm>
 #include <functional>
 #include <memory>
 #include <optional>
 #include <set>
+#include <string>
+#include <string_view>
 #include <vector>
 
 namespace db {
@@ -97,6 +100,17 @@ public:
             _query = operation + "|" + query_string;
         } else {
             _query = query_string;
+        }
+        return *this;
+    }
+    audit_info& set_query_string(std::string&& query_string, std::string_view operation) {
+        if (operation.empty()) {
+            _query = sstring(query_string);
+        } else {
+            _query = sstring(sstring::initialized_later{}, operation.size() + 1 + query_string.size());
+            std::ranges::copy(operation, _query.begin());
+            _query[operation.size()] = '|';
+            std::ranges::copy(query_string, _query.begin() + operation.size() + 1);
         }
         return *this;
     }

--- a/test/alternator/test_audit.py
+++ b/test/alternator/test_audit.py
@@ -256,6 +256,20 @@ def test_audit_dml_operations(dynamodb, cql, alternator_audit_enabled):
         _assert_audit_entries(new_rows, expected, ks_name, table.name)
 
 
+# A large request must remain covered by its memory permit until the audit
+# write completes. This reproduces issue #31297.
+def test_audit_large_request(dynamodb, cql, alternator_audit_enabled):
+    with new_test_table(dynamodb, **HASH_ONLY_SCHEMA) as table:
+        ks_name = f"alternator_{table.name}"
+        cql.execute("UPDATE system.config SET value=%s WHERE name='audit_keyspaces'", (ks_name,))
+        before_rows = _get_audit_log_rows(cql)
+        marker = "audit-large-request-end"
+        table.put_item(Item={"p": "pk", "v": "x" * (256 * 1024) + marker})
+        new_rows = _get_new_audit_log_rows(cql, before_rows, expected_new_row_count=1)
+        expected = [("DML", "LOCAL_QUORUM", False, ks_name, table.name, ["PutItem", marker])]
+        _assert_audit_entries(new_rows, expected, ks_name, table.name)
+
+
 # Test auditing of the DML batch operation: BatchWriteItem.
 # A single BatchWriteItem call produces one audit entry regardless of the number of items in the batch.
 # Batch operations leave keyspace_name empty because they can span multiple tables.


### PR DESCRIPTION
## Summary

Large Alternator requests could allocate memory not covered by their request
permit:

- auditing serialized and retained a complete request copy after the callback's
  permit reference had been released;
- batch audit filtering reparsed and serialized the retained request;
- syslog escaping and formatting created additional full-size copies;
- compressed requests acquired permits from their encoded size even though the
  decoded JSON could be much larger.

This PR makes request admission cover the supported audit and compression paths
through audit completion.

## Changes

- Keep the request permit alive through `audit::inspect()`.
- Use an exact-size, two-pass JSON serializer for retained audit queries and
  filtered batch queries, avoiding RapidJSON's oversized print scratch buffer.
- Reserve request memory according to the path:
  - 2x for operations whose category cannot be audited;
  - 4x for ordinary table-audited operations;
  - 8x for batch or syslog-capable audit paths.
- Snapshot the category-level audit decision at admission so a live audit
  configuration update cannot enable auditing for an under-reserved in-flight
  request.
- Reserve compressed requests from the maximum decoded request size, then
  return excess units after decompression.
- Avoid impossible semaphore waits when an estimate exceeds the limiter's
  capacity by waiting for capacity and recording the remainder as debt.
- Allocate syslog escaping and formatted messages at their exact sizes.
- Make the regression tests inspect the current request's permit directly,
  rather than aggregate use of the CQL/Alternator shared semaphore.

## Deferred follow-ups

The following real issues and feature gaps are intentionally outside this PR:

- Incomplete or slow request bodies can retain admission units indefinitely:
  #23510.
- RapidJSON DOM and parse-stack amplification for structurally dense JSON is
  not bounded by the encoded request size: #31314.
- Retained Alternator request text in trace state is not included in the
  request permit: #31321.
- Tiny HTTP chunks can amplify `temporary_buffer` and vector metadata beyond
  the payload-based permit: #31315.
- Alternator `Query` requests using `VectorSearch` currently bypass audit
  logging. Adding audit coverage is deferred to #31344; this PR only releases
  the conservative audit reservation for this path.
- Seastar accepts requests containing both `Transfer-Encoding: chunked` and
  `Content-Length`, exposing inconsistent framing metadata:
  https://github.com/scylladb/seastar/issues/3648.

## Testing

- `./tools/toolchain/dbuild ninja -j2 build/dev/scylla`
- Entire Alternator audit module: 21 passed
- Focused permit and audit cases: 500/500 passed across 100 repetitions
- Exact JSON serializer: 100/100 passed
- Syslog audit legacy/rules modes: 2 passed

Fixes #31296
Fixes #31297