### PR TITLE
transport: audit the outcome of the whole SASL login

### DIFF
--- a/test/cluster/test_audit.py
+++ b/test/cluster/test_audit.py
@@ -1269,6 +1269,29 @@ class CQLAuditTester(AuditTester):
                 error = next(iter(errors))
                 assert isinstance(error, AuthenticationFailed)
 
+    async def _test_negative_audit_records_auth_no_login(self):
+        """
+        Test that a valid password on a role that is not permitted to log in is
+        audited as a failed AUTH attempt (SCYLLADB-3964).
+        """
+        session = await self.prepare(user="cassandra", password="cassandra", create_keyspace=False)
+        session.execute("CREATE ROLE no_login_role WITH PASSWORD = 'no_login_role' AND LOGIN = false")
+
+        expected_entry = AuditEntry(category="AUTH", statement="LOGIN", table="", ks="", user="no_login_role", cl="", error=True)
+        with self.assert_entries_were_added(session, [expected_entry], filter_out_cassandra_auth=True):
+            try:
+                servers = await self.manager.running_servers()
+                no_login_auth = PlainTextAuthProvider(username="no_login_role", password="no_login_role")
+                await self.manager.get_cql_exclusive(servers[0], auth_provider=no_login_auth)
+                pytest.fail()
+            except NoHostAvailable as e:
+                errors = e.errors.values()
+                assert len(errors) == 1
+                error = next(iter(errors))
+                assert isinstance(error, AuthenticationFailed)
+
+        session.execute("DROP ROLE IF EXISTS no_login_role")
+
     async def _test_negative_audit_records_admin(self):
         """
         Test that failed ADMIN statements are audited.
@@ -2542,6 +2565,7 @@ async def test_audit_table_auth(manager: ScyllaClusterManager, rules_mode: bool)
     t = CQLAuditTester(manager, rules_mode=rules_mode)
     await t._test_user_password_masking(AuditBackendTable)
     await t._test_negative_audit_records_auth()
+    await t._test_negative_audit_records_auth_no_login()
     await t._test_negative_audit_records_admin()
     await t._test_negative_audit_records_dml()
     await t._test_negative_audit_records_dcl()

--- a/transport/server.cc
+++ b/transport/server.cc
@@ -1564,11 +1564,23 @@ future<std::unique_ptr<cql_server::response>> cql_server::connection::process_au
         co_return make_auth_challenge(stream, std::move(challenge), trace_state);
     }
 
-    auto user = co_await coroutine::as_future(sasl_challenge->get_authenticated_user());
-    co_await audit::inspect_login(sasl_challenge->get_username(), client_state.get_client_address().addr(), user.failed());
-    client_state.set_login(user.get());
-    update_scheduling_group();
-    co_await client_state.check_user_can_login();
+    // The authenticator does not consult the LOGIN flag, so both checks have to
+    // run before the audit record can state the outcome of the login.
+    std::exception_ptr ex;
+    try {
+        client_state.set_login(co_await sasl_challenge->get_authenticated_user());
+        update_scheduling_group();
+        co_await client_state.check_user_can_login();
+    } catch (...) {
+        ex = std::current_exception();
+    }
+
+    co_await audit::inspect_login(sasl_challenge->get_username(), client_state.get_client_address().addr(), bool(ex));
+
+    if (ex) {
+        co_return coroutine::exception(std::move(ex));
+    }
+
     client_state.maybe_update_per_service_level_params();
     _authenticating = false;
     _ready = true;

--- a/transport/server.cc
+++ b/transport/server.cc
@@ -1557,28 +1557,23 @@ future<std::unique_ptr<cql_server::response>> cql_server::connection::process_au
     auto sasl_challenge = client_state.get_auth_service()->underlying_authenticator().new_sasl_challenge();
     utils::result_with_exception_ptr<bytes_view> buf = in.read_raw_bytes_view(in.bytes_left());
     if (!buf) {
-        return make_exception_future<std::unique_ptr<cql_server::response>>(std::move(buf).assume_error());
+        co_return coroutine::exception(std::move(buf).assume_error());
     }
     auto challenge = sasl_challenge->evaluate_response(buf.assume_value());
-    if (sasl_challenge->is_complete()) {
-        return sasl_challenge->get_authenticated_user().then_wrapped([this, sasl_challenge, stream, &client_state, challenge = std::move(challenge), trace_state](future<auth::authenticated_user> f) mutable {
-            bool failed = f.failed();
-            return audit::inspect_login(sasl_challenge->get_username(), client_state.get_client_address().addr(), failed).then(
-                    [this, stream, challenge = std::move(challenge), &client_state, sasl_challenge, ff = std::move(f), trace_state = std::move(trace_state)] () mutable {
-                client_state.set_login(ff.get());
-                update_scheduling_group();
-                auto f = client_state.check_user_can_login();
-                return f.then([this, &client_state, stream, challenge = std::move(challenge), trace_state]() mutable {
-                    client_state.maybe_update_per_service_level_params();
-                    _authenticating = false;
-                    _ready = true;
-                    on_connection_ready();
-                    return make_ready_future<std::unique_ptr<cql_server::response>>(make_auth_success(stream, std::move(challenge), trace_state));
-                });
-            });
-        });
+    if (!sasl_challenge->is_complete()) {
+        co_return make_auth_challenge(stream, std::move(challenge), trace_state);
     }
-    return make_ready_future<std::unique_ptr<cql_server::response>>(make_auth_challenge(stream, std::move(challenge), trace_state));
+
+    auto user = co_await coroutine::as_future(sasl_challenge->get_authenticated_user());
+    co_await audit::inspect_login(sasl_challenge->get_username(), client_state.get_client_address().addr(), user.failed());
+    client_state.set_login(user.get());
+    update_scheduling_group();
+    co_await client_state.check_user_can_login();
+    client_state.maybe_update_per_service_level_params();
+    _authenticating = false;
+    _ready = true;
+    on_connection_ready();
+    co_return make_auth_success(stream, std::move(challenge), trace_state);
 }
 
 future<std::unique_ptr<cql_server::response>> cql_server::connection::process_options(uint16_t stream, request_reader in, service::client_state& client_state,


### PR DESCRIPTION
`audit::inspect_login()` was told only whether the authenticator's credential check
threw, but the LOGIN flag is enforced one step later, by
`client_state::check_user_can_login()`, so a correct password on a `LOGIN = false`
role - or on a non-existent role - left an AUTH/LOGIN record with `error = false`
while the client was rejected with an authentication error. Run both checks
before writing the record and report their combined outcome; the record still
precedes on_connection_ready() and the original exception is re-thrown with
_authenticating and _ready untouched, so a rejected connection stays open for
another `AUTH_RESPONSE` exactly as before.

Fixes SCYLLADB-3964
Backport: none, it's a minor bugfix