### PR TITLE
test/boost: cover materialized view writetimes across flushes

### DIFF
--- a/test/boost/view_schema_test.cc
+++ b/test/boost/view_schema_test.cc
@@ -21,6 +21,7 @@
 #include "test/lib/cql_test_env.hh"
 #include "test/lib/cql_assertions.hh"
 #include "test/lib/eventually.hh"
+#include "test/lib/data_driven_test_case.hh"
 #include "exceptions/unrecognized_entity_exception.hh"
 #include "db/config.hh"
 #include "types/set.hh"
@@ -28,6 +29,7 @@
 #include "types/map.hh"
 #include "types/vector.hh"
 #include "utils/chunked_string.hh"
+
 
 BOOST_AUTO_TEST_SUITE(view_schema_test)
 
@@ -3054,7 +3056,15 @@ struct update_counter {
     }
 };
 
-SEASTAR_TEST_CASE(test_view_update_generating_writetime) {
+
+void maybe_flush_cluster(cql_test_env& e, bool flush){
+    if (flush){ 
+        e.db().invoke_on_all([] (replica::database& db) {
+            return db.flush_all_tables();}).get();
+    }
+}
+
+auto test_view_update_generating_writetime(bool flush) {
     // The test revolves around timestamps in materialized views and their relation to timestamps
     // in the base table. Values in an MV should have the same timestamp as the corresponding
     // ones in the base table. However, that only applies to values that are readable with `WRITETIME`.
@@ -3072,7 +3082,7 @@ SEASTAR_TEST_CASE(test_view_update_generating_writetime) {
     //        to the unselected columns from the base table. As a result, no view updates will be
     //        generated for unselected columns as a result.
 
-    return do_with_cql_env_thread([] (cql_test_env& e) {
+    return do_with_cql_env_thread([flush] (cql_test_env& e) {
 
         auto f1 = e.local_view_builder().wait_until_built("ks", "mv1");
         auto f2 = e.local_view_builder().wait_until_built("ks", "mv2");
@@ -3087,22 +3097,37 @@ SEASTAR_TEST_CASE(test_view_update_generating_writetime) {
         f2.get();
 
         auto total_t_view_updates = [&] {
-            return e.db().map_reduce0([] (replica::database& local_db) {
-                const db::view::stats& local_stats = local_db.find_column_family("ks", "t").get_view_stats();
-                return local_stats.view_updates_pushed_local + local_stats.view_updates_pushed_remote;
-            }, 0, std::plus<int64_t>()).get();
+            auto total = e.db().map_reduce0([] (replica::database& local_db) {
+                const db::view::stats& local_stats =
+                        local_db.find_column_family("ks", "t").get_view_stats();
+
+                return local_stats.view_updates_pushed_local
+                    + local_stats.view_updates_pushed_remote;
+            }, int64_t{0}, std::plus<int64_t>()).get();
+
+            maybe_flush_cluster(e, flush);
+
+            return total;
         };
 
         auto total_mv1_updates = [&] {
-            return e.db().map_reduce0([] (replica::database& local_db) {
+            auto total = e.db().map_reduce0([] (replica::database& local_db) {
                 return local_db.find_column_family("ks", "mv1").get_stats().writes.hist.count;
             }, 0, std::plus<int64_t>()).get();
+
+            maybe_flush_cluster(e, flush);
+
+            return total;
         };
 
         auto total_mv2_updates = [&] {
-            return e.db().map_reduce0([] (replica::database& local_db) {
+            auto total = e.db().map_reduce0([] (replica::database& local_db) {
                 return local_db.find_column_family("ks", "mv2").get_stats().writes.hist.count;
             }, 0, std::plus<int64_t>()).get();
+
+            maybe_flush_cluster(e, flush);
+
+            return total;
         };
 
         ::shared_ptr<cql_transport::messages::result_message> msg;
@@ -3221,6 +3246,10 @@ SEASTAR_TEST_CASE(test_view_update_generating_writetime) {
         });
     });
 }
+
+DATA_DRIVEN_TEST_CASE(test_view_update_generating_writetime, flush, false);
+DATA_DRIVEN_TEST_CASE(test_view_update_generating_writetime, flush, true);
+
 
 // Usually if only an unselected column in the base table is modified, we expect an optimization that a view
 // update is not done, but we had an bug(https://scylladb.atlassian.net/browse/SCYLLADB-808) where the existence

--- a/test/lib/data_driven_test_case.hh
+++ b/test/lib/data_driven_test_case.hh
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2015-present ScyllaDB
+ * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
+ */
+
+#include <boost/preprocessor/seq/fold_left.hpp>
+#include <boost/preprocessor/tuple/elem.hpp>
+#include <boost/preprocessor/variadic/to_seq.hpp>
+#include <boost/preprocessor/arithmetic/div.hpp>
+#include <boost/preprocessor/arithmetic/inc.hpp>
+#include <boost/preprocessor/arithmetic/mul.hpp>
+#include <boost/preprocessor/control/expr_if.hpp>
+#include <boost/preprocessor/punctuation/comma_if.hpp>
+#include <boost/preprocessor/repetition/repeat.hpp>
+#include <boost/preprocessor/tuple/elem.hpp>
+#include <boost/preprocessor/variadic/size.hpp>
+
+
+#define CONCAT_IMPL(a, b) a##b
+#define CONCAT(a, b) CONCAT_IMPL(a, b)
+
+#define APPEND_TOKEN(base, token)                               \
+    CONCAT(CONCAT(base, _), token)
+               
+#define APPEND_PARAMETER(base, parameter, value)                \
+    APPEND_TOKEN(APPEND_TOKEN(base, parameter), value)
+
+
+#define MAKE_PAIR(z, index, arguments)                          \
+BOOST_PP_COMMA_IF(index)(                                       \
+    BOOST_PP_TUPLE_ELEM(BOOST_PP_MUL(2, index), arguments),     \
+    BOOST_PP_TUPLE_ELEM(                                        \
+        BOOST_PP_INC(BOOST_PP_MUL(2, index)), arguments))
+
+#define MAKE_PAIRS(...)                                         \
+    BOOST_PP_REPEAT(                                            \
+        BOOST_PP_DIV(BOOST_PP_VARIADIC_SIZE(__VA_ARGS__), 2),   \
+        MAKE_PAIR,                                              \
+        (__VA_ARGS__))
+
+#define TEST_NAME_FOLD_OP(s, result, pair)                      \
+    APPEND_PARAMETER(                                           \
+        result,                                                 \
+        BOOST_PP_TUPLE_ELEM(2, 0, pair),                        \
+        BOOST_PP_TUPLE_ELEM(2, 1, pair))
+
+#define TEST_NAME(name, ...)                                    \
+    BOOST_PP_SEQ_FOLD_LEFT(                                     \
+        TEST_NAME_FOLD_OP,                                      \
+        name,                                                   \
+        BOOST_PP_VARIADIC_TO_SEQ(MAKE_PAIRS(__VA_ARGS__)))
+
+#define EXTRACT_VALUE(z, index, arguments)                      \
+    BOOST_PP_COMMA_IF(index)                                    \
+    BOOST_PP_TUPLE_ELEM(                                        \
+        BOOST_PP_INC(BOOST_PP_MUL(2, index)),                   \
+        arguments)
+
+#define EXTRACT_VALUES(...)                                     \
+    BOOST_PP_REPEAT(                                            \
+        BOOST_PP_DIV(BOOST_PP_VARIADIC_SIZE(__VA_ARGS__), 2),   \
+        EXTRACT_VALUE,                                          \
+        (__VA_ARGS__))
+
+#define DATA_DRIVEN_TEST_CASE(func, ...)                        \
+    SEASTAR_TEST_CASE(TEST_NAME(func, __VA_ARGS__)) {           \
+        return func(EXTRACT_VALUES(__VA_ARGS__));               \
+    }    


### PR DESCRIPTION
  Complete the Boost-test coverage corresponding to the dtest
  `test_no_base_column_in_view_pk_complex_timestamp_{with,without}_flush`
  variants.

  The existing test covered materialized-view update generation and
  writetime behavior without flushing. This series parameterizes it so the
  same assertions run against both memtable-only and flushed state.

  ## Changes
  - Add `DATA_DRIVEN_TEST_CASE`, a helper for parameterized asynchronous
    Seastar tests.
    - Accepts parameter-name/value pairs.
    - Includes the parameters in generated test names.
    - Passes only parameter values to the shared test implementation.
  - Run `test_view_update_generating_writetime` with flushing both disabled
    and enabled.
  - In the flush-enabled case, flush all tables while collecting update
    counters, ensuring subsequent mutations operate on previously flushed
    state.
  - Preserve the existing checks for writetimes and exact view-update
    counts for both materialized-view layouts.

 backport: This is a test-only change; production behavior is unchanged.
