### PR TITLE
[Backport 2026.1] s3: bound object storage memory and connections with dedicated semaphores

### DIFF
--- a/db/config.cc
+++ b/db/config.cc
@@ -1574,6 +1574,9 @@ db::config::config(std::shared_ptr<db::extensions> exts)
     , ldap_bind_passwd(this, "ldap_bind_passwd", value_status::Used, "", "Password used by LDAPRoleManager for binding to LDAP server.")
     , saslauthd_socket_path(this, "saslauthd_socket_path", value_status::Used, "", "UNIX domain socket on which saslauthd is listening.")
     , object_storage_endpoints(this, "object_storage_endpoints", liveness::LiveUpdate, value_status::Used, {}, "Object storage endpoints configuration.")
+    , object_storage_connections_per_shard(this, "object_storage_connections_per_shard", value_status::Used, 128,
+        "Maximum number of object storage connections per shard. "
+        "Connections are distributed proportionally across scheduling groups based on their shares.")
     , error_injections_at_startup(this, "error_injections_at_startup", error_injection_value_status, {}, "List of error injections that should be enabled on startup.")
     , topology_barrier_stall_detector_threshold_seconds(this, "topology_barrier_stall_detector_threshold_seconds", value_status::Used, 2, "Report sites blocking topology barrier if it takes longer than this.")
     , enable_tablets(this, "enable_tablets", value_status::Used, false, "Enable tablets for newly created keyspaces. (deprecated)")

--- a/db/config.cc
+++ b/db/config.cc
@@ -1577,6 +1577,8 @@ db::config::config(std::shared_ptr<db::extensions> exts)
     , object_storage_connections_per_shard(this, "object_storage_connections_per_shard", liveness::LiveUpdate, value_status::Used, 128,
         "Maximum number of object storage connections per shard. "
         "Connections are distributed proportionally across scheduling groups based on their shares.")
+    , object_storage_clients_memory_fraction(this, "object_storage_clients_memory_fraction", value_status::Unused, 0.01,
+        "Fraction of shard memory used as the buffer budget shared by all object storage clients.")
     , error_injections_at_startup(this, "error_injections_at_startup", error_injection_value_status, {}, "List of error injections that should be enabled on startup.")
     , topology_barrier_stall_detector_threshold_seconds(this, "topology_barrier_stall_detector_threshold_seconds", value_status::Used, 2, "Report sites blocking topology barrier if it takes longer than this.")
     , enable_tablets(this, "enable_tablets", value_status::Used, false, "Enable tablets for newly created keyspaces. (deprecated)")

--- a/db/config.cc
+++ b/db/config.cc
@@ -1574,7 +1574,7 @@ db::config::config(std::shared_ptr<db::extensions> exts)
     , ldap_bind_passwd(this, "ldap_bind_passwd", value_status::Used, "", "Password used by LDAPRoleManager for binding to LDAP server.")
     , saslauthd_socket_path(this, "saslauthd_socket_path", value_status::Used, "", "UNIX domain socket on which saslauthd is listening.")
     , object_storage_endpoints(this, "object_storage_endpoints", liveness::LiveUpdate, value_status::Used, {}, "Object storage endpoints configuration.")
-    , object_storage_connections_per_shard(this, "object_storage_connections_per_shard", value_status::Used, 128,
+    , object_storage_connections_per_shard(this, "object_storage_connections_per_shard", liveness::LiveUpdate, value_status::Used, 128,
         "Maximum number of object storage connections per shard. "
         "Connections are distributed proportionally across scheduling groups based on their shares.")
     , error_injections_at_startup(this, "error_injections_at_startup", error_injection_value_status, {}, "List of error injections that should be enabled on startup.")

--- a/db/config.hh
+++ b/db/config.hh
@@ -577,6 +577,7 @@ public:
 
     named_value<std::vector<object_storage_endpoint_param>> object_storage_endpoints;
     named_value<unsigned> object_storage_connections_per_shard;
+    named_value<double> object_storage_clients_memory_fraction;
 
     named_value<std::vector<error_injection_at_startup>> error_injections_at_startup;
     named_value<double> topology_barrier_stall_detector_threshold_seconds;

--- a/db/config.hh
+++ b/db/config.hh
@@ -576,6 +576,7 @@ public:
     const db::extensions& extensions() const;
 
     named_value<std::vector<object_storage_endpoint_param>> object_storage_endpoints;
+    named_value<unsigned> object_storage_connections_per_shard;
 
     named_value<std::vector<error_injection_at_startup>> error_injections_at_startup;
     named_value<double> topology_barrier_stall_detector_threshold_seconds;

--- a/main.cc
+++ b/main.cc
@@ -1281,7 +1281,10 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
 
             checkpoint(stop_signal, "starting storage manager");
             sstables::storage_manager::config stm_cfg;
-            stm_cfg.object_storage_clients_memory = std::clamp<size_t>(memory::stats().total_memory() * 0.01, 10 << 20, 100 << 20);
+            stm_cfg.object_storage_clients_memory = std::max<size_t>(10 << 20, memory::stats().total_memory() * cfg->object_storage_clients_memory_fraction());
+            startlog.info("Object storage clients memory budget: {} bytes ({}% of shard memory)",
+                          stm_cfg.object_storage_clients_memory,
+                          cfg->object_storage_clients_memory_fraction() * 100);
             sstm.start(std::ref(*cfg), stm_cfg).get();
             auto stop_sstm = defer_verbose_shutdown("sstables storage manager", [&sstm] {
                 sstm.stop().get();

--- a/sstables/object_storage_client.cc
+++ b/sstables/object_storage_client.cc
@@ -112,6 +112,9 @@ public:
         auto& epc = ep.get_s3_storage();
         _client->update_config_sync(epc.region, epc.iam_role_arn);
     }
+    void update_connections_per_shard(unsigned connections_per_shard) override {
+        _client->update_connections_per_shard(connections_per_shard);
+    }
     future<> close() override {
         return _client->close();
     }
@@ -310,6 +313,9 @@ public:
                 .finally([old_client = std::move(old_client), h = std::move(holder)] {
                     osclog.info("Old GCS client cleanup done, use_count={}", old_client.use_count());
                 });
+    }
+    void update_connections_per_shard(unsigned) override {
+        // GCS client does not support per-scheduling-group connection budgeting
     }
     future<> close() override {
         osclog.info("Closing GCS client...");

--- a/sstables/object_storage_client.cc
+++ b/sstables/object_storage_client.cc
@@ -6,13 +6,17 @@
  * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
  */
 
+#include <exception>
 #include <string>
 #include <optional>
 
 #include <seastar/core/future.hh>
+#include <seastar/core/gate.hh>
 #include <seastar/core/semaphore.hh>
 #include <seastar/core/iostream.hh>
 #include <fmt/core.h>
+
+#include "utils/log.hh"
 
 #include "db/object_storage_endpoint_param.hh"
 
@@ -29,6 +33,8 @@
 using namespace seastar;
 using namespace sstables;
 using namespace utils;
+
+static logging::logger osclog("object_storage_client");
 
 
 sstables::object_name::object_name(std::string_view bucket, std::string_view prefix, std::string_view type)
@@ -102,9 +108,9 @@ public:
     future<> upload_file(std::filesystem::path path, object_name name, utils::upload_progress& up, seastar::abort_source* as) override {
         return _client->upload_file(std::move(path), name.str(), up, as);
     }
-    future<> update_config(const db::object_storage_endpoint_param& ep) override {
+    void update_config_sync(const db::object_storage_endpoint_param& ep) override {
         auto& epc = ep.get_s3_storage();
-        return _client->update_config(epc.region, epc.iam_role_arn);
+        _client->update_config_sync(epc.region, epc.iam_role_arn);
     }
     future<> close() override {
         return _client->close();
@@ -131,6 +137,7 @@ class gs_client_wrapper : public sstables::object_storage_client {
     shared_ptr<gcp::storage::client> _client;
     semaphore& _memory;
     std::function<shared_ptr<gcp::storage::client>()> _shard_client;
+    seastar::gate _config_update_gate;
 public:
     gs_client_wrapper(const db::object_storage_endpoint_param& ep, semaphore& memory, shard_client_factory cf)
         : _client(make_gcs_client(ep, memory))
@@ -285,12 +292,30 @@ public:
         }
 
     }
-    future<> update_config(const db::object_storage_endpoint_param& ep) override {
-        auto client = std::exchange(_client, make_gcs_client(ep, _memory));
-        co_await client->close();
+    void update_config_sync(const db::object_storage_endpoint_param& ep) override {
+        if (_config_update_gate.is_closed()) {
+            osclog.info("config update gate is closed");
+            return;
+        }
+
+        osclog.info("Updating GCS client config");
+
+        auto holder = _config_update_gate.hold();
+        auto new_client = make_gcs_client(ep, _memory);
+        auto old_client = std::exchange(_client, std::move(new_client));
+        (void)old_client->close()
+                .handle_exception([](std::exception_ptr ex) {
+                    osclog.error("Failed to close old GCS client during config update: {}", ex);
+                })
+                .finally([old_client = std::move(old_client), h = std::move(holder)] {
+                    osclog.info("Old GCS client cleanup done, use_count={}", old_client.use_count());
+                });
     }
     future<> close() override {
-        return _client->close();
+        osclog.info("Closing GCS client...");
+        co_await _config_update_gate.close();
+        co_await _client->close();
+        osclog.info("Closed GCS client");
     }
 };
 

--- a/sstables/object_storage_client.cc
+++ b/sstables/object_storage_client.cc
@@ -66,17 +66,17 @@ fmt::formatter<sstables::object_name>::format(const sstables::object_name& n, fm
     return fmt::format_to(ctx.out(), "{}", n.str());
 }
 
-static shared_ptr<s3::client> make_s3_client(const db::object_storage_endpoint_param& ep, semaphore& memory, std::function<shared_ptr<s3::client>(std::string)> factory, unsigned connections_per_shard) {
+static shared_ptr<s3::client> make_s3_client(const db::object_storage_endpoint_param& ep, std::function<shared_ptr<s3::client>(std::string)> factory, unsigned connections_per_shard) {
     auto& epc = ep.get_s3_storage();
-    return s3::client::make(epc.endpoint, epc.region, epc.iam_role_arn, memory, std::move(factory), connections_per_shard);
+    return s3::client::make(epc.endpoint, epc.region, epc.iam_role_arn, std::move(factory), connections_per_shard);
 }
 
 class s3_client_wrapper : public sstables::object_storage_client {
     shared_ptr<s3::client> _client;
     shard_client_factory _cf;
 public:
-    s3_client_wrapper(const db::object_storage_endpoint_param& ep, semaphore& memory, shard_client_factory cf, unsigned connections_per_shard)
-        : _client(make_s3_client(ep, memory, std::bind_front(&s3_client_wrapper::shard_client, this), connections_per_shard))
+    s3_client_wrapper(const db::object_storage_endpoint_param& ep, shard_client_factory cf, unsigned connections_per_shard)
+        : _client(make_s3_client(ep, std::bind_front(&s3_client_wrapper::shard_client, this), connections_per_shard))
         , _cf(std::move(cf))
     {}
     shared_ptr<s3::client> shard_client(std::string host) const {
@@ -327,7 +327,7 @@ public:
 
 shared_ptr<object_storage_client> sstables::make_object_storage_client(const db::object_storage_endpoint_param& ep, semaphore& memory, shard_client_factory cf, unsigned connections_per_shard) {
     if (ep.is_s3_storage()) {
-        return seastar::make_shared<s3_client_wrapper>(ep, memory, std::move(cf), connections_per_shard);
+        return seastar::make_shared<s3_client_wrapper>(ep, std::move(cf), connections_per_shard);
     }
     if (ep.is_gs_storage()) {
         return seastar::make_shared<gs_client_wrapper>(ep, memory, std::move(cf));

--- a/sstables/object_storage_client.cc
+++ b/sstables/object_storage_client.cc
@@ -66,17 +66,17 @@ fmt::formatter<sstables::object_name>::format(const sstables::object_name& n, fm
     return fmt::format_to(ctx.out(), "{}", n.str());
 }
 
-static shared_ptr<s3::client> make_s3_client(const db::object_storage_endpoint_param& ep, semaphore& memory, std::function<shared_ptr<s3::client>(std::string)> factory) {
+static shared_ptr<s3::client> make_s3_client(const db::object_storage_endpoint_param& ep, semaphore& memory, std::function<shared_ptr<s3::client>(std::string)> factory, unsigned connections_per_shard) {
     auto& epc = ep.get_s3_storage();
-    return s3::client::make(epc.endpoint, epc.region, epc.iam_role_arn, memory, std::move(factory));
+    return s3::client::make(epc.endpoint, epc.region, epc.iam_role_arn, memory, std::move(factory), connections_per_shard);
 }
 
 class s3_client_wrapper : public sstables::object_storage_client {
     shared_ptr<s3::client> _client;
     shard_client_factory _cf;
 public:
-    s3_client_wrapper(const db::object_storage_endpoint_param& ep, semaphore& memory, shard_client_factory cf)
-        : _client(make_s3_client(ep, memory, std::bind_front(&s3_client_wrapper::shard_client, this)))
+    s3_client_wrapper(const db::object_storage_endpoint_param& ep, semaphore& memory, shard_client_factory cf, unsigned connections_per_shard)
+        : _client(make_s3_client(ep, memory, std::bind_front(&s3_client_wrapper::shard_client, this), connections_per_shard))
         , _cf(std::move(cf))
     {}
     shared_ptr<s3::client> shard_client(std::string host) const {
@@ -319,9 +319,9 @@ public:
     }
 };
 
-shared_ptr<object_storage_client> sstables::make_object_storage_client(const db::object_storage_endpoint_param& ep, semaphore& memory, shard_client_factory cf) {
+shared_ptr<object_storage_client> sstables::make_object_storage_client(const db::object_storage_endpoint_param& ep, semaphore& memory, shard_client_factory cf, unsigned connections_per_shard) {
     if (ep.is_s3_storage()) {
-        return seastar::make_shared<s3_client_wrapper>(ep, memory, std::move(cf));
+        return seastar::make_shared<s3_client_wrapper>(ep, memory, std::move(cf), connections_per_shard);
     }
     if (ep.is_gs_storage()) {
         return seastar::make_shared<gs_client_wrapper>(ep, memory, std::move(cf));

--- a/sstables/object_storage_client.hh
+++ b/sstables/object_storage_client.hh
@@ -81,7 +81,7 @@ public:
 
     virtual future<> upload_file(std::filesystem::path path, object_name, utils::upload_progress& up, seastar::abort_source* = nullptr) = 0;
 
-    virtual future<> update_config(const db::object_storage_endpoint_param&) = 0;
+    virtual void update_config_sync(const db::object_storage_endpoint_param&) = 0;
 
     virtual future<> close() = 0;
 };

--- a/sstables/object_storage_client.hh
+++ b/sstables/object_storage_client.hh
@@ -83,6 +83,7 @@ public:
     virtual future<> upload_file(std::filesystem::path path, object_name, utils::upload_progress& up, seastar::abort_source* = nullptr) = 0;
 
     virtual void update_config_sync(const db::object_storage_endpoint_param&) = 0;
+    virtual void update_connections_per_shard(unsigned) = 0;
 
     virtual future<> close() = 0;
 };

--- a/sstables/object_storage_client.hh
+++ b/sstables/object_storage_client.hh
@@ -17,6 +17,7 @@
 #include <fmt/core.h>
 
 #include "utils/lister.hh"
+#include "utils/s3/creds.hh"
 
 namespace seastar {
 class abort_source;
@@ -88,7 +89,7 @@ public:
 
 using shard_client_factory = std::function<shared_ptr<object_storage_client>(std::string)>;
 
-shared_ptr<object_storage_client> make_object_storage_client(const db::object_storage_endpoint_param&, semaphore&, shard_client_factory);
+shared_ptr<object_storage_client> make_object_storage_client(const db::object_storage_endpoint_param&, semaphore&, shard_client_factory, unsigned connections_per_shard = s3::endpoint_config::default_connections_per_shard);
 
 }
 

--- a/sstables/sstables_manager.cc
+++ b/sstables/sstables_manager.cc
@@ -84,6 +84,7 @@ storage_manager::storage_manager(const db::config& cfg, config stm_cfg)
     : _object_storage_clients_memory(stm_cfg.object_storage_clients_memory)
     , _connections_per_shard(cfg.object_storage_connections_per_shard())
     , _config_updater(std::make_unique<config_updater_sync>(cfg, *this))
+    , _connections_updater(std::make_unique<connections_updater_sync>(cfg, *this))
 {
     for (auto& e : cfg.object_storage_endpoints()) {
         _object_storage_endpoints.emplace(std::make_pair(e.key(), e));
@@ -164,6 +165,18 @@ storage_manager::config_updater_sync::config_updater_sync(const db::config& cfg,
         std::erase_if(sstm._object_storage_endpoints, [&updates](const auto& e) {
             return !updates.contains(e.first);
         });
+    }))
+{}
+
+storage_manager::connections_updater_sync::connections_updater_sync(const db::config& cfg, storage_manager& sstm)
+    : observer(cfg.object_storage_connections_per_shard.observe([&sstm] (unsigned new_value) {
+        smlogger.info("connections_updater: updating connections_per_shard to {}", new_value);
+        sstm._connections_per_shard = new_value;
+        for (auto& [endpoint, ep] : sstm._object_storage_endpoints) {
+            if (ep.client) {
+                ep.client->update_connections_per_shard(new_value);
+            }
+        }
     }))
 {}
 

--- a/sstables/sstables_manager.cc
+++ b/sstables/sstables_manager.cc
@@ -82,6 +82,7 @@ storage_manager::object_storage_endpoint::object_storage_endpoint(db::object_sto
 
 storage_manager::storage_manager(const db::config& cfg, config stm_cfg)
     : _object_storage_clients_memory(stm_cfg.object_storage_clients_memory)
+    , _connections_per_shard(cfg.object_storage_connections_per_shard())
     , _config_updater(std::make_unique<config_updater_sync>(cfg, *this))
 {
     for (auto& e : cfg.object_storage_endpoints()) {
@@ -120,7 +121,7 @@ shared_ptr<sstables::object_storage_client> storage_manager::get_endpoint_client
     if (ep.client == nullptr) {
         ep.client = make_object_storage_client(ep.cfg, _object_storage_clients_memory, [&ct = container()] (std::string ep) {
             return ct.local().get_endpoint_client(ep);
-        });
+        }, _connections_per_shard);
     }
     return ep.client;
 }

--- a/sstables/sstables_manager.cc
+++ b/sstables/sstables_manager.cc
@@ -9,6 +9,7 @@
 #include <seastar/coroutine/parallel_for_each.hh>
 #include <seastar/coroutine/switch_to.hh>
 #include <unordered_map>
+#include <unordered_set>
 #include "utils/log.hh"
 #include "sstables/sstables_manager.hh"
 #include "sstables/sstable_directory.hh"
@@ -81,7 +82,7 @@ storage_manager::object_storage_endpoint::object_storage_endpoint(db::object_sto
 
 storage_manager::storage_manager(const db::config& cfg, config stm_cfg)
     : _object_storage_clients_memory(stm_cfg.object_storage_clients_memory)
-    , _config_updater(std::make_unique<config_updater>(cfg, *this))
+    , _config_updater(std::make_unique<config_updater_sync>(cfg, *this))
 {
     for (auto& e : cfg.object_storage_endpoints()) {
         _object_storage_endpoints.emplace(std::make_pair(e.key(), e));
@@ -97,10 +98,6 @@ storage_manager::storage_manager(const db::config& cfg, config stm_cfg)
 }
 
 future<> storage_manager::stop() {
-    if (_config_updater) {
-        co_await _config_updater->action.join();
-    }
-
     for (auto ep : _object_storage_endpoints) {
         if (ep.second.client != nullptr) {
             co_await ep.second.client->close();
@@ -108,34 +105,6 @@ future<> storage_manager::stop() {
     }
 }
 
-future<> storage_manager::update_config(const db::config& cfg) {
-    // Updates S3 client configurations if the endpoint is already known and
-    // removes the entries that are not present in the new configuration.
-    // Even though we remove obsolete S3 clients from this map, each IO
-    // holds a shared_ptr to the client, so the clients will be kept alive for
-    // as long as needed. 
-    // This was split in two loops to guarantee the code is exception safe with
-    // regards to _s3_endpoints content.
-    std::unordered_set<sstring> updates;
-    for (auto& e : cfg.object_storage_endpoints()) {
-        auto endpoint = e.key();
-        updates.insert(endpoint);
-
-        auto [it, added] = _object_storage_endpoints.try_emplace(endpoint, e);
-        if (!added) {
-            if (it->second.client != nullptr) {
-                co_await it->second.client->update_config(e);
-            }
-            it->second.cfg = e;
-        }
-    }
-
-    std::erase_if(_object_storage_endpoints, [&updates](const auto& e) {
-        return !updates.contains(e.first);
-    });
-
-    co_return;
-}
 
 auto storage_manager::get_endpoint(const sstring& endpoint) -> object_storage_endpoint& {
     auto found = _object_storage_endpoints.find(endpoint);
@@ -170,11 +139,31 @@ std::vector<sstring> storage_manager::endpoints(sstring type) const noexcept {
     }) | std::views::keys | std::ranges::to<std::vector>();
 }
 
-storage_manager::config_updater::config_updater(const db::config& cfg, storage_manager& sstm)
-    : action([&sstm, &cfg] () mutable {
-        return sstm.update_config(cfg);
-    })
-    , observer(cfg.object_storage_endpoints.observe(action.make_observer()))
+storage_manager::config_updater_sync::config_updater_sync(const db::config& cfg, storage_manager& sstm)
+    : observer(cfg.object_storage_endpoints.observe([&sstm, &cfg] (const std::vector<db::object_storage_endpoint_param>&) {
+        // Sync part: runs atomically in the current reactor turn 
+        // Update _object_storage_endpoints so that any subsequent call to
+        // get_endpoint_client() immediately sees the new configuration.
+        // Each client's update_config_sync() spawns its own async background
+        // work (credential refresh for S3, old client close for GCS) into a
+        // client-local gated fiber.
+        std::unordered_set<sstring> updates;
+        for (auto& e : cfg.object_storage_endpoints()) {
+            auto endpoint = e.key();
+            smlogger.info("config_updater: endpoint={}, config={}", endpoint, e);
+            updates.insert(endpoint);
+            auto [it, added] = sstm._object_storage_endpoints.try_emplace(endpoint, e);
+            if (!added) {
+                if (it->second.client) {
+                    it->second.client->update_config_sync(e);
+                }
+                it->second.cfg = e;
+            }
+        }
+        std::erase_if(sstm._object_storage_endpoints, [&updates](const auto& e) {
+            return !updates.contains(e.first);
+        });
+    }))
 {}
 
 sstables::sstable::version_types sstables_manager::get_highest_supported_format() const noexcept {

--- a/sstables/sstables_manager.hh
+++ b/sstables/sstables_manager.hh
@@ -61,10 +61,9 @@ struct sstable_snapshot_metadata {
 };
 
 class storage_manager : public peering_sharded_service<storage_manager> {
-    struct config_updater {
-        serialized_action action;
+    struct config_updater_sync {
         utils::observer<std::vector<db::object_storage_endpoint_param>> observer;
-        config_updater(const db::config& cfg, storage_manager&);
+        config_updater_sync(const db::config& cfg, storage_manager&);
     };
 
     struct object_storage_endpoint {
@@ -75,10 +74,9 @@ class storage_manager : public peering_sharded_service<storage_manager> {
 
     semaphore _object_storage_clients_memory;
     std::unordered_map<sstring, object_storage_endpoint> _object_storage_endpoints;
-    std::unique_ptr<config_updater> _config_updater;
+    std::unique_ptr<config_updater_sync> _config_updater;
     seastar::metrics::metric_groups metrics;
 
-    future<> update_config(const db::config&);
     object_storage_endpoint& get_endpoint(const sstring& ep);
 
 public:

--- a/sstables/sstables_manager.hh
+++ b/sstables/sstables_manager.hh
@@ -66,6 +66,11 @@ class storage_manager : public peering_sharded_service<storage_manager> {
         config_updater_sync(const db::config& cfg, storage_manager&);
     };
 
+    struct connections_updater_sync {
+        utils::observer<unsigned> observer;
+        connections_updater_sync(const db::config& cfg, storage_manager&);
+    };
+
     struct object_storage_endpoint {
         db::object_storage_endpoint_param cfg;
         shared_ptr<object_storage_client> client;
@@ -76,6 +81,7 @@ class storage_manager : public peering_sharded_service<storage_manager> {
     unsigned _connections_per_shard;
     std::unordered_map<sstring, object_storage_endpoint> _object_storage_endpoints;
     std::unique_ptr<config_updater_sync> _config_updater;
+    std::unique_ptr<connections_updater_sync> _connections_updater;
     seastar::metrics::metric_groups metrics;
 
     object_storage_endpoint& get_endpoint(const sstring& ep);

--- a/sstables/sstables_manager.hh
+++ b/sstables/sstables_manager.hh
@@ -73,6 +73,7 @@ class storage_manager : public peering_sharded_service<storage_manager> {
     };
 
     semaphore _object_storage_clients_memory;
+    unsigned _connections_per_shard;
     std::unordered_map<sstring, object_storage_endpoint> _object_storage_endpoints;
     std::unique_ptr<config_updater_sync> _config_updater;
     seastar::metrics::metric_groups metrics;

--- a/test/boost/aws_error_injection_test.cc
+++ b/test/boost/aws_error_injection_test.cc
@@ -56,7 +56,7 @@ static void register_policy(const std::string& key, failure_policy policy) {
     cln.make_request(std::move(req), [](const http::reply&, input_stream<char>&&) -> future<> { return seastar::make_ready_future(); }).get();
 }
 
-void test_client_upload_file(std::string_view test_name, failure_policy policy, size_t total_size, size_t memory_size) {
+void test_client_upload_file(std::string_view test_name, failure_policy policy, size_t total_size) {
     tmpdir tmp;
     const auto file_path = tmp.path() / fmt::format("test-{}", ::getpid());
     {
@@ -75,8 +75,7 @@ void test_client_upload_file(std::string_view test_name, failure_policy policy, 
     const auto object_name = fmt::format("/{}/{}-{}", "test", test_name, ::getpid());
     register_policy(object_name, policy);
 
-    semaphore mem{memory_size};
-    auto client = s3::client::make(get_address(), make_minio_config(), mem);
+    auto client = s3::client::make(get_address(), make_minio_config());
     auto client_shutdown = deferred_close(*client);
     client->upload_file(file_path, object_name).get();
 }
@@ -85,24 +84,21 @@ SEASTAR_THREAD_TEST_CASE(test_multipart_upload_file_success) {
     const size_t part_size = 5_MiB;
     const size_t remainder_size = part_size / 2;
     const size_t total_size = 4 * part_size + remainder_size;
-    const size_t memory_size = part_size;
-    BOOST_REQUIRE_NO_THROW(test_client_upload_file(seastar_test::get_name(), failure_policy::SUCCESS, total_size, memory_size));
+    BOOST_REQUIRE_NO_THROW(test_client_upload_file(seastar_test::get_name(), failure_policy::SUCCESS, total_size));
 }
 
 SEASTAR_THREAD_TEST_CASE(test_multipart_upload_file_retryable_success) {
     const size_t part_size = 5_MiB;
     const size_t remainder_size = part_size / 2;
     const size_t total_size = 4 * part_size + remainder_size;
-    const size_t memory_size = part_size;
-    BOOST_REQUIRE_NO_THROW(test_client_upload_file(seastar_test::get_name(), failure_policy::RETRYABLE_FAILURE, total_size, memory_size));
+    BOOST_REQUIRE_NO_THROW(test_client_upload_file(seastar_test::get_name(), failure_policy::RETRYABLE_FAILURE, total_size));
 }
 
 SEASTAR_THREAD_TEST_CASE(test_multipart_upload_file_failure_1) {
     const size_t part_size = 5_MiB;
     const size_t remainder_size = part_size / 2;
     const size_t total_size = 4 * part_size + remainder_size;
-    const size_t memory_size = part_size;
-    BOOST_REQUIRE_EXCEPTION(test_client_upload_file(seastar_test::get_name(), failure_policy::NEVERENDING_RETRYABLE_FAILURE, total_size, memory_size),
+    BOOST_REQUIRE_EXCEPTION(test_client_upload_file(seastar_test::get_name(), failure_policy::NEVERENDING_RETRYABLE_FAILURE, total_size),
             storage_io_error, [](const storage_io_error& e) {
                 return e.code().value() == EIO && e.what() == "S3 request failed. Code: 1. Reason: We encountered an internal error. Please try again."sv;
             });
@@ -112,8 +108,7 @@ SEASTAR_THREAD_TEST_CASE(test_multipart_upload_file_failure_2) {
     const size_t part_size = 5_MiB;
     const size_t remainder_size = part_size / 2;
     const size_t total_size = 4 * part_size + remainder_size;
-    const size_t memory_size = part_size;
-    BOOST_REQUIRE_EXCEPTION(test_client_upload_file(seastar_test::get_name(), failure_policy::NONRETRYABLE_FAILURE, total_size, memory_size), storage_io_error,
+    BOOST_REQUIRE_EXCEPTION(test_client_upload_file(seastar_test::get_name(), failure_policy::NONRETRYABLE_FAILURE, total_size), storage_io_error,
             [](const storage_io_error& e) {
                 return e.code().value() == EIO && e.what() == "S3 request failed. Code: 2. Reason: Something went terribly wrong"sv;
             });
@@ -124,8 +119,7 @@ void do_test_client_multipart_upload(failure_policy policy, bool is_jumbo = fals
 
     register_policy(name, policy);
     testlog.info("Make client");
-    semaphore mem(16 << 20);
-    auto cln = s3::client::make(get_address(), make_minio_config(), mem);
+    auto cln = s3::client::make(get_address(), make_minio_config());
     auto close_client = deferred_close(*cln);
 
     testlog.info("Upload object");

--- a/test/boost/s3_test.cc
+++ b/test/boost/s3_test.cc
@@ -770,57 +770,6 @@ SEASTAR_THREAD_TEST_CASE(test_chunked_download_data_source_with_delays_proxy) {
     test_chunked_download_data_source(make_proxy_client, 20_MiB);
 }
 
-void do_test_chunked_download_data_source_memory(const client_maker_function& client_maker, size_t object_size) {
-    const sstring base_name(fmt::format("test_object-{}", ::getpid()));
-
-    tmpdir tmp;
-    const auto file_path = tmp.path() / base_name;
-
-    create_file(file_path, object_size).get();
-
-    testlog.info("Make client\n");
-    auto cln = client_maker();
-    auto close_client = deferred_close(*cln);
-    const auto object_name = fmt::format("/{}/{}", tests::getenv_safe("S3_BUCKET_FOR_TEST"), base_name);
-    auto delete_object = deferred_delete_object(cln, object_name);
-    cln->upload_file(file_path, object_name).get();
-
-    testlog.info("Test client memory exhaust");
-    std::vector<input_stream<char>> clients;
-    for (auto _ : {1, 2, 3}) {
-        clients.emplace_back(cln->make_chunked_download_source(object_name, s3::full_range));
-    }
-    testlog.info("Wait to exhaust client memory.");
-    // Allow the background fiber time to fill the buffer queue.
-    // This may introduce some unpredictability in the queue's contents,
-    // but that's intentional—we want to verify the client's ability to handle such conditions.
-    seastar::sleep(100ms).get();
-    std::mt19937_64 rand_gen(std::random_device{}());
-    std::uniform_int_distribution<std::size_t> dist(0, clients.size() - 1);
-    while (true) {
-        auto idx = dist(rand_gen);
-        // Introduce additional randomness: read from input streams in a non-deterministic order,
-        // and sleep briefly between reads to give the background fiber time to potentially stall while filling the queue.
-        seastar::sleep(std::chrono::microseconds(50 * (idx + 1))).get();
-        auto buf = clients[idx].read().get();
-        testlog.info("Got {} bytes from client {}", buf.size(), idx);
-        if (buf.empty()) {
-            clients[idx].close().get();
-            clients.erase(clients.begin() + idx);
-
-            // Recalculate distribution range. May overflow if last client was removed - this is acceptable for the test.
-            dist = std::uniform_int_distribution<std::size_t>(0, clients.size() - 1);
-        }
-        if (clients.empty()) {
-            break;
-        }
-    }
-}
-
-SEASTAR_THREAD_TEST_CASE(test_chunked_download_data_source_memory) {
-    do_test_chunked_download_data_source_memory(make_minio_client, 20_MiB);
-}
-
 void test_object_copy(const client_maker_function& client_maker, size_t chunk_size, size_t chunks) {
     const sstring name(fmt::format("/{}/testobject-{}", tests::getenv_safe("S3_BUCKET_FOR_TEST"), ::getpid()));
     const sstring name_copy(fmt::format("/{}/testobject-{}-copy", tests::getenv_safe("S3_BUCKET_FOR_TEST"), ::getpid()));

--- a/test/boost/s3_test.cc
+++ b/test/boost/s3_test.cc
@@ -420,7 +420,6 @@ SEASTAR_TEST_CASE(test_client_upload_file_single_part_proxy) {
     co_await test_client_upload_file(make_proxy_client, seastar_test::get_name(), total_size, memory_size);
 }
 
-
 void client_readable_file(const client_maker_function& client_maker) {
     const sstring name(fmt::format("/{}/testroobject-{}", tests::getenv_safe("S3_BUCKET_FOR_TEST"), ::getpid()));
 

--- a/test/boost/s3_test.cc
+++ b/test/boost/s3_test.cc
@@ -53,22 +53,22 @@ using namespace std::chrono_literals;
 //   export AWS_SESSION_TOKEN=${aws_session_token}
 //   export AWS_DEFAULT_REGION="us-east-2"
 
-static shared_ptr<s3::client> make_proxy_client(semaphore& mem) {
+static shared_ptr<s3::client> make_proxy_client() {
     s3::endpoint_config cfg = {
         .port = std::stoul(tests::getenv_safe("PROXY_S3_SERVER_PORT")),
         .use_https = false,
         .region = ::getenv("AWS_DEFAULT_REGION") ? : "local",
     };
-    return s3::client::make(tests::getenv_safe("PROXY_S3_SERVER_HOST"), make_lw_shared<s3::endpoint_config>(std::move(cfg)), mem);
+    return s3::client::make(tests::getenv_safe("PROXY_S3_SERVER_HOST"), make_lw_shared<s3::endpoint_config>(std::move(cfg)));
 }
 
-static shared_ptr<s3::client> make_minio_client(semaphore& mem) {
+static shared_ptr<s3::client> make_minio_client() {
     s3::endpoint_config cfg = {
         .port = std::stoul(tests::getenv_safe("S3_SERVER_PORT_FOR_TEST")),
         .use_https = ::getenv("AWS_DEFAULT_REGION") != nullptr,
         .region = ::getenv("AWS_DEFAULT_REGION") ? : "local",
     };
-    return s3::client::make(tests::getenv_safe("S3_SERVER_ADDRESS_FOR_TEST"), make_lw_shared<s3::endpoint_config>(std::move(cfg)), mem);
+    return s3::client::make(tests::getenv_safe("S3_SERVER_ADDRESS_FOR_TEST"), make_lw_shared<s3::endpoint_config>(std::move(cfg)));
 }
 
 static future<uint32_t> create_file(const std::string& path, size_t file_size) {
@@ -87,7 +87,7 @@ static future<uint32_t> create_file(const std::string& path, size_t file_size) {
     co_return ret_val;
 }
 
-using client_maker_function = std::function<shared_ptr<s3::client>(semaphore&)>;
+using client_maker_function = std::function<shared_ptr<s3::client>()>;
 
 /*
  * Tests below expect minio server to be running on localhost
@@ -99,8 +99,7 @@ void client_put_get_object(const client_maker_function& client_maker) {
     const sstring name(fmt::format("/{}/testobject-{}", tests::getenv_safe("S3_BUCKET_FOR_TEST"), ::getpid()));
 
     testlog.info("Make client\n");
-    semaphore mem(16 << 20);
-    auto cln = client_maker(mem);
+    auto cln = client_maker();
     auto close_client = deferred_close(*cln);
 
     testlog.info("Put object {}\n", name);
@@ -153,8 +152,7 @@ void do_test_client_multipart_upload(const client_maker_function& client_maker, 
     const sstring name(fmt::format("/{}/test{}object-{}", tests::getenv_safe("S3_BUCKET_FOR_TEST"), with_copy_upload ? "jumbo" : "large", ::getpid()));
 
     testlog.info("Make client\n");
-    semaphore mem(16<<20);
-    auto cln = client_maker(mem);
+    auto cln = client_maker();
     auto close_client = deferred_close(*cln);
 
     testlog.info("Upload object (with copy = {})\n", with_copy_upload);
@@ -217,50 +215,13 @@ SEASTAR_THREAD_TEST_CASE(test_client_multipart_copy_upload_proxy) {
     do_test_client_multipart_upload(make_proxy_client, true);
 }
 
-void client_multipart_upload_fallback(const client_maker_function& client_maker) {
-    const sstring name(fmt::format("/{}/testfbobject-{}", tests::getenv_safe("S3_BUCKET_FOR_TEST"), ::getpid()));
-
-    testlog.info("Make client");
-    semaphore mem(0);
-    mem.broken(); // so that any attempt to use it throws
-    auto cln = client_maker(mem);
-    auto close_client = deferred_close(*cln);
-
-    testlog.info("Upload object");
-    auto out = output_stream<char>(cln->make_upload_sink(name));
-    auto close = seastar::deferred_close(out);
-
-    temporary_buffer<char> data = sstring("1A3B5C7890").release();
-    out.write(reinterpret_cast<const char*>(data.begin()), data.size()).get();
-
-    testlog.info("Flush upload");
-    out.flush().get(); // if it tries to do regular flush, memory claim would throw
-    auto delete_object = deferred_delete_object(cln, name);
-
-    testlog.info("Closing");
-    close.close_now();
-
-    testlog.info("Get object content");
-    temporary_buffer<char> res = cln->get_object_contiguous(name).get();
-    BOOST_REQUIRE_EQUAL(to_sstring(std::move(res)), to_sstring(std::move(data)));
-}
-
-SEASTAR_THREAD_TEST_CASE(test_client_multipart_upload_fallback_minio) {
-    client_multipart_upload_fallback(make_minio_client);
-}
-
-SEASTAR_THREAD_TEST_CASE(test_client_multipart_upload_fallback_proxy) {
-    client_multipart_upload_fallback(make_proxy_client);
-}
-
 // A zero-byte component is not hypothetical. BTI's Rows.db is empty for an
 // sstable holding only small partitions, and sstables/mx/writer.cc papers over
 // that by appending four bytes of padding before closing the writer. The tests
 // below pin down what each upload path does when nothing at all is written.
 
 void do_test_client_put_empty_object(const client_maker_function& client_maker) {
-    semaphore mem(16<<20);
-    auto cln = client_maker(mem);
+    auto cln = client_maker();
     auto close_client = deferred_close(*cln);
     const sstring name(fmt::format("/{}/testfbobject-{}", tests::getenv_safe("S3_BUCKET_FOR_TEST"), ::getpid()));
 
@@ -272,8 +233,7 @@ void do_test_client_put_empty_object(const client_maker_function& client_maker) 
 }
 
 void do_test_client_upload_empty_object(const client_maker_function& client_maker, bool with_copy_upload) {
-    semaphore mem(16<<20);
-    auto cln = client_maker(mem);
+    auto cln = client_maker();
     auto close_client = deferred_close(*cln);
     const sstring name(fmt::format("/{}/testfbobject-{}", tests::getenv_safe("S3_BUCKET_FOR_TEST"), ::getpid()));
 
@@ -297,8 +257,7 @@ void do_test_client_upload_empty_object(const client_maker_function& client_make
 // Reading a zero-length object needs the same care as writing one: no byte range
 // is satisfiable on an empty object, so a ranged GET is answered with 416.
 void do_test_download_empty_object(const client_maker_function& client_maker, bool is_chunked) {
-    semaphore mem(16<<20);
-    auto cln = client_maker(mem);
+    auto cln = client_maker();
     auto close_client = deferred_close(*cln);
     const sstring name(fmt::format("/{}/testfbobject-{}", tests::getenv_safe("S3_BUCKET_FOR_TEST"), ::getpid()));
 
@@ -334,7 +293,7 @@ SEASTAR_THREAD_TEST_CASE(test_client_copy_upload_empty_object_minio) {
 
 using with_remainder_t = bool_class<class with_remainder_tag>;
 
-future<> test_client_upload_file(const client_maker_function& client_maker, std::string_view test_name, size_t total_size, size_t memory_size) {
+future<> test_client_upload_file(const client_maker_function& client_maker, std::string_view test_name, size_t total_size) {
     tmpdir tmp;
     const auto file_path = tmp.path() / "test";
 
@@ -345,8 +304,7 @@ future<> test_client_upload_file(const client_maker_function& client_maker, std:
                                          ::getpid());
 
     // 2. upload the file to s3
-    semaphore mem{memory_size};
-    auto client = client_maker(mem);
+    auto client = client_maker();
     co_await client->upload_file(file_path, object_name);
     // 3. retrieve the object from s3 and retrieve the object from S3 and
     //    compare it with the pattern
@@ -379,53 +337,46 @@ future<> test_client_upload_file(const client_maker_function& client_maker, std:
 SEASTAR_TEST_CASE(test_client_upload_file_multi_part_without_remainder_minio) {
     const size_t part_size = 5_MiB;
     const size_t total_size = 4 * part_size;
-    const size_t memory_size = part_size;
-    co_await test_client_upload_file(make_minio_client, seastar_test::get_name(), total_size, memory_size);
+    co_await test_client_upload_file(make_minio_client, seastar_test::get_name(), total_size);
 }
 
 SEASTAR_TEST_CASE(test_client_upload_file_multi_part_without_remainder_proxy) {
     const size_t part_size = 5_MiB;
     const size_t total_size = 4 * part_size;
-    const size_t memory_size = part_size;
-    co_await test_client_upload_file(make_proxy_client, seastar_test::get_name(), total_size, memory_size);
+    co_await test_client_upload_file(make_proxy_client, seastar_test::get_name(), total_size);
 }
 
 SEASTAR_TEST_CASE(test_client_upload_file_multi_part_with_remainder_minio) {
     const size_t part_size = 5_MiB;
     const size_t remainder_size = part_size / 2;
     const size_t total_size = 4 * part_size + remainder_size;
-    const size_t memory_size = part_size;
-    co_await test_client_upload_file(make_minio_client, seastar_test::get_name(), total_size, memory_size);
+    co_await test_client_upload_file(make_minio_client, seastar_test::get_name(), total_size);
 }
 
 SEASTAR_TEST_CASE(test_client_upload_file_multi_part_with_remainder_proxy) {
     const size_t part_size = 5_MiB;
     const size_t remainder_size = part_size / 2;
     const size_t total_size = 4 * part_size + remainder_size;
-    const size_t memory_size = part_size;
-    co_await test_client_upload_file(make_proxy_client, seastar_test::get_name(), total_size, memory_size);
+    co_await test_client_upload_file(make_proxy_client, seastar_test::get_name(), total_size);
 }
 
 SEASTAR_TEST_CASE(test_client_upload_file_single_part_minio) {
     const size_t part_size = 5_MiB;
     const size_t total_size = part_size / 2;
-    const size_t memory_size = part_size;
-    co_await test_client_upload_file(make_minio_client, seastar_test::get_name(), total_size, memory_size);
+    co_await test_client_upload_file(make_minio_client, seastar_test::get_name(), total_size);
 }
 
 SEASTAR_TEST_CASE(test_client_upload_file_single_part_proxy) {
     const size_t part_size = 5_MiB;
     const size_t total_size = part_size / 2;
-    const size_t memory_size = part_size;
-    co_await test_client_upload_file(make_proxy_client, seastar_test::get_name(), total_size, memory_size);
+    co_await test_client_upload_file(make_proxy_client, seastar_test::get_name(), total_size);
 }
 
 void client_readable_file(const client_maker_function& client_maker) {
     const sstring name(fmt::format("/{}/testroobject-{}", tests::getenv_safe("S3_BUCKET_FOR_TEST"), ::getpid()));
 
     testlog.info("Make client\n");
-    semaphore mem(16<<20);
-    auto cln = client_maker(mem);
+    auto cln = client_maker();
     auto close_client = deferred_close(*cln);
 
     testlog.info("Put object {}\n", name);
@@ -474,8 +425,7 @@ void client_readable_file_stream(const client_maker_function& client_maker) {
     const sstring name(fmt::format("/{}/teststreamobject-{}", tests::getenv_safe("S3_BUCKET_FOR_TEST"), ::getpid()));
 
     testlog.info("Make client\n");
-    semaphore mem(16<<20);
-    auto cln = client_maker(mem);
+    auto cln = client_maker();
     auto close_client = deferred_close(*cln);
 
     testlog.info("Put object {}\n", name);
@@ -505,8 +455,7 @@ SEASTAR_THREAD_TEST_CASE(test_client_readable_file_stream_proxy) {
 void client_put_get_tagging(const client_maker_function& client_maker) {
     const sstring name(fmt::format("/{}/testobject-{}",
                                    tests::getenv_safe("S3_BUCKET_FOR_TEST"), ::getpid()));
-    semaphore mem(16<<20);
-    auto client = client_maker(mem);
+    auto client = client_maker();
 
     auto close_client = deferred_close(*client);
     auto data = sstring("1234567890ABCDEF").release();
@@ -556,8 +505,7 @@ static std::unordered_set<sstring> populate_bucket(shared_ptr<s3::client> client
 void client_list_objects(const client_maker_function& client_maker) {
     const sstring bucket = tests::getenv_safe("S3_BUCKET_FOR_TEST");
     const sstring prefix(fmt::format("testprefix-{}/", ::getpid()));
-    semaphore mem(16<<20);
-    auto client = client_maker(mem);
+    auto client = client_maker();
     auto close_client = deferred_close(*client);
 
     // Put extra object to check list-by-prefix filters it out
@@ -588,8 +536,7 @@ SEASTAR_THREAD_TEST_CASE(test_client_list_objects_proxy) {
 void client_list_objects_incomplete(const client_maker_function& client_maker) {
     const sstring bucket = tests::getenv_safe("S3_BUCKET_FOR_TEST");
     const sstring prefix(fmt::format("testprefix-{}/", ::getpid()));
-    semaphore mem(16<<20);
-    auto client = client_maker(mem);
+    auto client = client_maker();
     auto close_client = deferred_close(*client);
 
     populate_bucket(client, bucket, prefix, 8);
@@ -612,8 +559,7 @@ SEASTAR_THREAD_TEST_CASE(test_client_list_objects_incomplete_proxy) {
 
 void client_broken_bucket(const client_maker_function& client_maker) {
     const sstring name(fmt::format("/{}/testobject-{}", "NO_BUCKET", ::getpid()));
-    semaphore mem(16 << 20);
-    auto client = client_maker(mem);
+    auto client = client_maker();
 
     auto close_client = deferred_close(*client);
     auto data = sstring("1234567890ABCDEF").release();
@@ -628,8 +574,7 @@ SEASTAR_THREAD_TEST_CASE(test_client_broken_bucket_minio) {
 
 void client_missing_prefix(const client_maker_function& client_maker) {
     const sstring name(fmt::format("/{}/testobject-{}", tests::getenv_safe("S3_BUCKET_FOR_TEST"), ::getpid()));
-    semaphore mem(16 << 20);
-    auto client = client_maker(mem);
+    auto client = client_maker();
 
     auto close_client = deferred_close(*client);
     BOOST_REQUIRE_EXCEPTION(client->get_object_size(name).get(), storage_io_error, [](const storage_io_error& e) {
@@ -643,8 +588,7 @@ SEASTAR_THREAD_TEST_CASE(test_client_missing_prefix_minio) {
 
 void client_access_missing_object(const client_maker_function& client_maker) {
     const sstring name(fmt::format("/{}/testobject-{}", tests::getenv_safe("S3_BUCKET_FOR_TEST"), ::getpid()));
-    semaphore mem(16 << 20);
-    auto client = client_maker(mem);
+    auto client = client_maker();
 
     auto close_client = deferred_close(*client);
     BOOST_REQUIRE_EXCEPTION(client->get_object_tagging(name).get(), storage_io_error, [](const storage_io_error& e) {
@@ -660,8 +604,7 @@ SEASTAR_THREAD_TEST_CASE(test_object_reupload) {
     // Pay attention, we are reuploading the same file during the test
     const sstring name(fmt::format("/{}/testobject-{}", tests::getenv_safe("S3_BUCKET_FOR_TEST"), ::getpid()));
 
-    semaphore mem(16 << 20);
-    auto cln = make_minio_client(mem);
+    auto cln = make_minio_client();
     auto close_client = deferred_close(*cln);
     auto delete_object = deferred_delete_object(cln, name);
     constexpr std::string_view content{"1234567890"};
@@ -710,8 +653,7 @@ void test_download_data_source(const client_maker_function& client_maker, bool i
     const sstring name(fmt::format("/{}/testdatasourceobject-{}", tests::getenv_safe("S3_BUCKET_FOR_TEST"), ::getpid()));
 
     testlog.info("Make client\n");
-    semaphore mem(16<<20);
-    auto cln = client_maker(mem);
+    auto cln = client_maker();
     auto close_client = deferred_close(*cln);
     auto delete_object = deferred_delete_object(cln, name);
 
@@ -762,8 +704,7 @@ void test_chunked_download_data_source(const client_maker_function& client_maker
     create_file(file_path, object_size).get();
 
     testlog.info("Make client\n");
-    semaphore mem(16 << 20);
-    auto cln = client_maker(mem);
+    auto cln = client_maker();
     auto close_client = deferred_close(*cln);
     const auto object_name = fmt::format("/{}/{}", tests::getenv_safe("S3_BUCKET_FOR_TEST"), base_name);
     auto delete_object = deferred_delete_object(cln, object_name);
@@ -838,8 +779,7 @@ void do_test_chunked_download_data_source_memory(const client_maker_function& cl
     create_file(file_path, object_size).get();
 
     testlog.info("Make client\n");
-    semaphore mem(1_MiB);
-    auto cln = client_maker(mem);
+    auto cln = client_maker();
     auto close_client = deferred_close(*cln);
     const auto object_name = fmt::format("/{}/{}", tests::getenv_safe("S3_BUCKET_FOR_TEST"), base_name);
     auto delete_object = deferred_delete_object(cln, object_name);
@@ -885,8 +825,7 @@ void test_object_copy(const client_maker_function& client_maker, size_t chunk_si
     const sstring name(fmt::format("/{}/testobject-{}", tests::getenv_safe("S3_BUCKET_FOR_TEST"), ::getpid()));
     const sstring name_copy(fmt::format("/{}/testobject-{}-copy", tests::getenv_safe("S3_BUCKET_FOR_TEST"), ::getpid()));
 
-    semaphore mem(16 << 20);
-    auto cln = client_maker(mem);;
+    auto cln = client_maker();;
     auto close_client = deferred_close(*cln);
     auto delete_object = deferred_delete_object(cln, name);
     auto delete_copy_object = deferred_delete_object(cln, name_copy);

--- a/test/boost/s3_test.cc
+++ b/test/boost/s3_test.cc
@@ -421,32 +421,6 @@ SEASTAR_TEST_CASE(test_client_upload_file_single_part_proxy) {
 }
 
 
-SEASTAR_THREAD_TEST_CASE(test_client_abort_stuck_semaphore) {
-    const sstring base_name(fmt::format("test_object-{}", ::getpid()));
-    constexpr size_t object_size = 128_KiB;
-
-    tmpdir tmp;
-    const auto file_path = tmp.path() / base_name;
-
-    create_file(file_path, object_size).get();
-
-    testlog.info("Make client\n");
-    semaphore mem(32_KiB);
-    auto cln = make_minio_client(mem);
-    auto close_client = deferred_close(*cln);
-    const auto object_name = fmt::format("/{}/{}", tests::getenv_safe("S3_BUCKET_FOR_TEST"), base_name);
-    auto delete_object = deferred_delete_object(cln, object_name);
-    abort_source as;
-    auto upload = cln->upload_file(file_path, object_name, {}, {}, &as);
-    auto ex = std::make_exception_ptr(std::runtime_error("Cancelling!"));
-    as.request_abort_ex(ex);
-    upload.wait();
-    BOOST_REQUIRE(upload.failed());
-    BOOST_REQUIRE_EXCEPTION(std::rethrow_exception(upload.get_exception()), semaphore_aborted, [](const semaphore_aborted& e) {
-        return e.what() == "Semaphore aborted"sv;
-    });
-}
-
 void client_readable_file(const client_maker_function& client_maker) {
     const sstring name(fmt::format("/{}/testroobject-{}", tests::getenv_safe("S3_BUCKET_FOR_TEST"), ::getpid()));
 

--- a/test/perf/perf_s3_client.cc
+++ b/test/perf/perf_s3_client.cc
@@ -23,7 +23,6 @@ class tester {
     std::chrono::seconds _duration;
     std::string _object_name;
     size_t _object_size;
-    semaphore _mem;
     shared_ptr<s3::client> _client;
     utils::estimated_histogram _latencies;
     unsigned _errors = 0;
@@ -49,8 +48,7 @@ public:
             : _duration(dur)
             , _object_name(std::move(object_name))
             , _object_size(obj_size)
-            , _mem(memory::stats().total_memory())
-            , _client(s3::client::make(tests::getenv_safe("S3_SERVER_ADDRESS_FOR_TEST"), make_config(sockets), _mem))
+            , _client(s3::client::make(tests::getenv_safe("S3_SERVER_ADDRESS_FOR_TEST"), make_config(sockets)))
             , _part_size_mb(part_size)
             , _remove_file(false)
     {}

--- a/utils/s3/client.cc
+++ b/utils/s3/client.cc
@@ -1021,7 +1021,7 @@ future<> client::multipart_upload::upload_part(memory_data_sink_buffers bufs) {
     req._headers["Content-Length"] = seastar::format("{}", size);
     req.set_query_param("partNumber", seastar::format("{}", part_number + 1));
     req.set_query_param("uploadId", _upload_id);
-    req.write_body("bin", size, [this, part_number, bufs = std::move(bufs), p = std::move(mpu)] (output_stream<char>&& out_) mutable -> future<> {
+    req.write_body("bin", size, [this, part_number, bufs = std::move(bufs)] (output_stream<char>&& out_) mutable -> future<> {
         auto out = std::move(out_);
         std::exception_ptr ex;
         s3l.trace("upload {} part data (upload id {})", part_number, _upload_id);
@@ -1037,8 +1037,6 @@ future<> client::multipart_upload::upload_part(memory_data_sink_buffers bufs) {
         if (ex) {
             co_await coroutine::return_exception_ptr(std::move(ex));
         }
-        // note: At this point the buffers are sent, but the response is not yet
-        // received. However, claim is released and next part may start uploading
     });
 
     // Do upload in the background so that several parts could go in parallel.
@@ -1062,7 +1060,7 @@ future<> client::multipart_upload::upload_part(memory_data_sink_buffers bufs) {
     }, http::reply::status_type::ok, _as).handle_exception([this, part_number] (auto ex) {
         // ... the exact exception only remains in logs
         s3l.warn("couldn't upload part {}: {} (upload id {})", part_number, ex, _upload_id);
-    }).finally([gh = std::move(gh)] {});
+    }).finally([gh = std::move(gh), mpu = std::move(mpu)] {});
 }
 
 future<> client::multipart_upload::abort_upload() {
@@ -1663,6 +1661,8 @@ class client::do_upload_file : private multipart_upload {
     future<> upload_part(file f, uint64_t offset, uint64_t part_size, uint64_t part_number) {
         // upload a part in a multipart upload, see
         // https://docs.aws.amazon.com/AmazonS3/latest/API/API_UploadPart.html
+        //
+        // The claim is held for the whole request, including the response
         auto mpu = co_await claim_unit(_client->_mpus_sem, _as);
 
         auto req = http::request::make("PUT", _client->_host, _object_name);
@@ -1670,7 +1670,7 @@ class client::do_upload_file : private multipart_upload {
         req.set_query_param("partNumber", to_sstring(part_number + 1));
         req.set_query_param("uploadId", _upload_id);
         s3l.trace("PUT part {}, {} bytes (upload id {})", part_number, part_size, _upload_id);
-        req.write_body("bin", part_size, [f=std::move(f), mpu=std::move(mpu), offset, part_size, &progress = _progress] (output_stream<char>&& out_) {
+        req.write_body("bin", part_size, [f=std::move(f), offset, part_size, &progress = _progress] (output_stream<char>&& out_) {
             auto input = make_file_input_stream(f, offset, part_size, input_stream_options());
             auto output = std::move(out_);
             return copy_to(std::move(input), std::move(output), _transmit_size, progress);

--- a/utils/s3/client.cc
+++ b/utils/s3/client.cc
@@ -254,6 +254,10 @@ future<semaphore_units<>> client::claim_memory(size_t size, abort_source* as) {
     return get_units(_memory, size);
 }
 
+static future<semaphore_units<>> claim_unit(semaphore& sem, seastar::abort_source* as) {
+    return as ? get_units(sem, 1, *as) : get_units(sem, 1);
+}
+
 client::group_client::group_client(std::unique_ptr<http::experimental::connection_factory> f, unsigned max_conn) : http(std::move(f), max_conn) {
 }
 
@@ -1017,7 +1021,7 @@ future<> client::multipart_upload::upload_part(memory_data_sink_buffers bufs) {
         co_await start_upload();
     }
 
-    auto claim = co_await _client->claim_memory(bufs.size(), _as);
+    auto mpu = co_await claim_unit(_client->_mpus_sem, _as);
 
     unsigned part_number = _part_etags.size();
     _part_etags.emplace_back();
@@ -1027,7 +1031,7 @@ future<> client::multipart_upload::upload_part(memory_data_sink_buffers bufs) {
     req._headers["Content-Length"] = seastar::format("{}", size);
     req.set_query_param("partNumber", seastar::format("{}", part_number + 1));
     req.set_query_param("uploadId", _upload_id);
-    req.write_body("bin", size, [this, part_number, bufs = std::move(bufs), p = std::move(claim)] (output_stream<char>&& out_) mutable -> future<> {
+    req.write_body("bin", size, [this, part_number, bufs = std::move(bufs), p = std::move(mpu)] (output_stream<char>&& out_) mutable -> future<> {
         auto out = std::move(out_);
         std::exception_ptr ex;
         s3l.trace("upload {} part data (upload id {})", part_number, _upload_id);
@@ -1672,14 +1676,14 @@ class client::do_upload_file : private multipart_upload {
     future<> upload_part(file f, uint64_t offset, uint64_t part_size, uint64_t part_number) {
         // upload a part in a multipart upload, see
         // https://docs.aws.amazon.com/AmazonS3/latest/API/API_UploadPart.html
-        auto mem_units = co_await _client->claim_memory(_transmit_size, _as);
+        auto mpu = co_await claim_unit(_client->_mpus_sem, _as);
 
         auto req = http::request::make("PUT", _client->_host, _object_name);
         req._headers["Content-Length"] = to_sstring(part_size);
         req.set_query_param("partNumber", to_sstring(part_number + 1));
         req.set_query_param("uploadId", _upload_id);
         s3l.trace("PUT part {}, {} bytes (upload id {})", part_number, part_size, _upload_id);
-        req.write_body("bin", part_size, [f=std::move(f), mem_units=std::move(mem_units), offset, part_size, &progress = _progress] (output_stream<char>&& out_) {
+        req.write_body("bin", part_size, [f=std::move(f), mpu=std::move(mpu), offset, part_size, &progress = _progress] (output_stream<char>&& out_) {
             auto input = make_file_input_stream(f, offset, part_size, input_stream_options());
             auto output = std::move(out_);
             return copy_to(std::move(input), std::move(output), _transmit_size, progress);

--- a/utils/s3/client.cc
+++ b/utils/s3/client.cc
@@ -93,7 +93,7 @@ future<> ignore_reply(const http::reply& rep, input_stream<char>&& in_) {
     co_await util::skip_entire_stream(in);
 }
 
-client::client(std::string host, endpoint_config_ptr cfg, semaphore& mem, global_factory gf, private_tag, std::unique_ptr<http::experimental::retry_strategy> rs)
+client::client(std::string host, endpoint_config_ptr cfg, global_factory gf, private_tag, std::unique_ptr<http::experimental::retry_strategy> rs)
         : _host(std::move(host))
         , _cfg(std::move(cfg))
         , _creds_sem(1)
@@ -117,7 +117,6 @@ client::client(std::string host, endpoint_config_ptr cfg, semaphore& mem, global
             }();
         })
         , _gf(std::move(gf))
-        , _memory(mem)
         , _retry_strategy(std::move(rs)) {
     _creds_provider_chain
         .add_credentials_provider(std::make_unique<aws::environment_aws_credentials_provider>())
@@ -173,11 +172,11 @@ void client::update_connections_per_shard(unsigned connections_per_shard) {
     });
 }
 
-shared_ptr<client> client::make(std::string endpoint, endpoint_config_ptr cfg, semaphore& mem, global_factory gf) {
-    return seastar::make_shared<client>(std::move(endpoint), std::move(cfg), mem, std::move(gf), private_tag{});
+shared_ptr<client> client::make(std::string endpoint, endpoint_config_ptr cfg, global_factory gf) {
+    return seastar::make_shared<client>(std::move(endpoint), std::move(cfg), std::move(gf), private_tag{});
 }
 
-shared_ptr<client> client::make(std::string ep, std::string region, std::string iam_role_arn, semaphore& memory, global_factory gf, unsigned connections_per_shard) {
+shared_ptr<client> client::make(std::string ep, std::string region, std::string iam_role_arn, global_factory gf, unsigned connections_per_shard) {
     auto url = utils::http::parse_simple_url(ep);
     endpoint_config cfg = {
         .port = url.port,
@@ -186,7 +185,7 @@ shared_ptr<client> client::make(std::string ep, std::string region, std::string 
         .role_arn = std::move(iam_role_arn),
         .connections_per_shard = connections_per_shard,
     };
-    return make(url.host, make_lw_shared<endpoint_config>(std::move(cfg)), memory, gf);
+    return make(url.host, make_lw_shared<endpoint_config>(std::move(cfg)), gf);
 }
 
 future<> client::update_credentials_and_rearm() {
@@ -245,13 +244,6 @@ future<> client::authorize(http::request& req) {
         utils::aws::unsigned_content,
         _cfg->region, "s3", query_string);
     req._headers["Authorization"] = seastar::format("AWS4-HMAC-SHA256 Credential={}/{}/{}/s3/aws4_request,SignedHeaders={},Signature={}", _credentials.access_key_id, time_point_st, _cfg->region, signed_headers_list, sig);
-}
-
-future<semaphore_units<>> client::claim_memory(size_t size, abort_source* as) {
-    if (as) {
-        return get_units(_memory, size, *as);
-    }
-    return get_units(_memory, size);
 }
 
 static future<semaphore_units<>> claim_unit(semaphore& sem, seastar::abort_source* as) {

--- a/utils/s3/client.cc
+++ b/utils/s3/client.cc
@@ -129,7 +129,13 @@ client::client(std::string host, endpoint_config_ptr cfg, semaphore& mem, global
     }
 }
 
-future<> client::update_config(std::string region, std::string ira) {
+void client::update_config_sync(std::string region, std::string ira) {
+    if (_config_update_gate.is_closed()) {
+        s3l.info("config update gate is closed");
+        return;
+    }
+    auto holder = _config_update_gate.hold();
+
     endpoint_config new_cfg = {
         .port = _cfg->port,
         .use_https = _cfg->use_https,
@@ -137,10 +143,19 @@ future<> client::update_config(std::string region, std::string ira) {
         .role_arn = std::move(ira),
     };
     _cfg = make_lw_shared<endpoint_config>(std::move(new_cfg));
-    auto units = co_await get_units(_creds_sem, 1);
-    _creds_provider_chain.invalidate_credentials();
-    _credentials = {};
-    _creds_update_timer.rearm(lowres_clock::now());
+
+    (void)get_units(_creds_sem, 1).then_wrapped([this, h = std::move(holder)](future<semaphore_units<>> f) {
+        try {
+            s3l.info("Invalidating credentials");
+            
+            auto units = f.get();
+            _creds_provider_chain.invalidate_credentials();
+            _credentials = {};
+            _creds_update_timer.rearm(lowres_clock::now());
+        } catch (...) {
+            s3l.error("Failed to refresh credentials during config update: {}", std::current_exception());
+        }
+    });
 }
 
 shared_ptr<client> client::make(std::string endpoint, endpoint_config_ptr cfg, semaphore& mem, global_factory gf) {
@@ -1857,6 +1872,9 @@ file client::make_readable_file(sstring object_name, seastar::abort_source* as) 
 }
 
 future<> client::close() {
+    s3l.info("Closing S3 client...");
+
+    co_await _config_update_gate.close();
     {
         auto units = co_await get_units(_creds_sem, 1);
         _creds_invalidation_timer.cancel();
@@ -1865,6 +1883,8 @@ future<> client::close() {
     co_await coroutine::parallel_for_each(_https, [] (auto& it) -> future<> {
         co_await it.second.http.close();
     });
+
+    s3l.info("Closed S3 client");
 }
 
 client::bucket_lister::bucket_lister(shared_ptr<client> client, sstring bucket, sstring prefix, size_t objects_per_page, size_t entries_batch)

--- a/utils/s3/client.cc
+++ b/utils/s3/client.cc
@@ -1724,7 +1724,6 @@ class client::do_upload_file : private multipart_upload {
     future<> put_object(file&& f, uint64_t len) {
         // https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObject.html
         s3l.trace("PUT {} ({})", _object_name, _path.native());
-        auto mem_units = co_await _client->claim_memory(_transmit_size, _as);
 
         auto req = http::request::make("PUT", _client->_host, _object_name);
         if (_tag) {

--- a/utils/s3/client.cc
+++ b/utils/s3/client.cc
@@ -159,6 +159,20 @@ void client::update_config_sync(std::string region, std::string ira) {
     });
 }
 
+void client::update_connections_per_shard(unsigned connections_per_shard) {
+    if (_config_update_gate.is_closed()) {
+        s3l.info("config update gate is closed");
+        return;
+    }
+    auto holder = _config_update_gate.hold();
+    (void)with_semaphore(_rebalance_sem, 1, [this, connections_per_shard] {
+        _cfg->connections_per_shard = connections_per_shard;
+        return rebalance_connections();
+    }).handle_exception([holder = std::move(holder)](auto ex) {
+        s3l.warn("Failed to rebalance connections after config update: {}", ex);
+    });
+}
+
 shared_ptr<client> client::make(std::string endpoint, endpoint_config_ptr cfg, semaphore& mem, global_factory gf) {
     return seastar::make_shared<client>(std::move(endpoint), std::move(cfg), mem, std::move(gf), private_tag{});
 }

--- a/utils/s3/client.cc
+++ b/utils/s3/client.cc
@@ -10,6 +10,7 @@
 #include <exception>
 #include <initializer_list>
 #include <memory>
+#include <numeric>
 #include <stdexcept>
 #if __has_include(<rapidxml.h>)
 #include <rapidxml.h>
@@ -162,13 +163,14 @@ shared_ptr<client> client::make(std::string endpoint, endpoint_config_ptr cfg, s
     return seastar::make_shared<client>(std::move(endpoint), std::move(cfg), mem, std::move(gf), private_tag{});
 }
 
-shared_ptr<client> client::make(std::string ep, std::string region, std::string iam_role_arn, semaphore& memory, global_factory gf) {
+shared_ptr<client> client::make(std::string ep, std::string region, std::string iam_role_arn, semaphore& memory, global_factory gf, unsigned connections_per_shard) {
     auto url = utils::http::parse_simple_url(ep);
     endpoint_config cfg = {
         .port = url.port,
         .use_https = url.is_https(),
         .region = std::move(region),
         .role_arn = std::move(iam_role_arn),
+        .connections_per_shard = connections_per_shard,
     };
     return make(url.host, make_lw_shared<endpoint_config>(std::move(cfg)), memory, gf);
 }
@@ -274,23 +276,67 @@ void client::group_client::register_metrics(std::string class_name, std::string 
     });
 }
 
-client::group_client& client::find_or_create_client() {
+future<client::group_client&> client::find_or_create_client() {
     auto sg = current_scheduling_group();
-    auto it = _https.find(sg);
-    if (it == _https.end()) [[unlikely]] {
-        auto factory = std::make_unique<utils::http::dns_connection_factory>(_host, _cfg->port, _cfg->use_https, s3l);
-        // Limit the maximum number of connections this group's http client
-        // may have proportional to its shares. Shares are typically in the
-        // range of 100...1000, thus resulting in 1..10 connections
-        unsigned max_connections = _cfg->max_connections.has_value() ? *_cfg->max_connections : std::max((unsigned)(sg.get_shares() / 100), 1u);
-        it = _https.emplace(std::piecewise_construct,
-            std::forward_as_tuple(sg),
-            std::forward_as_tuple(std::move(factory), max_connections)
-        ).first;
-
-        it->second.register_metrics(sg.name(), _host);
+    if (const auto it = _https.find(sg); it != _https.end()) [[likely]] {
+        return make_ready_future<client::group_client&>(it->second);
     }
-    return it->second;
+    return find_or_create_client_slow();
+}
+
+future<client::group_client&> client::find_or_create_client_slow() {
+    // Slow path: serialize creation + rebalance
+    auto sg = current_scheduling_group();
+    auto units = co_await get_units(_rebalance_sem, 1);
+    // Re-check after acquiring lock (another fiber may have created it)
+    auto it = _https.find(sg);
+    if (it != _https.end()) {
+        co_return it->second;
+    }
+
+    auto factory = std::make_unique<utils::http::dns_connection_factory>(_host, _cfg->port, _cfg->use_https, s3l);
+    unsigned max_connections = _cfg->max_connections.value_or(1);
+    it = _https.emplace(std::piecewise_construct,
+        std::forward_as_tuple(sg),
+        std::forward_as_tuple(std::move(factory), max_connections)
+    ).first;
+    it->second.register_metrics(sg.name(), _host);
+    if (!_cfg->max_connections) {
+        co_await rebalance_connections();
+    }
+    co_return it->second;
+}
+
+future<> client::rebalance_connections() {
+    auto total_shares = std::accumulate(_https.begin(), _https.end(), 0.0f, [](float sum, const auto& entry) { return sum + entry.first.get_shares(); });
+    unsigned total_assigned = 0;
+    scheduling_group max_shares_sg;
+    float max_shares = 0;
+    unsigned max_shares_connections = 0;
+
+    for (auto& [sg, gc] : _https) {
+        unsigned max_connections = std::max(static_cast<unsigned>(_cfg->connections_per_shard * sg.get_shares() / total_shares), 1u);
+        total_assigned += max_connections;
+        if (sg.get_shares() > max_shares) {
+            max_shares = sg.get_shares();
+            max_shares_sg = sg;
+            max_shares_connections = max_connections;
+        }
+        s3l.debug("Rebalancing S3 client for scheduling group '{}' (shares={}, total_shares={}, connections_per_shard={}): max_connections={}",
+                  sg.name(),
+                  sg.get_shares(),
+                  total_shares,
+                  _cfg->connections_per_shard,
+                  max_connections);
+        co_await gc.http.set_maximum_connections(max_connections);
+    }
+
+    // Assign remainder to the group with the most shares
+    unsigned remainder;
+    if (!__builtin_sub_overflow(_cfg->connections_per_shard, total_assigned, &remainder) && remainder > 0) {
+        s3l.debug("Assigning {} remainder connections to scheduling group '{}'", remainder, max_shares_sg.name());
+        co_await _https.at(max_shares_sg).http.set_maximum_connections(max_shares_connections + remainder);
+    }
 }
 
 [[noreturn]] void map_s3_client_exception(std::exception_ptr ex) {
@@ -422,7 +468,7 @@ future<> client::make_request(http::request req,
     auto request = std::move(req);
     auto handler = wrap_handler(request, std::move(handle), expected);
     co_await authorize(request);
-    auto& gc = find_or_create_client();
+    auto& gc = co_await find_or_create_client();
 
     co_await gc.http.make_request(request, handler, rs, std::nullopt, as).handle_exception([err_handler = std::move(err_handler)](auto ex) {
         err_handler(std::move(ex));
@@ -435,11 +481,11 @@ future<> client::make_request(http::request req,
                               error_handler err_handler,
                               std::optional<http::reply::status_type> expected,
                               seastar::abort_source* as) {
-    auto& gc = find_or_create_client();
+    auto& gc = co_await find_or_create_client();
     auto handle = [&gc, handle = std::move(handle_ex)] (const http::reply& rep, input_stream<char>&& in) {
         return handle(gc, rep, std::move(in));
     };
-    return make_request(std::move(req), std::move(handle), rs, std::move(err_handler), expected, as);
+    co_await make_request(std::move(req), std::move(handle), rs, std::move(err_handler), expected, as);
 }
 
 future<> client::make_request(http::request req, reply_handler_ext handle_ex, std::optional<http::reply::status_type> expected, seastar::abort_source* as) {
@@ -1291,7 +1337,7 @@ class client::chunked_download_source final : public seastar::data_source_impl {
                 }
 
                 if (auto units = try_get_units(_client->_memory, _socket_buff_size); !_is_finished && !_buffers.empty() && !units) {
-                    auto& gc = _client->find_or_create_client();
+                    auto& gc = co_await _client->find_or_create_client();
                     ++gc.downloads_blocked_on_memory;
                     co_await _bg_fiber_cv.when([this] {
                         return _is_finished || _buffers.empty() || try_get_units(_client->_memory, _socket_buff_size);

--- a/utils/s3/client.cc
+++ b/utils/s3/client.cc
@@ -762,8 +762,6 @@ sstring parse_multipart_copy_upload_etag(sstring& body) {
 
 class client::multipart_upload {
 protected:
-    static constexpr size_t _max_multipart_concurrency = 16;
-
     shared_ptr<client> _client;
     sstring _object_name;
     sstring _upload_id;
@@ -850,7 +848,7 @@ private:
             auto parts = std::views::iota(size_t{0}, (source_size + part_size - 1) / part_size);
             _part_etags.resize(parts.size());
             co_await max_concurrent_for_each(parts,
-                                             _max_multipart_concurrency,
+                                             max_client_mpu_in_flight,
                                              [part_size, source_size, this](auto part_num) -> future<> {
                                                  auto part_offset = part_num * part_size;
                                                  auto actual_part_size = std::min(source_size - part_offset, part_size);
@@ -1694,7 +1692,7 @@ class client::do_upload_file : private multipart_upload {
         std::exception_ptr ex;
         try {
             co_await max_concurrent_for_each(std::views::iota(size_t{0}, (total_size + part_size - 1) / part_size),
-                                             _max_multipart_concurrency,
+                                             max_client_mpu_in_flight,
                                              [part_size, total_size, this, f = file{f}](auto part_num) -> future<> {
                                                  auto part_offset = part_num * part_size;
                                                  auto actual_part_size = std::min(total_size - part_offset, part_size);

--- a/utils/s3/client.cc
+++ b/utils/s3/client.cc
@@ -286,9 +286,9 @@ void client::group_client::register_metrics(std::string class_name, std::string 
                 sm::description("Total time spend writing data to objects"), {ep_label, sg_label}),
         sm::make_counter("total_read_prefetch_bytes", [this] { return prefetch_bytes; },
                 sm::description("Total number of bytes requested from object"), {ep_label, sg_label}),
-         sm::make_counter("downloads_blocked_on_memory",
-                          [this] { return downloads_blocked_on_memory; },
-                          sm::description("Counts the number of times S3 client downloads were delayed due to insufficient memory availability"),
+         sm::make_counter("downloads_starving_on_max_concurrency",
+                          [this] { return downloads_starving_on_max_concurrency; },
+                          sm::description("Counts the number of times S3 client downloads were starving on max concurrency limit"),
                           {ep_label, sg_label})
 
     });
@@ -1323,12 +1323,6 @@ data_sink client::make_upload_jumbo_sink(sstring object_name, std::optional<unsi
 }
 
 class client::chunked_download_source final : public seastar::data_source_impl {
-    struct claimed_buffer {
-        temporary_buffer<char> _buffer;
-        std::optional<semaphore_units<>> _claimed_memory;
-        claimed_buffer(temporary_buffer<char>&& buf, std::optional<semaphore_units<>>&& claimed_memory) noexcept
-            : _buffer(std::move(buf)), _claimed_memory(std::move(claimed_memory)) {}
-    };
     shared_ptr<client> _client;
     sstring _object_name;
     seastar::abort_source* _as;
@@ -1337,7 +1331,7 @@ class client::chunked_download_source final : public seastar::data_source_impl {
     static constexpr size_t _max_buffers_size = 5_MiB;
     static constexpr double _buffers_low_watermark = 0.5;
     static constexpr double _buffers_high_watermark = 0.9;
-    std::deque<claimed_buffer> _buffers;
+    std::deque<temporary_buffer<char>> _buffers;
     size_t _buffers_size = 0;
     bool _is_finished = false;
     bool _is_contiguous_mode = false;
@@ -1348,17 +1342,21 @@ class client::chunked_download_source final : public seastar::data_source_impl {
     future<> make_filling_fiber() {
         seastar::http::experimental::no_retry_strategy no_retry;
         s3l.trace("Fiber starts cycle for object '{}'", _object_name);
+        auto units = try_get_units(_client->_buffered_dl_sem, 1);
         while (!_is_finished) {
             try {
                 if (!_is_finished && _buffers_size >= _max_buffers_size * _buffers_low_watermark) {
                     co_await _bg_fiber_cv.when([this] { return _is_finished || (_buffers_size < _max_buffers_size * _buffers_low_watermark); });
                 }
 
-                if (auto units = try_get_units(_client->_memory, _socket_buff_size); !_is_finished && !_buffers.empty() && !units) {
+                if (!_is_finished && !_buffers.empty() && !units) {
                     auto& gc = co_await _client->find_or_create_client();
-                    ++gc.downloads_blocked_on_memory;
-                    co_await _bg_fiber_cv.when([this] {
-                        return _is_finished || _buffers.empty() || try_get_units(_client->_memory, _socket_buff_size);
+                    ++gc.downloads_starving_on_max_concurrency;
+                    co_await _bg_fiber_cv.when([this, &units] {
+                        if (_is_finished || _buffers.empty())
+                            return true;
+                        units = try_get_units(_client->_buffered_dl_sem, 1);
+                        return units.has_value();
                     });
                 }
 
@@ -1385,7 +1383,7 @@ class client::chunked_download_source final : public seastar::data_source_impl {
                     }
                     if (current_range.length() == 0) {
                         s3l.trace("Fiber for object '{}' completed downloading, signals EOS and leaving fiber", _object_name);
-                    _buffers.emplace_back(temporary_buffer<char>(), co_await _client->claim_memory(0, _as));
+                        _buffers.emplace_back(temporary_buffer<char>());
                         _get_cv.signal();
                         _is_finished = true;
                         co_return;
@@ -1404,7 +1402,7 @@ class client::chunked_download_source final : public seastar::data_source_impl {
                 }
                 co_await _client->make_request(
                     std::move(req),
-                    [this, start = s3_clock::now(), discover_size, pf_length = discover_size ? 0 : current_range.length()](
+                    [this, &units, start = s3_clock::now(), discover_size, pf_length = discover_size ? 0 : current_range.length()](
                         group_client& gc, const http::reply& reply, input_stream<char>&& in_) mutable -> future<> {
                         if (reply._status != http::reply::status_type::ok && reply._status != http::reply::status_type::partial_content) {
                             s3l.warn("Fiber for object '{}' failed: {}. Exiting", _object_name, reply._status);
@@ -1429,13 +1427,12 @@ class client::chunked_download_source final : public seastar::data_source_impl {
 
                             s3l.trace("Fiber for object '{}' will try to read within range {}", _object_name, _range);
                             temporary_buffer<char> buf;
-                            auto units = try_get_units(_client->_memory, _socket_buff_size);
+                            if (!units) {
+                                units = try_get_units(_client->_buffered_dl_sem, 1);
+                            }
                             if (_buffers.empty() || units) {
                                 buf = co_await in.read();
                                 assert(buf.size() <= _socket_buff_size);
-                                if (units) {
-                                    units->return_units(_socket_buff_size - buf.size());
-                                }
                             } else {
                                 break;
                             }
@@ -1445,7 +1442,7 @@ class client::chunked_download_source final : public seastar::data_source_impl {
                             _buffers_size += buff_size;
                             if (buff_size == 0 && _range.length() == 0) {
                                 s3l.trace("Fiber for object '{}' signals EOS", _object_name);
-                                _buffers.emplace_back(std::move(buf), std::move(units));
+                                _buffers.emplace_back(std::move(buf));
                                 _get_cv.signal();
                                 _is_finished = true;
                                 break;
@@ -1455,7 +1452,7 @@ class client::chunked_download_source final : public seastar::data_source_impl {
                                 break;
                             }
                             s3l.trace("Fiber for object '{}' pushes {} bytes buffer", _object_name, buff_size);
-                            _buffers.emplace_back(std::move(buf), std::move(units));
+                            _buffers.emplace_back(std::move(buf));
                             _get_cv.signal();
                             utils::get_local_injector().inject("break_s3_inflight_req", [] {
                                 // Inject a non-`aws_error` after partial data download to verify proper
@@ -1495,12 +1492,12 @@ public:
             if (!_buffers.empty()) {
                 auto claimed_buff = std::move(_buffers.front());
                 _buffers.pop_front();
-                _buffers_size -= claimed_buff._buffer.size();
+                _buffers_size -= claimed_buff.size();
                 if (_buffers_size < _max_buffers_size * _buffers_low_watermark) {
                     _bg_fiber_cv.signal();
                 }
-                s3l.trace("get() for object '{}' popped buffer of {} bytes", _object_name, claimed_buff._buffer.size());
-                co_return std::move(claimed_buff._buffer);
+                s3l.trace("get() for object '{}' popped buffer of {} bytes", _object_name, claimed_buff.size());
+                co_return std::move(claimed_buff);
             }
             _bg_fiber_cv.signal();
             s3l.trace("get() for object '{}' waiting for buffer", _object_name);

--- a/utils/s3/client.hh
+++ b/utils/s3/client.hh
@@ -142,12 +142,9 @@ class client : public enable_shared_from_this<client> {
     semaphore _rebalance_sem{1};
     using global_factory = std::function<shared_ptr<client>(std::string)>;
     global_factory _gf;
-    semaphore& _memory;
     std::unique_ptr<seastar::http::experimental::retry_strategy> _retry_strategy;
 
     struct private_tag {};
-
-    future<semaphore_units<>> claim_memory(size_t mem, seastar::abort_source* as);
 
     future<> update_credentials_and_rearm();
     future<> authorize(http::request&);
@@ -186,9 +183,9 @@ class client : public enable_shared_from_this<client> {
     future<> get_object_header(sstring object_name, http::experimental::client::reply_handler handler, seastar::abort_source* = nullptr);
 public:
 
-    client(std::string host, endpoint_config_ptr cfg, semaphore& mem, global_factory gf, private_tag, std::unique_ptr<seastar::http::experimental::retry_strategy> rs = nullptr);
-    static shared_ptr<client> make(std::string endpoint, endpoint_config_ptr cfg, semaphore& memory, global_factory gf = {});
-    static shared_ptr<client> make(std::string url, std::string region, std::string iam_role_arn, semaphore& memory, global_factory gf = {}, unsigned connections_per_shard = endpoint_config::default_connections_per_shard);
+    client(std::string host, endpoint_config_ptr cfg, global_factory gf, private_tag, std::unique_ptr<seastar::http::experimental::retry_strategy> rs = nullptr);
+    static shared_ptr<client> make(std::string endpoint, endpoint_config_ptr cfg, global_factory gf = {});
+    static shared_ptr<client> make(std::string url, std::string region, std::string iam_role_arn, global_factory gf = {}, unsigned connections_per_shard = endpoint_config::default_connections_per_shard);
 
     future<uint64_t> get_object_size(sstring object_name, seastar::abort_source* = nullptr);
     future<stats> get_object_stats(sstring object_name, seastar::abort_source* = nullptr);

--- a/utils/s3/client.hh
+++ b/utils/s3/client.hh
@@ -134,6 +134,7 @@ class client : public enable_shared_from_this<client> {
         void register_metrics(std::string class_name, std::string host);
     };
     std::unordered_map<seastar::scheduling_group, group_client> _https;
+    semaphore _rebalance_sem{1};
     using global_factory = std::function<shared_ptr<client>(std::string)>;
     global_factory _gf;
     semaphore& _memory;
@@ -145,7 +146,9 @@ class client : public enable_shared_from_this<client> {
 
     future<> update_credentials_and_rearm();
     future<> authorize(http::request&);
-    group_client& find_or_create_client();
+    future<group_client&> find_or_create_client();
+    future<group_client&> find_or_create_client_slow();
+    future<> rebalance_connections();
 
     using error_handler = std::function<void(std::exception_ptr)>;
     using reply_handler_ext = noncopyable_function<future<>(group_client&, const http::reply&, input_stream<char>&& body)>;
@@ -180,7 +183,7 @@ public:
 
     client(std::string host, endpoint_config_ptr cfg, semaphore& mem, global_factory gf, private_tag, std::unique_ptr<seastar::http::experimental::retry_strategy> rs = nullptr);
     static shared_ptr<client> make(std::string endpoint, endpoint_config_ptr cfg, semaphore& memory, global_factory gf = {});
-    static shared_ptr<client> make(std::string url, std::string region, std::string iam_role_arn, semaphore& memory, global_factory gf = {});
+    static shared_ptr<client> make(std::string url, std::string region, std::string iam_role_arn, semaphore& memory, global_factory gf = {}, unsigned connections_per_shard = endpoint_config::default_connections_per_shard);
 
     future<uint64_t> get_object_size(sstring object_name, seastar::abort_source* = nullptr);
     future<stats> get_object_stats(sstring object_name, seastar::abort_source* = nullptr);

--- a/utils/s3/client.hh
+++ b/utils/s3/client.hh
@@ -30,6 +30,7 @@ namespace s3 {
 using s3_clock = std::chrono::steady_clock;
 
 static constexpr size_t max_client_mpu_in_flight = 32;
+static constexpr size_t max_client_buffered_downloads_in_flight = 32;
 
 class range {
     friend struct fmt::formatter<range>;
@@ -109,6 +110,7 @@ class client : public enable_shared_from_this<client> {
     endpoint_config_ptr _cfg;
     semaphore _creds_sem;
     semaphore _mpus_sem{max_client_mpu_in_flight};
+    semaphore _buffered_dl_sem{max_client_buffered_downloads_in_flight};
     timer<seastar::lowres_clock> _creds_invalidation_timer;
     timer<seastar::lowres_clock> _creds_update_timer;
     aws_credentials _credentials;
@@ -131,7 +133,7 @@ class client : public enable_shared_from_this<client> {
         io_stats read_stats;
         io_stats write_stats;
         uint64_t prefetch_bytes = 0;
-        uint64_t downloads_blocked_on_memory = 0;
+        uint64_t downloads_starving_on_max_concurrency = 0;
         seastar::metrics::metric_groups metrics;
         group_client(std::unique_ptr<http::experimental::connection_factory> f, unsigned max_conn);
         void register_metrics(std::string class_name, std::string host);

--- a/utils/s3/client.hh
+++ b/utils/s3/client.hh
@@ -29,6 +29,8 @@ namespace s3 {
 
 using s3_clock = std::chrono::steady_clock;
 
+static constexpr size_t max_client_mpu_in_flight = 32;
+
 class range {
     friend struct fmt::formatter<range>;
 
@@ -106,6 +108,7 @@ class client : public enable_shared_from_this<client> {
     std::string _host;
     endpoint_config_ptr _cfg;
     semaphore _creds_sem;
+    semaphore _mpus_sem{max_client_mpu_in_flight};
     timer<seastar::lowres_clock> _creds_invalidation_timer;
     timer<seastar::lowres_clock> _creds_update_timer;
     aws_credentials _credentials;

--- a/utils/s3/client.hh
+++ b/utils/s3/client.hh
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <seastar/core/file.hh>
+#include <seastar/core/gate.hh>
 #include <seastar/core/metrics_registration.hh>
 #include <seastar/core/sstring.hh>
 #include <seastar/core/shared_ptr.hh>
@@ -109,6 +110,7 @@ class client : public enable_shared_from_this<client> {
     timer<seastar::lowres_clock> _creds_update_timer;
     aws_credentials _credentials;
     aws::aws_credentials_provider_chain _creds_provider_chain;
+    seastar::gate _config_update_gate;
 
     struct io_stats {
         uint64_t ops = 0;
@@ -212,7 +214,7 @@ public:
                          upload_progress& up,
                          seastar::abort_source* = nullptr);
 
-    future<> update_config(std::string reg, std::string ira);
+    void update_config_sync(std::string reg, std::string ira);
 
     struct handle {
         std::string _host;

--- a/utils/s3/client.hh
+++ b/utils/s3/client.hh
@@ -218,6 +218,7 @@ public:
                          seastar::abort_source* = nullptr);
 
     void update_config_sync(std::string reg, std::string ira);
+    void update_connections_per_shard(unsigned connections_per_shard);
 
     struct handle {
         std::string _host;

--- a/utils/s3/creds.hh
+++ b/utils/s3/creds.hh
@@ -27,12 +27,15 @@ struct aws_credentials {
 };
 
 struct endpoint_config {
+    static constexpr unsigned default_connections_per_shard = 128;
+
     unsigned port;
     bool use_https;
     std::string region;
     // Amazon Resource Names (ARNs) to access AWS resources
     std::string role_arn;
     std::optional<unsigned> max_connections;
+    unsigned connections_per_shard = default_connections_per_shard;
 
     std::strong_ordering operator<=>(const endpoint_config& o) const = default;
 };


### PR DESCRIPTION
Backport to `branch-2026.1` of the object storage memory and connection management work: [#29719](https://github.com/scylladb/scylladb/pull/29719), [#30278](https://github.com/scylladb/scylladb/pull/30278) and [#30520](https://github.com/scylladb/scylladb/pull/30520), plus one prerequisite and one follow-up fix.

All three were originally merged with `backport/none` on the grounds that keyspaces on object storage were not operational. `branch-2026.1` is the LTS branch, so that reasoning no longer holds for it: the bounding mechanism these PRs replace is the one that ships to LTS users, and it is the one that misbehaves under load.

### Problem

Three separate limits in the object storage client are either wrong, unreachable, or coupled to something they should not be coupled to.

**Concurrency is bounded by a byte budget.** Every multipart upload part and every buffered download claims bytes from one shared per-shard memory semaphore before it may proceed. The right number of *operations* to run in parallel does not follow from the number of *bytes* available, so the two drift apart: an operator tuning the memory budget silently changes how many uploads can run at once, and the same byte pool is used to bound two unrelated workloads. When the pool is exhausted the fibers block on the semaphore rather than being shed cleanly.

**The connection pool size is not tunable.** The S3 client keeps a separate HTTP connection pool per scheduling group, sized as `shares/100`, which yields 1-10 connections and takes no account of how many groups share the shard's connections. Groups with low share counts are under-provisioned, and nothing can be changed at runtime.

**The buffer budget is a hard-coded formula.** The budget shared by all object storage clients is `1% of shard memory` clamped to `[10 MiB, 100 MiB]`. It cannot be tuned per deployment and the ceiling does not scale with shard size.

### Changes

**Connection pool sizing (from #29719).** A new `object_storage_connections_per_shard` config option (default `128`) gives each shard a total connection budget, distributed across scheduling groups in proportion to their shares: `max_connections = budget * group_shares / total_shares`. Remainder connections go to the group with the most shares. Creating a new scheduling group's client rebalances all existing groups through `set_maximum_connections`, serialized on a semaphore so concurrent rebalances cannot race. The option is `LiveUpdate`: a `storage_manager` observer propagates changes to every existing S3 client under the same semaphore.

**Buffer budget sizing (from #30278).** A new `object_storage_clients_memory_fraction` config option (a `double`, default `0.01`) replaces the hard-coded formula. The budget becomes `shard_memory * fraction` with a 10 MiB floor, and is logged at startup. It is deliberately not live-updateable, since the budget is consumed when the storage manager starts.

**Operation-counting semaphores (from #30520).** The byte semaphore is replaced by two dedicated counting semaphores that bound operations directly:

- `put_object` no longer claims memory at all. It streams through `copy_to` with a fixed 64 KiB `_transmit_size`, so it is already bounded, consistent with how stream-to-stream copies are not gated on a memory semaphore.
- Multipart upload concurrency is bounded by a per-client counting semaphore (`_mpus_sem`, `max_client_mpu_in_flight = 32`). This replaces the previous `_max_multipart_concurrency = 16` and becomes the single source of truth, also feeding `max_concurrent_for_each` in `multipart_upload` and `copy_s3_object`.
- Buffered download concurrency (today only `chunked_download_source`) is bounded by a per-client counting semaphore (`_buffered_dl_sem`, `max_client_buffered_downloads_in_flight = 32`). Back-pressure moves from per-buffer to per-fiber: a unit is held opportunistically by the filling fiber, and when it cannot be acquired while buffers are still queued the fiber parks on `_bg_fiber_cv` until the queue drains or a unit frees up. Per-fiber memory stays bounded by the existing 5 MiB `_max_buffers_size` watermark.
- The memory semaphore itself is removed from the S3 client: the `_memory` field, `claim_memory()`, and the `semaphore& memory` parameter on `client::client` / `client::make`. `make_object_storage_client` keeps its `semaphore& memory` parameter, because the GCS wrapper still uses it.

**Resulting bound.** A fully saturated client holds at most `32 x 5 MiB = 160 MiB` of download buffers and `32 x part_size` of upload buffers per client per shard — roughly 320 MiB under realistic part sizes, where before the ceiling was whatever the byte budget happened to be.

### Commits not in the three PRs

Two commits are included that are not part of #29719, #30278 or #30520.

`sstables/utils/s3: split config update into sync and async parts` ([24a7b146fa](https://github.com/scylladb/scylladb/commit/24a7b146faff165bfc1310f350716b6e29f9c97a)) is a **required prerequisite**. `client::update_connections_per_shard`, added by the second commit of #29719, holds `_config_update_gate` to fire the rebalance as a gate-guarded background fiber, and that gate is declared by this commit. Without it the branch does not compile.

`s3_client: hold the MPU claim in the part upload's own scope` ([26ca745908](https://github.com/scylladb/scylladb/commit/26ca745908b), [#30992](https://github.com/scylladb/scylladb/pull/30992)) is a **follow-up fix to this series**. Both multipart upload paths claimed an MPU unit and moved it into the `write_body()` closure, so the bound on parts in flight rested on where seastar happens to store the body writer. It is included so the backport does not ship the imprecise bound.

Nothing else was carried. In particular this series does **not** bring the metrics machinery rewrite, the seastar `http::experimental` namespace graduation, the S3 test fixture and per-bucket isolation refactor, or the credentials-provider retry-strategy factory. Those are improvements to the branch, not part of this feature, and the conflicts they would have resolved were resolved by hand against `branch-2026.1`'s existing idiom instead.

### Deviations from upstream

**Adapted to `branch-2026.1`'s code, not master's.** The branch already carries S3 commits that on master land *after* #30520 — notably the backport of "do not send a Range header when downloading a whole object". `chunked_download_source` here is therefore a later generation than the one #30520 was written against, and the semaphore change was re-derived on top of it rather than reverting to master's older shape. The same applies to the metrics registration, which keeps this branch's `add_group("s3", {...})` initializer-list form, so only the counter is renamed and `scripts/metrics-config.yml` needs no entry.

**One test deletion moved earlier, for bisectability.** `test_client_abort_stuck_semaphore` saturates a 32 KiB memory semaphore and expects `semaphore_aborted` out of the claim that `s3_client: remove unnecessary memory claim` removes. Upstream deletes the test two commits later, which leaves #30520 unbisectable in between — the same hole exists on master. Here the deletion sits in the commit that invalidates the test, so every commit of this series builds and passes. Both affected commit messages carry a `Backport note:` recording this.

### User-visible changes

| | Before | After |
|---|---|---|
| `object_storage_connections_per_shard` | did not exist; pool was `shares/100` | new, default `128`, live-updateable |
| `object_storage_clients_memory_fraction` | did not exist; budget was `1%` clamped to `[10 MiB, 100 MiB]` | new, default `0.01`, `scylla.yaml` only, 10 MiB floor and no ceiling |
| metric `scylla_s3_downloads_blocked_on_memory` | present | renamed to `scylla_s3_downloads_starving_on_max_concurrency` |

The metric rename will break dashboards and alerts that reference the old name. The removed `100 MiB` ceiling only changes the effective budget above roughly 10 GiB per shard; note also that after this series the budget feeds only the GCS wrapper, since the S3 client no longer draws on it. `object_storage_clients_memory_fraction` is registered as `value_status::Unused`, so — exactly as on master — it is honoured from `scylla.yaml` but rejected as a command-line flag.

### Verification

Built and tested in the branch-pinned frozen toolchain (`scylladb/scylla-toolchain:branch-2026.1-fedora-43-20260714`).

Every one of the 12 commits was checked individually: `ninja scylla s3_test aws_error_injection_test`, then `test.py --mode dev test/boost/s3_test.cc test/boost/aws_error_injection_test.cc`. All 12 build, and all 12 pass — 61 tests before the series starts removing obsolete ones, 57 at the tip. `scripts/get_description.py --validate` passes.

### Issue references

Fixes: https://scylladb.atlassian.net/browse/SCYLLADB-1704
Fixes: https://scylladb.atlassian.net/browse/SCYLLADB-1917
Fixes: https://scylladb.atlassian.net/browse/SCYLLADB-2052
Fixes: https://scylladb.atlassian.net/browse/SCYLLADB-2563
Fixes: https://scylladb.atlassian.net/browse/SCYLLADB-569

### Backport

This PR *is* the backport, targeting `branch-2026.1`. The work is present in `master` and, by inheritance from the branch cut, in `branch-2026.3`. It is **not** in `branch-2026.2`, which was cut before these PRs merged — so landing this on 2026.1 alone makes the 2026.1 to 2026.2 upgrade path a regression for this code. A matching backport to `branch-2026.2` should follow.
