### PR TITLE
alternator: apply JSON yield threshold to bytes

### DIFF
--- a/alternator/server.cc
+++ b/alternator/server.cc
@@ -1147,7 +1147,34 @@ future<> server::stop() {
     });
 }
 
-internal::json_parser::json_parser() : _run_parse_json_thread(async([this] {
+bool internal::should_parse_json_yieldably(const chunked_content& content) {
+    size_t size = 0;
+    for (const auto& chunk : content) {
+        size += chunk.size();
+        if (size >= internal::yieldable_parsing_threshold) {
+            return true;
+        }
+    }
+    return false;
+}
+
+static thread_attributes json_parser_thread_attributes(scheduling_group sg) {
+    thread_attributes attr;
+    attr.sched_group = sg;
+#ifdef SANITIZE
+    // ASAN's stack instrumentation makes RapidJSON's recursive parser exceed
+    // Seastar's default thread stack before the nesting guard can report an
+    // error. Parsing is serialized, so the larger stack has a bounded cost.
+    // See #31347 for evaluating iterative and resumable alternatives to the
+    // parser thread.
+    attr.stack_size = 512 * KB;
+#endif
+    return attr;
+}
+
+internal::json_parser::json_parser()
+        : _worker_scheduling_group(current_scheduling_group())
+        , _run_parse_json_thread(async(json_parser_thread_attributes(_worker_scheduling_group), [this] {
         while (true) {
             _document_waiting.wait().get();
             if (_as.abort_requested()) {
@@ -1165,10 +1192,23 @@ internal::json_parser::json_parser() : _run_parse_json_thread(async([this] {
 }
 
 future<rjson::value> internal::json_parser::parse(chunked_content&& content) {
-    if (content.size() < yieldable_parsing_threshold) {
+    if (!should_parse_json_yieldably(content)) {
         return make_ready_future<rjson::value>(rjson::parse(std::move(content)));
     }
-    return with_semaphore(_parsing_sem, 1, [this, content = std::move(content)] () mutable {
+
+    auto sg = current_scheduling_group();
+    return with_semaphore(_parsing_sem, 1, [this, sg, content = std::move(content)] () mutable {
+        // A Seastar thread cannot change its construction-time scheduling
+        // group. Reuse the worker for its own group; otherwise create a
+        // per-request thread in the caller's group.
+        if (sg != _worker_scheduling_group) {
+            // FIXME: #31349. Reuse the worker by switching its scheduling
+            // group once scylladb/seastar#3651 is available.
+            return async(json_parser_thread_attributes(sg), [content = std::move(content)] () mutable {
+                return rjson::parse_yieldable(std::move(content));
+            });
+        }
+
         _raw_document = std::move(content);
         _document_waiting.signal();
         return _document_parsed.wait().then([this] {

--- a/alternator/server.cc
+++ b/alternator/server.cc
@@ -1147,7 +1147,7 @@ future<> server::stop() {
     });
 }
 
-server::json_parser::json_parser() : _run_parse_json_thread(async([this] {
+internal::json_parser::json_parser() : _run_parse_json_thread(async([this] {
         while (true) {
             _document_waiting.wait().get();
             if (_as.abort_requested()) {
@@ -1164,7 +1164,7 @@ server::json_parser::json_parser() : _run_parse_json_thread(async([this] {
     })) {
 }
 
-future<rjson::value> server::json_parser::parse(chunked_content&& content) {
+future<rjson::value> internal::json_parser::parse(chunked_content&& content) {
     if (content.size() < yieldable_parsing_threshold) {
         return make_ready_future<rjson::value>(rjson::parse(std::move(content)));
     }
@@ -1180,7 +1180,7 @@ future<rjson::value> server::json_parser::parse(chunked_content&& content) {
     });
 }
 
-future<> server::json_parser::stop() {
+future<> internal::json_parser::stop() {
     _as.request_abort();
     _document_waiting.signal();
     _document_parsed.broken();

--- a/alternator/server.hh
+++ b/alternator/server.hh
@@ -29,6 +29,29 @@ namespace alternator {
 
 using chunked_content = rjson::chunked_content;
 
+namespace internal {
+
+class json_parser {
+    static constexpr size_t yieldable_parsing_threshold = 16*KB;
+    chunked_content _raw_document;
+    rjson::value _parsed_document;
+    std::exception_ptr _current_exception;
+    semaphore _parsing_sem{1};
+    condition_variable _document_waiting;
+    condition_variable _document_parsed;
+    abort_source _as;
+    future<> _run_parse_json_thread;
+public:
+    json_parser();
+    // Moving a chunked_content into parse() allows parse() to free each
+    // chunk as soon as it is parsed, so when chunks are relatively small,
+    // we don't need to store the sum of unparsed and parsed sizes.
+    future<rjson::value> parse(chunked_content&& content);
+    future<> stop();
+};
+
+}
+
 class server : public peering_sharded_service<server> {
     // The maximum size of a request body that Alternator will accept,
     // in bytes. This is a safety measure to prevent Alternator from
@@ -77,25 +100,7 @@ class server : public peering_sharded_service<server> {
 
     ::shared_ptr<seastar::tls::server_credentials> _credentials;
 
-    class json_parser {
-        static constexpr size_t yieldable_parsing_threshold = 16*KB;
-        chunked_content _raw_document;
-        rjson::value _parsed_document;
-        std::exception_ptr _current_exception;
-        semaphore _parsing_sem{1};
-        condition_variable _document_waiting;
-        condition_variable _document_parsed;
-        abort_source _as;
-        future<> _run_parse_json_thread;
-    public:
-        json_parser();
-        // Moving a chunked_content into parse() allows parse() to free each
-        // chunk as soon as it is parsed, so when chunks are relatively small,
-        // we don't need to store the sum of unparsed and parsed sizes.
-        future<rjson::value> parse(chunked_content&& content);
-        future<> stop();
-    };
-    json_parser _json_parser;
+    internal::json_parser _json_parser;
 
     // The server maintains a list of ongoing requests, that are being handled
     // by handle_api_request(). It uses this list in get_client_data(), which
@@ -146,4 +151,3 @@ private:
 };
 
 }
-

--- a/alternator/server.hh
+++ b/alternator/server.hh
@@ -10,8 +10,9 @@
 
 #include "alternator/executor.hh"
 #include "utils/scoped_item_list.hh"
-#include <seastar/core/future.hh>
 #include <seastar/core/condition-variable.hh>
+#include <seastar/core/future.hh>
+#include <seastar/core/scheduling.hh>
 #include <seastar/http/httpd.hh>
 #include <seastar/net/tls.hh>
 #include <optional>
@@ -31,8 +32,15 @@ using chunked_content = rjson::chunked_content;
 
 namespace internal {
 
+inline constexpr size_t yieldable_parsing_threshold = 16*KB;
+
+bool should_parse_json_yieldably(const chunked_content& content);
+
 class json_parser {
-    static constexpr size_t yieldable_parsing_threshold = 16*KB;
+    // In production the parser is constructed with the server in
+    // statement_scheduling_group, which the service-level controller reuses
+    // as sl:default.
+    scheduling_group _worker_scheduling_group;
     chunked_content _raw_document;
     rjson::value _parsed_document;
     std::exception_ptr _current_exception;

--- a/test/boost/alternator_unit_test.cc
+++ b/test/boost/alternator_unit_test.cc
@@ -8,8 +8,12 @@
 
 #include "test/lib/scylla_test_case.hh"
 
-#include <seastar/util/defer.hh>
+#include <optional>
+
+#include <seastar/core/deleter.hh>
 #include <seastar/core/memory.hh>
+#include <seastar/core/temporary_buffer.hh>
+#include <seastar/util/defer.hh>
 #include "utils/base64.hh"
 #include "utils/rjson.hh"
 #include "alternator/serialization.hh"
@@ -18,6 +22,7 @@
 #include "cdc/generation.hh"
 #include "alternator/executor.hh"
 #include "alternator/executor_util.hh"
+#include "alternator/server.hh"
 #include "dht/token-sharding.hh"
 #include "alternator/expressions.hh"
 #include "alternator/streams.hh"
@@ -26,11 +31,108 @@
 #include <seastar/core/coroutine.hh>
 #include <seastar/coroutine/maybe_yield.hh>
 #include <seastar/core/sleep.hh>
+#include <seastar/core/with_scheduling_group.hh>
 
 namespace alternator {
     const cdc::stream_id& find_parent_shard_in_previous_generation(db_clock::time_point prev_timestamp, const utils::chunked_vector<cdc::stream_id>& prev_streams, const cdc::stream_id& child);
     extern const sstring SPURIOUS_RANGE_KEY_ADDED_TO_GSI_AND_USER_DIDNT_SPECIFY_RANGE_KEY_TAG_KEY;
     extern const sstring NUMBER_OF_USER_SPECIFIED_GSI_RANGE_KEYS_TAG_KEY;
+}
+
+BOOST_AUTO_TEST_CASE(test_yieldable_json_parsing_uses_content_size) {
+    // Regression test for #31298, part of #5943: the threshold applies to the
+    // sum of chunk bytes, not to the number of chunks.
+    constexpr auto threshold = alternator::internal::yieldable_parsing_threshold;
+    alternator::chunked_content content;
+    BOOST_REQUIRE(!alternator::internal::should_parse_json_yieldably(content));
+
+    content.emplace_back(threshold - 1);
+    BOOST_REQUIRE(!alternator::internal::should_parse_json_yieldably(content));
+    content.clear();
+
+    content.emplace_back(threshold);
+    BOOST_REQUIRE(alternator::internal::should_parse_json_yieldably(content));
+    content.clear();
+
+    content.emplace_back(threshold / 2);
+    content.emplace_back(threshold / 2 - 1);
+    BOOST_REQUIRE(!alternator::internal::should_parse_json_yieldably(content));
+
+    content.emplace_back(1);
+    BOOST_REQUIRE(alternator::internal::should_parse_json_yieldably(content));
+}
+
+SEASTAR_THREAD_TEST_CASE(test_yieldable_json_parsing_preserves_scheduling_group) {
+    // #31298 makes the threaded path normal for large requests; it must keep
+    // charging parsing CPU to the authenticated user's service level.
+    auto sg1 = create_scheduling_group("alternator_json_parser_test_1", 100).get();
+    auto destroy_sg1 = defer([&] noexcept { destroy_scheduling_group(sg1).get(); });
+    auto sg2 = create_scheduling_group("alternator_json_parser_test_2", 100).get();
+    auto destroy_sg2 = defer([&] noexcept { destroy_scheduling_group(sg2).get(); });
+
+    alternator::internal::json_parser parser;
+    auto stop_parser = defer([&] noexcept { parser.stop().get(); });
+    auto make_content = [] (std::optional<scheduling_group>& parsed_in) {
+        std::string document = R"({"value":")";
+        document.append(alternator::internal::yieldable_parsing_threshold, 'x');
+        document += R"("})";
+        temporary_buffer<char> buffer(document.data(), document.size());
+        auto* data = buffer.get_write();
+        auto size = buffer.size();
+        // chunked_content_stream releases this buffer while parsing it, so
+        // the deleter observes the parser thread's actual scheduling group.
+        auto deleter = make_deleter(buffer.release(), [&parsed_in] () noexcept {
+            parsed_in = current_scheduling_group();
+        });
+        alternator::chunked_content content;
+        content.emplace_back(data, size, std::move(deleter));
+        return content;
+    };
+
+    auto parse_in_group = [&parser, &make_content] (scheduling_group sg) {
+        std::optional<scheduling_group> parsed_in;
+        auto value = with_scheduling_group(sg, [&parser, content = make_content(parsed_in)] () mutable {
+            return parser.parse(std::move(content));
+        }).get();
+        BOOST_REQUIRE(parsed_in);
+        BOOST_REQUIRE(*parsed_in == sg);
+        return value;
+    };
+
+    BOOST_REQUIRE(parse_in_group(current_scheduling_group()).IsObject());
+    BOOST_REQUIRE(parse_in_group(sg1).IsObject());
+    BOOST_REQUIRE(parse_in_group(sg2).IsObject());
+}
+
+SEASTAR_THREAD_TEST_CASE(test_yieldable_json_parsing_rejects_deep_nesting) {
+    // Regression test for the debug CI failure on #31304. A large, deeply
+    // nested request must propagate rjson::error from either threaded path
+    // instead of aborting the process.
+    constexpr size_t nested_levels = 4000;
+    std::string document;
+    document.reserve(nested_levels * 5 + 2);
+    for (size_t i = 0; i < nested_levels; ++i) {
+        document += R"({"":)";
+    }
+    document += "{}";
+    document.append(nested_levels, '}');
+
+    alternator::internal::json_parser parser;
+    auto stop_parser = defer([&] noexcept { parser.stop().get(); });
+    auto make_content = [&document] {
+        alternator::chunked_content content;
+        content.emplace_back(document.data(), document.size());
+        return content;
+    };
+
+    BOOST_REQUIRE(alternator::internal::should_parse_json_yieldably(make_content()));
+    BOOST_REQUIRE_THROW(parser.parse(make_content()).get(), rjson::error);
+
+    auto sg = create_scheduling_group("alternator_json_nested_test", 100).get();
+    auto destroy_sg = defer([&] noexcept { destroy_scheduling_group(sg).get(); });
+    BOOST_REQUIRE_THROW(with_scheduling_group(sg, [&parser, content = make_content()] () mutable {
+        return parser.parse(std::move(content));
+    }).get(), rjson::error);
 }
 
 // Builds a schema_ptr simulating a GSI with an irrelevant to the user


### PR DESCRIPTION
## Problem

Alternator’s JSON yield threshold is 16 KiB:

https://github.com/scylladb/scylladb/blob/77d2162507c3dee0ac9cfb705e2e84195d4c2c7c/alternator/server.hh#L80-L85

However, `chunked_content` is a vector of chunks:

https://github.com/scylladb/scylladb/blob/77d2162507c3dee0ac9cfb705e2e84195d4c2c7c/utils/rjson.hh#L233-L237

The parser compared the threshold with `content.size()`, which returns the number of chunks rather than their total size in bytes:

https://github.com/scylladb/scylladb/blob/77d2162507c3dee0ac9cfb705e2e84195d4c2c7c/alternator/server.cc#L1167-L1170

Even multi-megabyte requests normally contain far fewer than 16,384 chunks, so large requests used the non-yielding parser on the reactor and could cause stalls.

Correcting the threshold makes the threaded parser path normal for large requests again, exposing a latent scheduling-group problem. The existing parser thread is created once and reused:

https://github.com/scylladb/scylladb/blob/77d2162507c3dee0ac9cfb705e2e84195d4c2c7c/alternator/server.cc#L1149-L1165

A Seastar thread remains bound to its construction-time scheduling group. Parsing requests from other service levels on that thread would charge their CPU usage to the worker’s group instead of the authenticated user’s group. Both problems must therefore be fixed together.

## How the new logic works

The parser sums chunk sizes until the total reaches 16 KiB:

https://github.com/scylladb/scylladb/blob/338b3284e99d60dcbafd0100add6276b9d03e8a7/alternator/server.cc#L1150-L1159

For smaller requests, it calls `rjson::parse()` directly without a semaphore or thread. For larger requests, it captures the caller’s scheduling group and acquires the existing shard-local parser semaphore:

- Callers in the parser worker’s group reuse that worker.
- Callers in another group use a per-invocation thread assigned to their group.

Both threaded paths call `rjson::parse_yieldable()`. The semaphore bounds parser concurrency and thread-stack usage.

https://github.com/scylladb/scylladb/blob/338b3284e99d60dcbafd0100add6276b9d03e8a7/alternator/server.cc#L1187-L1213

The parser is moved into `alternator::internal` so this behavior can be tested directly.

## Deferred items

#31347 - Compare synchronous, threaded, iterative, and resumable coroutine parsing; decide the threshold and whether the parser thread remains.

#31349 - Reuse the persistent JSON parser worker across service levels after scylladb/seastar#3651, avoiding per-request stack allocation.

#31318 - The shard-local parser semaphore remains FIFO, allowing cross-service-level head-of-line blocking.

#5943 - Improve yield granularity inside `rjson` and address other sources of stalls while processing large requests.

Fixes #31298
Refs #31318
Refs #31347
Refs #5943
