### PR TITLE
auth: fix argument order in ldap_role_manager::set_attribute

### DIFF
--- a/auth/ldap_role_manager.cc
+++ b/auth/ldap_role_manager.cc
@@ -475,7 +475,7 @@ future<role_manager::attribute_vals> ldap_role_manager::query_attribute_for_all(
 
 future<> ldap_role_manager::set_attribute(
         std::string_view role_name, std::string_view attribute_name, std::string_view attribute_value, ::service::group0_batch& mc) {
-    return _std_mgr.set_attribute(role_name, attribute_value, attribute_value, mc);
+    return _std_mgr.set_attribute(role_name, attribute_name, attribute_value, mc);
 }
 
 future<> ldap_role_manager::remove_attribute(std::string_view role_name, std::string_view attribute_name, ::service::group0_batch& mc) {

--- a/test/cluster/auth_cluster/test_ldap_service_levels.py
+++ b/test/cluster/auth_cluster/test_ldap_service_levels.py
@@ -1,0 +1,177 @@
+#
+# Copyright (C) 2026-present ScyllaDB
+#
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
+#
+
+import asyncio
+import logging
+import os
+import time
+
+from cassandra.auth import PlainTextAuthProvider
+
+from test.cluster.auth_cluster import extra_scylla_config_options as auth_config
+from test.pylib.driver_utils import safe_driver_shutdown
+from test.pylib.scylla_cluster_manager import ScyllaClusterManager
+from test.pylib.skip_types import skip_env
+from test.pylib.util import unique_name, wait_for, wait_for_cql_and_get_hosts
+
+logger = logging.getLogger(__name__)
+
+# The slapd fixture data (test/pylib/ldap_server.py) defines people jsmith
+# (member of group role1) and jdoe (member of group role3).
+LDAP_GROUPS = ["role1", "role2", "role3"]
+
+BATCH_QUERIES = 10
+
+
+def ldap_config():
+    host = os.environ.get("SEASTAR_LDAP_HOST")
+    port = os.environ.get("SEASTAR_LDAP_PORT")
+    if not host or not port:
+        skip_env("needs the LDAP server started by the test.py harness")
+    return {
+        **auth_config,
+        "role_manager": "com.scylladb.auth.LDAPRoleManager",
+        "ldap_url_template":
+            f"ldap://{host}:{port}/dc=example,dc=com?cn?sub"
+            "?(uniqueMember=uid={USER},ou=People,dc=example,dc=com)",
+        "ldap_attr_role": "cn",
+        "ldap_bind_dn": "cn=root,dc=example,dc=com",
+        "ldap_bind_passwd": "secret",
+    }
+
+
+async def start_server(manager: ScyllaClusterManager):
+    server = await manager.server_add(config=ldap_config())
+    cql = manager.get_cql()
+    await wait_for_cql_and_get_hosts(cql, [server], time.time() + 60)
+
+    for group in LDAP_GROUPS:
+        await cql.run_async(f"CREATE ROLE {group}")
+
+    # A connection moves from the sl:driver group to its user's service
+    # level group when it runs a query on a user table, such as demo.t.
+    await cql.run_async("CREATE KEYSPACE demo WITH replication = "
+                        "{'class': 'NetworkTopologyStrategy', 'replication_factor': 1}")
+    await cql.run_async("CREATE TABLE demo.t (id int PRIMARY KEY)")
+
+    return server, cql
+
+
+def run_query_batch(session):
+    for _ in range(BATCH_QUERIES):
+        session.execute("SELECT * FROM demo.t")
+
+
+async def requests_served_in_group(manager: ScyllaClusterManager, server, group):
+    metrics = await manager.metrics.query(server.ip_addr)
+    count = metrics.get("scylla_transport_cql_requests_count",
+                        {"scheduling_group_name": group})
+    return count or 0
+
+
+async def wait_until_served_in_group(manager, server, user_session, group, deadline):
+    # Nothing else maps to `group`, so the counter growing by a full batch
+    # proves the user's requests execute under the attached service level.
+    async def full_batch_lands_in_group():
+        before = await requests_served_in_group(manager, server, group)
+        await asyncio.to_thread(run_query_batch, user_session)
+        after = await requests_served_in_group(manager, server, group)
+        if after - before >= BATCH_QUERIES:
+            return True
+        logger.info("%s served %d of %d requests", group, after - before, BATCH_QUERIES)
+        return None
+    await wait_for(full_batch_lands_in_group, deadline, label=f"requests in {group}")
+
+
+async def wait_until_not_served_in_group(manager, server, user_session, group, deadline):
+    async def batch_avoids_group():
+        before = await requests_served_in_group(manager, server, group)
+        await asyncio.to_thread(run_query_batch, user_session)
+        after = await requests_served_in_group(manager, server, group)
+        if after <= before:
+            return True
+        logger.info("%s still served %d requests", group, after - before)
+        return None
+    await wait_for(batch_avoids_group, deadline, label=f"no requests in {group}")
+
+
+def connect_as(manager: ScyllaClusterManager, server, username, password):
+    cluster = manager.con_gen([server.ip_addr], manager.port, manager.use_ssl,
+                              PlainTextAuthProvider(username=username, password=password))
+    return cluster, cluster.connect()
+
+
+async def test_ldap_attach_service_level(manager: ScyllaClusterManager):
+    """ATTACH, LIST and DROP SERVICE LEVEL for a user whose roles come from
+    LDAP."""
+    server, cql = await start_server(manager)
+
+    sl = "sl_" + unique_name()
+    await cql.run_async(f"CREATE SERVICE LEVEL {sl}")
+    await cql.run_async("CREATE ROLE jsmith WITH password='jsmithpass' AND login=true")
+    await cql.run_async("GRANT SELECT ON demo.t TO jsmith")
+
+    await cql.run_async(f"ATTACH SERVICE LEVEL {sl} TO jsmith")
+
+    attached = await cql.run_async("LIST ATTACHED SERVICE LEVEL OF jsmith")
+    assert [(row.role, row.service_level) for row in attached] == [("jsmith", sl)]
+    attached = await cql.run_async("LIST ALL ATTACHED SERVICE LEVELS")
+    assert ("jsmith", sl) in [(row.role, row.service_level) for row in attached]
+
+    listed = await cql.run_async(f"LIST SERVICE LEVEL {sl}")
+    assert [row.service_level for row in listed] == [sl]
+    assert sl in [row.service_level for row in await cql.run_async("LIST ALL SERVICE LEVELS")]
+
+    cluster, session = connect_as(manager, server, "jsmith", "jsmithpass")
+    try:
+        await wait_until_served_in_group(manager, server, session, f"sl:{sl}",
+                                         time.time() + 60)
+
+        await cql.run_async("DETACH SERVICE LEVEL FROM jsmith")
+        assert len(await cql.run_async("LIST ATTACHED SERVICE LEVEL OF jsmith")) == 0
+        await wait_until_not_served_in_group(manager, server, session, f"sl:{sl}",
+                                             time.time() + 60)
+
+        await cql.run_async(f"ATTACH SERVICE LEVEL {sl} TO jsmith")
+        await wait_until_served_in_group(manager, server, session, f"sl:{sl}",
+                                         time.time() + 60)
+
+        # DROP also detaches the level from every role.
+        await cql.run_async(f"DROP SERVICE LEVEL {sl}")
+        assert sl not in [row.service_level for row in await cql.run_async("LIST ALL SERVICE LEVELS")]
+        assert len(await cql.run_async("LIST ATTACHED SERVICE LEVEL OF jsmith")) == 0
+        await wait_until_not_served_in_group(manager, server, session, f"sl:{sl}",
+                                             time.time() + 60)
+    finally:
+        safe_driver_shutdown(cluster)
+
+
+async def test_ldap_granted_role_service_level(manager: ScyllaClusterManager):
+    """A service level attached to a group role reaches the group's members.
+    jdoe is a member of role3 in the LDAP directory only. No GRANT statement
+    runs, the grant comes from LDAP."""
+    server, cql = await start_server(manager)
+
+    sl = "sl_" + unique_name()
+    await cql.run_async(f"CREATE SERVICE LEVEL {sl}")
+    await cql.run_async("CREATE ROLE jdoe WITH password='jdoepass' AND login=true")
+    await cql.run_async("GRANT SELECT ON demo.t TO jdoe")
+
+    await cql.run_async(f"ATTACH SERVICE LEVEL {sl} TO role3")
+
+    effective = await cql.run_async("LIST EFFECTIVE SERVICE LEVEL OF jdoe")
+    assert effective and all(row.effective_service_level == sl for row in effective)
+
+    cluster, session = connect_as(manager, server, "jdoe", "jdoepass")
+    try:
+        await wait_until_served_in_group(manager, server, session, f"sl:{sl}",
+                                         time.time() + 60)
+
+        await cql.run_async(f"DROP SERVICE LEVEL {sl}")
+        await wait_until_not_served_in_group(manager, server, session, f"sl:{sl}",
+                                             time.time() + 60)
+    finally:
+        safe_driver_shutdown(cluster)

--- a/test/ldap/role_manager_test.cc
+++ b/test/ldap/role_manager_test.cc
@@ -587,7 +587,7 @@ SEASTAR_TEST_CASE(ldap_delegates_config) {
     });
 }
 
-SEASTAR_TEST_CASE(ldap_delegates_attributes, *boost::unit_test::expected_failures(3)) {
+SEASTAR_TEST_CASE(ldap_delegates_attributes) {
     return do_with_cql_env_thread([](cql_test_env& env) {
         auto fetch_all_attributes = [&env] {
             auto rows = dynamic_pointer_cast<cql_transport::messages::result_message::rows>(

--- a/test/ldap/role_manager_test.cc
+++ b/test/ldap/role_manager_test.cc
@@ -21,9 +21,13 @@
 #include "test/lib/exception_utils.hh"
 #include "test/lib/log.hh"
 #include "test/lib/test_utils.hh"
+#include <set>
+
 #include "ldap_common.hh"
 #include "service/migration_manager.hh"
 #include "test/lib/cql_test_env.hh"
+#include "transport/messages/result_message.hh"
+#include "types/types.hh"
 
 auto make_manager(cql_test_env& env) {
     auto stop_role_manager = [] (auth::standard_role_manager* m) {
@@ -583,23 +587,43 @@ SEASTAR_TEST_CASE(ldap_delegates_config) {
     });
 }
 
-SEASTAR_TEST_CASE(ldap_delegates_attributes) {
+SEASTAR_TEST_CASE(ldap_delegates_attributes, *boost::unit_test::expected_failures(3)) {
     return do_with_cql_env_thread([](cql_test_env& env) {
+        auto fetch_all_attributes = [&env] {
+            auto rows = dynamic_pointer_cast<cql_transport::messages::result_message::rows>(
+                    env.execute_cql("SELECT role, name, value FROM system.role_attributes").get());
+            BOOST_REQUIRE(rows);
+            std::set<sstring> attributes;
+            for (const auto& row : rows->rs().result_set().rows()) {
+                auto text = [] (const managed_bytes_opt& cell) {
+                    return cell ? value_cast<sstring>(utf8_type->deserialize(managed_bytes_view(*cell))) : sstring("<null>");
+                };
+                attributes.insert(seastar::format("({}, {}, {})", text(row[0]), text(row[1]), text(row[2])));
+            }
+            return attributes;
+        };
         auto m = make_ldap_manager(env);
         m->start().get();
         do_with_mc(env, [&] (service::group0_batch& b) {
             m->create("r", auth::role_config{}, b).get();
         });
         BOOST_REQUIRE(!m->get_attribute("r", "a", auth::internal_distributed_query_state()).get());
+        // set_attribute then remove_attribute must restore this exact table
+        // content. A row stored under a wrong name or role is invisible to
+        // get_attribute, so only comparing the whole table can prove it.
+        const auto baseline = fetch_all_attributes();
         do_with_mc(env, [&] (service::group0_batch& b) {
             m->set_attribute("r", "a", "3", b).get();
         });
-        // TODO: uncomment when failure is fixed.
-        //BOOST_REQUIRE_EQUAL("3", *m->get_attribute("r", "a").get());
+        BOOST_CHECK_EQUAL("3", m->get_attribute("r", "a", auth::internal_distributed_query_state()).get().value_or("<no attribute>"));
+        auto with_attribute = baseline;
+        with_attribute.insert("(r, a, 3)");
+        BOOST_CHECK_EQUAL(fetch_all_attributes(), with_attribute);
         do_with_mc(env, [&] (service::group0_batch& b) {
             m->remove_attribute("r", "a", b).get();
         });
         BOOST_REQUIRE(!m->get_attribute("r", "a", auth::internal_distributed_query_state()).get());
+        BOOST_CHECK_EQUAL(fetch_all_attributes(), baseline);
     });
 }
 


### PR DESCRIPTION
Under `LDAPRoleManager`, `ATTACH SERVICE LEVEL` reports success but no attachment happens. `ldap_role_manager::set_attribute` passes the attribute value where its delegate expects the attribute name. The attachment is stored under the wrong name and no reader finds it.

The first commit enables the assertion that was commented out in `ldap_delegates_attributes` and compares the full content of `system.role_attributes` against a snapshot. `set_attribute` must add exactly the expected row and `remove_attribute` must restore the snapshot. The three checks fail on the bug, so the test is marked `expected_failures`. The second commit fixes the argument order and drops the marker.

Fixes SCYLLADB-3980

This is a bug present from commit 288f9b2b15 (2024-12-03), so backport to all the supported versions is required.