### PR TITLE
alternator: mark views as built based on the keyspace's actual strategy

### DIFF
--- a/alternator/executor.cc
+++ b/alternator/executor.cc
@@ -1719,33 +1719,7 @@ future<executor::request_return_type> executor::create_table_on_shard0(service::
 
     co_await verify_create_permission(enforce_authorization, warn_authorization, client_state, _stats);
 
-    if (stream_enabled) {
-        auto existing_ks = _proxy.data_dictionary().try_find_keyspace(keyspace_name);
-        const bool uses_tablets = existing_ks ? existing_ks->uses_tablets() : get_initial_tablet_count(tags_map, _proxy.features(), tablets_mode).has_value();
-        if (uses_tablets) {
-            if (!_proxy.features().cdc_block_tablet_merges_for_alternator_streams) {
-                co_return api_error::validation(
-                        "Alternator Streams on tablet tables are not supported until all nodes in the cluster "
-                        "support blocking tablet merges for Alternator Streams");
-            }
-            block_tablet_merges_for_alternator_streams(builder, /*defer_enablement=*/false);
-        }
-    }
-
-    schema_ptr schema = builder.build();
-    for (auto& view_builder : view_builders) {
-        // Note below we don't need to add virtual columns, as all
-        // base columns were copied to view. TODO: reconsider the need
-        // for virtual columns when we support Projection.
-        for (const column_definition& regular_cdef : schema->regular_columns()) {
-            if (!view_builder.has_column(*cql3::to_identifier(regular_cdef))) {
-                view_builder.with_column(regular_cdef.name(), regular_cdef.type, column_kind::regular_column);
-            }
-        }
-        const bool include_all_columns = true;
-        view_builder.with_view_info(schema, include_all_columns, ""/*where clause*/);
-    }
-
+    schema_ptr schema;
     size_t retries = _mm.get_concurrent_ddl_retries();
     for (;;) {
         auto group0_guard = co_await _mm.start_group0_operation();
@@ -1756,6 +1730,30 @@ future<executor::request_return_type> executor::create_table_on_shard0(service::
         locator::replication_strategy_params params(ksm->strategy_options(), ksm->initial_tablets(), ksm->consistency_option());
         const auto& topo = _proxy.local_db().get_token_metadata().get_topology();
         auto rs = locator::abstract_replication_strategy::create_replication_strategy(ksm->strategy_name(), params, topo);
+
+        if (stream_enabled && rs->uses_tablets()) {
+            if (!_proxy.features().cdc_block_tablet_merges_for_alternator_streams) {
+                co_return api_error::validation(
+                        "Alternator Streams on tablet tables are not supported until all nodes in the cluster "
+                        "support blocking tablet merges for Alternator Streams");
+            }
+            // Never cleared, so it survives a retry that resolves vnodes. Harmless:
+            // only the tablet allocator reads it, and it doesn't see vnodes tables.
+            block_tablet_merges_for_alternator_streams(builder, /*defer_enablement=*/false);
+        }
+        schema = builder.build();
+        for (auto& view_builder : view_builders) {
+            // Note below we don't need to add virtual columns, as all
+            // base columns were copied to view. TODO: reconsider the need
+            // for virtual columns when we support Projection.
+            for (const column_definition& regular_cdef : schema->regular_columns()) {
+                if (!view_builder.has_column(*cql3::to_identifier(regular_cdef))) {
+                    view_builder.with_column(regular_cdef.name(), regular_cdef.type, column_kind::regular_column);
+                }
+            }
+            const bool include_all_columns = true;
+            view_builder.with_view_info(schema, include_all_columns, ""/*where clause*/);
+        }
 
         // Vector indexes is a new feature that we decided to only support
         // on tablets.

--- a/alternator/executor.cc
+++ b/alternator/executor.cc
@@ -26,7 +26,6 @@
 #include "locator/abstract_replication_strategy.hh"
 #include "utils/log.hh"
 #include "schema/schema_builder.hh"
-#include "exceptions/exceptions.hh"
 #include "service/client_state.hh"
 #include "mutation/timestamp.hh"
 #include "types/map.hh"
@@ -1721,7 +1720,8 @@ future<executor::request_return_type> executor::create_table_on_shard0(service::
     co_await verify_create_permission(enforce_authorization, warn_authorization, client_state, _stats);
 
     if (stream_enabled) {
-        const bool uses_tablets = get_initial_tablet_count(tags_map, _proxy.features(), tablets_mode).has_value();
+        auto existing_ks = _proxy.data_dictionary().try_find_keyspace(keyspace_name);
+        const bool uses_tablets = existing_ks ? existing_ks->uses_tablets() : get_initial_tablet_count(tags_map, _proxy.features(), tablets_mode).has_value();
         if (uses_tablets) {
             if (!_proxy.features().cdc_block_tablet_merges_for_alternator_streams) {
                 co_return api_error::validation(
@@ -1751,7 +1751,8 @@ future<executor::request_return_type> executor::create_table_on_shard0(service::
         auto group0_guard = co_await _mm.start_group0_operation();
         auto ts = group0_guard.write_timestamp();
         utils::chunked_vector<mutation> schema_mutations;
-        auto ksm = create_keyspace_metadata(keyspace_name, _proxy, _gossiper, ts, tags_map, _proxy.features(), tablets_mode);
+        auto existing_ks = _proxy.data_dictionary().try_find_keyspace(keyspace_name);
+        auto ksm = existing_ks ? existing_ks->metadata() : create_keyspace_metadata(keyspace_name, _proxy, _gossiper, ts, tags_map, _proxy.features(), tablets_mode);
         locator::replication_strategy_params params(ksm->strategy_options(), ksm->initial_tablets(), ksm->consistency_option());
         const auto& topo = _proxy.local_db().get_token_metadata().get_topology();
         auto rs = locator::abstract_replication_strategy::create_replication_strategy(ksm->strategy_name(), params, topo);
@@ -1780,12 +1781,10 @@ future<executor::request_return_type> executor::create_table_on_shard0(service::
             }
         }
         bool table_already_exists = false;
-        try {
+        if (existing_ks) {
+            table_already_exists = _proxy.data_dictionary().has_schema(keyspace_name, table_name);
+        } else {
             schema_mutations = service::prepare_new_keyspace_announcement(_proxy.local_db(), ksm, ts);
-        } catch (exceptions::already_exists_exception&) {
-            if (_proxy.data_dictionary().has_schema(keyspace_name, table_name)) {
-                table_already_exists = true;
-            }
         }
         if (table_already_exists) {
             // The user may have retried a CreateTable operation after it timed

--- a/test/alternator/test_encoding.py
+++ b/test/alternator/test_encoding.py
@@ -2,19 +2,19 @@
 #
 # SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
 
-# Tests for the on-disk encoding of Alternator data. Specifically, these
-# tests verify that the internal format used to store DynamoDB attribute
-# values in the underlying Scylla table hasn't accidentally changed. If
-# Alternator's encoding were to change, sstables written by an older version
-# would become unreadable by a newer version - an unacceptable compatibility
-# breakage. So if any of these tests fail, the reason should be carefully
-# analyzed, and the test should only be updated if the encoding change was
-# intentional and backward compatibility was handled.
+# Tests for the way Alternator stores its data in Scylla: the encoding of the
+# attribute values, and the keyspace and CQL schema holding them. These tests verify that
+# this internal representation hasn't accidentally changed - if it did, data
+# written by an older version would become unreadable or inaccessible to a
+# newer version, an unacceptable compatibility breakage. So if any of these
+# tests fail, the reason should be carefully analyzed, and the test should
+# only be updated if the change was intentional and backward compatibility
+# was handled.
 #
 # Background on the encoding (see also issue #19770):
 # Alternator stores each DynamoDB table in keyspace "alternator_{table_name}",
 # table "{table_name}". The key attributes (hash key and optional range key)
-# are stored as regular CQL columns with their native CQL types (text for S,
+# are stored as separate CQL columns with their native CQL types (text for S,
 # blob for B, decimal for N). All other (non-key) attributes are stored
 # together in a single CQL column named ":attrs" of type map<text, blob>.
 # The map key is the attribute name; the map value encodes the type and value
@@ -42,7 +42,9 @@ from decimal import Decimal
 
 import pytest
 
-from .util import new_test_table, random_string
+from .util import new_test_table, precreated_keyspace, random_string, scylla_config_read, tablets_option, unique_table_name, wait_for_gsi
+from test.cqlpy.util import keyspace_has_tablets
+from test.pylib.skip_types import skip_env
 
 # All tests in this file are scylla-only (they access CQL internals)
 @pytest.fixture(scope="function", autouse=True)
@@ -309,3 +311,84 @@ def test_index_key_not_schema_column(dynamodb, cql, table_with_indexes):
     # (type byte 0x00 followed by raw UTF-8 bytes).
     assert attrs['x'] == b'\x00' + b'hello'
     assert attrs['y'] == b'\x00' + b'world'
+
+# The enforced tablets mode refuses to create a keyspace with vnodes, so a test
+# that needs one cannot run.
+def skip_if_tablets_enforced(dynamodb):
+    if scylla_config_read(dynamodb, 'tablets_mode_for_new_keyspaces') == '"enforced"':
+        skip_env('Cannot pre-create a keyspace with vnodes when tablets are enforced')
+
+# The keyspace which a user pre-created with CQL is used as it is: Alternator
+# creates the table in it without touching its configuration. Check this with
+# an option Alternator never sets itself, so that the pre-creation technique
+# stays tested once tablets are the only option left.
+def test_precreated_keyspace(dynamodb, cql):
+    name = unique_table_name()
+    with precreated_keyspace(cql, name, 'AND DURABLE_WRITES = false'):
+        with new_test_table(dynamodb, name=name,
+                KeySchema=[{'AttributeName': 'p', 'KeyType': 'HASH'}],
+                AttributeDefinitions=[{'AttributeName': 'p', 'AttributeType': 'S'}]) as table:
+            assert not cql.execute("SELECT durable_writes FROM system_schema.keyspaces "
+                f"WHERE keyspace_name = 'alternator_{name}'").one().durable_writes
+            # Sanity check that the table in this keyspace is usable.
+            p = random_string()
+            table.put_item(Item={'p': p, 'x': 'hello'})
+            assert table.get_item(Key={'p': p}, ConsistentRead=True)['Item'] == {'p': p, 'x': 'hello'}
+
+# A table lands in the pre-created keyspace, so it is that keyspace - and not
+# the "system:initial_tablets" tag, which only configures a keyspace Alternator
+# creates itself - that decides whether the table uses tablets or vnodes.
+@pytest.mark.parametrize('tablets', [False, True])
+def test_precreated_keyspace_tablets(dynamodb, cql, tablets):
+    if not tablets:
+        skip_if_tablets_enforced(dynamodb)
+    name = unique_table_name()
+    with precreated_keyspace(cql, name, tablets_option(tablets)):
+        # Ask, via the tag, for the opposite of what the keyspace was pre-created with.
+        with new_test_table(dynamodb, name=name,
+                Tags=[{'Key': 'system:initial_tablets', 'Value': 'none' if tablets else '0'}],
+                KeySchema=[{'AttributeName': 'p', 'KeyType': 'HASH'}],
+                AttributeDefinitions=[{'AttributeName': 'p', 'AttributeType': 'S'}]):
+            assert keyspace_has_tablets(cql, 'alternator_' + name) == tablets
+
+# CreateTable pre-marks the views implementing a table's GSIs as built when the
+# table uses tablets. Here the pre-created keyspace uses tablets while the tag
+# asks for vnodes - if the views are left unmarked, the GSI remains in
+# IndexStatus CREATING forever. Reproduces SCYLLADB-3976.
+def test_precreated_keyspace_gsi(dynamodb, cql):
+    name = unique_table_name()
+    with precreated_keyspace(cql, name, tablets_option(True)):
+        with new_test_table(dynamodb, name=name,
+                Tags=[{'Key': 'system:initial_tablets', 'Value': 'none'}],
+                KeySchema=[{'AttributeName': 'p', 'KeyType': 'HASH'}],
+                AttributeDefinitions=[{'AttributeName': 'p', 'AttributeType': 'S'},
+                                      {'AttributeName': 'x', 'AttributeType': 'S'}],
+                GlobalSecondaryIndexes=[{'IndexName': 'gsi',
+                    'KeySchema': [{'AttributeName': 'x', 'KeyType': 'HASH'}],
+                    'Projection': {'ProjectionType': 'ALL'}}]) as table:
+            # Without this the test would pass vacuously: a GSI on a keyspace
+            # using vnodes becomes ACTIVE anyway.
+            assert keyspace_has_tablets(cql, 'alternator_' + name)
+            wait_for_gsi(table, 'gsi')
+
+# Alternator Streams block tablet merges, which would otherwise produce shards
+# incompatible with the Streams API - but only on a table that uses tablets, so
+# here too the pre-created keyspace, and not the tag, has to decide.
+# The assertion below is on that mechanism, not on a guarantee: once Streams can
+# cope with merged tablets and the blocking goes away, this test starts failing,
+# and should be dropped along with the mechanism rather than repaired.
+@pytest.mark.parametrize('tablets', [False, True])
+def test_precreated_keyspace_streams(dynamodb, cql, tablets):
+    if not tablets:
+        skip_if_tablets_enforced(dynamodb)
+    name = unique_table_name()
+    with precreated_keyspace(cql, name, tablets_option(tablets)):
+        # Ask, via the tag, for the opposite of what the keyspace was pre-created with.
+        with new_test_table(dynamodb, name=name,
+                Tags=[{'Key': 'system:initial_tablets', 'Value': 'none' if tablets else '0'}],
+                KeySchema=[{'AttributeName': 'p', 'KeyType': 'HASH'}],
+                AttributeDefinitions=[{'AttributeName': 'p', 'AttributeType': 'S'}],
+                StreamSpecification={'StreamEnabled': True, 'StreamViewType': 'KEYS_ONLY'}):
+            desc = [row.create_statement for row in
+                    cql.execute(f'DESC TABLE "alternator_{name}"."{name}"')]
+            assert any("'tablet_merge_blocked': 'true'" in s for s in desc) == tablets

--- a/test/alternator/test_vector.py
+++ b/test/alternator/test_vector.py
@@ -13,14 +13,14 @@ import json
 import struct
 import decimal
 from decimal import Decimal
-from contextlib import contextmanager
+from contextlib import contextmanager, nullcontext
 from functools import cache
 
 from botocore.exceptions import ClientError
 import boto3.dynamodb.types
 
 from test.pylib.skip_types import skip_env
-from .util import random_string, new_test_table, unique_table_name, scylla_config_read, scylla_config_write, client_no_transform, is_aws, manual_request
+from .util import random_string, new_test_table, precreated_keyspace, tablets_option, unique_table_name, scylla_config_read, scylla_config_write, client_no_transform, is_aws, manual_request
 
 # Monkey-patch the boto3 library to stop doing its own error-checking on
 # numbers. This works around a bug https://github.com/boto/boto3/issues/2500
@@ -380,6 +380,33 @@ def test_createtable_vectorindexes_vnodes_forbidden(vs):
                 }]
             ) as table:
             pass
+
+# The same restriction has to be checked on a keyspace which the user
+# pre-created with CQL, because that is the keyspace the table lands in - the
+# "system:initial_tablets" tag, which asks for the opposite here, only
+# configures a keyspace that Alternator creates itself.
+# When we finally remove vnode support from the code, this test should be
+# deleted.
+@pytest.mark.parametrize('tablets', [False, True])
+def test_createtable_vectorindexes_precreated_keyspace(vs, cql, tablets):
+    if not tablets and scylla_config_read(vs, 'tablets_mode_for_new_keyspaces') == '"enforced"':
+        skip_env('Cannot pre-create a keyspace with vnodes when tablets are enforced')
+    name = unique_table_name()
+    with precreated_keyspace(cql, name, tablets_option(tablets)):
+        expected = nullcontext() if tablets else pytest.raises(
+                ClientError, match='ValidationException.*vnodes')
+        with expected:
+            # Ask, via the tag, for the opposite of what the keyspace was pre-created with.
+            with new_test_table(vs, name=name,
+                Tags=[{'Key': 'system:initial_tablets', 'Value': 'none' if tablets else '0'}],
+                KeySchema=[ { 'AttributeName': 'p', 'KeyType': 'HASH' }],
+                AttributeDefinitions=[{ 'AttributeName': 'p', 'AttributeType': 'S' }],
+                VectorIndexes=[
+                    {   'IndexName': 'hello',
+                        'VectorAttribute': {'AttributeName': 'x', 'Dimensions': 7}
+                    }]
+                ) as table:
+                pass
 
 # Verify that a vector index's IndexName follows the same naming rules as
 # table names - name length from 3 up to 192 (max_table_name_length) and

--- a/test/alternator/util.py
+++ b/test/alternator/util.py
@@ -175,6 +175,27 @@ def new_test_table(dynamodb, **kwargs):
         print(f"Deleting table {table.name}")
         table.delete()
 
+# A user may pre-create with CQL the keyspace "alternator_{name}" which
+# Alternator uses for a table named {name}, to configure it differently from
+# what Alternator would have picked. This context manager creates such a
+# keyspace, with the given extra CREATE KEYSPACE "options", for a table
+# created inside the "with" to re-use.
+@contextmanager
+def precreated_keyspace(cql, name, options=''):
+    cql.execute(f'CREATE KEYSPACE "alternator_{name}" WITH REPLICATION = '
+        "{'class': 'NetworkTopologyStrategy', 'replication_factor': 1} " + options)
+    try:
+        yield
+    finally:
+        # DeleteTable drops the keyspace, so this only matters if the table
+        # was never created.
+        cql.execute(f'DROP KEYSPACE IF EXISTS "alternator_{name}"')
+
+# A CREATE KEYSPACE option asking for tablets or for vnodes, to pass to
+# precreated_keyspace().
+def tablets_option(enabled):
+    return "AND TABLETS = {'enabled': %s}" % str(enabled).lower()
+
 # DynamoDB's ListTables request returns up to a single page of table names
 # (e.g., up to 100) and it is up to the caller to call it again and again
 # to get the next page. This is a utility function which calls it repeatedly

--- a/test/cluster/test_alternator.py
+++ b/test/cluster/test_alternator.py
@@ -2084,4 +2084,42 @@ async def test_alternator_mtls_and_plain_http(manager: ManagerClient, tmp_path):
         alternator_bad.meta.client.list_tables()
 
 
-
+# The rule: a GSI is a materialized view, and a keyspace holding views must be
+# RF-rack-valid while it uses tablets - the replication factor of a datacenter
+# has to match its rack count. CreateTable rejects a GSI that would break this.
+#
+# The interesting case: when the CreateTable request asks for vnodes through
+# the "system:initial_tablets" tag, the RF-rack validity check is skipped,
+# because the rule covers tablets only. That is wrong when the keyspace was
+# pre-created with tablets, because the table lands in that keyspace anyway:
+# the GSI gets created whatever the racks look like.
+#
+# What the test pins down: it pre-creates a tablets keyspace whose RF does not
+# match the rack count, and then creates a table with a GSI asking for vnodes.
+# The RF-rack-invalid error is the proof that the table went into the
+# pre-created keyspace and was checked against it - had the tag been believed,
+# the GSI would just have been created.
+async def test_gsi_in_precreated_rf_rack_invalid_keyspace(manager: ManagerClient):
+    # Two nodes in one rack, and rf_rack_valid_keyspaces off so that an
+    # RF-rack-invalid keyspace with RF=2 can be created at all.
+    servers = await manager.servers_add(2,
+        config=alternator_config | {'rf_rack_valid_keyspaces': False},
+        property_file={'dc': 'dc1', 'rack': 'rack1'})
+    cql = manager.get_cql()
+    alternator = get_alternator(servers[0].ip_addr)
+    name = unique_table_name()
+    cql.execute(f'CREATE KEYSPACE "alternator_{name}" WITH REPLICATION = '
+        "{'class': 'NetworkTopologyStrategy', 'dc1': 2} AND TABLETS = {'enabled': true}")
+    try:
+        with pytest.raises(ClientError, match='ValidationException.*racks'):
+            alternator.create_table(TableName=name,
+                Tags=[{'Key': 'system:initial_tablets', 'Value': 'none'}],
+                BillingMode='PAY_PER_REQUEST',
+                KeySchema=[{'AttributeName': 'p', 'KeyType': 'HASH'}],
+                AttributeDefinitions=[{'AttributeName': 'p', 'AttributeType': 'S'},
+                                      {'AttributeName': 'x', 'AttributeType': 'S'}],
+                GlobalSecondaryIndexes=[{'IndexName': 'gsi',
+                    'KeySchema': [{'AttributeName': 'x', 'KeyType': 'HASH'}],
+                    'Projection': {'ProjectionType': 'ALL'}}])
+    finally:
+        cql.execute(f'DROP KEYSPACE IF EXISTS "alternator_{name}"')

--- a/test/cqlpy/util.py
+++ b/test/cqlpy/util.py
@@ -16,6 +16,7 @@ import collections
 import ssl
 from contextlib import contextmanager
 
+from cassandra import InvalidRequest
 from cassandra.auth import PlainTextAuthProvider
 from cassandra.cluster import Cluster, ConsistencyLevel, ExecutionProfile, EXEC_PROFILE_DEFAULT
 from cassandra.policies import RoundRobinPolicy
@@ -91,7 +92,7 @@ def keyspace_has_tablets(cql, keyspace):
 
     try:
         res = list(cql.execute(f"SELECT * FROM system_schema.scylla_keyspaces WHERE keyspace_name='{keyspace}'"))
-    except:
+    except InvalidRequest:
         # Antique versions of Scylla are is_scylla() but did not have
         # the scylla_keyspaces table. They didn't have tablets either, so
         # we should just return False.


### PR DESCRIPTION
Alternator `CreateTable` synthesizes the metadata of the keyspace it would
create - from the request tag, the local config and a replication factor of its
own - and bases every decision it makes on it, also when the keyspace already
exists. A keyspace **pre-created with CQL** is left alone and the table is
created in it as it is, so on that path those decisions are made against a
keyspace that isn't there, and nothing downstream re-checks them:

- GSI/LSI views are not pre-marked as built in a tablets keyspace, and
  `DescribeTable` reports `IndexStatus: CREATING` indefinitely,
- Alternator Streams do not block the tablet merges they cannot handle in a
  tablets keyspace, and block them on vnodes,
- vector indexes are accepted on vnodes and refused on tablets,
- RF-rack validity is verified against the wrong replication factors, or - when
  the tag asks for vnodes - not at all, letting a GSI land in an
  RF-rack-invalid keyspace, which a node then refuses to start with.

Fix by taking the existing keyspace's metadata when there is one, so the tag
and the config apply only to a keyspace Alternator creates itself. They are
consequently no longer validated when they cannot have any effect: under
`tablets_mode_for_new_keyspaces: enforced`, a tag asking for vnodes is now
ignored rather than rejected when the keyspace already exists.

A pre-existing race of the same kind is closed on top: the Streams
tablet-merge decision and the schema build both happen before CreateTable
takes the group0 guard and are never redone, so a keyspace created in the
meantime - or before a retry - is used together with a schema that predates
it. Both move into the guarded retry loop. Credits for spotting the bug go to @coderabbitai at
https://github.com/scylladb/scylladb/pull/31243#discussion_r3854502945

Fixes SCYLLADB-3976

Backport to all active branches where the problem exists.