### PR TITLE
strong_consistency: Optimize IO by removing store_commit_idx IO from write hot path

### DIFF
--- a/db/commitlog/commitlog.cc
+++ b/db/commitlog/commitlog.cc
@@ -92,6 +92,9 @@ class db::cf_holder {
 public:
     virtual ~cf_holder() {};
     virtual void release_cf_count(const cf_id_type&, const replay_position&) = 0;
+    // Take an additional reference at an already-referenceed position, for the given
+    // column family. Symmetric with release_cf_count: the two must balance.
+    virtual rp_handle acquire_cf_count(const cf_id_type&, const replay_position&) = 0;
 };
 
 const db::replay_position db::replay_position::max = db::replay_position(std::numeric_limits<db::segment_id_type>::max(), std::numeric_limits<db::position_type>::max());
@@ -775,7 +778,27 @@ class db::commitlog::segment : public enable_shared_from_this<segment>, public c
     size_t _buffer_ostream_size = 0;
     std::unordered_map<cf_id_type, uint64_t> _cf_dirty;
     std::unordered_map<cf_id_type, gc_clock::time_point> _cf_min_time;
-    std::unordered_multimap<replay_position, rp_handle> _extended_segments;
+    // Tail segments of an entry that did not fit in this (head) segment, keyed
+    // by the position the write reported for it, with a count of the references
+    // outstanding at that position. The count exists because several references can
+    // share one position: a strongly consistent raft batch is a single
+    // commitlog entry, and each of its entries takes a reference at that entry's
+    // position (commitlog::acquire_cf_count). Without it, the first of those
+    // references to be released would take the tails with it while the head is
+    // still dirty, leaving a head fragment whose continuation has been
+    // reclaimed — unreadable on replay.
+    //
+    // Today the erase-by-position below cannot fire at all, because the store
+    // site keys these by a default-constructed position rather than the head
+    // entry's (SCYLLADB-3986), so the tails are in practice freed only when the
+    // whole head segment goes clean. The count is kept regardless: it makes the
+    // shared ownership explicit, so repairing that keying cannot silently break
+    // the callers that hold several references at one position.
+    struct extended_entry {
+        uint32_t owners = 1;
+        std::vector<rp_handle> tail_pins;
+    };
+    std::unordered_map<replay_position, extended_entry> _extended_segments;
     time_point _sync_time;
     utils::flush_queue<replay_position, std::less<replay_position>, clock_type> _pending_ops;
 
@@ -866,8 +889,10 @@ public:
             mode = dispose_mode::Delete;
         } else if (_segment_manager->cfg.warn_about_segments_left_on_disk_after_shutdown) {
             clogger.warn("Segment {} is dirty and is left on disk.", *this);
-            for (auto& [rp, h] : _extended_segments) {
-                h.release(); // do not clear out sequential seqments either.
+            for (auto& [rp, e] : _extended_segments) {
+                for (auto& h : e.tail_pins) {
+                    h.release(); // do not clear out sequential seqments either.
+                }
             }
         }
 
@@ -906,8 +931,27 @@ public:
         }
     }
     void release_cf_count(const cf_id_type& cf, const replay_position& rp) override {
-        _extended_segments.erase(rp);
+        // Last one out frees the tails (see extended_entry). Positions with no
+        // fragmented entry are absent from the map, which is the common case —
+        // and, per SCYLLADB-3986, currently every position is, so this never
+        // fires today.
+        if (auto it = _extended_segments.find(rp); it != _extended_segments.end() && --it->second.owners == 0) {
+            _extended_segments.erase(it);
+        }
         release_cf_count(cf);
+    }
+
+    rp_handle acquire_cf_count(const cf_id_type& cf, const replay_position& rp) override {
+        SCYLLA_ASSERT(contains(rp));
+        _cf_dirty[cf]++; // increase use count for cf.
+        _cf_min_time.emplace(cf, gc_clock::now()); // if value already exists this does nothing.
+        if (auto it = _extended_segments.find(rp); it != _extended_segments.end()) {
+            ++it->second.owners; // a fragmented entry's tails must outlive this reference too
+        }
+        // References are a pure count, so several may share one position; the only
+        // position-keyed state in the release path is _extended_segments, and
+        // the owner count above is what makes sharing safe there.
+        return rp_handle(static_pointer_cast<cf_holder>(shared_from_this()), cf, rp);
     }
 
     bool must_sync() {
@@ -1886,7 +1930,7 @@ future<> db::commitlog::segment_manager::oversized_allocation(entry_writer& writ
                         // be replayed, in which case we want to be able to
                         // reconstruct a fragmented entry, if for no other
                         // reason to be able to clear its state (see replay_state).
-                        seg_ptr->_extended_segments.emplace(pw._rp, std::move(pw._h));
+                        seg_ptr->_extended_segments[pw._rp].tail_pins.push_back(std::move(pw._h));
                     }
                 }
             }
@@ -3276,6 +3320,12 @@ future<utils::chunked_vector<db::rp_handle>> db::commitlog::add_raft_entries(
         }
     };
     return _segment_manager->allocate_when_possible(cl_raft_entries_writer(std::move(entry_writers), id), db::no_timeout);
+}
+
+db::rp_handle db::commitlog::acquire_cf_count(const rp_handle& src, const cf_id_type& id) {
+    // The source handle names the segment and the position, so there is no
+    // lookup and no way to ask for a segment that is already gone.
+    return src._h->acquire_cf_count(id, src._rp);
 }
 
 db::commitlog::commitlog(config cfg)

--- a/db/commitlog/commitlog.hh
+++ b/db/commitlog/commitlog.hh
@@ -245,6 +245,31 @@ public:
             const cf_id_type& id, utils::chunked_vector<commitlog_raft_log_entry_writer> entry_writers);
 
     /**
+     * Take an additional reference at `src`'s position, accounted to the given
+     * column family, without writing anything. ("Reference" is defined on
+     * rp_handle in replay_position.hh: one unit of a segment's per-table
+     * dirty count.) The new handle holds the
+     * segment — prevents it from being discarded or recycled — exactly like
+     * one returned from an add_*() call, and is released the same two ways: by
+     * handing it to a memtable (released when discard_completed_segments()
+     * runs for that memtable's flush) or by destroying it.
+     *
+     * This is possible because segment retention accounting is a pure per-cf
+     * count (segment::_cf_dirty, matched by mark_clean() at flush) rather than
+     * a set of positions: the holding cf need not be one the segment was
+     * written for, and several references at one position may coexist. The one
+     * piece of position-keyed state, the tail pins of a fragmented entry
+     * (segment::extended_entry), counts its owners for exactly that reason, so
+     * the tails outlive every reference at the head position rather than the first
+     * one to be released.
+     *
+     * `src` must be a live handle; it is the proof that the segment is still
+     * there, so there is no lookup and no failure mode. One reference per call:
+     * the new handle is independent of `src` and of every other reference.
+     */
+    rp_handle acquire_cf_count(const rp_handle& src, const cf_id_type& id);
+
+    /**
      * Modifies the per-CF dirty cursors of any commit log segments for the column family according to the position
      * given. Discards any commit log segments that are no longer used.
      *

--- a/db/commitlog/commitlog_entry.cc
+++ b/db/commitlog/commitlog_entry.cc
@@ -44,7 +44,9 @@ void commitlog_mutation_entry_writer::compute_size() {
 
 template<typename Output>
 inline void commitlog_raft_log_entry_writer::serialize(Output& out) const {
-    ser::writer_of_commitlog_entry<Output>(out).write_item_raft_commitlog_entry(_item).end_commitlog_entry();
+    ser::writer_of_commitlog_entry<Output>(out)
+            .write_item_raft_commitlog_entry(_item)
+            .end_commitlog_entry();
 }
 
 void commitlog_raft_log_entry_writer::write(ostream& out) const {
@@ -75,8 +77,8 @@ auto read_variant_commitlog_entry(const fragmented_temporary_buffer& buffer) {
     auto view = ser::deserialize(in, std::type_identity<ser::commitlog_entry_view>());
     return seastar::visit(
             view.item(),
-            [](raft_commitlog_entry raft_log_entry) {
-                return commitlog_entry{.item = std::move(raft_log_entry)};
+            [](raft_commitlog_entry raft_batch) {
+                return commitlog_entry{.item = std::move(raft_batch)};
             },
             [](const ser::mutation_entry_view& entry_view) {
                 return commitlog_entry{.item = mutation_entry(entry_view.mapping(), entry_view.mutation())};

--- a/db/commitlog/commitlog_entry.hh
+++ b/db/commitlog/commitlog_entry.hh
@@ -93,19 +93,50 @@ public:
     frozen_mutation&& mutation() && { return std::move(_mutation); }
 };
 
-// A Raft log entry (command, configuration change, or dummy) together with
-// its group ID.  Stored in the database commitlog when the strongly-consistent
-// tables experimental feature is enabled and the segment uses the variant
-// serialization format.
-struct raft_commitlog_entry {
-    raft::group_id group_id;
-    raft::log_entry_ptr entry;
+// A raft log position: an entry's index and the term it was appended in.
+// Always the pair of one real entry — the commit_idx entries and the covering
+// raft_groups mutations both persist such a pair, and raft requires the term
+// at a given index to be exact.
+struct raft_term_and_index {
+    raft::index_t idx{0};
+    raft::term_t term{0};
 };
 
-// The on-disk envelope for variant-format commitlog segments. Each
-// entry contains exactly one of the variant alternatives: a mutation_entry
-// (normal table write) or a raft_commitlog_entry (Raft log entry for
-// strongly-consistent tables).
+// One raft batch as it is stored in the commitlog: the group id once, the
+// entries the batch appended (commands, configuration changes, dummies), and
+// how far the group had committed when the batch was written.
+//
+// The whole batch is a single commitlog entry, which is what keeps the group
+// id and the entry envelope from being repeated per raft entry. The batch also
+// carries its own retention: the write returns one reference, which
+// raft_commitlog holds until every command in the batch has reached a memtable,
+// minting each command's own reference from it (commitlog::acquire_cf_count) at
+// the batch's position.
+//
+// (commit_idx, commit_idx_term) is the crash-replay floor: startup restores
+// the highest surviving value per group into system.raft_groups, so replay
+// applies the entries below it to memtables instead of re-adding them to the
+// raft log. The term is stored next to the index because the entry at that
+// index is normally in an earlier batch, whose segment may already be gone —
+// so the restore cannot look the term up. Zero means this group had not
+// observed a commit index yet; the floor only ever advances, so an
+// unrecoverable batch costs only floor tightness.
+struct raft_commitlog_entry {
+    raft::group_id group_id;
+    std::vector<raft::log_entry_ptr> entries;
+    raft::index_t commit_idx{0};
+    raft::term_t commit_idx_term{0};
+};
+
+// The on-disk envelope for variant-format commitlog segments. Each entry
+// contains exactly one of the variant alternatives: a mutation_entry (normal
+// table write) or a raft_commitlog_entry (one batch of raft entries for a
+// strongly-consistent table).
+//
+// NOTE: the variant alternative index is the on-disk discriminator, so new
+// alternatives must only ever be appended at the end. Reordering or inserting
+// in the middle would change the discriminator of existing alternatives and
+// corrupt the reading of previously written segments.
 using commitlog_entry_variant = std::variant<raft_commitlog_entry, mutation_entry>;
 struct commitlog_entry {
     commitlog_entry_variant item;
@@ -178,15 +209,17 @@ public:
     frozen_mutation&& mutation() && { return std::move(_me).mutation(); }
 };
 
-// Writer for Raft log entries to the database commit log using the commitlog_entry format.
+// Writer for one raft batch in the database commit log, using the
+// commitlog_entry format. Produced by raft_commitlog::write_batches() and
+// accounted to the raft group's target table — the batch's cf.
 class commitlog_raft_log_entry_writer {
-public:
 protected:
     raft_commitlog_entry _item;
     std::size_t _size = std::numeric_limits<std::size_t>::max();
 
     template<typename Output>
     void serialize(Output& out) const;
+
     void compute_size();
 
 public:
@@ -200,7 +233,11 @@ public:
 
     using ostream = typename seastar::memory_output_stream<detail::sector_split_iterator>;
     void write(ostream& out) const;
-    const raft_commitlog_entry& get_log_entry() const {
+
+    raft::group_id group_id() const {
+        return _item.group_id;
+    }
+    const raft_commitlog_entry& item() const {
         return _item;
     }
 };

--- a/db/commitlog/commitlog_replayer.cc
+++ b/db/commitlog/commitlog_replayer.cc
@@ -230,10 +230,15 @@ future<> db::commitlog_replayer::impl::process(
         const auto& read_entry = cer.entry().item;
 
         if (std::holds_alternative<raft_commitlog_entry>(read_entry)) {
-            const auto& raft_entry = std::get<raft_commitlog_entry>(read_entry);
+            // One raft batch: its entries, plus the commit_idx the group had
+            // reached when it was written.
+            const auto& batch = std::get<raft_commitlog_entry>(read_entry);
             SCYLLA_ASSERT(_raft_buffer);
-            rlogger.debug("Adding raft log entry for group {} at {} to replay buffer", raft_entry.group_id, rp);
-            _raft_buffer->local().add(raft_entry.group_id, raft_entry.entry);
+            rlogger.debug("Adding raft batch for group {} at {} to replay buffer: {} entries, commit_idx {} (term {})",
+                    batch.group_id, rp, batch.entries.size(), batch.commit_idx, batch.commit_idx_term);
+            for (const auto& entry : batch.entries) {
+                _raft_buffer->local().add(batch.group_id, entry);
+            }
             co_return;
         } else if (std::holds_alternative<mutation_entry>(read_entry)) {
             const auto& mut_entry = std::get<mutation_entry>(read_entry);

--- a/db/commitlog/commitlog_replayer.cc
+++ b/db/commitlog/commitlog_replayer.cc
@@ -231,13 +231,19 @@ future<> db::commitlog_replayer::impl::process(
 
         if (std::holds_alternative<raft_commitlog_entry>(read_entry)) {
             // One raft batch: its entries, plus the commit_idx the group had
-            // reached when it was written.
+            // reached when it was written. The latter lets
+            // process_raft_replayed_items() restore a commit_idx that a crash
+            // dropped from the raft_groups memtable before it flushed.
             const auto& batch = std::get<raft_commitlog_entry>(read_entry);
             SCYLLA_ASSERT(_raft_buffer);
             rlogger.debug("Adding raft batch for group {} at {} to replay buffer: {} entries, commit_idx {} (term {})",
                     batch.group_id, rp, batch.entries.size(), batch.commit_idx, batch.commit_idx_term);
             for (const auto& entry : batch.entries) {
                 _raft_buffer->local().add(batch.group_id, entry);
+            }
+            if (batch.commit_idx != raft::index_t{0}) {
+                _raft_buffer->local().add_commit_idx(batch.group_id,
+                        raft_term_and_index{.idx = batch.commit_idx, .term = batch.commit_idx_term});
             }
             co_return;
         } else if (std::holds_alternative<mutation_entry>(read_entry)) {

--- a/db/commitlog/raft_commitlog_replay_buffer.cc
+++ b/db/commitlog/raft_commitlog_replay_buffer.cc
@@ -27,6 +27,7 @@
 
 #include <algorithm>
 #include <seastar/core/coroutine.hh>
+#include <seastar/coroutine/parallel_for_each.hh>
 #include <seastar/core/on_internal_error.hh>
 #include <seastar/coroutine/maybe_yield.hh>
 
@@ -126,7 +127,7 @@ filter_entries_result filter_entries(utils::chunked_vector<raft::log_entry_ptr>&
 } // anonymous namespace
 
 future<> raft_commitlog_replay_buffer::process_raft_replayed_items(replica::database& db, cql3::query_processor& qp, db::system_keyspace& sys_ks) {
-    if (remaining_groups() == 0) {
+    if (remaining_groups() == 0 && _replayed_commit_idx_by_group.empty()) {
         co_return;
     }
 
@@ -137,6 +138,30 @@ future<> raft_commitlog_replay_buffer::process_raft_replayed_items(replica::data
     SCYLLA_ASSERT(new_commitlog_ptr);
 
     logger.info("processing {} raft groups with {} total entries from commitlog replay", remaining_groups(), total_entries());
+
+    // Restore the recovered commit_idx values first: a crash can leave the
+    // persisted system.raft_groups value behind the replayed commit_idx
+    // records, and the loop below reads it to decide which entries are
+    // committed. A group can have a record and no surviving entries at all
+    // (its entries' segments were reclaimed while a record's was not), which
+    // is why this runs over the records rather than over the entries. Each record carries the exact term of the entry at its
+    // index, so the pair goes straight to system.raft_groups — the
+    // boot-time snapshot bump needs it exact (see make_raft_schema's
+    // commit_idx_term comment). Groups absent from tablet metadata are
+    // skipped, like their entries are: the tablet moved away or was dropped,
+    // so nothing may resurrect its row. The writes are independent, so run
+    // them concurrently.
+    co_await seastar::coroutine::parallel_for_each(_replayed_commit_idx_by_group,
+            [&qp, &group_to_table] (const auto& entry) -> future<> {
+        const auto& [group_id, committed] = entry;
+        if (!group_to_table.contains(group_id)) {
+            logger.debug("group {} not found in tablet metadata, discarding recovered commit_idx {}",
+                    group_id, committed.idx);
+            co_return;
+        }
+        co_await service::strong_consistency::raft_groups_storage::store_commit_idx_if_higher(
+                qp, group_id, this_shard_id(), committed.idx, committed.term);
+    });
 
     for (auto& [group_id, entries_list] : _replayed_commitlog_entries_by_group) {
         if (entries_list.empty()) {
@@ -169,8 +194,6 @@ future<> raft_commitlog_replay_buffer::process_raft_replayed_items(replica::data
         uint64_t applied = 0;
         auto& group_data = _per_group_data[group_id];
         raft::log_entry_ptr_list uncommitted;
-        // Term of the last committed entry, for the snapshot descriptor below.
-        std::optional<raft::term_t> last_committed_term;
 
         for (auto& entry : filtered.entries) {
             // Apply committed command entries to the memtables. It is safe not to append them
@@ -186,14 +209,11 @@ future<> raft_commitlog_replay_buffer::process_raft_replayed_items(replica::data
                 ++applied;
             }
 
-            if (entry->idx <= commit_idx) {
-                last_committed_term = entry->term;
-            }
-
             // Only uncommitted entries go back to the raft log (and to the new
             // commitlog, below). Committed entries have already been applied to
-            // memtables above and are covered by the snapshot descriptor
-            // advanced below.
+            // memtables above and are covered by the snapshot index that
+            // bump_snapshot_indices() advances to commit_idx after replay (the
+            // sole snapshot-index advancer on startup).
             if (entry->idx > commit_idx) {
                 uncommitted.push_back(std::move(entry));
             }
@@ -224,32 +244,63 @@ future<> raft_commitlog_replay_buffer::process_raft_replayed_items(replica::data
             }
         }
 
-
-        // Advance the persisted snapshot index to commit_idx. This tells the raft
-        // server (which sets _applied_idx = snapshot.idx on restart) that all
-        // committed entries have already been applied, preventing double-application
-        // through the state machine.
-        if (last_committed_term) {
-            // Strongly-consistent tablet raft groups don't use real snapshots,
-            // so we generate a random snapshot ID just to satisfy the schema requirement.
-            co_await service::strong_consistency::raft_groups_storage::store_snapshot_index(
-                    qp, group_id, this_shard_id(), raft::snapshot_descriptor{
-                        .idx = commit_idx,
-                        .term = *last_committed_term,
-                        .id = raft::snapshot_id(utils::make_random_uuid()),
-                    });
-            logger.debug("group {}: advanced snapshot to idx={}, term={}", group_id, commit_idx, *last_committed_term);
-        }
-
         logger.debug("group {}: discarded_leader_change={}, applied={}, rewritten={}, total_in_log={}", group_id, filtered.discarded_leader_change, applied,
                 uncommitted.size(), group_data.entries.size());
     }
 
     // The old items are not needed anymore.
     _replayed_commitlog_entries_by_group.clear();
+    _replayed_commit_idx_by_group.clear();
     logger.info("Raft groups commit log replayed data processing complete");
 }
 
+future<> raft_commitlog_replay_buffer::bump_snapshot_indices(replica::database& db, cql3::query_processor& qp) {
+    // See header for rationale. Runs for every known raft group and is the sole
+    // place that advances the persisted snapshot index on startup. store_snapshot_index
+    // has an internal "only advance" guard, so groups whose snapshot is already at or
+    // beyond commit_idx (e.g. from a prior run) are left untouched.
+    const auto token_metadata = db.get_shared_token_metadata().get();
+    const auto group_to_table = build_group_to_table_map(*token_metadata);
+
+    // Process groups concurrently: each does independent CQL reads/writes, and
+    // doing them serially would make startup O(groups) round-trips.
+    co_await seastar::coroutine::parallel_for_each(group_to_table,
+            [&qp] (const auto& entry) -> future<> {
+        const auto group_id = entry.first;
+        const auto [commit_idx, commit_idx_term] =
+                co_await service::strong_consistency::raft_groups_storage::load_commit_idx_and_term(qp, group_id, this_shard_id());
+        if (commit_idx.value() == 0) {
+            co_return;
+        }
+        auto [snap_idx, snap_term] = co_await service::strong_consistency::raft_groups_storage::load_snapshot_idx_and_term(qp, group_id, this_shard_id());
+        if (snap_idx >= commit_idx) {
+            co_return;
+        }
+        // The bumped snapshot term must be the exact term of the entry at
+        // commit_idx: it feeds raft's election check (log::is_up_to_date via
+        // last_term() on an empty log — a too-low term makes this replica
+        // vote for candidates missing its committed entries) and log matching
+        // at the snapshot boundary (log::match_term — any wrong term makes
+        // the leader back off below the snapshot and fall back to a snapshot
+        // transfer, which strongly consistent groups do not implement).
+        // commit_idx_term is written atomically with commit_idx; it can only
+        // be missing for a row written by a build predating the column, where
+        // the old snapshot's term is the only value available.
+        if (!commit_idx_term) {
+            logger.warn("group {}: no commit_idx_term persisted for commit_idx {} (pre-upgrade row); "
+                    "falling back to the last snapshot's term {}", group_id, commit_idx, snap_term);
+        }
+        const auto bump_term = commit_idx_term.value_or(snap_term);
+        co_await service::strong_consistency::raft_groups_storage::store_snapshot_index(
+                qp, group_id, this_shard_id(), raft::snapshot_descriptor{
+                    .idx = commit_idx,
+                    .term = bump_term,
+                    .id = raft::snapshot_id(utils::make_random_uuid()),
+                });
+        logger.debug("group {}: post-replay catch-up, advanced snapshot idx {} -> {} (term={})",
+                group_id, snap_idx, commit_idx, bump_term);
+    });
+}
 namespace raft_buffer_detail {
 entry_ordering_check_result check_entry_ordering(raft_term_and_idx current, raft_term_and_idx last) {
     if (last.idx == raft::index_t{0}) {

--- a/db/commitlog/raft_commitlog_replay_buffer.cc
+++ b/db/commitlog/raft_commitlog_replay_buffer.cc
@@ -223,18 +223,15 @@ future<> raft_commitlog_replay_buffer::process_raft_replayed_items(replica::data
 
         // Rewrite uncommitted entries to the new commitlog the same way
         // store_log_entries() does: one batch, whose reference keeps the new
-        // segment alive until the group's own apply() mints from it.
-        //
-        // The cover map write_batches() fills is local for now — the
-        // references it collects are released as soon as it goes out of scope,
-        // and the batch's own reference is what keeps the segment. A later
-        // commit hands the map to raft_commitlog instead, so that the
-        // rewritten entries are covered at commit time like any others.
+        // segment alive until the group's own apply() mints from it, and
+        // whose raft_groups reference goes straight into group_data.covers — the
+        // segment->cover map that seeds the group's parked covers when its
+        // raft_commitlog is constructed, for commit-time coverage of the
+        // rewritten entries (see raft_commitlog).
         if (!uncommitted.empty()) {
-            service::strong_consistency::pending_cover_map covers;
             auto batch_handle = co_await service::strong_consistency::raft_commitlog::write_batches(
                     *new_commitlog_ptr, table_id, db::system_keyspace::raft_groups()->id(), group_id, uncommitted,
-                    raft_term_and_index{}, covers);
+                    raft_term_and_index{}, group_data.covers);
             group_data.rewritten = service::strong_consistency::batch_ref{
                     .first = uncommitted.front()->idx,
                     .last = uncommitted.back()->idx,

--- a/db/commitlog/raft_commitlog_replay_buffer.cc
+++ b/db/commitlog/raft_commitlog_replay_buffer.cc
@@ -194,6 +194,7 @@ future<> raft_commitlog_replay_buffer::process_raft_replayed_items(replica::data
         uint64_t applied = 0;
         auto& group_data = _per_group_data[group_id];
         raft::log_entry_ptr_list uncommitted;
+        std::optional<std::pair<raft::index_t, raft::configuration>> committed_config;
 
         for (auto& entry : filtered.entries) {
             // Apply committed command entries to the memtables. It is safe not to append them
@@ -209,6 +210,16 @@ future<> raft_commitlog_replay_buffer::process_raft_replayed_items(replica::data
                 ++applied;
             }
 
+            // A committed configuration entry is dropped like every other
+            // committed non-command entry, so its content has to be persisted
+            // here or the group would come back with the configuration of its
+            // last snapshot — the bootstrap one for a group that never
+            // snapshotted (SCYLLADB-3842). Entries ascend, so the last one
+            // seen is the newest committed configuration.
+            if (entry->idx <= commit_idx && std::holds_alternative<raft::configuration>(entry->data)) {
+                committed_config = std::pair(entry->idx, std::get<raft::configuration>(entry->data));
+            }
+
             // Only uncommitted entries go back to the raft log (and to the new
             // commitlog, below). Committed entries have already been applied to
             // memtables above and are covered by the snapshot index that
@@ -219,6 +230,21 @@ future<> raft_commitlog_replay_buffer::process_raft_replayed_items(replica::data
             }
 
             co_await seastar::coroutine::maybe_yield();
+        }
+
+        // Fold the newest committed configuration the replayed log carried
+        // into system.raft_groups, next to the commit_idx restored above and
+        // in the same cells the covering mutations write. It is not restored
+        // into the snapshot configuration directly: bump_snapshot_indices()
+        // does that, and it must be the only writer there — its guard compares
+        // against the snapshot index, so a second writer holding a
+        // configuration from another source would pass the same guard and
+        // could overwrite a newer configuration with an older one. Merging the
+        // two sources here, where they can be compared by config_idx, leaves
+        // that path a single source to read.
+        if (committed_config) {
+            co_await service::strong_consistency::raft_groups_storage::store_committed_config_if_higher(
+                    qp, group_id, this_shard_id(), committed_config->second, committed_config->first);
         }
 
         // Rewrite uncommitted entries to the new commitlog the same way
@@ -268,6 +294,19 @@ future<> raft_commitlog_replay_buffer::bump_snapshot_indices(replica::database& 
                 co_await service::strong_consistency::raft_groups_storage::load_commit_idx_and_term(qp, group_id, this_shard_id());
         if (commit_idx.value() == 0) {
             co_return;
+        }
+        // The configuration the covering mutations persisted is newer than the
+        // snapshot's whenever its entry's index is — restore it before the
+        // bump, so the descriptor the group starts from carries the group's
+        // real membership even if it never snapshotted (SCYLLADB-3842).
+        // This is the only writer of the snapshot configuration on startup:
+        // process_raft_replayed_items() has already merged what the replayed
+        // entries carried into these same cells, so the value read here is the
+        // newest of both sources.
+        if (auto config = co_await service::strong_consistency::raft_groups_storage::load_committed_config(
+                    qp, group_id, this_shard_id())) {
+            co_await service::strong_consistency::raft_groups_storage::store_snapshot_config_if_newer(
+                    qp, group_id, this_shard_id(), config->second, config->first);
         }
         auto [snap_idx, snap_term] = co_await service::strong_consistency::raft_groups_storage::load_snapshot_idx_and_term(qp, group_id, this_shard_id());
         if (snap_idx >= commit_idx) {

--- a/db/commitlog/raft_commitlog_replay_buffer.cc
+++ b/db/commitlog/raft_commitlog_replay_buffer.cc
@@ -153,24 +153,23 @@ future<> raft_commitlog_replay_buffer::process_raft_replayed_items(replica::data
         }
         const auto table_id = table_it->second;
 
-        // Query commit_idx from raft system tables. We treat commit_idx as
-        // the effective snapshot index: all entries up to commit_idx are committed
-        // and will be applied to memtables during replay.
-        const auto commit_idx = co_await service::strong_consistency::raft_groups_storage::load_commit_idx(qp, group_id, this_shard_id());
-
-        logger.debug("group {}: {} entries, commit_idx={}", group_id, entries_list.size(), commit_idx);
-
         // First pass: filter entries (leader changes, out-of-order tails).
         // This must be done before any database writes to avoid applying entries that would
         // later be discarded due to leader changes.
         auto filtered = filter_entries(entries_list, group_id);
 
-        // Second pass: Apply committed entries to database and rewrite uncommitted entries to commitlog.
-        uint64_t applied = 0;
-        uint64_t rewritten = 0;
-        auto& group_data = _per_group_data[group_id];
+        // Query commit_idx from raft system tables. We treat commit_idx as the
+        // effective snapshot index: all entries up to commit_idx are committed
+        // and will be applied to memtables during replay.
+        const auto commit_idx = co_await service::strong_consistency::raft_groups_storage::load_commit_idx(qp, group_id, this_shard_id());
 
-        // Track the term of the last committed entry to update the snapshot descriptor.
+        logger.debug("group {}: {} entries, commit_idx={}", group_id, entries_list.size(), commit_idx);
+
+        // Second pass: Apply committed entries to database and collect uncommitted entries.
+        uint64_t applied = 0;
+        auto& group_data = _per_group_data[group_id];
+        raft::log_entry_ptr_list uncommitted;
+        // Term of the last committed entry, for the snapshot descriptor below.
         std::optional<raft::term_t> last_committed_term;
 
         for (auto& entry : filtered.entries) {
@@ -191,28 +190,40 @@ future<> raft_commitlog_replay_buffer::process_raft_replayed_items(replica::data
                 last_committed_term = entry->term;
             }
 
-            // Rewrite uncommitted entries to the new commitlog to obtain rp_handles
-            // that ensure the commitlog segments won't be deleted.
+            // Only uncommitted entries go back to the raft log (and to the new
+            // commitlog, below). Committed entries have already been applied to
+            // memtables above and are covered by the snapshot descriptor
+            // advanced below.
             if (entry->idx > commit_idx) {
-                commitlog_raft_log_entry_writer writer(raft_commitlog_entry{.group_id = group_id, .entry = entry});
-                const auto write_fn = [&writer](auto& out) {
-                    return writer.write(out);
-                };
-                const auto target_size = writer.size();
-                auto handle = co_await new_commitlog_ptr->add(table_id, target_size, db::no_timeout, db::commitlog_force_sync::yes, write_fn);
-                group_data.replay_positions.push_back(service::strong_consistency::index_and_replay_position{.index = entry->idx, .replay_position_handle = std::move(handle)});
-                ++rewritten;
-            }
-
-            // Only add uncommitted entries to the raft log. Committed entries have
-            // already been applied to memtables above and will be covered by the
-            // updated snapshot descriptor (see below).
-            if (entry->idx > commit_idx) {
-                group_data.entries.push_back(std::move(entry));
+                uncommitted.push_back(std::move(entry));
             }
 
             co_await seastar::coroutine::maybe_yield();
         }
+
+        // Rewrite uncommitted entries to the new commitlog the same way
+        // store_log_entries() does: one batch, whose reference keeps the new
+        // segment alive until the group's own apply() mints from it.
+        //
+        // The cover map write_batches() fills is local for now — the
+        // references it collects are released as soon as it goes out of scope,
+        // and the batch's own reference is what keeps the segment. A later
+        // commit hands the map to raft_commitlog instead, so that the
+        // rewritten entries are covered at commit time like any others.
+        if (!uncommitted.empty()) {
+            service::strong_consistency::pending_cover_map covers;
+            auto batch_handle = co_await service::strong_consistency::raft_commitlog::write_batches(
+                    *new_commitlog_ptr, table_id, db::system_keyspace::raft_groups()->id(), group_id, uncommitted,
+                    raft_term_and_index{}, covers);
+            group_data.rewritten = service::strong_consistency::batch_ref{
+                    .first = uncommitted.front()->idx,
+                    .last = uncommitted.back()->idx,
+                    .reference = std::move(batch_handle)};
+            for (auto& entry : uncommitted) {
+                group_data.entries.push_back(std::move(entry));
+            }
+        }
+
 
         // Advance the persisted snapshot index to commit_idx. This tells the raft
         // server (which sets _applied_idx = snapshot.idx on restart) that all
@@ -231,13 +242,14 @@ future<> raft_commitlog_replay_buffer::process_raft_replayed_items(replica::data
         }
 
         logger.debug("group {}: discarded_leader_change={}, applied={}, rewritten={}, total_in_log={}", group_id, filtered.discarded_leader_change, applied,
-                rewritten, group_data.entries.size());
+                uncommitted.size(), group_data.entries.size());
     }
 
     // The old items are not needed anymore.
     _replayed_commitlog_entries_by_group.clear();
     logger.info("Raft groups commit log replayed data processing complete");
 }
+
 namespace raft_buffer_detail {
 entry_ordering_check_result check_entry_ordering(raft_term_and_idx current, raft_term_and_idx last) {
     if (last.idx == raft::index_t{0}) {

--- a/db/commitlog/raft_commitlog_replay_buffer.hh
+++ b/db/commitlog/raft_commitlog_replay_buffer.hh
@@ -112,6 +112,14 @@ class raft_commitlog_replay_buffer {
     // Populated via add() during replay, then consumed and cleared by process_raft_replayed_items().
     std::unordered_map<raft::group_id, utils::chunked_vector<raft::log_entry_ptr>> _replayed_commitlog_entries_by_group;
 
+    // Highest commit_idx (with its term) seen per group across the replayed
+    // commit_idx entries. Used by process_raft_replayed_items() to restore
+    // system.raft_groups after a crash dropped the value from the raft_groups
+    // memtable before it flushed. A group may have such a record and no
+    // replayed log entries, if its entries' segments were reclaimed while a
+    // record's segment was not.
+    std::unordered_map<raft::group_id, raft_term_and_index> _replayed_commit_idx_by_group;
+
     // Resulting entries and rp_handles written to the new (post-crash) commitlog,
     // raft_commitlog instances when tablet Raft groups start.
     std::unordered_map<raft::group_id, service::strong_consistency::replayed_data_per_group> _per_group_data;
@@ -122,6 +130,18 @@ public:
     void add(const raft::group_id group_id, raft::log_entry_ptr entry) {
         _replayed_commitlog_entries_by_group[group_id].push_back(std::move(entry));
         ++_total_entries;
+    }
+
+    // Record a commit_idx read from a replayed commit_idx entry, keeping the
+    // highest per group. Any such record is a true statement about the past —
+    // commit indexes only advance and committed entries are never replaced —
+    // so the highest one is the tightest safe floor, and its term is exactly
+    // the term of the entry at that index.
+    void add_commit_idx(const raft::group_id group_id, raft_term_and_index committed) {
+        auto& slot = _replayed_commit_idx_by_group[group_id];
+        if (committed.idx > slot.idx) {
+            slot = committed;
+        }
     }
 
     // Get the replayed items for a group. These are removed from the buffer since they are now owned by the caller (raft_commitlog).
@@ -151,7 +171,12 @@ public:
     // Process the raft replay items after commitlog replay completes but before
     // old commitlog segments are deleted and memtables are flushed.
     //
-    // For each raft group in the buffer:
+    // First restores the commit_idx values the replayed entries carried (see
+    // add_commit_idx()) into system.raft_groups — only-advance, index and
+    // term together — so the steps below and bump_snapshot_indices() observe
+    // the post-crash value and treat those entries as committed.
+    //
+    // Then, for each raft group in the buffer:
     //   1. Reads commit_idx from the raft system tables.
     //   2. Filters entries: detects leader changes (discards replaced uncommitted
     //      entries) and stops at out-of-order tails from older pre-crash segments.
@@ -168,5 +193,24 @@ public:
     //   6. Non-command entries (configuration, dummy) are kept in the raft log but
     //      don't need mutation application or commitlog rewrite.
     future<> process_raft_replayed_items(replica::database& db, cql3::query_processor& qp, db::system_keyspace& sys_ks);
+
+    // For every strongly-consistent raft group known to this shard, ensure that
+    // system.raft_groups_snapshots.idx >= system.raft_groups.commit_idx.
+    //
+    // system.raft_groups.commit_idx is written independently of
+    // store_snapshot_descriptor (and reaches the sstable via the raft_groups
+    // memtable rather than a synchronous write). On a clean shutdown
+    // the SC tablet memtables flush and their commitlog segments are reclaimed,
+    // so on the next startup the commitlog can be empty (or contain only
+    // uncommitted entries) for a group even though its persisted commit_idx > 0.
+    //
+    // Without this bump, raft::server::start would observe
+    // commit_idx > log.stable_idx (== snapshot.idx for an empty log) and trip
+    // its "committed index cannot be larger then persisted one" assert.
+    //
+    // This is the sole place that advances the persisted snapshot index during
+    // startup; it must be called unconditionally on every startup (independent
+    // of whether there were any commitlog segments to replay).
+    future<> bump_snapshot_indices(replica::database& db, cql3::query_processor& qp);
 };
 } // namespace db

--- a/db/commitlog/replay_position.hh
+++ b/db/commitlog/replay_position.hh
@@ -68,6 +68,28 @@ class cf_holder;
 
 using cf_id_type = table_id;
 
+// One reference in a commitlog segment's use count.
+//
+// A segment counts, per table, how many outstanding references there are to it
+// (segment::_cf_dirty — master calls this the "use count"), and it cannot be
+// discarded or recycled while any table's count is non-zero
+// (segment::is_clean() is that map being empty). An rp_handle owns exactly one
+// such reference, so "the segment is still referenced" and "an rp_handle for it
+// exists somewhere" are the same statement.
+//
+// A reference is acquired either by a write, which returns one per entry, or by
+// commitlog::acquire_cf_count(), which takes another at a live handle's
+// position without writing any bytes. It is given up in one of three ways:
+//
+//   - destroying the handle, which decrements the count
+//     (segment::release_cf_count);
+//   - handing it to a memtable with rp_set::put(), which moves the reference
+//     into the memtable's own per-segment count; that memtable's flush then
+//     decrements it (commitlog::discard_completed_segments);
+//   - calling release(), which *abandons* the decrement: the reference stays
+//     outstanding for the life of the process and the segment is kept. Note
+//     that this is the opposite of what the name suggests. It exists so that
+//     segments can deliberately survive shutdown for replay.
 class rp_handle {
 public:
     rp_handle() noexcept;
@@ -75,6 +97,8 @@ public:
     rp_handle& operator=(rp_handle&&) noexcept;
     ~rp_handle();
 
+    // Abandon this reference's decrement — see the note above: the segment is
+    // *kept*, not released. Returns the position the handle held.
     replay_position release();
 
     operator bool() const {

--- a/idl/commitlog.idl.hh
+++ b/idl/commitlog.idl.hh
@@ -18,7 +18,9 @@ class mutation_entry [[writable]] {
 
 struct raft_commitlog_entry [[writable]] {
     raft::group_id group_id;
-    raft::log_entry_ptr entry;
+    std::vector<raft::log_entry_ptr> entries;
+    raft::index_t commit_idx;
+    raft::term_t commit_idx_term;
 };
 
 struct commitlog_entry [[writable]] {

--- a/main.cc
+++ b/main.cc
@@ -2208,10 +2208,12 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
                     // uncommitted entries are now in new segments).
                     supervisor::notify("processing raft replay buffer");
                     raft_replay_buffer.invoke_on_all([&db, &qp](db::raft_commitlog_replay_buffer& buffer) mutable {
-                        if (buffer.remaining_groups()) {
-                            return buffer.process_raft_replayed_items(db.local(), qp.local(), sys_ks.local());
-                        }
-                        return make_ready_future<>();
+                        // Called unconditionally — the buffer returns early when it
+                        // holds nothing. A group may have a replayed commit_idx
+                        // record but no log entries (its entries' segments were
+                        // reclaimed while a record's was not); the buffer restores
+                        // those floors too.
+                        return buffer.process_raft_replayed_items(db.local(), qp.local(), sys_ks.local());
                     }).get();
 
                     startlog.info("replaying commit log - flushing memtables");
@@ -2228,6 +2230,18 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
                         return make_ready_future<>();
                     }).get();
                 }
+
+                // Reconcile system.raft_groups_snapshots.idx with system.raft_groups.commit_idx
+                // for every known strongly-consistent tablet raft group. Must run unconditionally
+                // (independent of whether there were commitlog segments to replay): after a clean
+                // shutdown all SC tablet segments have been reclaimed, yet the persisted
+                // commit_idx may still be ahead of the persisted snapshot idx, which would
+                // otherwise trip the "committed index cannot be larger then persisted one"
+                // assert in raft::server::start.
+                supervisor::notify("bumping raft snapshot indices");
+                raft_replay_buffer.invoke_on_all([&db, &qp](db::raft_commitlog_replay_buffer& buffer) mutable {
+                    return buffer.bump_snapshot_indices(db.local(), qp.local());
+                }).get();
             }
 
             // Once stuff is replayed, we can empty RP:s from truncation records. 

--- a/replica/tablets.cc
+++ b/replica/tablets.cc
@@ -127,8 +127,30 @@ schema_ptr make_raft_schema(sstring name, bool is_group0) {
         .with_column("vote", uuid_type, column_kind::static_column)
         // id of the most recent persisted snapshot
         .with_column("snapshot_id", uuid_type, column_kind::static_column)
-        .with_column("commit_idx", long_type, column_kind::static_column)
+        .with_column("commit_idx", long_type, column_kind::static_column);
 
+    if (!is_group0) {
+        // Term of the entry at commit_idx. Persisted together with commit_idx
+        // (same mutation) so that the boot-time snapshot bump can restore an
+        // exact (idx, term) pair: the snapshot term takes part in both leader
+        // elections (log::is_up_to_date via last_term() on an empty log) and
+        // log matching at the snapshot boundary (log::match_term), and an
+        // inexact value is unsafe in both roles.
+        builder.with_column("commit_idx_term", long_type, column_kind::static_column);
+        // The group's newest committed configuration and the index of the
+        // entry that carried it, written by the same mutation as commit_idx
+        // when that entry's segment is covered (see raft_groups_storage::
+        // store_commit_idx). This is what makes a committed configuration
+        // durable without waiting for a snapshot: the alternative is the
+        // configuration entry in the commitlog, which only survives while its
+        // segment does. Compared against the persisted snapshot index on
+        // startup, since a snapshot's own configuration accounts for every
+        // configuration entry at or below its index (SCYLLADB-3842).
+        builder.with_column("config", bytes_type, column_kind::static_column);
+        builder.with_column("config_idx", long_type, column_kind::static_column);
+    }
+
+    builder
         .with_hash_version()
         .set_caching_options(caching_options::get_disabled_caching_options());
 

--- a/service/strong_consistency/raft_commitlog.cc
+++ b/service/strong_consistency/raft_commitlog.cc
@@ -39,6 +39,7 @@ raft_commitlog::raft_commitlog(raft::group_id group_id, db::commitlog& commitlog
     , _raft_groups_table_id(raft_groups_table_id)
     , _commit_log(commitlog)
     , _replayed_entries(std::move(replayed_data.entries)) {
+    _pending_covers = std::move(replayed_data.covers);
     // The rewritten batch, if replay rewrote anything, holds the reference on the
     // entries above the recovered commit index. Its range is what tells us
     // which replayed entries those are: everything below was already applied
@@ -59,9 +60,9 @@ raft_commitlog::raft_commitlog(raft::group_id group_id, db::commitlog& commitlog
         }
     }
     logger.debug("starting raft_commitlog group_id={}, table_id={}, replayed_entries={}, "
-            "rewritten_from={}, pending_commands={}",
+            "rewritten_from={}, pending_commands={}, pending_covers={}",
             _group_id, _table_id, _replayed_entries.size(), rewritten_from,
-            _pending_commands.size());
+            _pending_commands.size(), _pending_covers.size());
 }
 
 raft_commitlog::~raft_commitlog() {
@@ -72,7 +73,14 @@ raft_commitlog::~raft_commitlog() {
     for (auto& batch : _batch_refs) {
         batch.reference.release();
     }
-    logger.debug("released {} batch references for group_id={}", _batch_refs.size(), _group_id);
+    for (auto& [segment, cover] : _pending_covers) {
+        cover.segment_holder.release();
+    }
+    for (auto& orphan : _orphaned_holders) {
+        orphan.segment_holder.release();
+    }
+    logger.debug("released {} batch references, {} parked covers and {} orphaned holders for group_id={}",
+            _batch_refs.size(), _pending_covers.size(), _orphaned_holders.size(), _group_id);
 }
 
 seastar::future<db::rp_handle> raft_commitlog::write_batches(db::commitlog& cl,
@@ -140,14 +148,8 @@ seastar::future<> raft_commitlog::store_log_entries(const raft::log_entry_ptr_li
         co_return;
     }
 
-    // The cover map is local for now: the references it collects are released as
-    // soon as this call returns (the batch's own reference keeps the segment
-    // alive), and commit_idx is still persisted by store_commit_idx()'s CQL
-    // write. A later commit keeps the map across batches and hands the references
-    // to covering raft_groups mutations.
-    pending_cover_map covers;
     auto batch_handle = co_await write_batches(_commit_log, _table_id, _raft_groups_table_id, _group_id, entries,
-            _last_committed, covers);
+            _last_committed, _pending_covers);
 
     bool has_commands = false;
     for (const auto& log_entry_ptr : entries) {
@@ -167,8 +169,8 @@ seastar::future<> raft_commitlog::store_log_entries(const raft::log_entry_ptr_li
                 .last = entries.back()->idx,
                 .reference = std::move(batch_handle)});
     }
-    logger.debug("store_log_entries completed: batch_refs={}, pending_commands={}",
-            _batch_refs.size(), _pending_commands.size());
+    logger.debug("store_log_entries completed: batch_refs={}, pending_commands={}, pending_covers={}",
+            _batch_refs.size(), _pending_commands.size(), _pending_covers.size());
 }
 
 void raft_commitlog::note_commit_idx(const raft::index_t idx) {
@@ -221,6 +223,26 @@ void raft_commitlog::truncate_log(const raft::index_t idx) {
     while (!_appended_terms.empty() && _appended_terms.back().idx >= idx) {
         _appended_terms.pop_back();
     }
+    // Covers whose max_idx refers to truncated entries can never pop with a
+    // correct (idx, term) pair, and leaving them parked would wedge
+    // take_committed_covers()'s prefix pop for every later cover (the reused
+    // indexes land in new, smaller-max covers behind them). Their references
+    // must survive, though — the segments may still hold this group's earlier
+    // entries — so the references move to _orphaned_holders, each tagged with the
+    // release floor it must wait for: idx - 1 bounds the live entries left
+    // in its segment from above, and a lower value must not release it (a
+    // surviving pre-truncation cover can pop first, and its value would leave
+    // entries between it and the truncation point uncovered).
+    while (!_pending_covers.empty() && std::prev(_pending_covers.end())->second.max_idx >= idx) {
+        const auto last = std::prev(_pending_covers.end());
+        if (last->second.segment_holder) {
+            _orphaned_holders.push_back(orphaned_holder{
+                .release_floor = idx - raft::index_t{1},
+                .segment_holder = std::move(last->second.segment_holder),
+            });
+        }
+        _pending_covers.erase(last);
+    }
 }
 
 void raft_commitlog::truncate_log_tail(const raft::index_t index) {
@@ -236,8 +258,53 @@ void raft_commitlog::truncate_log_tail(const raft::index_t index) {
     while (!_batch_refs.empty() && _batch_refs.front().last <= index) {
         _batch_refs.pop_front();
     }
+    // _pending_covers is left alone: covers up to the snapshot index (<= the
+    // applied <= the commit index) were already taken by
+    // take_committed_covers(), which store_commit_idx() drives before entries
+    // can be applied, let alone snapshotted; segments still pending extend
+    // beyond it.
     logger.debug("truncate_log_tail completed: batch_refs={}, pending_commands={}",
             _batch_refs.size(), _pending_commands.size());
+}
+
+std::vector<segment_cover> raft_commitlog::take_committed_covers(raft::index_t commit_idx) {
+    std::vector<segment_cover> ret;
+    // The map's key order is also its max_idx order (see pending_cover_map),
+    // so the fully-committed covers form a prefix.
+    while (!_pending_covers.empty() && _pending_covers.begin()->second.max_idx <= commit_idx) {
+        auto node = _pending_covers.extract(_pending_covers.begin());
+        auto& cover = node.mapped();
+        if (!cover.segment_holder) {
+            // Replayed data constructed without real handles (tests); there
+            // is no reference to manage and nothing for a pin to guarantee.
+            continue;
+        }
+        ret.push_back(segment_cover{
+            .segment = node.key(),
+            .max_idx = cover.max_idx,
+            .max_term = cover.max_term,
+            .segment_holder = std::move(cover.segment_holder),
+        });
+    }
+    if (!ret.empty()) {
+        // References parked by truncate_log() whose floor this pop reaches ride
+        // the last cover's mutation: its value is >= their floors, hence >=
+        // any index remaining in their segments. References with higher floors
+        // stay parked for a later pop.
+        for (auto it = _orphaned_holders.begin(); it != _orphaned_holders.end(); ) {
+            if (it->release_floor <= ret.back().max_idx) {
+                ret.back().extra_holders.push_back(std::move(it->segment_holder));
+                it = _orphaned_holders.erase(it);
+            } else {
+                ++it;
+            }
+        }
+    }
+    if (!ret.empty()) {
+        logger.debug("take_committed_covers: group_id={}, commit_idx={}, covers={}, remaining_pending={}",
+                _group_id, commit_idx, ret.size(), _pending_covers.size());
+    }
+    return ret;
 }
 
 std::vector<index_and_replay_position> raft_commitlog::acquire_replay_position_handles_for(const raft::log_entry_ptr_list& entries) {

--- a/service/strong_consistency/raft_commitlog.cc
+++ b/service/strong_consistency/raft_commitlog.cc
@@ -30,6 +30,13 @@ bool is_command_entry(const raft::log_entry& e) {
     return std::holds_alternative<raft::command>(e.data);
 }
 
+// Configuration entries carry state no covering value can reconstruct, so the
+// configuration is persisted by the covering mutation itself and the entry has
+// to stay readable until then; their handles therefore follow a different
+// release rule than commands and dummies (see SCYLLADB-3842).
+bool is_config_entry(const raft::log_entry& e) {
+    return std::holds_alternative<raft::configuration>(e.data);
+}
 } // namespace
 
 raft_commitlog::raft_commitlog(raft::group_id group_id, db::commitlog& commitlog, table_id target_table_id,
@@ -57,6 +64,21 @@ raft_commitlog::raft_commitlog(raft::group_id group_id, db::commitlog& commitlog
         }
         if (is_command_entry(*e)) {
             _pending_commands.push_back(e->idx);
+        } else if (is_config_entry(*e)) {
+            // A configuration that was still uncommitted at the crash commits
+            // after the restart, and only a covering mutation will make it
+            // durable — the replay-time restore handles committed ones only.
+            // Without this seeding it would reach note_commit_idx() unknown,
+            // its covering mutation would carry no configuration, and the
+            // entry would be released anyway: the SCYLLADB-3842 loss on the
+            // one path the replay-time restore does not cover.
+            //
+            // Indexes here are above the recovered commit index, hence above
+            // any config_idx already durable in system.raft_groups (that one
+            // was written by a covering mutation, in the same mutation as a
+            // commit_idx at or below the recovered one), so a covering
+            // mutation can only ever advance the persisted configuration.
+            _appended_configs.emplace_back(e->idx, std::get<raft::configuration>(e->data));
         }
     }
     logger.debug("starting raft_commitlog group_id={}, table_id={}, replayed_entries={}, "
@@ -157,6 +179,8 @@ seastar::future<> raft_commitlog::store_log_entries(const raft::log_entry_ptr_li
         if (is_command_entry(*log_entry_ptr)) {
             _pending_commands.push_back(log_entry_ptr->idx);
             has_commands = true;
+        } else if (is_config_entry(*log_entry_ptr)) {
+            _appended_configs.emplace_back(log_entry_ptr->idx, std::get<raft::configuration>(log_entry_ptr->data));
         }
     }
     // Only a batch containing commands needs its reference kept: apply() mints
@@ -181,6 +205,14 @@ void raft_commitlog::note_commit_idx(const raft::index_t idx) {
     while (!_appended_terms.empty() && _appended_terms.front().idx <= idx) {
         _last_committed = _appended_terms.front();
         _appended_terms.pop_front();
+    }
+    // Same for the configurations: the newest one the commit index has reached
+    // is the one a covering mutation must persist. An older pending
+    // configuration is superseded and can be dropped — configurations are
+    // whole member sets, not deltas.
+    while (!_appended_configs.empty() && _appended_configs.front().first <= idx) {
+        _committed_config = std::move(_appended_configs.front());
+        _appended_configs.pop_front();
     }
 }
 
@@ -222,6 +254,9 @@ void raft_commitlog::truncate_log(const raft::index_t idx) {
     // not end up in a floor, and their configurations must not be persisted.
     while (!_appended_terms.empty() && _appended_terms.back().idx >= idx) {
         _appended_terms.pop_back();
+    }
+    while (!_appended_configs.empty() && _appended_configs.back().first >= idx) {
+        _appended_configs.pop_back();
     }
     // Covers whose max_idx refers to truncated entries can never pop with a
     // correct (idx, term) pair, and leaving them parked would wedge
@@ -305,6 +340,17 @@ std::vector<segment_cover> raft_commitlog::take_committed_covers(raft::index_t c
                 _group_id, commit_idx, ret.size(), _pending_covers.size());
     }
     return ret;
+}
+
+std::optional<std::pair<raft::index_t, raft::configuration>> raft_commitlog::take_committed_config(const raft::index_t idx) {
+    if (!_committed_config || _committed_config->first > idx) {
+        // Nothing committed in this range, or the configuration belongs to a
+        // segment that is not covered yet — it must ride that segment's
+        // mutation, not an earlier one, or the entry could be reclaimed before
+        // its configuration is durable.
+        return std::nullopt;
+    }
+    return std::exchange(_committed_config, std::nullopt);
 }
 
 std::vector<index_and_replay_position> raft_commitlog::acquire_replay_position_handles_for(const raft::log_entry_ptr_list& entries) {

--- a/service/strong_consistency/raft_commitlog.cc
+++ b/service/strong_consistency/raft_commitlog.cc
@@ -11,6 +11,8 @@
 #include "db/commitlog/commitlog_entry.hh"
 #include "raft/raft.hh"
 
+#include <limits>
+
 #include "raft_commitlog.hh"
 
 #include "idl/commitlog.dist.hh"
@@ -21,47 +23,163 @@
 namespace service::strong_consistency {
 namespace {
 seastar::logger logger("raft_commitlog");
+
+// Command entries are the ones state_machine::apply() consumes; their
+// handles move to the target table's memtable there.
+bool is_command_entry(const raft::log_entry& e) {
+    return std::holds_alternative<raft::command>(e.data);
 }
 
-raft_commitlog::raft_commitlog(raft::group_id group_id, db::commitlog& commitlog, table_id target_table_id, replayed_data_per_group replayed_data)
+} // namespace
+
+raft_commitlog::raft_commitlog(raft::group_id group_id, db::commitlog& commitlog, table_id target_table_id,
+        db::cf_id_type raft_groups_table_id, replayed_data_per_group replayed_data)
     : _group_id(group_id)
     , _table_id(target_table_id)
+    , _raft_groups_table_id(raft_groups_table_id)
     , _commit_log(commitlog)
-    , _replay_positions(std::move(replayed_data.replay_positions))
     , _replayed_entries(std::move(replayed_data.entries)) {
-    logger.debug("starting raft_commitlog group_id={}, table_id={}, replayed_entries={}", _group_id, _table_id, _replayed_entries.size());
+    // The rewritten batch, if replay rewrote anything, holds the reference on the
+    // entries above the recovered commit index. Its range is what tells us
+    // which replayed entries those are: everything below was already applied
+    // by replay and needs nothing from us.
+    const auto rewritten_from = replayed_data.rewritten
+            ? replayed_data.rewritten->first
+            : raft::index_t(std::numeric_limits<uint64_t>::max());
+    if (replayed_data.rewritten) {
+        _batch_refs.push_back(std::move(*replayed_data.rewritten));
+    }
+    for (const auto& e : _replayed_entries) {
+        _appended_terms.push_back(raft_term_and_index{.idx = e->idx, .term = e->term});
+        if (e->idx < rewritten_from) {
+            continue;
+        }
+        if (is_command_entry(*e)) {
+            _pending_commands.push_back(e->idx);
+        }
+    }
+    logger.debug("starting raft_commitlog group_id={}, table_id={}, replayed_entries={}, "
+            "rewritten_from={}, pending_commands={}",
+            _group_id, _table_id, _replayed_entries.size(), rewritten_from,
+            _pending_commands.size());
 }
 
 raft_commitlog::~raft_commitlog() {
-    // Release all remaining replay position handles without decrementing
-    // segment dirty counts. This keeps commitlog segments alive after this
-    // object is destroyed, ensuring uncommitted raft entries remain
-    // available for replay after restart.
-    for (auto& entry : _replay_positions) {
-        entry.replay_position_handle.release();
+    // Release every remaining reference without decrementing segment dirty counts.
+    // This keeps the commitlog segments alive after this object is destroyed,
+    // so the uncommitted raft entries (and the commit indexes their batch
+    // headers carry) remain available for replay after a restart.
+    for (auto& batch : _batch_refs) {
+        batch.reference.release();
     }
-    logger.debug("released {} replay position handles for group_id={}", _replay_positions.size(), _group_id);
+    logger.debug("released {} batch references for group_id={}", _batch_refs.size(), _group_id);
+}
+
+seastar::future<db::rp_handle> raft_commitlog::write_batches(db::commitlog& cl,
+        db::cf_id_type table_id, db::cf_id_type raft_groups_table_id, raft::group_id group_id,
+        const raft::log_entry_ptr_list& entries, raft_term_and_index committed, pending_cover_map& covers) {
+    SCYLLA_ASSERT(!entries.empty());
+
+    // One commitlog entry for the whole batch: the group id, the entries, and
+    // the group's last committed (index, term) as the crash-replay floor. The
+    // per-entry framing this replaces repeated the group id and an envelope
+    // for every entry, and paid for a separate trailing record whose only
+    // novel payload was one index.
+    utils::chunked_vector<commitlog_raft_log_entry_writer> writers;
+    writers.emplace_back(raft_commitlog_entry{
+            .group_id = group_id,
+            .entries = {entries.begin(), entries.end()},
+            .commit_idx = committed.idx,
+            .commit_idx_term = committed.term});
+    if (logger.is_enabled(seastar::log_level::debug)) {
+        logger.debug("  storing batch: group_id={}, idx={}..{}, committed=({}, {})", group_id,
+                entries.front()->idx, entries.back()->idx, committed.idx, committed.term);
+    }
+
+    // A single write, force_sync. Below the commitlog's oversized threshold
+    // (half a segment: 32MB at the default 64MB segment size) the batch is
+    // placed atomically in one segment. Raft caps a batch at max_log_size
+    // (20MB for tablet groups), so at the default segment size the threshold
+    // is unreachable; with smaller configured segments the commitlog
+    // fragments the entry across segments, which requires
+    // allow_fragmented_entries (the fragmented_commitlog_entries cluster
+    // feature; strongly consistent tables are gated behind an experimental
+    // flag, so in practice it is on). Either way the batch has exactly one
+    // position — its head segment — and the tail segments of a fragmented
+    // entry outlive every reference taken at that position, because the head
+    // segment counts the references holding them (segment::extended_entry).
+    auto handles = co_await cl.add_raft_entries(table_id, std::move(writers));
+    SCYLLA_ASSERT(handles.size() == 1);
+    auto batch_handle = std::move(handles[0]);
+
+    // The segment must also be held on behalf of system.raft_groups: without
+    // that, a target-table flush could reclaim it before a covering commit_idx
+    // value is durable. One reference per segment, not per batch — a segment
+    // already in the caller's cover map keeps the reference it has (it has existed
+    // continuously since the batch that first wrote to it, which is the
+    // property the coverage relies on) and only its (max_idx, max_term) pair
+    // advances. Batches keep landing in the same still-active segment, so that
+    // is the common case.
+    //
+    // Entries ascend, so the batch's last entry carries the highest index the
+    // group has put in this segment.
+    const auto segment = batch_handle.rp().id;
+    auto [it, inserted] = covers.try_emplace(segment);
+    it->second.max_idx = entries.back()->idx;
+    it->second.max_term = entries.back()->term;
+    if (inserted) {
+        it->second.segment_holder = cl.acquire_cf_count(batch_handle, raft_groups_table_id);
+    }
+
+    co_return batch_handle;
 }
 
 seastar::future<> raft_commitlog::store_log_entries(const raft::log_entry_ptr_list& entries) {
     logger.debug("store_log_entries: group_id={}, num_entries={}", _group_id, entries.size());
+    if (entries.empty()) {
+        co_return;
+    }
 
-    utils::chunked_vector<commitlog_raft_log_entry_writer> writers;
-    writers.reserve(entries.size());
+    // The cover map is local for now: the references it collects are released as
+    // soon as this call returns (the batch's own reference keeps the segment
+    // alive), and commit_idx is still persisted by store_commit_idx()'s CQL
+    // write. A later commit keeps the map across batches and hands the references
+    // to covering raft_groups mutations.
+    pending_cover_map covers;
+    auto batch_handle = co_await write_batches(_commit_log, _table_id, _raft_groups_table_id, _group_id, entries,
+            _last_committed, covers);
 
+    bool has_commands = false;
     for (const auto& log_entry_ptr : entries) {
-        logger.debug("  storing log entry: idx={}, term={}", log_entry_ptr->idx, log_entry_ptr->term);
-        writers.emplace_back(raft_commitlog_entry{.group_id = _group_id, .entry = log_entry_ptr});
+        _appended_terms.push_back(raft_term_and_index{.idx = log_entry_ptr->idx, .term = log_entry_ptr->term});
+        if (is_command_entry(*log_entry_ptr)) {
+            _pending_commands.push_back(log_entry_ptr->idx);
+            has_commands = true;
+        }
     }
-
-    auto replay_handles = co_await _commit_log.add_raft_entries(_table_id, std::move(writers));
-
-    for (size_t i = 0; i < entries.size(); ++i) {
-        const auto& log_entry_ptr = entries[i];
-        _replay_positions.push_back(
-                index_and_replay_position{.index = log_entry_ptr->idx, .replay_position_handle = std::move(replay_handles[i])});
+    // Only a batch containing commands needs its reference kept: apply() mints
+    // from it, and nothing else will. A batch of dummies and configurations is
+    // outlived by its segment's cover (see batch_ref), so its reference goes
+    // here.
+    if (has_commands) {
+        _batch_refs.push_back(batch_ref{
+                .first = entries.front()->idx,
+                .last = entries.back()->idx,
+                .reference = std::move(batch_handle)});
     }
-    logger.debug("store_log_entries completed: total_entries_in_map={}", _replay_positions.size());
+    logger.debug("store_log_entries completed: batch_refs={}, pending_commands={}",
+            _batch_refs.size(), _pending_commands.size());
+}
+
+void raft_commitlog::note_commit_idx(const raft::index_t idx) {
+    // Consume the appended entries the commit index has reached; the last one
+    // consumed is the pair the next batch records as its floor. Raft advances
+    // the commit index before the entries are applied, so every entry at or
+    // below idx is still tracked here — no lookup can miss.
+    while (!_appended_terms.empty() && _appended_terms.front().idx <= idx) {
+        _last_committed = _appended_terms.front();
+        _appended_terms.pop_front();
+    }
 }
 
 raft::log_entries raft_commitlog::load_log() {
@@ -71,50 +189,105 @@ raft::log_entries raft_commitlog::load_log() {
 
 void raft_commitlog::truncate_log(const raft::index_t idx) {
     logger.debug("truncate_log: group_id={}, idx={}", _group_id, idx);
-    // Remove entries with index >= idx (Raft semantics: truncate from idx onward).
-    // The deque is sorted by index, so binary search finds the cut point.
-    auto it = std::ranges::lower_bound(_replay_positions, idx, {}, &index_and_replay_position::index);
-    _replay_positions.erase(it, _replay_positions.end());
+    // Remove entries with index >= idx (Raft semantics: truncate from idx
+    // onward). Everything here is index-ordered, so each is a back trim.
+    //
+    // The discarded commands will never be applied, so nothing will ever mint
+    // a memtable reference for them.
+    while (!_pending_commands.empty() && _pending_commands.back() >= idx) {
+        _pending_commands.pop_back();
+    }
+    // A batch entirely at or above the truncation point is gone: its reference can
+    // go with it, because its entries are discarded and its segment's
+    // retention for anything else is the business of that segment's cover.
+    while (!_batch_refs.empty() && _batch_refs.back().first >= idx) {
+        _batch_refs.pop_back();
+    }
+    // A batch straddling the truncation point keeps its reference — its surviving
+    // commands may still be waiting for apply() — with its range clamped so
+    // the drain check below only looks at what survived.
+    if (!_batch_refs.empty() && _batch_refs.back().last >= idx) {
+        _batch_refs.back().last = idx - raft::index_t{1};
+    }
+    // ...and if nothing survived that needs it, it goes too: the surviving
+    // entries are then dummies, configurations, or commands already handed to
+    // a memtable, none of which depend on this reference.
+    while (!_batch_refs.empty()
+            && (_pending_commands.empty() || _pending_commands.back() < _batch_refs.back().first)) {
+        _batch_refs.pop_back();
+    }
+    // The discarded entries can no longer be committed, so their terms must
+    // not end up in a floor, and their configurations must not be persisted.
+    while (!_appended_terms.empty() && _appended_terms.back().idx >= idx) {
+        _appended_terms.pop_back();
+    }
 }
 
 void raft_commitlog::truncate_log_tail(const raft::index_t index) {
     logger.debug("truncate_log_tail: group_id={}, index={}", _group_id, index);
-    // Remove entries with index <= the given index. The handles are destructed
-    // normally, decrementing segment dirty counts and allowing commitlog
-    // segments to be reclaimed once no other references hold them.
-    auto it = std::ranges::upper_bound(_replay_positions, index, {}, &index_and_replay_position::index);
-    _replay_positions.erase(_replay_positions.begin(), it);
-    logger.debug("truncate_log_tail completed: remaining_map_size={}", _replay_positions.size());
+    // Entries at or below a persisted snapshot index are all applied — raft
+    // does not snapshot past what the state machine consumed — so nothing here
+    // is still waiting on them. Front trims, and the references are destructed
+    // normally, decrementing segment dirty counts and letting segments be
+    // reclaimed once nothing else holds them.
+    while (!_pending_commands.empty() && _pending_commands.front() <= index) {
+        _pending_commands.pop_front();
+    }
+    while (!_batch_refs.empty() && _batch_refs.front().last <= index) {
+        _batch_refs.pop_front();
+    }
+    logger.debug("truncate_log_tail completed: batch_refs={}, pending_commands={}",
+            _batch_refs.size(), _pending_commands.size());
 }
 
 std::vector<index_and_replay_position> raft_commitlog::acquire_replay_position_handles_for(const raft::log_entry_ptr_list& entries) {
-    logger.debug("acquire_replay_position_handles_for: group_id={}, entries_count={}, current_map_size={}", _group_id, entries.size(),
-            _replay_positions.size());
+    logger.debug("acquire_replay_position_handles_for: group_id={}, entries_count={}, pending_commands={}",
+            _group_id, entries.size(), _pending_commands.size());
 
     std::vector<index_and_replay_position> ret;
     ret.reserve(entries.size());
 
-    // Move replay position handles for requested entries. The entries may not be
-    // contiguous in _replay_positions because non-command entries (configuration,
-    // dummy) are also tracked there but are not passed to state_machine::apply().
-    // We scan forward through _replay_positions, skipping non-matching entries
-    // (which are the non-command items). This is O(n) since both sequences are
-    // sorted by index and we only move forward.
-    auto it = _replay_positions.begin();
+    // Both sequences are command-only and index-sorted, so a single forward
+    // walk matches them up, as does a second one over the batches. A pending
+    // command below the requested one is left where it is rather than dropped:
+    // its data never reached a memtable, so its batch's reference must go on
+    // holding the segment.
+    auto pending = _pending_commands.begin();
+    auto batch = _batch_refs.begin();
     for (const auto& entry : entries) {
-        // Skip non-command entries that have indices below the one we're looking for.
-        while (it != _replay_positions.end() && it->index < entry->idx) {
-            ++it;
+        while (pending != _pending_commands.end() && *pending < entry->idx) {
+            ++pending;
         }
-        if (it == _replay_positions.end() || it->index != entry->idx) {
-            on_internal_error(logger, fmt::format("missing replay position handle for group_id={}, idx={}", _group_id, entry->idx));
+        if (pending == _pending_commands.end() || *pending != entry->idx) {
+            on_internal_error(logger, fmt::format("no pending command for group_id={}, idx={}", _group_id, entry->idx));
         }
-        ret.emplace_back(index_and_replay_position{.index = it->index, .replay_position_handle = std::move(it->replay_position_handle)});
-        it = _replay_positions.erase(it);
+        while (batch != _batch_refs.end() && batch->last < entry->idx) {
+            ++batch;
+        }
+        if (batch == _batch_refs.end() || batch->first > entry->idx) {
+            on_internal_error(logger, fmt::format("no batch reference for group_id={}, idx={}", _group_id, entry->idx));
+        }
+        // The minted handle carries the batch's position — the position the
+        // mutation was really written at — so the target memtable's recorded
+        // replay position, and the truncation and cleanup records derived from
+        // it, stay truthful.
+        ret.emplace_back(index_and_replay_position{
+                .index = entry->idx,
+                .replay_position_handle = _commit_log.acquire_cf_count(batch->reference, _table_id)});
+        pending = _pending_commands.erase(pending);
     }
 
-    logger.debug(
-            "acquire_replay_position_handles_for completed: returned_count={}, remaining_map_size={}", ret.size(), _replay_positions.size());
+    // A batch with no pending command left has nothing more to hand out: the
+    // memtables hold references of their own now, and its other entry kinds are
+    // outlived by the segment's cover. Front only — commands are applied in
+    // index order, so earlier batches drain first.
+    while (!_batch_refs.empty()
+            && (_pending_commands.empty() || _pending_commands.front() > _batch_refs.front().last)) {
+        _batch_refs.pop_front();
+    }
+
+    logger.debug("acquire_replay_position_handles_for completed: returned={}, batch_refs={}, pending_commands={}",
+            ret.size(), _batch_refs.size(), _pending_commands.size());
     return ret;
 }
 } // namespace service::strong_consistency

--- a/service/strong_consistency/raft_commitlog.hh
+++ b/service/strong_consistency/raft_commitlog.hh
@@ -62,7 +62,9 @@ using pending_cover_map = std::map<db::segment_id_type, pending_cover>;
 //
 // Dummy and configuration entries need no reference of their own. The segment's
 // cover has max_idx >= their index, so it is released only once a durable
-// commit index covers them, by which point replay does not need the entries.
+// commit index covers them, by which point replay does not need the entries;
+// and a committed configuration is persisted by the very mutation that
+// carries the cover's reference (take_committed_config()).
 struct batch_ref {
     raft::index_t first;
     raft::index_t last;
@@ -166,6 +168,22 @@ private:
         db::rp_handle segment_holder;
     };
     std::vector<orphaned_holder> _orphaned_holders;
+    // Configurations of the configuration entries appended but not yet known
+    // to be committed, in index order. note_commit_idx() promotes the ones
+    // the commit index has reached into _committed_config, and truncate_log()
+    // drops the discarded tail. A configuration is a handful of members, and
+    // only the in-flight window is held.
+    //
+    // Fed from both sources of an uncommitted entry: store_log_entries() for
+    // entries appended in this run, and the constructor for entries the
+    // commitlog replay rewrote. Missing the second one loses a configuration
+    // that was uncommitted at a crash and commits after the restart, since
+    // the replay-side recovery only handles committed ones (SCYLLADB-3842).
+    std::deque<std::pair<raft::index_t, raft::configuration>> _appended_configs;
+    // The newest committed configuration not yet handed to a covering
+    // mutation, with the index of the entry that carried it. Consumed by
+    // take_committed_config().
+    std::optional<std::pair<raft::index_t, raft::configuration>> _committed_config;
     // (index, term) of the entries appended but not yet known to be
     // committed, in index order. note_commit_idx() consumes the prefix the
     // commit index has reached, keeping the last consumed pair in
@@ -253,6 +271,15 @@ public:
     // mutation and its pin share a memtable generation, so the pin can only
     // be released by the flush that makes the covering value durable.
     std::vector<segment_cover> take_committed_covers(raft::index_t commit_idx);
+
+    // Hand out the newest committed configuration whose entry is at or below
+    // `idx`, if one is pending. The caller must persist it in the same
+    // system.raft_groups mutation as the covering value for that entry's
+    // segment: the configuration then becomes durable exactly when the
+    // segment's reference is released, so the entry can only be reclaimed once
+    // its configuration is safe. Returns nothing when no configuration was
+    // committed in that range, or when it has already been handed out.
+    std::optional<std::pair<raft::index_t, raft::configuration>> take_committed_config(raft::index_t idx);
 
     // Mint a memtable reference for each of the specified command entries from
     // the reference of the batch it was written in, and forget the command. Each

--- a/service/strong_consistency/raft_commitlog.hh
+++ b/service/strong_consistency/raft_commitlog.hh
@@ -30,8 +30,7 @@ struct index_and_replay_position {
 // value; the segment is the key), parked until every entry at or below that
 // index is committed. The reference is taken (commitlog::acquire_cf_count) when
 // the group first writes to the segment and pins it from that moment until
-// the map that holds it goes away. A later commit keeps the map across
-// batches and attaches the reference to a covering raft_groups mutation.
+// take_committed_covers() attaches it to a covering raft_groups mutation.
 struct pending_cover {
     // Highest raft index the group has written to the reference's segment, and
     // that entry's term. The pair is persisted together by the covering
@@ -45,9 +44,9 @@ struct pending_cover {
 // A group's covers, keyed by commitlog segment: one reference per segment,
 // updated in place by write_batches(). Batches arrive in index order and
 // segments advance monotonically, so the key order is also the max_idx
-// order — the fully-committed covers always form a prefix and the covers a
-// truncation invalidates form a suffix, which is what lets a later commit
-// consume them from the front.
+// order — the fully-committed covers always form a prefix
+// (take_committed_covers()) and the covers a truncation invalidates form a
+// suffix (truncate_log()).
 using pending_cover_map = std::map<db::segment_id_type, pending_cover>;
 
 // One reference on the commitlog entry a batch was written as, with the batch's
@@ -76,6 +75,26 @@ struct replayed_data_per_group {
     // `entries` are the rewritten (uncommitted) ones.
     std::optional<batch_ref> rewritten;
     raft::log_entries entries;
+    // The cover map write_batches() built while the commitlog replay
+    // rewrote the group's batches into the new commitlog; moved wholesale
+    // into the group's _pending_covers on construction.
+    pending_cover_map covers;
+};
+
+// A commitlog segment all of whose entries (for this group) are committed,
+// together with the highest raft index the group appended to it and the reference
+// that has held the segment since the group first wrote to it. Produced by
+// take_committed_covers(); see its comment for the contract.
+struct segment_cover {
+    db::segment_id_type segment;
+    raft::index_t max_idx;
+    raft::term_t max_term;
+    db::rp_handle segment_holder;
+    // References of covers removed by truncate_log() (see _orphaned_holders),
+    // attached once this cover's max_idx reaches their floors. Each must
+    // enter the raft_groups memtable with the same covering mutation as
+    // segment_holder.
+    std::vector<db::rp_handle> extra_holders;
 };
 
 // This class implements the persistence for raft log using database commit log.
@@ -86,14 +105,20 @@ struct replayed_data_per_group {
 // applied index in that segment exists — otherwise a restart would recover a
 // commit index behind data already flushed to SSTables. That invariant is
 // maintained with plain dirty-count references and no flush hooks:
-//  - each batch is one commitlog entry, and its reference is held here
-//    (_batch_refs) until every command in it has been handed to a
-//    memtable;
+//  - the first time the group writes to a segment, a raft_groups-accounted
+//    reference for it is taken (commitlog::acquire_cf_count) and
+//    parked here (_pending_covers), pinning the segment from that moment;
 //  - applied command entries pin their segment through the target table's
-//    memtable (apply() mints their handles from the batch's reference),
-//    released by that memtable's flush once the data is durable.
-// A later commit adds the raft_groups-accounted cover that makes the
-// commit_idx value itself durable before a segment may go.
+//    memtable (their handles move there in apply()), released by that
+//    memtable's flush once the data is durable;
+//  - once every entry in a segment is committed, a covering
+//    system.raft_groups mutation carrying the segment's max index enters the
+//    raft_groups memtable together with the parked reference
+//    (take_committed_covers(), driven by store_commit_idx()), released by
+//    that memtable's flush once the value is durable.
+// The reference exists continuously from write to the raft_groups flush that
+// persists its covering value, so there is no window in which the target
+// table's memtable is a segment's sole owner.
 class raft_commitlog {
 private:
     const raft::group_id _group_id;
@@ -117,6 +142,30 @@ private:
     // pending command left is dropped. Eight bytes per in-flight command
     // rather than a handle each, and nothing at all for the other kinds.
     std::deque<raft::index_t> _pending_commands;
+    // The group's parked references (see pending_cover_map). Updated in place
+    // by write_batches() and seeded by the constructor (the map built while
+    // the commitlog replay rewrote the group's batches); consumed by
+    // take_committed_covers() once the whole index range is committed;
+    // covers invalidated by truncate_log() move their references to
+    // _orphaned_holders.
+    pending_cover_map _pending_covers;
+    // References of covers truncate_log() removed from _pending_covers: their
+    // max_idx referred to truncated entries, and leaving them parked would
+    // wedge take_committed_covers()'s prefix pop, but their segments may
+    // still hold this group's earlier entries and must stay pinned. Each
+    // reference carries the release floor a covering value must reach before the
+    // reference may ride it: the truncation point minus one, an upper bound on the
+    // live entries left in the orphaned segment (everything at or above the
+    // truncation point was discarded). It is unrelated to the commit index
+    // recovered at startup, which this code also calls a floor.
+    // take_committed_covers() attaches a reference to the last cover of the first
+    // pop that reaches its release floor; a pop of lower, pre-truncation
+    // covers leaves it parked.
+    struct orphaned_holder {
+        raft::index_t release_floor;
+        db::rp_handle segment_holder;
+    };
+    std::vector<orphaned_holder> _orphaned_holders;
     // (index, term) of the entries appended but not yet known to be
     // committed, in index order. note_commit_idx() consumes the prefix the
     // commit index has reached, keeping the last consumed pair in
@@ -161,13 +210,13 @@ public:
     // in the batch has been applied (see batch_ref).
     //
     // Static so the commitlog replay's rewrite path can write the same
-    // format, building the caller's cover map as it goes.
+    // format, building the map that seeds the group's _pending_covers.
     static future<db::rp_handle> write_batches(db::commitlog& cl, db::cf_id_type table_id,
             db::cf_id_type raft_groups_table_id, raft::group_id group_id,
             const raft::log_entry_ptr_list& entries, raft_term_and_index committed, pending_cover_map& covers);
 
-    // Persist the given log entries in the commit log via write_batches(),
-    // keeping the batch's reference and the
+    // Persist the given log entries in the commit log via write_batches()
+    // (which maintains _pending_covers), keeping the batch's reference and the
     // indexes of its command entries. The batch header carries the pair
     // note_commit_idx() last saw.
     future<> store_log_entries(const raft::log_entry_ptr_list& entries);
@@ -190,6 +239,20 @@ public:
     // segments holding those entries to be reclaimed.
     // Called from store_snapshot_descriptor after the snapshot is persisted.
     void truncate_log_tail(raft::index_t index);
+
+    // Pop and return covers for the segments whose entries are all committed
+    // at `commit_idx` (write_batches() keeps one cover per segment, so no
+    // coalescing happens here). Commitment — not application — is the gate:
+    // the covering value only claims that entries at or below it are
+    // committed, and a committed entry stays recoverable whether or not it
+    // has been applied, because its batch's reference is held until apply()
+    // mints from it and the target table's memtable then holds that reference
+    // until the data is durable. Contract for the caller (raft_groups_storage): for each
+    // cover, apply a system.raft_groups mutation carrying a commit index >=
+    // max_idx to the raft_groups memtable together with the pin. The
+    // mutation and its pin share a memtable generation, so the pin can only
+    // be released by the flush that makes the covering value durable.
+    std::vector<segment_cover> take_committed_covers(raft::index_t commit_idx);
 
     // Mint a memtable reference for each of the specified command entries from
     // the reference of the batch it was written in, and forget the command. Each

--- a/service/strong_consistency/raft_commitlog.hh
+++ b/service/strong_consistency/raft_commitlog.hh
@@ -10,48 +10,174 @@
 #include "raft/raft.hh"
 #include "db/commitlog/commitlog.hh"
 #include <deque>
+#include <map>
 
 namespace service::strong_consistency {
+
+// A db::rp_handle held here is one reference in a commitlog segment's use
+// count: the segment cannot be discarded or recycled while it exists. See
+// rp_handle in db/commitlog/replay_position.hh for the three ways a reference
+// is given up — in particular that rp_handle::release() keeps the segment
+// rather than releasing it.
+
 struct index_and_replay_position {
     raft::index_t index;
     db::rp_handle replay_position_handle;
 };
 
-// Raft indexes only increase, so entries are naturally sorted by index.
-// A deque allows efficient access from both ends: front removal for
-// truncate_log_tail() and back removal for truncate_log().
-using replay_position_list = std::deque<index_and_replay_position>;
+// A segment's raft_groups-accounted reference together with the highest raft
+// index the group has written to that segment so far (the pending_cover_map
+// value; the segment is the key), parked until every entry at or below that
+// index is committed. The reference is taken (commitlog::acquire_cf_count) when
+// the group first writes to the segment and pins it from that moment until
+// the map that holds it goes away. A later commit keeps the map across
+// batches and attaches the reference to a covering raft_groups mutation.
+struct pending_cover {
+    // Highest raft index the group has written to the reference's segment, and
+    // that entry's term. The pair is persisted together by the covering
+    // mutation; the term must be exact — see make_raft_schema()'s
+    // commit_idx_term comment.
+    raft::index_t max_idx;
+    raft::term_t max_term;
+    db::rp_handle segment_holder;
+};
+
+// A group's covers, keyed by commitlog segment: one reference per segment,
+// updated in place by write_batches(). Batches arrive in index order and
+// segments advance monotonically, so the key order is also the max_idx
+// order — the fully-committed covers always form a prefix and the covers a
+// truncation invalidates form a suffix, which is what lets a later commit
+// consume them from the front.
+using pending_cover_map = std::map<db::segment_id_type, pending_cover>;
+
+// One reference on the commitlog entry a batch was written as, with the batch's
+// raft index range. It is what keeps the segment alive between the write and
+// apply(): the segment's cover can be released by a raft_groups flush before
+// the applier fiber runs, and until every command in the batch has reached a
+// memtable this reference is the only thing left holding the segment.
+//
+// One reference serves the whole batch because the batch is one commitlog entry,
+// so all of its entries share a position; apply() mints a per-command handle
+// from it (commitlog::acquire_cf_count), which then carries that same
+// position into the target memtable.
+//
+// Dummy and configuration entries need no reference of their own. The segment's
+// cover has max_idx >= their index, so it is released only once a durable
+// commit index covers them, by which point replay does not need the entries.
+struct batch_ref {
+    raft::index_t first;
+    raft::index_t last;
+    db::rp_handle reference;
+};
 
 struct replayed_data_per_group {
-    replay_position_list replay_positions;
+    // The reference on the batch the commitlog replay rewrote this group's
+    // uncommitted entries as, if it rewrote any. Its range says which of
+    // `entries` are the rewritten (uncommitted) ones.
+    std::optional<batch_ref> rewritten;
     raft::log_entries entries;
 };
 
 // This class implements the persistence for raft log using database commit log.
 // It is used by tablet raft groups to persist their log entries.
+//
+// Segment lifetime. A commitlog segment holding raft entries may be reclaimed
+// only once a durable system.raft_groups commit_idx value >= the highest
+// applied index in that segment exists — otherwise a restart would recover a
+// commit index behind data already flushed to SSTables. That invariant is
+// maintained with plain dirty-count references and no flush hooks:
+//  - each batch is one commitlog entry, and its reference is held here
+//    (_batch_refs) until every command in it has been handed to a
+//    memtable;
+//  - applied command entries pin their segment through the target table's
+//    memtable (apply() mints their handles from the batch's reference),
+//    released by that memtable's flush once the data is durable.
+// A later commit adds the raft_groups-accounted cover that makes the
+// commit_idx value itself durable before a segment may go.
 class raft_commitlog {
 private:
     const raft::group_id _group_id;
     const db::cf_id_type _table_id;
+    // cf the segments' references are minted under (system.raft_groups): the
+    // covering mutation rides that table's memtable, so its flush both
+    // persists the value and releases the references it carried.
+    const db::cf_id_type _raft_groups_table_id;
     // Common commit log.
     db::commitlog& _commit_log;
-    // Replay positions in the commit log for each raft log entry.
-    // Contains entries that have been added but not yet removed by either:
-    //  - truncate_log() (leader change discarding uncommitted tail)
-    //  - truncate_log_tail() (snapshot allowing old entries to be reclaimed)
-    // After a snapshot, some entries with index below the snapshot index may
-    // still be present, in accordance with raft trailing log settings.
-    replay_position_list _replay_positions;
+    // One reference per appended batch, in index order (see batch_ref). Held
+    // until every command in the batch has been handed to a memtable by
+    // acquire_replay_position_handles_for(); a batch with no commands at all
+    // never needs one. truncate_log() drops the batches a leader change
+    // discarded and clamps a straddling one; truncate_log_tail() drops what a
+    // snapshot covered.
+    std::deque<batch_ref> _batch_refs;
+    // Indexes of the command entries appended but not yet handed to apply(),
+    // in order. Drained by acquire_replay_position_handles_for(), which mints
+    // each command's memtable reference from its batch's reference; a batch with no
+    // pending command left is dropped. Eight bytes per in-flight command
+    // rather than a handle each, and nothing at all for the other kinds.
+    std::deque<raft::index_t> _pending_commands;
+    // (index, term) of the entries appended but not yet known to be
+    // committed, in index order. note_commit_idx() consumes the prefix the
+    // commit index has reached, keeping the last consumed pair in
+    // _last_committed; truncate_log() drops the discarded tail. Small: it
+    // only ever holds the in-flight window.
+    std::deque<raft_term_and_index> _appended_terms;
+    // (index, term) of the last entry known to be committed, recorded by
+    // every batch's trailing commit_idx entry. Zero until the first commit
+    // index this instance observes; until then no record is written, which
+    // costs nothing — a replay-restored floor or an earlier run's covering
+    // mutations already cover everything committed before this instance.
+    raft_term_and_index _last_committed{};
     // The log entries that were loaded from database commit log on startup.
     raft::log_entries _replayed_entries;
 
 public:
-    raft_commitlog(raft::group_id group_id, db::commitlog& commit_log, table_id target_table_id, replayed_data_per_group replayed_data);
+    raft_commitlog(raft::group_id group_id, db::commitlog& commit_log, table_id target_table_id,
+            db::cf_id_type raft_groups_table_id, replayed_data_per_group replayed_data);
 
     ~raft_commitlog();
 
-    // Persist the given log entries in the commit log and get the replay position handles for them.
+    // Write the given entries to the commit log as ONE commitlog entry: the
+    // group id once, the entries, and `committed` — the index and term of the
+    // last entry the group had committed — as the batch header.
+    //
+    // That pair is the crash-replay floor: startup restores the highest
+    // surviving value per group into system.raft_groups, so replay applies
+    // the entries below it to memtables instead of re-adding them to the raft
+    // log. The term travels with the index because the entry at that index is
+    // normally in an earlier batch, whose segment may already be gone, so the
+    // restore cannot look it up — and the boot-time snapshot bump needs it
+    // exact (see make_raft_schema's commit_idx_term comment). A zero index
+    // means this instance has not observed a commit index yet.
+    //
+    // `covers` is the caller's cover map, updated in place: a segment new to
+    // the map gets a reference of its own (commitlog::acquire_cf_count) — one per
+    // segment per group, not one per batch — while a segment already there
+    // keeps its reference and only its (max index, term) pair advances.
+    //
+    // Returns the batch's own reference, accounted to the target table and
+    // carrying the batch's position. The caller keeps it until every command
+    // in the batch has been applied (see batch_ref).
+    //
+    // Static so the commitlog replay's rewrite path can write the same
+    // format, building the caller's cover map as it goes.
+    static future<db::rp_handle> write_batches(db::commitlog& cl, db::cf_id_type table_id,
+            db::cf_id_type raft_groups_table_id, raft::group_id group_id,
+            const raft::log_entry_ptr_list& entries, raft_term_and_index committed, pending_cover_map& covers);
+
+    // Persist the given log entries in the commit log via write_batches(),
+    // keeping the batch's reference and the
+    // indexes of its command entries. The batch header carries the pair
+    // note_commit_idx() last saw.
     future<> store_log_entries(const raft::log_entry_ptr_list& entries);
+
+    // Record that the group has committed up to `idx`. Keeps the (index,
+    // term) pair of the last committed entry, which the next batch's header
+    // persists as the crash-replay floor. The
+    // term is taken from the entry itself: raft calls this before the entry
+    // is applied, so it is still tracked here.
+    void note_commit_idx(raft::index_t idx);
 
     // Get the log items that were loaded from database commit log on startup.
     raft::log_entries load_log();
@@ -65,10 +191,17 @@ public:
     // Called from store_snapshot_descriptor after the snapshot is persisted.
     void truncate_log_tail(raft::index_t index);
 
-    // Move replay position handles out of the map for the specified indices.
-    // The handles are handed to memtables in the raft state machine apply(),
-    // and removed from the map since the memtable now owns segment lifetime.
-    // Triggers on_internal_error if an entry is missing from the map.
+    // Mint a memtable reference for each of the specified command entries from
+    // the reference of the batch it was written in, and forget the command. Each
+    // returned handle carries the batch's position, which is the position the
+    // mutation was actually written at, so the memtable's recorded replay
+    // position stays truthful. A batch with no pending command left is
+    // dropped, since the memtables now hold references of their own.
+    //
+    // This opens no window where the target memtable is the segment's sole
+    // owner: the batch's reference exists continuously from the write until the
+    // last of its commands is handed over here. Triggers on_internal_error if
+    // a requested entry has no pending command or no batch to mint from.
     std::vector<index_and_replay_position> acquire_replay_position_handles_for(const raft::log_entry_ptr_list& entries);
 };
 } // namespace service::strong_consistency

--- a/service/strong_consistency/raft_groups_storage.cc
+++ b/service/strong_consistency/raft_groups_storage.cc
@@ -70,13 +70,25 @@ future<std::pair<raft::term_t, raft::server_id>> raft_groups_storage::load_term_
     co_return std::pair(vote_term, vote);
 }
 
+// Serialize a raft::configuration for the system.raft_groups config cell,
+// using the IDL serializer the log entries' data variant already uses
+// (idl/raft_storage.idl.hh).
+static bytes serialize_config(const raft::configuration& config) {
+    bytes_ostream out;
+    ser::serialize(out, config);
+    return bytes(out.linearize());
+}
+
 // Build a static-only system.raft_groups mutation that sets commit_idx and
-// commit_idx_term for the (shard, group_id) partition. Both cells are set at
-// one timestamp, so a reader never sees a mismatched (index, term) pair.
-// Applied in-memory (see store_commit_idx) with the covered segment's
-// reference attached so it rides the raft_groups memtable flush.
+// commit_idx_term for the (shard, group_id) partition, plus the group's newest
+// committed configuration when one is being persisted. Every cell is set at
+// one timestamp, so a reader never sees a mismatched (index, term) pair, nor a
+// configuration paired with the wrong index. Applied in-memory (see
+// store_commit_idx) with the covered segment's reference attached so it rides the
+// raft_groups memtable flush.
 static mutation make_commit_idx_mutation(shard_id shard, raft::group_id group_id,
         raft::index_t commit_idx, raft::term_t commit_idx_term,
+        const std::optional<std::pair<raft::index_t, raft::configuration>>& config,
         api::timestamp_type ts) {
     auto schema = db::system_keyspace::raft_groups();
     auto pk = partition_key::from_exploded(*schema, {
@@ -86,6 +98,10 @@ static mutation make_commit_idx_mutation(shard_id shard, raft::group_id group_id
     mutation m(schema, std::move(pk));
     m.set_static_cell("commit_idx", data_value(int64_t(commit_idx.value())), ts);
     m.set_static_cell("commit_idx_term", data_value(int64_t(commit_idx_term.value())), ts);
+    if (config) {
+        m.set_static_cell("config", data_value(serialize_config(config->second)), ts);
+        m.set_static_cell("config_idx", data_value(int64_t(config->first.value())), ts);
+    }
     return m;
 }
 
@@ -103,15 +119,17 @@ future<> raft_groups_storage::store_commit_idx(raft::index_t idx) {
     // committed entry, which the next batch records as the crash-replay
     // floor.
     //
-    // The covers are consumed before the first apply_in_memory(), so a throw
-    // from one of them loses them: raft turns an
+    // The covers and the configuration are consumed before the first
+    // apply_in_memory(), so a throw from one of them loses them: raft turns an
     // exception here into a background error and stops the group (see
     // server_impl::io_fiber), it does not retry. Both losses degrade safely.
     // A lost cover means the segment can be reclaimed without a durable
     // covering value, so replay recovers a lower floor and re-commits entries
     // that were already committed — the direction store_commit_idx() is
     // allowed to fail in at all (raft treats persisting the commit index as
-    // optional), and re-applying a committed command is idempotent.
+    // optional), and re-applying a committed command is idempotent. A lost
+    // configuration is still in its commitlog entry, whose handle is only
+    // released below, past every throw site.
     _raft_commitlog.note_commit_idx(idx);
 
     auto covers = _raft_commitlog.take_committed_covers(idx);
@@ -128,8 +146,15 @@ future<> raft_groups_storage::store_commit_idx(raft::index_t idx) {
         // to the highest value. The mutation and the segment's reference enter
         // the raft_groups memtable atomically, so the reference can only be
         // released by the flush that makes the covering value durable.
+        // A configuration committed in this segment's range rides the same
+        // mutation, so it becomes durable exactly when this segment's reference is
+        // released — the entry carrying it can only be reclaimed once its
+        // configuration is safe. take_committed_config() hands it out at the
+        // first cover whose range contains it, which is that entry's own
+        // segment (SCYLLADB-3842).
+        auto config = _raft_commitlog.take_committed_config(cover.max_idx);
         auto m = make_commit_idx_mutation(_shard, _group_id, cover.max_idx, cover.max_term,
-                api::new_timestamp());
+                config, api::new_timestamp());
         co_await db.apply_in_memory(m, cf, std::move(cover.segment_holder), db::no_timeout);
         // References of covers a leader-change truncation invalidated (see
         // raft_commitlog::truncate_log()); each rides this same mutation, so
@@ -309,6 +334,27 @@ future<> raft_groups_storage::update_snapshot(const raft::snapshot_descriptor &s
     ).discard_result();
 }
 
+future<std::optional<std::pair<raft::index_t, raft::configuration>>>
+raft_groups_storage::load_committed_config(cql3::query_processor& qp, raft::group_id gid, shard_id shard) {
+    static const auto load_cql = format("SELECT config, config_idx FROM system.{} WHERE shard = ? AND group_id = ? LIMIT 1",
+        db::system_keyspace::RAFT_GROUPS);
+    auto rs = co_await qp.execute_internal(load_cql, {int16_t(shard), gid.id}, cql3::query_processor::cache_internal::yes);
+    if (rs->empty()) {
+        co_return std::nullopt;
+    }
+    const auto& row = rs->one();
+    if (!row.has("config") || !row.has("config_idx")) {
+        // No configuration has been covered yet, or the row predates the
+        // columns.
+        co_return std::nullopt;
+    }
+    const auto blob = row.get_blob_unfragmented("config");
+    auto in = ser::as_input_stream(blob);
+    co_return std::pair(
+            raft::index_t(static_cast<uint64_t>(row.get_as<int64_t>("config_idx"))),
+            ser::deserialize(in, std::type_identity<raft::configuration>()));
+}
+
 future<std::pair<raft::index_t, raft::term_t>>
 raft_groups_storage::load_snapshot_idx_and_term(cql3::query_processor& qp, raft::group_id gid, shard_id shard) {
     static const auto load_cql = format("SELECT idx, term FROM system.{} WHERE shard = ? AND group_id = ?",
@@ -321,6 +367,61 @@ raft_groups_storage::load_snapshot_idx_and_term(cql3::query_processor& qp, raft:
     co_return std::pair(
             raft::index_t(row.get_or<int64_t>("idx", 0)),
             raft::term_t(row.get_or<int64_t>("term", 0)));
+}
+
+future<> raft_groups_storage::store_committed_config_if_higher(cql3::query_processor& qp, raft::group_id gid,
+        shard_id shard, const raft::configuration& config, raft::index_t config_idx) {
+    // Only advance: a configuration recovered from the replayed entries can be
+    // older than the one the covering mutations already made durable (the
+    // replayed log may end in a discarded tail, or the newer configuration's
+    // own entry may already be gone).
+    if (const auto persisted = co_await load_committed_config(qp, gid, shard);
+            persisted && config_idx <= persisted->first) {
+        co_return;
+    }
+    // A real CQL write, unlike the covering mutations: this runs during
+    // replay, before any group is started, so it must reach the new commitlog
+    // to survive a crash before the raft_groups memtable flushes.
+    static const auto store_cql = format("INSERT INTO system.{} (shard, group_id, config, config_idx) VALUES (?, ?, ?, ?)",
+        db::system_keyspace::RAFT_GROUPS);
+    co_await qp.execute_internal(store_cql,
+            {int16_t(shard), gid.id, data_value(serialize_config(config)), int64_t(config_idx.value())},
+            cql3::query_processor::cache_internal::yes);
+    rgslog.info("group {}: recovered the configuration committed at index {} from the commitlog", gid, config_idx);
+}
+
+future<> raft_groups_storage::store_snapshot_config_if_newer(cql3::query_processor& qp, raft::group_id gid,
+        shard_id shard, const raft::configuration& config, raft::index_t config_idx) {
+    // The persisted snapshot's configuration is the one in effect at its index,
+    // so it already accounts for every configuration entry at or below it.
+    static const auto load_snp_idx_cql = format("SELECT idx FROM system.{} WHERE shard = ? AND group_id = ?",
+        db::system_keyspace::RAFT_GROUPS_SNAPSHOTS);
+    auto rs = co_await qp.execute_internal(load_snp_idx_cql, {int16_t(shard), gid.id}, cql3::query_processor::cache_internal::yes);
+    if (!rs->empty() && rs->one().has("idx")) {
+        const auto snap_idx = raft::index_t(static_cast<uint64_t>(rs->one().get_as<int64_t>("idx")));
+        if (config_idx <= snap_idx) {
+            co_return;
+        }
+    }
+    // Replace the stored configuration wholesale: it is a set of members, not
+    // a delta. A crash in the middle only means replay runs again and rewrites
+    // the same rows from the same commitlog entry.
+    static const auto delete_cfg_cql = format("DELETE FROM system.{} WHERE shard = ? AND group_id = ?",
+        db::system_keyspace::RAFT_GROUPS_SNAPSHOT_CONFIG);
+    co_await qp.execute_internal(delete_cfg_cql, {int16_t(shard), gid.id}, cql3::query_processor::cache_internal::yes);
+    static const auto store_cfg_cql = format("INSERT INTO system.{} (shard, group_id, disposition, server_id, can_vote) VALUES (?, ?, ?, ?, ?)",
+        db::system_keyspace::RAFT_GROUPS_SNAPSHOT_CONFIG);
+    for (const raft::config_member& srv : config.current) {
+        co_await qp.execute_internal(store_cfg_cql,
+                {int16_t(shard), gid.id, "CURRENT", srv.addr.id.id, srv.can_vote},
+                cql3::query_processor::cache_internal::yes);
+    }
+    for (const raft::config_member& srv : config.previous) {
+        co_await qp.execute_internal(store_cfg_cql,
+                {int16_t(shard), gid.id, "PREVIOUS", srv.addr.id.id, srv.can_vote},
+                cql3::query_processor::cache_internal::yes);
+    }
+    rgslog.info("group {}: restored the snapshot configuration from the one committed at index {}", gid, config_idx);
 }
 
 future<> raft_groups_storage::store_snapshot_index(cql3::query_processor& qp, raft::group_id gid, shard_id shard, const raft::snapshot_descriptor& snap) {

--- a/service/strong_consistency/raft_groups_storage.cc
+++ b/service/strong_consistency/raft_groups_storage.cc
@@ -19,6 +19,11 @@
 #include "idl/raft_storage.dist.impl.hh"
 
 #include "cql3/query_processor.hh"
+#include "mutation/mutation.hh"
+#include "mutation/timestamp.hh"
+#include "replica/database.hh"
+#include "service/storage_proxy.hh"
+#include "types/types.hh"
 
 #include <seastar/core/coroutine.hh>
 
@@ -82,8 +87,48 @@ future<> raft_groups_storage::store_commit_idx(raft::index_t idx) {
     });
 }
 
+// Execute the CQL INSERT that persists (commit_idx, commit_idx_term) to
+// system.raft_groups. Used during commitlog replay
+// (store_commit_idx_if_higher), before any raft group is running.
+static future<> store_commit_idx_cql(cql3::query_processor& qp, raft::group_id gid, shard_id shard,
+        raft::index_t commit_idx, raft::term_t commit_idx_term) {
+    static const auto store_cql = format("INSERT INTO system.{} (shard, group_id, commit_idx, commit_idx_term) VALUES (?, ?, ?, ?)",
+        db::system_keyspace::RAFT_GROUPS);
+    return qp.execute_internal(
+        store_cql,
+        {int16_t(shard), gid.id, int64_t(commit_idx.value()), int64_t(commit_idx_term.value())},
+        cql3::query_processor::cache_internal::yes).discard_result();
+}
+
+future<> raft_groups_storage::store_commit_idx_if_higher(cql3::query_processor& qp, raft::group_id gid, shard_id shard,
+        raft::index_t commit_idx, raft::term_t commit_idx_term) {
+    // Only advance, never regress: a prior run (or an earlier replay) may
+    // already have persisted a value at or beyond the recovered one.
+    const auto persisted = co_await load_commit_idx(qp, gid, shard);
+    if (commit_idx <= persisted) {
+        co_return;
+    }
+    co_await store_commit_idx_cql(qp, gid, shard, commit_idx, commit_idx_term);
+}
+
 future<raft::index_t> raft_groups_storage::load_commit_idx() {
     return load_commit_idx(_qp, _group_id, _shard);
+}
+
+future<std::pair<raft::index_t, std::optional<raft::term_t>>>
+raft_groups_storage::load_commit_idx_and_term(cql3::query_processor& qp, raft::group_id gid, shard_id shard) {
+    static const auto load_cql = format("SELECT commit_idx, commit_idx_term FROM system.{} WHERE shard = ? AND group_id = ? LIMIT 1",
+        db::system_keyspace::RAFT_GROUPS);
+    auto rs = co_await qp.execute_internal(load_cql, {int16_t(shard), gid.id}, cql3::query_processor::cache_internal::yes);
+    if (rs->empty()) {
+        co_return std::pair(raft::index_t(0), std::nullopt);
+    }
+    const auto& row = rs->one();
+    std::optional<raft::term_t> term;
+    if (row.has("commit_idx_term")) {
+        term = raft::term_t(row.get_as<int64_t>("commit_idx_term"));
+    }
+    co_return std::pair(raft::index_t(row.get_or<int64_t>("commit_idx", 0)), term);
 }
 
 future<raft::index_t> raft_groups_storage::load_commit_idx(cql3::query_processor& qp, raft::group_id gid, shard_id shard) {
@@ -187,8 +232,10 @@ future<> raft_groups_storage::truncate_log(raft::index_t idx) {
 }
 
 future<> raft_groups_storage::abort() {
-    // wait for pending write requests to complete.
-    // TODO: should we wait for all kinds of requests?
+    // Wait for pending write requests to complete. The covering work in
+    // store_commit_idx() needs no guarding here: it runs on the raft
+    // io_fiber, which raft::server::abort() awaits before aborting the
+    // persistence.
     return std::move(_pending_op_fut);
 }
 
@@ -201,6 +248,20 @@ future<> raft_groups_storage::update_snapshot(const raft::snapshot_descriptor &s
         {int16_t(_shard), _group_id.id, snap.id.id},
         cql3::query_processor::cache_internal::yes
     ).discard_result();
+}
+
+future<std::pair<raft::index_t, raft::term_t>>
+raft_groups_storage::load_snapshot_idx_and_term(cql3::query_processor& qp, raft::group_id gid, shard_id shard) {
+    static const auto load_cql = format("SELECT idx, term FROM system.{} WHERE shard = ? AND group_id = ?",
+        db::system_keyspace::RAFT_GROUPS_SNAPSHOTS);
+    auto rs = co_await qp.execute_internal(load_cql, {int16_t(shard), gid.id}, cql3::query_processor::cache_internal::yes);
+    if (rs->empty()) {
+        co_return std::pair(raft::index_t(0), raft::term_t(0));
+    }
+    const auto& row = rs->one();
+    co_return std::pair(
+            raft::index_t(row.get_or<int64_t>("idx", 0)),
+            raft::term_t(row.get_or<int64_t>("term", 0)));
 }
 
 future<> raft_groups_storage::store_snapshot_index(cql3::query_processor& qp, raft::group_id gid, shard_id shard, const raft::snapshot_descriptor& snap) {

--- a/service/strong_consistency/raft_groups_storage.cc
+++ b/service/strong_consistency/raft_groups_storage.cc
@@ -70,26 +70,85 @@ future<std::pair<raft::term_t, raft::server_id>> raft_groups_storage::load_term_
     co_return std::pair(vote_term, vote);
 }
 
+// Build a static-only system.raft_groups mutation that sets commit_idx and
+// commit_idx_term for the (shard, group_id) partition. Both cells are set at
+// one timestamp, so a reader never sees a mismatched (index, term) pair.
+// Applied in-memory (see store_commit_idx) with the covered segment's
+// reference attached so it rides the raft_groups memtable flush.
+static mutation make_commit_idx_mutation(shard_id shard, raft::group_id group_id,
+        raft::index_t commit_idx, raft::term_t commit_idx_term,
+        api::timestamp_type ts) {
+    auto schema = db::system_keyspace::raft_groups();
+    auto pk = partition_key::from_exploded(*schema, {
+        short_type->decompose(int16_t(shard)),
+        timeuuid_type->decompose(group_id.id),
+    });
+    mutation m(schema, std::move(pk));
+    m.set_static_cell("commit_idx", data_value(int64_t(commit_idx.value())), ts);
+    m.set_static_cell("commit_idx_term", data_value(int64_t(commit_idx_term.value())), ts);
+    return m;
+}
+
 future<> raft_groups_storage::store_commit_idx(raft::index_t idx) {
-    // Keep the (index, term) pair of the last committed entry, which the next
-    // batch records in the commitlog as the crash-replay floor. Raft calls
-    // this before the entries are applied, so the entry at idx is still
-    // tracked and its term is exact.
+    // IO-free: no per-committed-batch CQL write on the raft io_fiber. The
+    // value reaches system.raft_groups through the covering mutations below
+    // (durable once the raft_groups memtable flushes) and, after a crash,
+    // through the commit_idx records the replayed raft entries carry.
+    //
+    // The io_fiber calls this *before* pushing entries to the applier_fiber,
+    // so the commit index seen here is always >= the raft index of any entry
+    // that has been applied to a memtable — and the covers attached below
+    // reach the raft_groups memtable before their entries can be applied.
+    // note_commit_idx() also keeps the (index, term) pair of the last
+    // committed entry, which the next batch records as the crash-replay
+    // floor.
+    //
+    // The covers are consumed before the first apply_in_memory(), so a throw
+    // from one of them loses them: raft turns an
+    // exception here into a background error and stops the group (see
+    // server_impl::io_fiber), it does not retry. Both losses degrade safely.
+    // A lost cover means the segment can be reclaimed without a durable
+    // covering value, so replay recovers a lower floor and re-commits entries
+    // that were already committed — the direction store_commit_idx() is
+    // allowed to fail in at all (raft treats persisting the commit index as
+    // optional), and re-applying a committed command is idempotent.
     _raft_commitlog.note_commit_idx(idx);
 
-    return execute_with_linearization_point([this, idx] {
-        static const auto store_cql = format("INSERT INTO system.{} (shard, group_id, commit_idx) VALUES (?, ?, ?)",
-            db::system_keyspace::RAFT_GROUPS);
-        return _qp.execute_internal(
-            store_cql,
-            {int16_t(_shard), _group_id.id, int64_t(idx.value())},
-            cql3::query_processor::cache_internal::yes).discard_result();
-    });
+    auto covers = _raft_commitlog.take_committed_covers(idx);
+    if (covers.empty()) {
+        co_return;
+    }
+    auto& db = _qp.proxy().local_db();
+    auto& cf = db.find_column_family(db::system_keyspace::raft_groups()->id());
+    for (auto& cover : covers) {
+        // One covering mutation per fully-committed segment, carrying the
+        // highest index the group appended to it. All covers write the same
+        // static cell; values only grow and this fiber is the sole runtime
+        // writer, so per-mutation api::new_timestamp() resolves last-write-wins
+        // to the highest value. The mutation and the segment's reference enter
+        // the raft_groups memtable atomically, so the reference can only be
+        // released by the flush that makes the covering value durable.
+        auto m = make_commit_idx_mutation(_shard, _group_id, cover.max_idx, cover.max_term,
+                api::new_timestamp());
+        co_await db.apply_in_memory(m, cf, std::move(cover.segment_holder), db::no_timeout);
+        // References of covers a leader-change truncation invalidated (see
+        // raft_commitlog::truncate_log()); each rides this same mutation, so
+        // whichever memtable generation holds the reference also holds a
+        // covering value for its segment.
+        for (auto& holder : cover.extra_holders) {
+            co_await db.apply_in_memory(m, cf, std::move(holder), db::no_timeout);
+        }
+    }
+    // Nothing else to release: dummy and configuration entries never took a
+    // reference of their own (see batch_ref), and a command's reference is the
+    // target memtable's business once apply() minted it.
 }
 
 // Execute the CQL INSERT that persists (commit_idx, commit_idx_term) to
-// system.raft_groups. Used during commitlog replay
-// (store_commit_idx_if_higher), before any raft group is running.
+// system.raft_groups. Only used during commitlog replay
+// (store_commit_idx_if_higher), before any raft group is running; at runtime
+// the pair is written exclusively by store_commit_idx()'s in-memory covering
+// mutations.
 static future<> store_commit_idx_cql(cql3::query_processor& qp, raft::group_id gid, shard_id shard,
         raft::index_t commit_idx, raft::term_t commit_idx_term) {
     static const auto store_cql = format("INSERT INTO system.{} (shard, group_id, commit_idx, commit_idx_term) VALUES (?, ?, ?, ?)",

--- a/service/strong_consistency/raft_groups_storage.cc
+++ b/service/strong_consistency/raft_groups_storage.cc
@@ -28,7 +28,8 @@ logging::logger rgslog("raft_groups_storage");
 
 raft_groups_storage::raft_groups_storage(cql3::query_processor& qp, raft::group_id gid, raft::server_id server_id, shard_id shard, db::commitlog& commit_log,
         table_id target_table_id, replayed_data_per_group replayed_data)
-    : _raft_commitlog(gid, commit_log, target_table_id, std::move(replayed_data))
+    : _raft_commitlog(gid, commit_log, target_table_id,
+            db::system_keyspace::raft_groups()->id(), std::move(replayed_data))
     , _group_id(std::move(gid))
     , _server_id(std::move(server_id))
     , _qp(qp)
@@ -65,6 +66,12 @@ future<std::pair<raft::term_t, raft::server_id>> raft_groups_storage::load_term_
 }
 
 future<> raft_groups_storage::store_commit_idx(raft::index_t idx) {
+    // Keep the (index, term) pair of the last committed entry, which the next
+    // batch records in the commitlog as the crash-replay floor. Raft calls
+    // this before the entries are applied, so the entry at idx is still
+    // tracked and its term is exact.
+    _raft_commitlog.note_commit_idx(idx);
+
     return execute_with_linearization_point([this, idx] {
         static const auto store_cql = format("INSERT INTO system.{} (shard, group_id, commit_idx) VALUES (?, ?, ?)",
             db::system_keyspace::RAFT_GROUPS);

--- a/service/strong_consistency/raft_groups_storage.hh
+++ b/service/strong_consistency/raft_groups_storage.hh
@@ -92,6 +92,32 @@ public:
     // disengaged for rows written before the commit_idx_term column existed.
     static future<std::pair<raft::index_t, std::optional<raft::term_t>>> load_commit_idx_and_term(
             cql3::query_processor& qp, raft::group_id gid, shard_id shard);
+    // Persist (config, config_idx) in system.raft_groups, but only if
+    // config_idx advances the persisted one. Used during commitlog replay to
+    // fold a configuration recovered from the replayed entries into the same
+    // cells the covering mutations write, so that the boot-time snapshot
+    // restore has a single source to read and the two cannot disagree.
+    static future<> store_committed_config_if_higher(cql3::query_processor& qp, raft::group_id gid, shard_id shard,
+            const raft::configuration& config, raft::index_t config_idx);
+    // Persist `config` as the group's snapshot configuration, but only if it is
+    // newer than what the persisted snapshot already reflects (config_idx must
+    // exceed the persisted snapshot index). Used during commitlog replay to
+    // recover a configuration that was committed but never snapshotted:
+    // replay drops committed non-command entries, and without this the group
+    // would come back with the configuration of its last snapshot — the
+    // bootstrap one for a group that never snapshotted (SCYLLADB-3842).
+    //
+    // Must have a single caller per startup: the guard compares against the
+    // snapshot index, so two callers holding configurations from different
+    // sources would both pass it and the last one would win regardless of age.
+    static future<> store_snapshot_config_if_newer(cql3::query_processor& qp, raft::group_id gid, shard_id shard,
+            const raft::configuration& config, raft::index_t config_idx);
+    // Load the newest committed configuration persisted by the covering
+    // mutations, with the index of the entry that carried it. Disengaged when
+    // no configuration has been covered yet (or the row predates the columns),
+    // in which case the snapshot's configuration is all there is.
+    static future<std::optional<std::pair<raft::index_t, raft::configuration>>> load_committed_config(
+            cql3::query_processor& qp, raft::group_id gid, shard_id shard);
     // Load the current persisted snapshot's (idx, term) for this group.
     // Returns (0, 0) if no snapshot has been recorded yet.
     static future<std::pair<raft::index_t, raft::term_t>> load_snapshot_idx_and_term(

--- a/service/strong_consistency/raft_groups_storage.hh
+++ b/service/strong_consistency/raft_groups_storage.hh
@@ -55,6 +55,14 @@ public:
 
     future<> store_term_and_vote(raft::term_t term, raft::server_id vote) override;
     future<std::pair<raft::term_t, raft::server_id>> load_term_and_vote() override;
+    // Records the new commit index and, purely in memory, covers every
+    // commitlog segment whose entries are now all committed: one
+    // system.raft_groups mutation carrying the segment's highest index is
+    // applied to the raft_groups memtable with the segment's parked reference
+    // attached, and dummy handles the covers made redundant are released.
+    // The value becomes durable when the raft_groups memtable flushes, which
+    // is also when the references are released. See raft_commitlog's class
+    // comment for the segment-lifetime invariant this maintains.
     future<> store_commit_idx(raft::index_t) override;
     future<raft::index_t> load_commit_idx() override;
     future<raft::log_entries> load_log() override;
@@ -75,6 +83,19 @@ public:
     // Static version that doesn't require constructing a full raft_groups_storage object.
     // Useful during commitlog replay when only read access to metadata is needed.
     static future<raft::index_t> load_commit_idx(cql3::query_processor& qp, raft::group_id gid, shard_id shard);
+    // Persist (commit_idx, commit_idx_term), but only if commit_idx advances
+    // the currently persisted value. Used during commitlog replay to restore
+    // the floor the replayed entries' commit_idx records carry.
+    static future<> store_commit_idx_if_higher(cql3::query_processor& qp, raft::group_id gid, shard_id shard,
+            raft::index_t commit_idx, raft::term_t commit_idx_term);
+    // Load the persisted (commit_idx, commit_idx_term) pair. The term is
+    // disengaged for rows written before the commit_idx_term column existed.
+    static future<std::pair<raft::index_t, std::optional<raft::term_t>>> load_commit_idx_and_term(
+            cql3::query_processor& qp, raft::group_id gid, shard_id shard);
+    // Load the current persisted snapshot's (idx, term) for this group.
+    // Returns (0, 0) if no snapshot has been recorded yet.
+    static future<std::pair<raft::index_t, raft::term_t>> load_snapshot_idx_and_term(
+            cql3::query_processor& qp, raft::group_id gid, shard_id shard);
     // Store snapshot idx and term without updating the configuration.
     // Used to advance the persisted snapshot index so that raft does not
     // re-apply already applied entries on restart. Only writes if the new

--- a/test/boost/commitlog_raft_replay_test.cc
+++ b/test/boost/commitlog_raft_replay_test.cc
@@ -50,6 +50,12 @@ raft::log_entry_ptr make_command_entry(raft::term_t term, raft::index_t idx) {
     return make_lw_shared<raft::log_entry>(raft::log_entry{.term = term, .idx = idx, .data = std::move(cmd)});
 }
 
+raft::log_entry_ptr make_command_entry_sized(raft::term_t term, raft::index_t idx, size_t payload_size) {
+    raft::command cmd;
+    ser::serialize(cmd, bytes(payload_size, 'x'));
+    return make_lw_shared<raft::log_entry>(raft::log_entry{.term = term, .idx = idx, .data = std::move(cmd)});
+}
+
 raft::log_entry_ptr make_config_entry(raft::term_t term, raft::index_t idx) {
     return make_lw_shared<raft::log_entry>(raft::log_entry{.term = term,
             .idx = idx,
@@ -1907,6 +1913,14 @@ SEASTAR_TEST_CASE(test_raft_commitlog_store_log_entries_records_commit_idx) {
         // The second carries the floor the first batch's entries established.
         BOOST_REQUIRE_EQUAL(batches[1].commit_idx, raft::index_t(2));
         BOOST_REQUIRE_EQUAL(batches[1].commit_idx_term, raft::term_t(1));
+
+        // Both batches landed in the same segment, covered by its single reference,
+        // which sits at the position of the batch that created it.
+        auto covers = persistence.take_committed_covers(raft::index_t(4));
+        BOOST_REQUIRE_EQUAL(covers.size(), 1);
+        BOOST_REQUIRE_EQUAL(covers[0].max_idx, raft::index_t(4));
+        BOOST_REQUIRE(bool(covers[0].segment_holder));
+        BOOST_REQUIRE_GT(covers[0].segment_holder.rp().pos, 0u);
     });
 }
 
@@ -1959,6 +1973,370 @@ SEASTAR_TEST_CASE(test_raft_commitlog_acquire_skips_non_command_entries) {
         // those above (11, 12) remain. Must not crash and the class'
         // destructor must succeed.
         persistence.truncate_log_tail(raft::index_t(10));
+    });
+}
+
+// Test: take_committed_covers() returns one cover per commitlog segment
+// whose entries are all committed — carrying the segment's highest index and
+// the reference taken for that segment as the pin. Covering the batch releases
+// nothing else: dummy and configuration entries never took a reference of their
+// own, and the batch's reference stays until apply() has minted from it for every
+// command it holds.
+//
+// Note this exercises the code paths but cannot *observe* segment retention:
+// commitlog::get_num_dirty_segments() only counts segments that have stopped
+// allocating, and this test writes a single still-allocating segment, so it
+// reads 0 whether or not a reference is held. End-to-end coverage comes from
+// test/cluster/test_strong_consistency_commitlog.py.
+SEASTAR_TEST_CASE(test_raft_commitlog_take_committed_covers_and_release) {
+    return cl_test([](commitlog& log) -> future<> {
+        auto gid = make_group_id();
+        auto tid = make_table_id();
+
+        service::strong_consistency::replayed_data_per_group replayed_data;
+        service::strong_consistency::raft_commitlog persistence(gid, log, tid, make_table_id(), std::move(replayed_data));
+
+        raft::log_entry_ptr_list entries;
+        entries.push_back(make_command_entry(raft::term_t(1), raft::index_t(1)));
+        entries.push_back(make_config_entry (raft::term_t(1), raft::index_t(2)));
+        entries.push_back(make_dummy_entry  (raft::term_t(1), raft::index_t(3)));
+        entries.push_back(make_command_entry(raft::term_t(1), raft::index_t(4)));
+        entries.push_back(make_dummy_entry  (raft::term_t(1), raft::index_t(5)));
+
+        co_await persistence.store_log_entries(entries);
+
+        // Grab a command handle to learn the batch's segment (this also
+        // mirrors the real flow: apply() acquires before coverage runs).
+        auto cmd_handles = persistence.acquire_replay_position_handles_for({entries[0]});
+        const auto batch_segment = cmd_handles[0].replay_position_handle.rp().id;
+
+        // The batch's highest index is 5, so at commit_idx=3 it is not yet
+        // fully committed and nothing is covered — the segment's hold stays
+        // parked.
+        auto covers = persistence.take_committed_covers(raft::index_t(3));
+        BOOST_REQUIRE(covers.empty());
+
+        // At commit_idx=5 the batch is fully committed: one cover, max_idx=5,
+        // pinned by the reference taken for the batch's segment (offset 0 —
+        // dirty-count accounting is per segment).
+        covers = persistence.take_committed_covers(raft::index_t(5));
+        BOOST_REQUIRE_EQUAL(covers.size(), 1);
+        BOOST_REQUIRE_EQUAL(covers[0].max_idx, raft::index_t(5));
+        BOOST_REQUIRE_EQUAL(covers[0].max_term, raft::term_t(1));
+        BOOST_REQUIRE(bool(covers[0].segment_holder));
+        BOOST_REQUIRE_EQUAL(covers[0].segment, batch_segment);
+        BOOST_REQUIRE_EQUAL(covers[0].segment_holder.rp().id, batch_segment);
+        BOOST_REQUIRE_GT(covers[0].segment_holder.rp().pos, 0u);
+
+        // Popped: asking again returns nothing.
+        BOOST_REQUIRE(persistence.take_committed_covers(raft::index_t(5)).empty());
+
+        // A later batch lands in the same (still active) segment. Its cover
+        // was taken, so the segment is no longer in the map and the batch
+        // mints a fresh reference for it — a second, independent reference on the
+        // same segment.
+        raft::log_entry_ptr_list more;
+        more.push_back(make_command_entry(raft::term_t(1), raft::index_t(6)));
+        co_await persistence.store_log_entries(more);
+        auto covers2 = persistence.take_committed_covers(raft::index_t(6));
+        BOOST_REQUIRE_EQUAL(covers2.size(), 1);
+        BOOST_REQUIRE_EQUAL(covers2[0].segment, covers[0].segment);
+        BOOST_REQUIRE_EQUAL(covers2[0].max_idx, raft::index_t(6));
+        BOOST_REQUIRE(bool(covers2[0].segment_holder));
+        BOOST_REQUIRE_EQUAL(covers2[0].segment_holder.rp().id, covers[0].segment);
+
+        // Dummies and configurations took no reference of their own, so covering
+        // the batch released nothing for them; command@4 must still be
+        // acquirable, minted from its batch's reference.
+        auto cmd4 = persistence.acquire_replay_position_handles_for({entries[3]});
+        BOOST_REQUIRE_EQUAL(cmd4.size(), 1);
+        BOOST_REQUIRE_EQUAL(cmd4[0].index, raft::index_t(4));
+        BOOST_REQUIRE(bool(cmd4[0].replay_position_handle));
+        BOOST_REQUIRE_EQUAL(cmd4[0].replay_position_handle.rp().id, batch_segment);
+
+        // truncate_log_tail() drops whatever a snapshot covered. It must
+        // accept the whole range without error, and the destructor below must
+        // then find nothing left to release.
+        persistence.truncate_log_tail(raft::index_t(6));
+    });
+}
+
+// Test: a batch landing in an already-parked segment extends that segment's
+// cover in place (the segment's existing reference is retained, no second reference
+// is created), so covering the segment yields exactly one cover
+// carrying the later batch's max index.
+SEASTAR_TEST_CASE(test_raft_commitlog_covers_coalesce_per_segment) {
+    return cl_test([](commitlog& log) -> future<> {
+        auto gid = make_group_id();
+        auto tid = make_table_id();
+
+        service::strong_consistency::replayed_data_per_group replayed_data;
+        service::strong_consistency::raft_commitlog persistence(gid, log, tid, make_table_id(), std::move(replayed_data));
+
+        raft::log_entry_ptr_list batch1 = {make_command_entry(raft::term_t(1), raft::index_t(1))};
+        raft::log_entry_ptr_list batch2 = {make_command_entry(raft::term_t(1), raft::index_t(2))};
+        co_await persistence.store_log_entries(batch1);
+        co_await persistence.store_log_entries(batch2);
+
+        // Both batches went to the same (still allocating) segment, so
+        // write_batches() extended the parked cover; at commit_idx=2 there is
+        // one cover with the later batch's max index, pinned by the first
+        // batch's own reference (retained because it has existed
+        // continuously).
+        auto covers = persistence.take_committed_covers(raft::index_t(2));
+        BOOST_REQUIRE_EQUAL(covers.size(), 1);
+        BOOST_REQUIRE_EQUAL(covers[0].max_idx, raft::index_t(2));
+        BOOST_REQUIRE(bool(covers[0].segment_holder));
+    });
+}
+
+// Test: truncate_log() removes covers whose max index was truncated —
+// leaving them parked would wedge take_committed_covers()'s prefix pop for
+// the covers of the reused indexes — and their references ride the first cover
+// popped afterwards that reaches their floor (the truncation point minus
+// one), so the truncated batches' segments stay pinned until a covering
+// value at or above every entry they may still hold is on its way to
+// durability.
+SEASTAR_TEST_CASE(test_raft_commitlog_truncated_covers_ride_next_cover) {
+    return cl_test([](commitlog& log) -> future<> {
+        auto gid = make_group_id();
+        auto tid = make_table_id();
+
+        service::strong_consistency::replayed_data_per_group replayed_data;
+        service::strong_consistency::raft_commitlog persistence(gid, log, tid, make_table_id(), std::move(replayed_data));
+
+        // A batch at term 1 whose tail gets truncated by a leader change.
+        raft::log_entry_ptr_list batch1;
+        for (int i = 1; i <= 3; ++i) {
+            batch1.push_back(make_command_entry(raft::term_t(1), raft::index_t(i)));
+        }
+        co_await persistence.store_log_entries(batch1);
+        persistence.truncate_log(raft::index_t(2));
+
+        // The new leader reuses idx 2 at term 2. Without the truncation
+        // handling, the parked cover (max_idx=3) would sit ahead of this
+        // batch's cover (max_idx=2) and block it at commit_idx=2.
+        raft::log_entry_ptr_list batch2;
+        batch2.push_back(make_command_entry(raft::term_t(2), raft::index_t(2)));
+        co_await persistence.store_log_entries(batch2);
+
+        auto covers = persistence.take_committed_covers(raft::index_t(2));
+        BOOST_REQUIRE_EQUAL(covers.size(), 1);
+        BOOST_REQUIRE_EQUAL(covers[0].max_idx, raft::index_t(2));
+        BOOST_REQUIRE_EQUAL(covers[0].max_term, raft::term_t(2));
+        BOOST_REQUIRE(bool(covers[0].segment_holder));
+        // The truncated batch's segment reference rides this cover.
+        BOOST_REQUIRE_EQUAL(covers[0].extra_holders.size(), 1);
+        BOOST_REQUIRE(bool(covers[0].extra_holders[0]));
+        BOOST_REQUIRE(persistence.take_committed_covers(raft::index_t(3)).empty());
+    });
+}
+
+// Test: an orphaned reference must NOT ride a pop of surviving pre-truncation
+// covers whose value is below its floor. Two segments: seg1's cover survives
+// a truncation that orphans seg2's, and committing only seg1's range must
+// pop seg1's cover with no extra pins — seg2 may still hold live entries
+// between seg1's max and the truncation point, so releasing its reference at
+// seg1's value would break the coverage invariant. The reference rides the next
+// cover that reaches the floor.
+SEASTAR_TEST_CASE(test_raft_commitlog_orphaned_pins_wait_for_their_floor) {
+    commitlog::config cfg;
+    cfg.commitlog_segment_size_in_mb = 1;
+    return cl_test(std::move(cfg), [](commitlog& log) -> future<> {
+        auto gid = make_group_id();
+        auto tid = make_table_id();
+
+        service::strong_consistency::replayed_data_per_group replayed_data;
+        service::strong_consistency::raft_commitlog persistence(gid, log, tid, make_table_id(), std::move(replayed_data));
+
+        // Three ~490KB batches (below the 512KB oversized threshold, so each
+        // is placed atomically): the first two fill seg1, the third rolls
+        // over to seg2. Covers: seg1 {max 14}, seg2 {max 21}.
+        for (int b = 0; b < 3; ++b) {
+            raft::log_entry_ptr_list batch;
+            for (int i = 1; i <= 7; ++i) {
+                batch.push_back(make_command_entry_sized(raft::term_t(1), raft::index_t(b * 7 + i), 70 * 1024));
+            }
+            co_await persistence.store_log_entries(batch);
+        }
+
+        // Leader change truncates from idx 18: seg2's cover (max 21 >= 18) is
+        // orphaned with floor 17; seg1's cover (max 14) survives. The new
+        // leader reuses idx 18.
+        persistence.truncate_log(raft::index_t(18));
+        raft::log_entry_ptr_list batch4;
+        batch4.push_back(make_command_entry(raft::term_t(2), raft::index_t(18)));
+        batch4.push_back(make_command_entry(raft::term_t(2), raft::index_t(19)));
+        co_await persistence.store_log_entries(batch4);
+
+        // Committing through 14 pops seg1's surviving cover only; the
+        // orphaned reference (floor 17) must stay parked.
+        auto covers = persistence.take_committed_covers(raft::index_t(14));
+        BOOST_REQUIRE_EQUAL(covers.size(), 1);
+        BOOST_REQUIRE_EQUAL(covers[0].max_idx, raft::index_t(14));
+        BOOST_REQUIRE(covers[0].extra_holders.empty());
+
+        // Committing the new leader's entries pops their cover (max 19 >=
+        // floor 17) and the orphaned reference rides it.
+        covers = persistence.take_committed_covers(raft::index_t(19));
+        BOOST_REQUIRE_EQUAL(covers.size(), 1);
+        BOOST_REQUIRE_EQUAL(covers[0].max_idx, raft::index_t(19));
+        BOOST_REQUIRE_EQUAL(covers[0].max_term, raft::term_t(2));
+        BOOST_REQUIRE_EQUAL(covers[0].extra_holders.size(), 1);
+        BOOST_REQUIRE(bool(covers[0].extra_holders[0]));
+        BOOST_REQUIRE(persistence.take_committed_covers(raft::index_t(21)).empty());
+    });
+}
+
+// Test: covers accumulate one per segment as the active segment rolls over,
+// and each batch touches exactly one — its own position — however many
+// segments its bytes span. The map key order is the max-index order that
+// take_committed_covers()'s prefix pop relies on. A segment that already has a
+// cover never gets a second reference; its cover is extended in place. Uses a tiny
+// segment size so a moderate batch fills segments quickly, and enables
+// fragmented entries as production does (the fragmented_commitlog_entries
+// cluster feature).
+SEASTAR_TEST_CASE(test_raft_commitlog_write_batches_covers_one_per_segment) {
+    commitlog::config cfg;
+    cfg.commitlog_segment_size_in_mb = 1;
+    cfg.allow_fragmented_entries = true;
+    return cl_test(std::move(cfg), [](commitlog& log) -> future<> {
+        auto gid = make_group_id();
+        auto tid = make_table_id();
+        auto rg_tid = make_table_id();
+
+        service::strong_consistency::pending_cover_map covers;
+
+        // A small batch first: takes one reference for the segment it lands in.
+        raft::log_entry_ptr_list small;
+        small.push_back(make_command_entry(raft::term_t(1), raft::index_t(1)));
+        auto small_handle = co_await service::strong_consistency::raft_commitlog::write_batches(
+                log, tid, rg_tid, gid, small, raft_term_and_index{}, covers);
+        BOOST_REQUIRE_EQUAL(covers.size(), 1);
+        const auto small_seg = covers.begin()->first;
+        BOOST_REQUIRE(bool(covers.begin()->second.segment_holder));
+        BOOST_REQUIRE_EQUAL(covers.begin()->second.segment_holder.rp().id, small_seg);
+
+        // A second batch in the same still-active segment extends that cover
+        // rather than adding one.
+        raft::log_entry_ptr_list same_segment;
+        same_segment.push_back(make_command_entry(raft::term_t(1), raft::index_t(2)));
+        auto same_handle = co_await service::strong_consistency::raft_commitlog::write_batches(
+                log, tid, rg_tid, gid, same_segment, raft_term_and_index{}, covers);
+        BOOST_REQUIRE_EQUAL(covers.size(), 1);
+        BOOST_REQUIRE_EQUAL(covers.begin()->first, small_seg);
+        BOOST_REQUIRE_EQUAL(covers.begin()->second.max_idx, raft::index_t(2));
+
+        // Now fill past the segment size in several batches, so later ones land
+        // in new segments and each contributes its own cover.
+        utils::chunked_vector<db::rp_handle> batch_handles;
+        uint64_t next = 3;
+        for (int batch = 0; batch < 6; ++batch) {
+            raft::log_entry_ptr_list entries;
+            for (int i = 0; i < 4; ++i, ++next) {
+                entries.push_back(make_command_entry_sized(raft::term_t(1), raft::index_t(next), 64 * 1024));
+            }
+            auto handle = co_await service::strong_consistency::raft_commitlog::write_batches(
+                    log, tid, rg_tid, gid, entries, raft_term_and_index{}, covers);
+            BOOST_REQUIRE(bool(handle));
+            batch_handles.emplace_back(std::move(handle));
+        }
+        BOOST_REQUIRE_GT(covers.size(), 1);
+
+        // One cover per segment (the map key), max indexes ascending with the
+        // segments, every reference at its own segment and at a real entry
+        // position — the batch record's, never offset 0.
+        BOOST_REQUIRE_EQUAL(covers.begin()->first, small_seg);
+        raft::index_t prev_idx{0};
+        for (const auto& [segment, c] : covers) {
+            BOOST_REQUIRE(bool(c.segment_holder));
+            BOOST_REQUIRE_EQUAL(c.segment_holder.rp().id, segment);
+            BOOST_REQUIRE_GT(c.segment_holder.rp().pos, 0u);
+            BOOST_REQUIRE_GT(c.max_idx, prev_idx);
+            prev_idx = c.max_idx;
+        }
+        BOOST_REQUIRE_EQUAL(std::prev(covers.end())->second.max_idx, raft::index_t(next - 1));
+
+        // Every batch's segment is covered by some reference.
+        for (const auto& h : batch_handles) {
+            BOOST_REQUIRE(covers.contains(h.rp().id));
+        }
+
+        // Release everything (this test manages the handles directly).
+        small_handle = {};
+        same_handle = {};
+        for (auto& h : batch_handles) {
+            h = {};
+        }
+        for (auto& [segment, c] : covers) {
+            c.segment_holder = {};
+        }
+    });
+}
+
+// Test: a batch large enough to be fragmented is still one commitlog entry at
+// one position, so it yields exactly one cover however many segments its bytes
+// span — and the segments holding those bytes are retained until that one
+// position is released. The tails are held by the commitlog's own head-segment
+// chaining (segment::_extended_segments), which frees them only when the head
+// segment goes clean, so the several references sharing the head's position —
+// the batch's own, the cover's, and the ones apply() mints — can be released in
+// any order without stranding a head fragment whose continuation is gone.
+SEASTAR_TEST_CASE(test_commitlog_fragmented_batch_is_one_cover) {
+    commitlog::config cfg;
+    cfg.commitlog_segment_size_in_mb = 1;
+    cfg.allow_fragmented_entries = true;
+    return cl_test(std::move(cfg), [](commitlog& log) -> future<> {
+        auto gid = make_group_id();
+        auto tid = make_table_id();
+        auto rg_tid = make_table_id();
+
+        // ~2.5MB in one batch, well past the oversized threshold (half of a
+        // 1MB segment), so the entry is fragmented across several segments.
+        service::strong_consistency::pending_cover_map covers;
+        raft::log_entry_ptr_list entries;
+        for (int i = 1; i <= 40; ++i) {
+            entries.push_back(make_command_entry_sized(raft::term_t(1), raft::index_t(i), 64 * 1024));
+        }
+        auto batch_handle = co_await service::strong_consistency::raft_commitlog::write_batches(
+                log, tid, rg_tid, gid, entries, raft_term_and_index{}, covers);
+
+        // One batch, one position, hence exactly one cover — and the cover's
+        // reference sits at the batch's own position.
+        BOOST_REQUIRE_EQUAL(covers.size(), 1);
+        BOOST_REQUIRE(bool(batch_handle));
+        const auto batch_rp = batch_handle.rp();
+        BOOST_REQUIRE(covers.begin()->second.segment_holder.rp() == batch_rp);
+
+        // References minted from the batch for apply() all carry that position, so
+        // the target memtable records the position the mutations were really
+        // written at.
+        std::vector<db::rp_handle> minted;
+        for (size_t i = 0; i < entries.size(); ++i) {
+            minted.push_back(log.acquire_cf_count(batch_handle, tid));
+            BOOST_REQUIRE(minted.back().rp() == batch_rp);
+        }
+
+        // Sealed segments carrying the batch's bytes are retained.
+        const auto sealed_dirty = log.get_num_dirty_segments();
+        BOOST_REQUIRE_GT(sealed_dirty, 0u);
+        BOOST_REQUIRE_EQUAL(log.get_num_segments_destroyed(), 0u);
+
+        // Releasing the minted references one at a time — as the target memtable's
+        // flush would — must not let a segment go while the batch's own reference
+        // and the cover still hold the position.
+        for (auto& h : minted) {
+            h = {};
+            BOOST_REQUIRE_EQUAL(log.get_num_dirty_segments(), sealed_dirty);
+            BOOST_REQUIRE_EQUAL(log.get_num_segments_destroyed(), 0u);
+        }
+        batch_handle = {};
+        BOOST_REQUIRE_EQUAL(log.get_num_dirty_segments(), sealed_dirty);
+
+        // The cover's reference is the last one at that position: releasing it is
+        // what finally lets the head segment — and with it the tails — go.
+        covers.begin()->second.segment_holder = {};
+        BOOST_REQUIRE_EQUAL(log.get_num_dirty_segments(), 0u);
     });
 }
 

--- a/test/boost/commitlog_raft_replay_test.cc
+++ b/test/boost/commitlog_raft_replay_test.cc
@@ -30,6 +30,7 @@
 #include "idl/commitlog.dist.impl.hh"
 #include "test/lib/mutation_source_test.hh"
 #include "service/strong_consistency/raft_commitlog.hh"
+#include "service/strong_consistency/raft_groups_storage.hh"
 #include "idl/raft_storage.dist.hh"
 #include "idl/raft_storage.dist.impl.hh"
 
@@ -63,8 +64,7 @@ table_id make_table_id() {
     return table_id(utils::UUID_gen::get_time_UUID());
 }
 
-future<> cl_test(noncopyable_function<future<>(commitlog&)> f) {
-    commitlog::config cfg;
+future<> cl_test(commitlog::config cfg, noncopyable_function<future<>(commitlog&)> f) {
     cfg.metrics_category_name = "commitlog";
     cfg.descriptor_tag = "variant";
     tmpdir tmp;
@@ -82,12 +82,16 @@ future<> cl_test(noncopyable_function<future<>(commitlog&)> f) {
             .finally([tmp = std::move(tmp)] {});
 }
 
+future<> cl_test(noncopyable_function<future<>(commitlog&)> f) {
+    return cl_test(commitlog::config{}, std::move(f));
+}
+
 // Write a raft log entry to the commitlog and return the rp_handle.
 future<rp_handle> write_raft_entry_to_commitlog(commitlog& cl, table_id tid, raft::group_id gid, raft::log_entry_ptr entry) {
-    commitlog_raft_log_entry_writer writer(raft_commitlog_entry{.group_id = gid, .entry = entry});
+    commitlog_raft_log_entry_writer writer(raft_commitlog_entry{.group_id = gid, .entries = {entry}});
     const auto target_size = writer.size();
     co_return co_await cl.add(tid, target_size, db::no_timeout, db::commitlog_force_sync::yes, [entry, gid](auto& out) {
-        commitlog_raft_log_entry_writer w(raft_commitlog_entry{.group_id = gid, .entry = entry});
+        commitlog_raft_log_entry_writer w(raft_commitlog_entry{.group_id = gid, .entries = {entry}});
         w.write(out);
     });
 }
@@ -111,13 +115,13 @@ SEASTAR_TEST_CASE(test_commitlog_raft_log_entry_writer) {
         // Verify size() and accessor for each entry type, then write to commitlog.
         std::vector<replay_position> rps;
         for (const auto& entry : entries) {
-            commitlog_raft_log_entry_writer writer(raft_commitlog_entry{.group_id = gid, .entry = entry});
+            commitlog_raft_log_entry_writer writer(raft_commitlog_entry{.group_id = gid, .entries = {entry}});
             // size() must exceed the bare raft::log_entry serialization because
             // the writer wraps it in a commitlog_entry + raft_commitlog_entry envelope.
             BOOST_REQUIRE_GT(writer.size(), 0u);
             BOOST_REQUIRE_GT(writer.size(), ser::get_sizeof(*entry));
-            BOOST_REQUIRE_EQUAL(writer.get_log_entry().group_id, gid);
-            BOOST_REQUIRE_EQUAL(writer.get_log_entry().entry->idx, entry->idx);
+            BOOST_REQUIRE_EQUAL(writer.item().group_id, gid);
+            BOOST_REQUIRE_EQUAL(writer.item().entries.at(0)->idx, entry->idx);
 
             auto handle = co_await write_raft_entry_to_commitlog(log, tid, gid, entry);
             rps.push_back(handle.rp());
@@ -147,9 +151,9 @@ SEASTAR_TEST_CASE(test_commitlog_raft_log_entry_writer) {
 
                         auto& rle = std::get<raft_commitlog_entry>(entry_var);
                         BOOST_REQUIRE_EQUAL(rle.group_id, gid);
-                        BOOST_REQUIRE_EQUAL(rle.entry->term, expected->term);
-                        BOOST_REQUIRE_EQUAL(rle.entry->idx, expected->idx);
-                        BOOST_REQUIRE_EQUAL(rle.entry->data.index(), expected->data.index());
+                        BOOST_REQUIRE_EQUAL(rle.entries.at(0)->term, expected->term);
+                        BOOST_REQUIRE_EQUAL(rle.entries.at(0)->idx, expected->idx);
+                        BOOST_REQUIRE_EQUAL(rle.entries.at(0)->data.index(), expected->data.index());
                         ++found;
                         co_return;
                     });
@@ -200,9 +204,9 @@ SEASTAR_TEST_CASE(test_commitlog_raft_entry_roundtrip) {
                         BOOST_REQUIRE_EQUAL(rle.group_id, gid);
 
                         auto idx = std::distance(rps.begin(), it);
-                        BOOST_REQUIRE_EQUAL(rle.entry->idx, entries[idx]->idx);
-                        BOOST_REQUIRE_EQUAL(rle.entry->term, entries[idx]->term);
-                        BOOST_REQUIRE(std::holds_alternative<raft::log_entry::dummy>(rle.entry->data));
+                        BOOST_REQUIRE_EQUAL(rle.entries.at(0)->idx, entries[idx]->idx);
+                        BOOST_REQUIRE_EQUAL(rle.entries.at(0)->term, entries[idx]->term);
+                        BOOST_REQUIRE(std::holds_alternative<raft::log_entry::dummy>(rle.entries.at(0)->data));
 
                         ++raft_entries_found;
                         co_return;
@@ -275,9 +279,9 @@ SEASTAR_TEST_CASE(test_commitlog_mixed_raft_and_mutation_entries) {
 
                             auto& rle = std::get<raft_commitlog_entry>(entry_var);
                             BOOST_REQUIRE_EQUAL(rle.group_id, gid);
-                            BOOST_REQUIRE_EQUAL(rle.entry->term, expected->term);
-                            BOOST_REQUIRE_EQUAL(rle.entry->idx, expected->idx);
-                            BOOST_REQUIRE_EQUAL(rle.entry->data.index(), expected->data.index());
+                            BOOST_REQUIRE_EQUAL(rle.entries.at(0)->term, expected->term);
+                            BOOST_REQUIRE_EQUAL(rle.entries.at(0)->idx, expected->idx);
+                            BOOST_REQUIRE_EQUAL(rle.entries.at(0)->data.index(), expected->data.index());
                             ++raft_found;
                         } else {
                             BOOST_REQUIRE(std::holds_alternative<mutation_entry>(entry_var));
@@ -316,7 +320,7 @@ SEASTAR_TEST_CASE(test_raft_replay_buffer_add_take) {
     // (processing moves entries from _replayed_commitlog_entries_by_group to _per_group_data)
     auto data = buffer.take_replayed_group_entries(gid1);
     BOOST_CHECK(data.entries.empty());
-    BOOST_CHECK(data.replay_positions.empty());
+    BOOST_CHECK(!data.rewritten.has_value());
 
     return make_ready_future<>();
 }
@@ -346,7 +350,7 @@ SEASTAR_TEST_CASE(test_raft_replay_buffer_process_discards_unknown_groups) {
                 // take should return empty since the group was discarded.
                 auto data = buffer.take_replayed_group_entries(gid);
                 BOOST_CHECK(data.entries.empty());
-                BOOST_CHECK(data.replay_positions.empty());
+                BOOST_CHECK(!data.rewritten.has_value());
             },
             std::move(db_cfg_ptr));
 }
@@ -572,7 +576,7 @@ SEASTAR_TEST_CASE(test_raft_replay_buffer_basic_operations) {
     // (entries are in _replayed_commitlog_entries_by_group, not _per_group_data)
     auto data1 = buffer.take_replayed_group_entries(gid1);
     BOOST_CHECK(data1.entries.empty());
-    BOOST_CHECK(data1.replay_positions.empty());
+    BOOST_CHECK(!data1.rewritten.has_value());
 
     // Non-existent group returns empty
     auto data_nonexistent = buffer.take_replayed_group_entries(make_group_id());
@@ -1525,9 +1529,9 @@ SEASTAR_TEST_CASE(test_end_to_end_commitlog_replay_full_verification) {
 
                         auto& rle = std::get<raft_commitlog_entry>(entry_var);
                         BOOST_REQUIRE_EQUAL(rle.group_id, expected.gid);
-                        BOOST_REQUIRE_EQUAL(rle.entry->term, expected.term);
-                        BOOST_REQUIRE_EQUAL(rle.entry->idx, expected.idx);
-                        BOOST_REQUIRE_EQUAL(rle.entry->data.index(), expected.variant_idx);
+                        BOOST_REQUIRE_EQUAL(rle.entries.at(0)->term, expected.term);
+                        BOOST_REQUIRE_EQUAL(rle.entries.at(0)->idx, expected.idx);
+                        BOOST_REQUIRE_EQUAL(rle.entries.at(0)->data.index(), expected.variant_idx);
                         ++found;
                         co_return;
                     });
@@ -1545,7 +1549,7 @@ SEASTAR_TEST_CASE(test_raft_commitlog_store_and_truncate_log) {
         auto tid = make_table_id();
 
         service::strong_consistency::replayed_data_per_group replayed_data;
-        service::strong_consistency::raft_commitlog persistence(gid, log, tid, std::move(replayed_data));
+        service::strong_consistency::raft_commitlog persistence(gid, log, tid, make_table_id(), std::move(replayed_data));
 
         // Store 10 entries.
         raft::log_entry_ptr_list all_entries;
@@ -1589,7 +1593,7 @@ SEASTAR_TEST_CASE(test_raft_commitlog_truncate_log_tail_releases_handles) {
         auto tid = make_table_id();
 
         service::strong_consistency::replayed_data_per_group replayed_data;
-        service::strong_consistency::raft_commitlog persistence(gid, log, tid, std::move(replayed_data));
+        service::strong_consistency::raft_commitlog persistence(gid, log, tid, make_table_id(), std::move(replayed_data));
 
         raft::log_entry_ptr_list all_entries;
         for (int i = 1; i <= 10; ++i) {
@@ -1655,7 +1659,7 @@ SEASTAR_TEST_CASE(test_replay_with_multiple_segments) {
                         auto& entry_var = reader.entry().item;
                         if (std::holds_alternative<raft_commitlog_entry>(entry_var)) {
                             auto& rle = std::get<raft_commitlog_entry>(entry_var);
-                            replayed_entries.emplace_back(rle.entry->idx, rle.entry->term);
+                            replayed_entries.emplace_back(rle.entries.at(0)->idx, rle.entries.at(0)->term);
                         }
                         co_return;
                     });
@@ -1718,7 +1722,7 @@ SEASTAR_TEST_CASE(test_mixed_raft_and_mutation_entries_replay_separation) {
 
                         if (std::holds_alternative<raft_commitlog_entry>(entry_var)) {
                             auto& rle = std::get<raft_commitlog_entry>(entry_var);
-                            buffer.add(rle.group_id, rle.entry);
+                            buffer.add(rle.group_id, rle.entries.at(0));
                         } else {
                             BOOST_REQUIRE(std::holds_alternative<mutation_entry>(entry_var));
                             ++mutation_count;
@@ -1742,7 +1746,7 @@ SEASTAR_TEST_CASE(test_raft_commitlog_combined_truncation) {
         auto tid = make_table_id();
 
         service::strong_consistency::replayed_data_per_group replayed_data;
-        service::strong_consistency::raft_commitlog persistence(gid, log, tid, std::move(replayed_data));
+        service::strong_consistency::raft_commitlog persistence(gid, log, tid, make_table_id(), std::move(replayed_data));
 
         raft::log_entry_ptr_list all_entries;
         for (int i = 1; i <= 10; ++i) {
@@ -1793,8 +1797,12 @@ SEASTAR_TEST_CASE(test_raft_commitlog_load_log_one_shot) {
         replayed_data.entries.push_back(make_command_entry(raft::term_t(1), raft::index_t(1)));
         replayed_data.entries.push_back(make_dummy_entry(raft::term_t(1), raft::index_t(2)));
         replayed_data.entries.push_back(make_config_entry(raft::term_t(2), raft::index_t(3)));
+        // The rewritten range says which of the entries were uncommitted; here
+        // all three were, as the replay rewrite would have left them.
+        replayed_data.rewritten = service::strong_consistency::batch_ref{
+                .first = raft::index_t(1), .last = raft::index_t(3), .reference = {}};
 
-        service::strong_consistency::raft_commitlog persistence(gid, log, tid, std::move(replayed_data));
+        service::strong_consistency::raft_commitlog persistence(gid, log, tid, make_table_id(), std::move(replayed_data));
 
         // First call should return the entries.
         auto entries = persistence.load_log();
@@ -1810,6 +1818,117 @@ SEASTAR_TEST_CASE(test_raft_commitlog_load_log_one_shot) {
     });
 }
 
+// Test: raft_commitlog::store_log_entries writes one commitlog entry per
+// batch — the group id once, the batch's entries, and the group's last
+// committed (index, term) — and takes one raft_groups reference for the segment
+// the batch lands in.
+//
+// Test for: SCYLLADB-2877
+SEASTAR_TEST_CASE(test_raft_commitlog_store_log_entries_records_commit_idx) {
+    return cl_test([](commitlog& log) -> future<> {
+        auto gid = make_group_id();
+        auto tid = make_table_id();
+
+        service::strong_consistency::replayed_data_per_group replayed_data;
+        service::strong_consistency::raft_commitlog persistence(gid, log, tid, make_table_id(), std::move(replayed_data));
+
+        raft::log_entry_ptr_list entries;
+        for (int i = 1; i <= 3; ++i) {
+            entries.push_back(make_command_entry(raft::term_t(1), raft::index_t(i)));
+        }
+        co_await persistence.store_log_entries(entries);
+        // Entries 1..2 commit, then a second batch trails that floor.
+        persistence.note_commit_idx(raft::index_t(2));
+        raft::log_entry_ptr_list more = {make_command_entry(raft::term_t(1), raft::index_t(4))};
+        co_await persistence.store_log_entries(more);
+        co_await log.sync_all_segments();
+
+        auto segments = log.get_active_segment_names();
+        BOOST_REQUIRE(!segments.empty());
+
+        std::vector<raft_commitlog_entry> batches;
+        for (auto& seg : segments) {
+            co_await db::commitlog::read_log_file(
+                    seg, db::commitlog::descriptor::FILENAME_PREFIX,
+                    [&](db::commitlog::buffer_and_replay_position buf_rp) -> future<> {
+                        auto&& [buf, _] = buf_rp;
+                        commitlog_entry_reader reader(buf, detail::commitlog_entry_serialization_format::variant);
+                        auto& entry_var = reader.entry().item;
+                        BOOST_REQUIRE(std::holds_alternative<raft_commitlog_entry>(entry_var));
+                        batches.push_back(std::get<raft_commitlog_entry>(entry_var));
+                        co_return;
+                    });
+        }
+
+        // One commitlog entry per batch, not per raft entry.
+        BOOST_REQUIRE_EQUAL(batches.size(), 2u);
+        BOOST_REQUIRE_EQUAL(batches[0].group_id, gid);
+        BOOST_REQUIRE_EQUAL(batches[0].entries.size(), 3u);
+        BOOST_REQUIRE_EQUAL(batches[0].entries.at(0)->idx, raft::index_t(1));
+        BOOST_REQUIRE_EQUAL(batches[0].entries.at(2)->idx, raft::index_t(3));
+        // The first batch had no commit index to record yet.
+        BOOST_REQUIRE_EQUAL(batches[0].commit_idx, raft::index_t(0));
+
+        BOOST_REQUIRE_EQUAL(batches[1].group_id, gid);
+        BOOST_REQUIRE_EQUAL(batches[1].entries.size(), 1u);
+        BOOST_REQUIRE_EQUAL(batches[1].entries.at(0)->idx, raft::index_t(4));
+        // The second carries the floor the first batch's entries established.
+        BOOST_REQUIRE_EQUAL(batches[1].commit_idx, raft::index_t(2));
+        BOOST_REQUIRE_EQUAL(batches[1].commit_idx_term, raft::term_t(1));
+    });
+}
+
+// Test: acquire_replay_position_handles_for() serves the requested command
+// entries — skipping dummy entries interleaved with them — moving the
+// handles out (the target memtable takes over the reference), so a repeated
+// request for the same entries fails. Configuration entries are not served
+// at all: they take no reference of their own.
+SEASTAR_TEST_CASE(test_raft_commitlog_acquire_skips_non_command_entries) {
+    return cl_test([](commitlog& log) -> future<> {
+        auto gid = make_group_id();
+        auto tid = make_table_id();
+
+        service::strong_consistency::replayed_data_per_group replayed_data;
+        service::strong_consistency::raft_commitlog persistence(gid, log, tid, make_table_id(), std::move(replayed_data));
+
+        // 3 command entries interleaved with 10 non-command entries
+        // (commands at idx 1, 7, 13; configuration/dummy fill the rest).
+        auto is_command_idx = [](int i) { return i == 1 || i == 7 || i == 13; };
+        raft::log_entry_ptr_list entries;
+        for (int i = 1; i <= 13; ++i) {
+            if (is_command_idx(i)) {
+                entries.push_back(make_command_entry(raft::term_t(1), raft::index_t(i)));
+            } else if (i % 2 == 0) {
+                entries.push_back(make_config_entry(raft::term_t(1), raft::index_t(i)));
+            } else {
+                entries.push_back(make_dummy_entry(raft::term_t(1), raft::index_t(i)));
+            }
+        }
+
+        co_await persistence.store_log_entries(entries);
+
+        raft::log_entry_ptr_list commands = {entries[0], entries[6], entries[12]};
+        auto handles = persistence.acquire_replay_position_handles_for(commands);
+        BOOST_REQUIRE_EQUAL(handles.size(), 3);
+        BOOST_REQUIRE_EQUAL(handles[0].index, raft::index_t(1));
+        BOOST_REQUIRE_EQUAL(handles[1].index, raft::index_t(7));
+        BOOST_REQUIRE_EQUAL(handles[2].index, raft::index_t(13));
+        for (const auto& h : handles) {
+            BOOST_REQUIRE(bool(h.replay_position_handle));
+        }
+
+        // The handles were moved out; the same request must now fail.
+        {
+            seastar::testing::scoped_no_abort_on_internal_error no_abort;
+            BOOST_REQUIRE_THROW(persistence.acquire_replay_position_handles_for(commands), std::runtime_error);
+        }
+
+        // Truncate the tail (<= idx 10): entries with idx <= 10 are released,
+        // those above (11, 12) remain. Must not crash and the class'
+        // destructor must succeed.
+        persistence.truncate_log_tail(raft::index_t(10));
+    });
+}
 
 // Test: commitlog::acquire_cf_count() takes an extra reference at a live handle's
 // position — under the same or a different column family, any number of times

--- a/test/boost/commitlog_raft_replay_test.cc
+++ b/test/boost/commitlog_raft_replay_test.cc
@@ -1818,6 +1818,38 @@ SEASTAR_TEST_CASE(test_raft_commitlog_load_log_one_shot) {
     });
 }
 
+// Test that a group whose only replayed record is a commit_idx entry (no log
+// entries) is still processed: process_raft_replayed_items runs its restore
+// pass even when remaining_groups() == 0, and — since the group is not in
+// tablet metadata — discards the recovered value instead of resurrecting a
+// system.raft_groups row for a moved-away/dropped tablet.
+SEASTAR_TEST_CASE(test_raft_replay_buffer_commit_idx_only_group) {
+    auto db_cfg_ptr = make_shared<db::config>();
+    db_cfg_ptr->experimental_features({db::experimental_features_t::feature::STRONGLY_CONSISTENT_TABLES});
+    return do_with_cql_env(
+            [](cql_test_env& env) -> future<> {
+                db::raft_commitlog_replay_buffer buffer;
+
+                auto gid = make_group_id();
+                // Only commit_idx entries survived replay for this group (e.g. the
+                // segment holding its raft log entries was already reclaimed).
+                // The highest value wins.
+                buffer.add_commit_idx(gid, raft_term_and_index{.idx = raft::index_t(3), .term = raft::term_t(1)});
+                buffer.add_commit_idx(gid, raft_term_and_index{.idx = raft::index_t(7), .term = raft::term_t(2)});
+                buffer.add_commit_idx(gid, raft_term_and_index{.idx = raft::index_t(5), .term = raft::term_t(2)});
+
+                BOOST_CHECK_EQUAL(buffer.remaining_groups(), 0);
+
+                co_await buffer.process_raft_replayed_items(env.local_db(), env.local_qp(), env.get_system_keyspace().local());
+
+                // The group has no tablet metadata, so nothing may be written.
+                const auto persisted = co_await service::strong_consistency::raft_groups_storage::load_commit_idx(
+                        env.local_qp(), gid, this_shard_id());
+                BOOST_CHECK_EQUAL(persisted, raft::index_t(0));
+            },
+            std::move(db_cfg_ptr));
+}
+
 // Test: raft_commitlog::store_log_entries writes one commitlog entry per
 // batch — the group id once, the batch's entries, and the group's last
 // committed (index, term) — and takes one raft_groups reference for the segment

--- a/test/boost/commitlog_raft_replay_test.cc
+++ b/test/boost/commitlog_raft_replay_test.cc
@@ -1810,4 +1810,43 @@ SEASTAR_TEST_CASE(test_raft_commitlog_load_log_one_shot) {
     });
 }
 
+
+// Test: commitlog::acquire_cf_count() takes an extra reference at a live handle's
+// position — under the same or a different column family, any number of times
+// — and every reference releases independently (accounting is a pure count; an
+// unbalanced release would trip the segment's internal assert). The new handle
+// carries the source's position, which is what keeps a memtable's recorded
+// replay position truthful when a batch's entries share one record.
+SEASTAR_TEST_CASE(test_commitlog_acquire_cf_count) {
+    return cl_test([](commitlog& log) -> future<> {
+        auto gid = make_group_id();
+        auto tid = make_table_id();
+        auto other_tid = make_table_id();
+
+        auto entry = make_command_entry(raft::term_t(1), raft::index_t(1));
+        auto handle = co_await write_raft_entry_to_commitlog(log, tid, gid, entry);
+        BOOST_REQUIRE(bool(handle));
+
+        // A second reference under the entry's own cf, at the same position.
+        auto dup = log.acquire_cf_count(handle, tid);
+        BOOST_REQUIRE(bool(dup));
+        BOOST_REQUIRE(dup.rp() == handle.rp());
+
+        // References under a cf the segment was never written for, as
+        // write_batches() takes them for system.raft_groups; repeats are legal.
+        auto pin1 = log.acquire_cf_count(handle, other_tid);
+        auto pin2 = log.acquire_cf_count(handle, other_tid);
+        BOOST_REQUIRE(bool(pin1));
+        BOOST_REQUIRE(pin1.rp() == handle.rp());
+        BOOST_REQUIRE(bool(pin2));
+
+        // A reference taken from a reference is just as good a source as the original.
+        auto chained = log.acquire_cf_count(pin1, other_tid);
+        BOOST_REQUIRE(chained.rp() == handle.rp());
+
+        // All five references release independently at destruction.
+        co_return;
+    });
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/cluster/test_strong_consistency_commitlog.py
+++ b/test/cluster/test_strong_consistency_commitlog.py
@@ -303,3 +303,85 @@ async def test_crash_recovery_after_flush(manager: ManagerClient):
             assert rows[0].c == pk * 10, f"pk={pk}: expected c={pk * 10}, got c={rows[0].c}"
 
     await manager.server_stop_gracefully(server.server_id)
+
+
+@pytest.mark.asyncio
+async def test_commit_idx_persisted_on_graceful_shutdown(manager: ManagerClient):
+    """A graceful shutdown must leave system.raft_groups.commit_idx covering every
+    write that was committed and applied, not just the value that was known when
+    the last raft batch was appended (the commit_idx entries in the commitlog
+    carry only the append-time value, and a clean shutdown discards the
+    commitlog).
+
+    That guarantee comes from commit-time coverage: the raft io_fiber writes a
+    covering commit_idx value into the raft_groups memtable when entries
+    commit — before they are even applied, let alone acknowledged
+    (raft_groups_storage::store_commit_idx) — and the drain flush persists
+    that memtable. This test pins the mechanism end to end:
+    the commit_idx observable while the node is live covers every acknowledged
+    write, and a graceful restart must come back with a snapshot index at least
+    that high — if the drain lost the raft_groups memtable, it could not."""
+    config = {
+        'experimental_features': ['strongly-consistent-tables'],
+        'commitlog_total_space_in_mb': 10000,
+    }
+    server = await manager.server_add(config=config)
+    (cql, hosts) = await manager.get_ready_cql([server])
+
+    async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 1} AND consistency = 'global'") as ks:
+        await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int);")
+        for pk in range(10):
+            await cql.run_async(f"INSERT INTO {ks}.test (pk, c) VALUES ({pk}, {pk * 10})")
+
+        table_id = await manager.get_table_id(ks.replace('"', ''), "test")
+        tablet_rows = await cql.run_async(f"SELECT raft_group_id FROM system.tablets WHERE table_id = {table_id}")
+        assert len(tablet_rows) == 1
+        group_id = tablet_rows[0].raft_group_id
+
+        # commit_idx as recorded by the commit-time covering mutations (read
+        # from the raft_groups memtable): the coverage runs before a write is
+        # even applied, let alone acknowledged, so with the inserts above
+        # executed sequentially this covers all of them.
+        pre_rows = await cql.run_async(f"SELECT commit_idx, commit_idx_term FROM system.raft_groups WHERE shard = 0 AND group_id = {group_id}")
+        assert len(pre_rows) == 1
+        pre_commit_idx = pre_rows[0].commit_idx
+        pre_commit_idx_term = pre_rows[0].commit_idx_term
+        assert pre_commit_idx >= 10, \
+            f"live commit_idx {pre_commit_idx} does not cover the 10 acknowledged inserts"
+        # The exact term of the entry at commit_idx is persisted atomically
+        # with the value; the startup bump feeds it into raft's election and
+        # log-matching checks, so it must never be missing on a covered row.
+        assert pre_commit_idx_term is not None and pre_commit_idx_term >= 1, \
+            f"live commit_idx_term is {pre_commit_idx_term}"
+
+        await manager.server_stop_gracefully(server.server_id)
+        await manager.server_start(server.server_id)
+        await reconnect_driver(manager)
+        cql = manager.get_cql()
+
+        for pk in range(10):
+            rows = await cql.run_async(f"SELECT * FROM {ks}.test WHERE pk = {pk};")
+            assert len(rows) == 1, f"Expected 1 row for pk={pk}, got {len(rows)}"
+            assert rows[0].c == pk * 10
+
+        # The startup bump sets raft_groups_snapshots.idx from the commit_idx that
+        # was persisted at shutdown, and nothing after startup moves it (post-restart
+        # commits advance system.raft_groups.commit_idx, not the snapshot index), so
+        # it is a stable witness of what shutdown actually persisted.
+        #
+        # The drain flushes the raft_groups memtable, making the covering
+        # values durable, so the bump must reach at least the commit_idx that
+        # was observable while the node was live. Were the covering values
+        # lost, the persisted commit_idx would fall back to whatever an
+        # earlier flush wrote (possibly nothing).
+        snp_rows = await cql.run_async(f"SELECT idx, term FROM system.raft_groups_snapshots WHERE shard = 0 AND group_id = {group_id}")
+        assert len(snp_rows) == 1
+        assert snp_rows[0].idx >= pre_commit_idx, \
+            f"snapshot idx {snp_rows[0].idx} is behind the pre-shutdown commit_idx {pre_commit_idx} " \
+            f"— was commit_idx persisted on shutdown?"
+        # The bump must carry the exact persisted term, not a stale snapshot
+        # term (a wrong term corrupts elections and log matching).
+        assert snp_rows[0].term >= pre_commit_idx_term, \
+            f"snapshot term {snp_rows[0].term} is behind the pre-shutdown commit_idx_term {pre_commit_idx_term}"
+
+    await manager.server_stop_gracefully(server.server_id)

--- a/test/raft/raft_sys_table_storage_test.cc
+++ b/test/raft/raft_sys_table_storage_test.cc
@@ -546,6 +546,12 @@ SEASTAR_TEST_CASE(test_groups_storage_shard_isolation) {
 
         auto idx0 = co_await storage0.load_commit_idx();
         BOOST_CHECK_EQUAL(raft::index_t(2000), idx0);
+        // The covering mutation persists the exact term of the entry at
+        // commit_idx alongside the value.
+        auto [pair_idx, pair_term] = co_await raft_groups_storage::load_commit_idx_and_term(qp, iso_gid, 0);
+        BOOST_CHECK_EQUAL(raft::index_t(2000), pair_idx);
+        BOOST_REQUIRE(pair_term.has_value());
+        BOOST_CHECK_EQUAL(raft::term_t(1), *pair_term);
 
         auto idx1 = co_await storage1.load_commit_idx();
         BOOST_CHECK_EQUAL(raft::index_t(0), idx1);

--- a/test/raft/raft_sys_table_storage_test.cc
+++ b/test/raft/raft_sys_table_storage_test.cc
@@ -19,6 +19,8 @@
 
 #include "service/raft/raft_sys_table_storage.hh"
 #include "service/strong_consistency/raft_groups_storage.hh"
+#include "service/strong_consistency/raft_commitlog.hh"
+#include "db/system_keyspace.hh"
 #include "dht/fixed_shard.hh"
 
 #include "test/lib/cql_test_env.hh"
@@ -132,6 +134,34 @@ static std::vector<raft::log_entry_ptr> create_test_log(size_t min_entries = 0, 
         testlog.info("  idx={} term={} type={}", e->idx, e->term, type);
     }
 
+    return entries;
+}
+
+// Like create_test_log() but with command entries only, randomized the same
+// way (length, first index, payloads, non-decreasing terms all derive from
+// tests::random). acquire_replay_position_handles_for() serves command
+// entries only (see state_machine::apply, which is handed only commands), so
+// tests exercising it use an all-command log rather than create_test_log()'s
+// mixed types.
+static std::vector<raft::log_entry_ptr> create_test_command_log(size_t min_entries = 3, size_t max_entries = 20) {
+    SCYLLA_ASSERT(min_entries >= 1 && min_entries <= max_entries);
+
+    uint64_t first_idx = tests::random::get_int<uint64_t>(1, 1000);
+    size_t count = tests::random::get_int(min_entries, max_entries);
+
+    std::vector<raft::log_entry_ptr> entries;
+    entries.reserve(count);
+    uint64_t term = 1;
+    for (size_t i = 0; i < count; ++i) {
+        raft::command cmd;
+        ser::serialize(cmd, tests::random::get_int(0, 100000));
+        term += tests::random::get_int(0, 3);
+        entries.push_back(make_lw_shared(raft::log_entry{
+            .term = raft::term_t(term),
+            .idx  = raft::index_t(first_idx + i),
+            .data = std::move(cmd)}));
+    }
+    testlog.info("create_test_command_log: {} entries, first_idx={}", entries.size(), first_idx);
     return entries;
 }
 
@@ -384,7 +414,7 @@ SEASTAR_TEST_CASE(test_groups_truncate_log) {
         raft_groups_storage storage(qp, gid, raft::server_id::create_random_id(), test_shard,
                 cl, dummy_table, {});
 
-        std::vector<raft::log_entry_ptr> entries = create_test_log(3, 20);
+        std::vector<raft::log_entry_ptr> entries = create_test_command_log(3, 20);
         co_await storage.store_log_entries(entries);
 
         // Truncate the last entry from the log (entries with idx >= entries.back()->idx)
@@ -501,11 +531,21 @@ SEASTAR_TEST_CASE(test_groups_storage_shard_isolation) {
         auto vote1 = co_await storage1.load_term_and_vote();
         BOOST_CHECK_EQUAL(raft::term_t{}, vote1.first);
 
-        // Commit index
-        co_await storage0.store_commit_idx(raft::index_t(42));
+        // Commit index. store_commit_idx() performs no CQL write; the value
+        // reaches system.raft_groups — what load_commit_idx() reads — through
+        // the covering mutations it applies to the raft_groups memtable once
+        // every entry of a commitlog segment is committed. Append one command
+        // at idx 2000 (past the replayed entries) and commit it.
+        std::vector<raft::log_entry_ptr> cmd;
+        raft::command c;
+        ser::serialize(c, 42);
+        cmd.push_back(make_lw_shared(raft::log_entry{
+            .term = raft::term_t(1), .idx = raft::index_t(2000), .data = std::move(c)}));
+        co_await storage0.store_log_entries(cmd);
+        co_await storage0.store_commit_idx(raft::index_t(2000));
 
         auto idx0 = co_await storage0.load_commit_idx();
-        BOOST_CHECK_EQUAL(raft::index_t(42), idx0);
+        BOOST_CHECK_EQUAL(raft::index_t(2000), idx0);
 
         auto idx1 = co_await storage1.load_commit_idx();
         BOOST_CHECK_EQUAL(raft::index_t(0), idx1);
@@ -585,12 +625,13 @@ SEASTAR_TEST_CASE(test_groups_store_and_get_replay_positions) {
         raft_groups_storage storage(qp, gid, raft::server_id::create_random_id(), test_shard,
                 cl, dummy_table, {});
 
-        std::vector<raft::log_entry_ptr> entries = create_test_log(3, 20);
+        std::vector<raft::log_entry_ptr> entries = create_test_command_log(3, 20);
         co_await storage.store_log_entries(entries);
 
-        // Acquire replay position handles for all entries.
-        // The handles are moved out of the internal map, transferring
-        // ownership to the caller (for attaching to memtables on apply).
+        // Acquire replay position handles for all entries. The handles are
+        // moved out (for attaching to memtables on apply); the batch's
+        // trailing commit_idx handle keeps pinning the segment until it is
+        // covered.
         raft::log_entry_ptr_list entries_to_get(entries.begin(), entries.end());
         auto handles = storage.acquire_replay_position_handles_for(entries_to_get);
         BOOST_CHECK_EQUAL(handles.size(), entries.size());
@@ -612,7 +653,7 @@ SEASTAR_TEST_CASE(test_groups_get_partial_replay_positions) {
         raft_groups_storage storage(qp, gid, raft::server_id::create_random_id(), test_shard,
                 cl, dummy_table, {});
 
-        std::vector<raft::log_entry_ptr> entries = create_test_log(3, 20);
+        std::vector<raft::log_entry_ptr> entries = create_test_command_log(3, 20);
         co_await storage.store_log_entries(entries);
 
         // Get handles only for the first half of entries
@@ -685,6 +726,50 @@ SEASTAR_TEST_CASE(test_groups_acquire_handles_skips_non_command_entries) {
     });
 }
 
+// Test that acquire_replay_position_handles_for rejects a request containing
+// an index for which no handle is tracked, even when the request's endpoints
+// match tracked entries: requesting [1, 5, 6] against tracked [1, 2, 6] must
+// fail on the missing idx 5 rather than hand out the idx-2 handle.
+SEASTAR_TEST_CASE(test_groups_acquire_handles_rejects_prefix_gap) {
+    return do_with_cql_env_strongly_consistent([] (cql_test_env& env) -> future<> {
+        cql3::query_processor& qp = env.local_qp();
+        auto& cl = *env.local_db().commitlog();
+        auto dummy_table = table_id(utils::UUID_gen::get_time_UUID());
+
+        raft_groups_storage storage(qp, gid, raft::server_id::create_random_id(), test_shard,
+                cl, dummy_table, {});
+
+        // Store commands at idx 1, 2, 6.
+        raft::command cmd1, cmd2, cmd6;
+        ser::serialize(cmd1, 1);
+        ser::serialize(cmd2, 2);
+        ser::serialize(cmd6, 6);
+        std::vector<raft::log_entry_ptr> entries = {
+            make_lw_shared(raft::log_entry{.term = raft::term_t(1), .idx = raft::index_t(1), .data = std::move(cmd1)}),
+            make_lw_shared(raft::log_entry{.term = raft::term_t(1), .idx = raft::index_t(2), .data = std::move(cmd2)}),
+            make_lw_shared(raft::log_entry{.term = raft::term_t(1), .idx = raft::index_t(6), .data = std::move(cmd6)}),
+        };
+        co_await storage.store_log_entries(entries);
+
+        // Request [1, 5, 6]: same size, same first and last index as the
+        // tracked [1, 2, 6] entries, but no handle exists for idx 5.
+        raft::command cmd5;
+        ser::serialize(cmd5, 5);
+        raft::log_entry_ptr_list mismatched = {
+            entries[0],
+            make_lw_shared(raft::log_entry{.term = raft::term_t(1), .idx = raft::index_t(5), .data = std::move(cmd5)}),
+            entries[2],
+        };
+        seastar::testing::scoped_no_abort_on_internal_error no_abort;
+        try {
+            storage.acquire_replay_position_handles_for(mismatched);
+            BOOST_FAIL("Expected on_internal_error for mid-prefix index mismatch");
+        } catch (...) {
+            // Expected — no handle is tracked for idx 5.
+        }
+    });
+}
+
 // Test truncate_log (head truncation) then verify remaining handles.
 // Store N>=3 entries, truncate at the second entry's idx (removes entries with idx >= second idx),
 // verify only the first entry can produce a valid handle, and later entries cannot.
@@ -697,7 +782,7 @@ SEASTAR_TEST_CASE(test_groups_truncate_log_then_get_handles_for_remaining) {
         raft_groups_storage storage(qp, gid, raft::server_id::create_random_id(), test_shard,
                 cl, dummy_table, {});
 
-        std::vector<raft::log_entry_ptr> entries = create_test_log(3, 20);
+        std::vector<raft::log_entry_ptr> entries = create_test_command_log(3, 20);
         co_await storage.store_log_entries(entries);
 
         // Truncate at the second entry's idx — entries with idx >= entries[1]->idx are removed.
@@ -742,7 +827,7 @@ SEASTAR_TEST_CASE(test_groups_store_snapshot_truncate_tail_then_get_handles) {
             }, raft::is_voter::yes};
         co_await storage.bootstrap(raft::configuration({srv}), false);
 
-        std::vector<raft::log_entry_ptr> entries = create_test_log(3, 20);
+        std::vector<raft::log_entry_ptr> entries = create_test_command_log(3, 20);
         co_await storage.store_log_entries(entries);
 
         // Store snapshot at entries[1]->idx with preserve_log_entries=1.

--- a/test/raft/raft_sys_table_storage_test.cc
+++ b/test/raft/raft_sys_table_storage_test.cc
@@ -474,6 +474,240 @@ SEASTAR_TEST_CASE(test_groups_store_load_snapshot_descriptor) {
     });
 }
 
+// Test that a committed configuration is persisted by the covering mutation,
+// without any snapshot: store_log_entries + store_commit_idx must leave the
+// configuration readable through load_committed_config(), and the boot-time
+// restore path must then hand it to the snapshot descriptor (SCYLLADB-3842).
+SEASTAR_TEST_CASE(test_groups_committed_config_persisted_by_coverage) {
+    return do_with_cql_env_strongly_consistent([] (cql_test_env& env) -> future<> {
+        cql3::query_processor& qp = env.local_qp();
+        auto& cl = *env.local_db().commitlog();
+        auto dummy_table = table_id(utils::UUID_gen::get_time_UUID());
+
+        raft_groups_storage storage(qp, gid, raft::server_id::create_random_id(), test_shard,
+                cl, dummy_table, {});
+
+        auto make_member = [] {
+            return raft::config_member{raft::server_address{
+                    raft::server_id::create_random_id(),
+                    ser::serialize_to_buffer<bytes>(gms::inet_address("localhost"))
+                }, raft::is_voter::yes};
+        };
+        // Bootstrap writes a snapshot descriptor carrying the initial
+        // configuration — that is what a group starts from, and what the
+        // committed configuration below has to replace.
+        raft::configuration initial_cfg({make_member()});
+        co_await storage.bootstrap(initial_cfg, false);
+        raft::configuration cfg({make_member()});
+
+        // A configuration entry at idx 1000, followed by a command so the
+        // batch's segment has a higher max index than the configuration.
+        std::vector<raft::log_entry_ptr> entries;
+        entries.push_back(make_lw_shared(raft::log_entry{
+                .term = raft::term_t(3), .idx = raft::index_t(1000), .data = cfg}));
+        raft::command cmd;
+        ser::serialize(cmd, 7);
+        entries.push_back(make_lw_shared(raft::log_entry{
+                .term = raft::term_t(3), .idx = raft::index_t(1001), .data = std::move(cmd)}));
+        co_await storage.store_log_entries(entries);
+
+        // Nothing is persisted until the segment is covered.
+        auto before_commit = co_await raft_groups_storage::load_committed_config(qp, gid, test_shard);
+        BOOST_CHECK(!before_commit.has_value());
+
+        // Committing the range covers the segment, and the covering mutation
+        // carries the configuration with the index of its entry.
+        co_await storage.store_commit_idx(raft::index_t(1001));
+        auto persisted = co_await raft_groups_storage::load_committed_config(qp, gid, test_shard);
+        BOOST_REQUIRE(persisted.has_value());
+        BOOST_CHECK_EQUAL(persisted->first, raft::index_t(1000));
+        BOOST_CHECK(persisted->second == cfg);
+
+        // Until the restore runs, the group would still start from the
+        // bootstrap configuration — that is the loss this closes.
+        auto snap = co_await storage.load_snapshot_descriptor();
+        BOOST_CHECK(snap.config == initial_cfg);
+
+        // The boot-time restore path turns the covered configuration into the
+        // snapshot descriptor's configuration, which is what the group starts
+        // from.
+        co_await raft_groups_storage::store_snapshot_config_if_newer(
+                qp, gid, test_shard, persisted->second, persisted->first);
+        snap = co_await storage.load_snapshot_descriptor();
+        BOOST_CHECK(snap.config == cfg);
+    });
+}
+
+// Test that a configuration committed but never snapshotted is recoverable:
+// store_snapshot_config_if_newer() replaces the stored configuration when the
+// committed entry is newer than the persisted snapshot index, and leaves it
+// alone when the snapshot already accounts for it (SCYLLADB-3842). This is what
+// commitlog replay uses for the committed configuration entries it drops.
+SEASTAR_TEST_CASE(test_groups_restore_committed_config_only_if_newer) {
+    return do_with_cql_env_strongly_consistent([] (cql_test_env& env) -> future<> {
+        cql3::query_processor& qp = env.local_qp();
+        auto& cl = *env.local_db().commitlog();
+        auto dummy_table = table_id(utils::UUID_gen::get_time_UUID());
+
+        raft_groups_storage storage(qp, gid, raft::server_id::create_random_id(), test_shard,
+                cl, dummy_table, {});
+
+        auto make_config = [] {
+            raft::config_member srv{raft::server_address{
+                    raft::server_id::create_random_id(),
+                    ser::serialize_to_buffer<bytes>(gms::inet_address("localhost"))
+                }, raft::is_voter::yes};
+            return raft::configuration({std::move(srv)});
+        };
+
+        // A snapshot at index 100 carrying config A.
+        const auto snap_cfg = make_config();
+        co_await storage.store_snapshot_descriptor(raft::snapshot_descriptor{
+                .idx = raft::index_t(100), .term = raft::term_t(1),
+                .config = snap_cfg, .id = raft::snapshot_id::create_random_id()}, 0);
+
+        // A configuration committed at index 50 is already accounted for by
+        // that snapshot: it must not overwrite config A.
+        co_await raft_groups_storage::store_snapshot_config_if_newer(
+                qp, gid, test_shard, make_config(), raft::index_t(50));
+        auto loaded = co_await storage.load_snapshot_descriptor();
+        BOOST_CHECK(loaded.config == snap_cfg);
+
+        // A configuration committed at index 150 is newer than the snapshot,
+        // so it replaces the stored one — this is the case that would
+        // otherwise be lost when the group never snapshots again.
+        const auto newer_cfg = make_config();
+        co_await raft_groups_storage::store_snapshot_config_if_newer(
+                qp, gid, test_shard, newer_cfg, raft::index_t(150));
+        loaded = co_await storage.load_snapshot_descriptor();
+        BOOST_CHECK(loaded.config == newer_cfg);
+        // Only the configuration changed; the snapshot index is untouched.
+        BOOST_CHECK_EQUAL(loaded.idx, raft::index_t(100));
+    });
+}
+
+// Test that a configuration entry which was still uncommitted at a crash is
+// persisted once it commits after the restart. The replay path only restores
+// *committed* configurations, so this one is carried by the rewritten entry
+// alone: the group must track it from construction, or its covering mutation
+// carries no configuration at all and the configuration ends up nowhere
+// durable once the entry's segment is reclaimed (SCYLLADB-3842).
+SEASTAR_TEST_CASE(test_groups_uncommitted_config_persisted_after_restart) {
+    return do_with_cql_env_strongly_consistent([] (cql_test_env& env) -> future<> {
+        cql3::query_processor& qp = env.local_qp();
+        auto& cl = *env.local_db().commitlog();
+        auto dummy_table = table_id(utils::UUID_gen::get_time_UUID());
+
+        raft::config_member srv{raft::server_address{
+                raft::server_id::create_random_id(),
+                ser::serialize_to_buffer<bytes>(gms::inet_address("localhost"))
+            }, raft::is_voter::yes};
+        const raft::configuration cfg({std::move(srv)});
+
+        // A configuration entry at idx 1000 and a command at 1001, both
+        // uncommitted — the state a crash leaves behind. Rewrite them to the
+        // commitlog exactly as the replay path does, and hand the result to
+        // the group as its replayed data.
+        raft::log_entry_ptr_list uncommitted;
+        uncommitted.push_back(make_lw_shared(raft::log_entry{
+                .term = raft::term_t(3), .idx = raft::index_t(1000), .data = cfg}));
+        raft::command cmd;
+        ser::serialize(cmd, 7);
+        uncommitted.push_back(make_lw_shared(raft::log_entry{
+                .term = raft::term_t(3), .idx = raft::index_t(1001), .data = std::move(cmd)}));
+
+        replayed_data_per_group replayed;
+        auto batch_handle = co_await raft_commitlog::write_batches(cl, dummy_table,
+                db::system_keyspace::raft_groups()->id(), gid, uncommitted,
+                raft_term_and_index{}, replayed.covers);
+        BOOST_REQUIRE(bool(batch_handle));
+        replayed.rewritten = batch_ref{
+                .first = uncommitted.front()->idx,
+                .last = uncommitted.back()->idx,
+                .reference = std::move(batch_handle)};
+        for (const auto& e : uncommitted) {
+            replayed.entries.push_back(e);
+        }
+
+        raft_groups_storage storage(qp, gid, raft::server_id::create_random_id(), test_shard,
+                cl, dummy_table, std::move(replayed));
+
+        // Nothing is persisted while the entries are uncommitted.
+        auto before_commit = co_await raft_groups_storage::load_committed_config(qp, gid, test_shard);
+        BOOST_CHECK(!before_commit.has_value());
+
+        // Committing the range covers the rewritten segment; the covering
+        // mutation has to carry the configuration of the entry it covers.
+        co_await storage.store_commit_idx(raft::index_t(1001));
+        auto persisted = co_await raft_groups_storage::load_committed_config(qp, gid, test_shard);
+        BOOST_REQUIRE(persisted.has_value());
+        BOOST_CHECK_EQUAL(persisted->first, raft::index_t(1000));
+        BOOST_CHECK(persisted->second == cfg);
+    });
+}
+
+// Test that a configuration recovered from the replayed entries and one already
+// durable in system.raft_groups are merged by index, not by write order. Replay
+// writes what the log carried through store_committed_config_if_higher(), so
+// the boot-time snapshot restore reads a single source and cannot regress a
+// newer configuration to an older one (SCYLLADB-3842).
+SEASTAR_TEST_CASE(test_groups_committed_config_restore_keeps_the_newest) {
+    return do_with_cql_env_strongly_consistent([] (cql_test_env& env) -> future<> {
+        cql3::query_processor& qp = env.local_qp();
+        auto& cl = *env.local_db().commitlog();
+        auto dummy_table = table_id(utils::UUID_gen::get_time_UUID());
+
+        raft_groups_storage storage(qp, gid, raft::server_id::create_random_id(), test_shard,
+                cl, dummy_table, {});
+
+        auto make_config = [] {
+            raft::config_member srv{raft::server_address{
+                    raft::server_id::create_random_id(),
+                    ser::serialize_to_buffer<bytes>(gms::inet_address("localhost"))
+                }, raft::is_voter::yes};
+            return raft::configuration({std::move(srv)});
+        };
+
+        // The bootstrap snapshot the group would otherwise come back with.
+        const auto initial_cfg = make_config();
+        co_await storage.bootstrap(initial_cfg, false);
+
+        // The durable state after a crash: a configuration covered at index 10
+        // reached an sstable, while the one covered at index 20 died with the
+        // raft_groups memtable. Replay recovers index 20 from the entry the
+        // segment's reference kept alive.
+        const auto older = make_config();
+        co_await raft_groups_storage::store_committed_config_if_higher(
+                qp, gid, test_shard, older, raft::index_t(10));
+        const auto newer = make_config();
+        co_await raft_groups_storage::store_committed_config_if_higher(
+                qp, gid, test_shard, newer, raft::index_t(20));
+
+        auto persisted = co_await raft_groups_storage::load_committed_config(qp, gid, test_shard);
+        BOOST_REQUIRE(persisted.has_value());
+        BOOST_CHECK_EQUAL(persisted->first, raft::index_t(20));
+        BOOST_CHECK(persisted->second == newer);
+
+        // A configuration recovered from a replayed log that ends in a
+        // discarded tail can be older than the durable one; it must not win.
+        co_await raft_groups_storage::store_committed_config_if_higher(
+                qp, gid, test_shard, make_config(), raft::index_t(15));
+        persisted = co_await raft_groups_storage::load_committed_config(qp, gid, test_shard);
+        BOOST_REQUIRE(persisted.has_value());
+        BOOST_CHECK_EQUAL(persisted->first, raft::index_t(20));
+        BOOST_CHECK(persisted->second == newer);
+
+        // What the boot-time restore then hands to the snapshot descriptor is
+        // that single merged value, replacing the bootstrap configuration.
+        auto snap = co_await storage.load_snapshot_descriptor();
+        BOOST_CHECK(snap.config == initial_cfg);
+        co_await raft_groups_storage::store_snapshot_config_if_newer(
+                qp, gid, test_shard, persisted->second, persisted->first);
+        snap = co_await storage.load_snapshot_descriptor();
+        BOOST_CHECK(snap.config == newer);
+    });
+}
+
 // Verify partitioner round-trip: token_for_shard -> shard_of returns the original shard
 SEASTAR_TEST_CASE(test_fixed_shard_partitioner_shard_mapping) {
     for (uint16_t shard = 0; shard < 256; ++shard) {


### PR DESCRIPTION
## Problem

Every committed raft batch of a strongly consistent tablet performs a synchronous CQL write of `commit_idx` to `system.raft_groups` (`raft_groups_storage::store_commit_idx`) on the raft io_fiber — a full memtable + commitlog write per batch, in the critical section of the fiber that also appends the log. Three disk IO operations per write cycle where eventual consistency needs two.

It cannot simply be deleted: `commit_idx` is what tells a restarting node which replayed raft entries are already committed. If a segment holding raft entries were reclaimed while the persisted `commit_idx` still sat below its entries, the node would come back with data in its SSTables that its raft log claims was never committed.

## Approach

`store_commit_idx()` becomes IO-free, under one invariant:

> A commitlog segment holding a group's raft entries may be reclaimed only once a durable `system.raft_groups.commit_idx` >= the highest index that group wrote to that segment exists.

**Terminology.** This PR says *reference* for one unit of a segment's per-table use count (`segment::_cf_dirty[cf]`), the thing an `rp_handle` owns. The concept is the codebase's, not new here: a segment cannot be discarded or recycled while any table's count is non-zero, so "the segment is still referenced" and "an `rp_handle` for it exists somewhere" are the same statement. `rp_handle::release()` is the trap in that vocabulary — it *abandons* the decrement and keeps the segment; the definition on `rp_handle` spells this out.

1. **One entry and one reference per batch.** A batch of raft entries becomes a single commitlog entry, so its entries share one position and the group id and envelope are written once instead of per entry. The write returns one reference, which `raft_commitlog` holds until `apply()` has minted a memtable reference for every command in the batch (`commitlog::acquire_cf_count`, the one new commitlog API — an extra use-count reference at a live handle's position, no bytes written). Only the indexes of commands awaiting `apply()` are tracked, eight bytes each rather than a handle. Dummy and configuration entries take no reference at all: the segment's cover has `max_idx >=` their index, so it outlives them, and a committed configuration is persisted by the very mutation that carries the cover's reference.

2. **A crash-replay floor in the batch header.** Each batch records the group's last committed `(index, term)` in its own header — no separate record, no extra entry. Startup restores the highest surviving value per group (only-advance), so replay applies the entries below it to memtables instead of re-adding them to the raft log. The term is stored next to the index because the entry at that index normally belongs to an *earlier* batch, whose segment may already be gone by the time the floor is read back, so the term cannot be looked up then. Losing a header to a reclaimed segment only lowers the floor, which is safe — it costs re-committing entries that were already committed.

3. **Commit-time coverage.** The group keeps one cover per segment it has written to: the highest index it put there, that entry's term, and a `system.raft_groups`-accounted reference to the segment, taken with `acquire_cf_count()` when the group first writes to it. `store_commit_idx()` (the existing `raft::persistence` call — no raft interface changes) pops the covers whose range is now fully committed and applies, per covered segment, one mutation carrying that `(index, term)` pair to the raft_groups memtable **with the segment's reference attached**. Value and reference share a memtable generation, so the reference can only be released by the flush that makes the value durable. Later batches in the same segment only advance the pair, so a segment is held once per group, not once per batch.

   Commitment, not application, is the gate — and that is safe: the value only asserts that entries at or below it are committed, and a committed entry stays recoverable whether or not it has been applied. Raft calls `store_commit_idx()` before pushing entries to the applier, so a cover is in the memtable before its entries can be applied, let alone acknowledged. References minted for `apply()` carry the batch record's real position, so the target memtable's recorded replay position — and the truncation and repair-cleanup records derived from it — stay truthful.

4. **Leader-change truncation.** `truncate_log()` drops the covers at or above the truncation point — their recorded indexes describe discarded entries, and leaving them would break the ordering the prefix pop relies on — but keeps their references, each tagged with a release floor of `idx - 1`, an upper bound on the live entries left in that segment. Such a reference rides the first covering mutation whose value reaches its floor; a pop of a surviving *lower* cover leaves it parked, which is the case that makes the floor necessary rather than decorative.

5. **Configurations persisted at commit time (SCYLLADB-3842).** A configuration entry that was committed but never snapshotted used to be lost on a crash: replay applies only committed *command* entries and drops the rest, and the post-replay snapshot bump wrote no configuration — so a group that never snapshots (`snapshot_threshold` is SIZE_MAX, `snapshot_threshold_log_size` is 10MB) came back with its bootstrap membership. Now the covering mutation also carries the group's newest committed configuration and the index of the entry that carried it (`config`, `config_idx`), handed out at the first cover whose range contains that entry — its own segment — so the configuration becomes durable exactly when that segment's reference is released. Replay recovers the configuration from the entry itself when a crash beat the flush, so the value is never in neither place.

   Two details are what make this airtight in both directions. The pending tracking is seeded from the *rewritten* entries in `raft_commitlog`'s constructor as well as from `store_log_entries()`, because a configuration that was still uncommitted at a crash commits after the restart and the replay-side recovery only handles committed ones — without the seeding its covering mutation would carry no configuration, and a configuration entry holds no reference of its own, so nothing would keep its segment once the cover was released. And on startup the two sources of a committed configuration (what the replayed entries carried, what the covering mutations already made durable) are merged in `system.raft_groups` by `config_idx`, leaving `store_snapshot_config_if_newer()` a single writer: its guard compares against the snapshot index, so two callers holding configurations of different ages would both pass it and the last one would win.

Nothing here asks `system.raft_groups` to flush on a schedule: the references make it a dirty CF pinning old segments, so the commitlog's own reclamation logic flushes it (measured: 14-17 flushes per node per 30s window under load, against 10-12 on base), with `commitlog_max_data_lifetime_in_seconds` as the age backstop. Crash recovery does not depend on that flush at all, since the floor comes from the batch headers. The raft_groups memtable is therefore always current with respect to the segments it pins — values are written at commit time, not seal time — so any flush of any memtable (pressure, nodetool, drain) is safe, and the reclamation path allocates nothing. A segment is reclaimed only after (a) the target table's memtable flushed and (b) a raft_groups flush persisted a value >= the segment's max index.

Design write-up (invariant, recovery, worked examples per step, multi-segment corner cases, alternatives considered): [Strongly consistent writes IO optimization design (v2: segment references)](https://scylladb.atlassian.net/wiki/spaces/RND/pages/449609745/).

Supersedes #30394 (same goal, flush-hook mechanism — the hook and the `update_applied_index` variant that followed it were both rejected in review) and #30945 (the `commit_idx_term` column, which this PR needs and therefore includes). Both can be closed if this lands.

## The commits

Seven, each building standalone, each carrying its own tests:

| # | commit | what it does |
|---|---|---|
| 1 | `commitlog: let a reference be taken at an already-referenced position` | `acquire_cf_count()`, plus the owner count on `_extended_segments` that makes shared positions safe by construction. No caller yet. |
| 2 | `replica: add commit_idx_term and the committed configuration to the tablet raft_groups schema` | three static columns, tablet groups only. Unused yet. |
| 3 | `commitlog: store a raft batch as one commitlog entry, holding one reference per batch` | the format change and the write path: batch framing, the header's floor, one reference per batch. |
| 4 | `commitlog: restore commit_idx and advance the snapshot index after replay` | reads the header back, and replaces the per-group snapshot advance with one unconditional bump. |
| 5 | `strong_consistency: cover committed raft entries with the segments' references` | the covers, and `store_commit_idx()` becoming IO-free. This is the commit that removes the write. |
| 6 | `strong_consistency: persist and restore a committed configuration` | SCYLLADB-3842, both directions. |
| 7 | `test: cover commit_idx persistence across a graceful restart` | the cluster test for the clean-shutdown path. |

Commit 3 is the large one (~730 lines with tests). It cannot usefully be split further: the format change, the write path and the reference model are the same change seen from three sides — the format is what makes one position per batch true, and one position per batch is what makes one reference per batch possible.

## Compatibility

- **On-disk commitlog format**: `raft_commitlog_entry` keeps its variant alternative but changes shape (`entry` becomes `entries`, plus the two header fields), so a segment containing raft entries is not interchangeable between a build before and after commit 3, in either direction. This affects only the `strongly-consistent-tables` experimental feature; segments with no SC raft entries are unaffected, and the variant format itself is unchanged for mutation entries. A clean shutdown flushes the SC memtables and reclaims those segments, so upgrade or rollback across this change should be done from a drained node. **Not yet verified:** whether replaying a mismatched segment fails loudly or misparses — worth confirming before this leaves experimental, and I can add a test for it if reviewers want it in this PR.
- **Schema**: `system.raft_groups` (tablet variant only, not group0's) gains three static columns: `commit_idx_term`, `config`, `config_idx`. Adding static columns is backwards compatible. Pre-upgrade rows have no term; the snapshot bump treats that as "term unknown" and falls back to the last snapshot's term with a warning. No new tables — `raft_groups_snapshots` and `raft_groups_snapshot_config` are pre-existing and untouched.
- **New commitlog API**: `commitlog::acquire_cf_count(src, cf)`. Nothing outside the SC raft path calls it. `segment::_extended_segments` also gains an owner count so several references may share one position safely; that is a no-op today (see SCYLLADB-3986) and exists so a later keying fix cannot silently break this path.
- `system.raft_groups.commit_idx` semantics unchanged (only-advance; may lag the true commit index by design — replay and the leader recover the difference).

## Performance

Measured locally against the branch point (3 nodes x 8 shards on one machine, `--unsafe-bypass-fsync 1`, concurrency 256, 5-byte payload, 30s per arm, rust-driver bench, three iterations per side), re-run after batch framing landed:

| metric (SC writes) | base | this branch | delta |
|---|---|---|---|
| throughput | 197.9k ops/s (189.6 / 204.7 / 199.2) | 248.7k ops/s (246.8 / 253.0 / 246.2) | **+25.7%** |
| average latency | 1.293 ms | 1.030 ms | **-20.4%** |
| regular tablets (control) | 538.8k ops/s | 542.8k ops/s | +0.7% |
| commitlog payload (written - slack) | 1861 B/op | 1264 B/op | **-32.1%** |
| commitlog total written | 4305 B/op | 4426 B/op | +2.8% |
| forced-sync slack | 2444 B/op | 3162 B/op | +29% |
| sync cycles | 0.98 /op | 1.04 /op | +6.6% |
| run-to-run spread | 7.7% | 2.7% | |

Two readings worth being explicit about, because they qualify the headline:

**The throughput and latency win is the io_fiber CQL-write removal, not the framing.** The same branch measured 246.3k ops/s before framing and 248.7k after — a 1% difference inside the 2.7% branch spread. The headline moved from +21% to +25.7% only because this base run came out lower (7.7% spread on the base side).

**Framing hits its byte goal but does not reduce disk bytes at this operating point.** The logical payload drops by a third, and very consistently (1264.0 / 1264.6 / 1264.2 B/op across iterations), but *total* bytes written rose slightly: at ~1 forced-sync cycle per operation the padding to the sync boundary dominates, so the saving is absorbed by slack. The earlier estimate that framing would cut 10-25% of commitlog write amplification does not hold here; converting the payload saving into disk bytes needs a regime where one sync cycle carries many entries (higher concurrency), which is worth measuring before claiming it. Where the saving does count today is replay cost and how much real data a segment holds.

At a 1 kB payload (measured on the pre-framing branch, two iterations per side, ~9% spread) the effect was not measurable: base 116.6k / 127.1k against 121.0k / 131.1k, with SC commitlog cost 7.3 kB/op on both sides. An SCT run under real fsync is still to be done; the earlier AWS/SCT measurement of the same io_fiber-side change (PR #30394) was +8.0% unthrottled SC rps and -32.6% SC p99 @ 50k rps (Confluence 434602091).

## Testing

Runtimes are the test binaries themselves (`-c1 -m4G`), measured on the final tree.

- `test/boost/combined_tests --run_test='commitlog_raft_replay_test/*'` — 38 cases, "No errors detected", 0.4s. Ten new: the batch record's format and header; one cover per batch however many segments a fragmented batch's bytes span; covers accumulating per segment as the active segment rolls over and extending in place when a batch lands in a segment already covered; a command's reference being minted from its batch's and handed out once, and never minted for a dummy or a configuration; truncation orphans and their release floor, including the case where a surviving lower cover must not release them; `acquire_cf_count()` independence, position propagation and chaining; a group whose only replayed batch establishes a floor.
- `test/boost/combined_tests --run_test='commitlog_test/*'` — 66 cases, "No errors detected", 49s. This is the regression net for the `_extended_segments` change.
- `test/raft/raft_sys_table_storage_test` — 25 cases, "No errors detected", 1.5s. Five new, four of them for the configuration work: persisted by coverage, the only-newer snapshot guard, an uncommitted-at-crash configuration that commits after the restart, and the merge of the two configuration sources by index.
- `test/cluster/test_strong_consistency_commitlog.py` — 7 passed in 11.5s, of which the new graceful-restart test is 3.5s on its own.
- All 7 commits build standalone (dev).

Both configuration regressions were verified to fail without their fix: with the constructor seeding removed, the uncommitted-config case fails on `persisted.has_value()`.

## Known follow-ups

- **Single source of truth** (@gusev-p on `main.cc`): drop `system.raft_groups_snapshots` / `..._snapshot_config` and reconstruct the snapshot descriptor from `system.raft_groups`. With `commit_idx`, `commit_idx_term` and now `config` all persisted there, the only remaining dependency is `bootstrap()`, which still persists the initial configuration through `store_snapshot_descriptor()`. That is also what would make snapshotting itself IO-free.
- **Measure framing where the sync padding does not absorb it**: higher concurrency, so one forced-sync cycle carries many entries. Only then can the 32% payload saving become a disk-bytes saving.
- **SCYLLADB-3986**: `segment::_extended_segments` keys a fragmented entry's tail pins by a default-constructed `replay_position`, so the per-entry release in `release_cf_count(cf, rp)` is dead code and the comment above the store site describes an early release that never happens. Filed with a reproducer that fails on master. This PR carries the owner count so that repairing the keying cannot break the callers that hold several references at one position — but the two must land together.
- **Tablet metadata is loaded before commitlog replay** (pre-existing). `build_group_to_table_map()` reads the token metadata loaded at `main.cc:2117`, before group0 log entries apply (2179) and before replay restores unflushed `system.tablets` mutations (2201) — `system.tablets` uses the regular commitlog, not the schema one, so the earlier schema replay does not cover it. A group absent from that map already has its replayed entries discarded today; this PR adds two consumers (the snapshot bump and the configuration restore) that skip such a group for the same reason. Fixing it means reloading tablet metadata after replay, which changes startup ordering for non-SC paths, so it is left out of here.
- **Replay memory** (SCYLLADB-1539): commitlog replay still buffers all raft entries in memory, and framing makes each record bigger (one record is now a whole batch), so this got marginally worse.
- **Parallel replay rewrite**: the per-group rewrite loop is sequential, so its forced-sync writes are not coalesced into one fdatasync.

Fixes: SCYLLADB-2877
Fixes: SCYLLADB-3357
Fixes: SCYLLADB-3842
