### PR TITLE
cql3: build strongly consistent statements by inheritance

### DIFF
--- a/audit/audit.cc
+++ b/audit/audit.cc
@@ -480,8 +480,12 @@ future<> inspect(shared_ptr<cql3::cql_statement> statement, const service::query
     }
     if (audit_info->batch()) {
         // Only the two CQL batch paths mark an audit_info as a batch, and both
-        // build a batch_statement, so the cast cannot pick the wrong type.
-        const auto* batch = static_cast<const cql3::statements::batch_statement*>(statement.get());
+        // build a batch_statement. Nothing enforces that, so check rather than
+        // trust it; this runs once per audited batch, so the cost is irrelevant.
+        const auto* batch = dynamic_cast<const cql3::statements::batch_statement*>(statement.get());
+        if (!batch) {
+            on_internal_error(logger, "audit_info marked as a batch on a statement which is not a batch_statement");
+        }
         return do_for_each(batch->get_statements(), [&query_state, &options, error] (auto&& m) {
             return inspect(m.statement, query_state, options, error);
         });

--- a/audit/audit.cc
+++ b/audit/audit.cc
@@ -15,6 +15,8 @@
 #include "db/config.hh"
 #include "cql3/cql_statement.hh"
 #include "cql3/query_processor.hh"
+#include "cql3/statements/batch_statement.hh"
+#include "cql3/statements/modification_statement.hh"
 #include "storage_helper.hh"
 #include "audit_cf_storage_helper.hh"
 #include "audit_syslog_storage_helper.hh"
@@ -477,12 +479,11 @@ future<> inspect(shared_ptr<cql3::cql_statement> statement, const service::query
         return make_ready_future<>();
     }
     if (audit_info->batch()) {
-        const auto& batch_infos = audit_info->batch_infos();
-        if (!batch_infos) {
-            on_internal_error(logger, "batch statements need to return valid inner statements");
-        }
-        return do_for_each(*batch_infos, [&query_state, &options, error] (const auto& inner) {
-            return inspect(inner.get(), query_state, options, error);
+        // Only the two CQL batch paths mark an audit_info as a batch, and both
+        // build a batch_statement, so the cast cannot pick the wrong type.
+        const auto* batch = static_cast<const cql3::statements::batch_statement*>(statement.get());
+        return do_for_each(batch->get_statements(), [&query_state, &options, error] (auto&& m) {
+            return inspect(m.statement, query_state, options, error);
         });
     } else {
         return inspect(*audit_info, query_state, options, error);

--- a/audit/audit.hh
+++ b/audit/audit.hh
@@ -21,7 +21,6 @@
 
 #include "enum_set.hh"
 
-#include <functional>
 #include <memory>
 #include <optional>
 #include <set>
@@ -79,7 +78,6 @@ protected:
     sstring _table;
     sstring _query;
     bool _batch; // used only for unpacking batches in CQL, not relevant for Alternator
-    std::optional<std::vector<std::reference_wrapper<const audit_info>>> _batch_infos;
     std::optional<audit_table_set> _alternator_batch_tables;
 public:
     audit_info(statement_category cat, sstring keyspace, sstring table, bool batch)
@@ -110,10 +108,6 @@ public:
     sstring category_string() const;
     statement_category category() const { return _category; }
     bool batch() const { return _batch; }
-    void set_batch_infos(std::vector<std::reference_wrapper<const audit_info>> batch_infos) {
-        _batch_infos = std::move(batch_infos);
-    }
-    const std::optional<std::vector<std::reference_wrapper<const audit_info>>>& batch_infos() const { return _batch_infos; }
 };
 
 using audit_info_ptr = std::unique_ptr<audit_info>;

--- a/cql3/query_options.cc
+++ b/cql3/query_options.cc
@@ -12,6 +12,7 @@
 #include "query_options.hh"
 #include "db/consistency_level_type.hh"
 #include "cql3/column_identifier.hh"
+#include "utils/on_internal_error.hh"
 
 namespace cql3 {
 
@@ -189,6 +190,15 @@ computed_function_values::mapped_type* query_options::find_cached_pk_function_ca
         return &it->second;
     }
     return nullptr;
+}
+
+locator::tablet_version_block query_options::get_negotiated_tablet_version_block() const {
+    if (!_tablet_version_block) {
+        utils::on_internal_error(
+            "The protocol extension tablets-routing-v2 requires that every EXECUTE request "
+            "carry a tablet_version_block");
+    }
+    return *_tablet_version_block;
 }
 
 }

--- a/cql3/query_options.hh
+++ b/cql3/query_options.hh
@@ -227,6 +227,17 @@ public:
         return _tablet_version_block;
     }
 
+    // Same, for a request which negotiated the tablets-routing-v2 protocol
+    // extension. The block is defined for EXECUTE requests only, and there it
+    // is guaranteed to be present: process_execute_internal() reads it
+    // unconditionally whenever the V2 extension is set and rejects the request
+    // with a protocol_exception if the byte is missing. Reaching the failure
+    // case here is therefore a server-side invariant violation, not a client
+    // error. A QUERY request never carries the block, so a caller which can be
+    // reached from process_query_internal() has to check
+    // get_tablet_version_block() instead of calling this.
+    locator::tablet_version_block get_negotiated_tablet_version_block() const;
+
     // Mainly for the sake of BatchQueryOptions
     const query_options& for_statement(size_t i) const {
         if (!_batch_options) {

--- a/cql3/query_processor.cc
+++ b/cql3/query_processor.cc
@@ -1113,22 +1113,19 @@ query_processor::execute_batch(
         service::query_state& query_state,
         query_options& options,
         std::unordered_map<prepared_cache_key_type, authorized_prepared_statements_cache::value_type> pending_authorization_entries) {
-    const auto batch_size = stmt->get_statements().size();
     return execute_batch_without_checking_exception_message(
             std::move(stmt),
             query_state,
             options,
-            batch_size,
             std::move(pending_authorization_entries))
             .then(cql_transport::messages::propagate_exception_as_future<::shared_ptr<cql_transport::messages::result_message>>);
 }
 
 future<::shared_ptr<cql_transport::messages::result_message>>
 query_processor::execute_batch_without_checking_exception_message(
-        ::shared_ptr<cql_statement> stmt,
+        ::shared_ptr<statements::batch_statement> stmt,
         service::query_state& query_state,
         query_options& options,
-        size_t batch_size,
         std::unordered_map<prepared_cache_key_type, authorized_prepared_statements_cache::value_type> pending_authorization_entries) {
     auto access_future = co_await coroutine::as_future(stmt->check_access(*this, query_state.get_client_state()));
     bool failed = access_future.failed();
@@ -1143,22 +1140,7 @@ query_processor::execute_batch_without_checking_exception_message(
                 log.error("failed to cache the entry: {}", std::current_exception());
             }
     });
-    _stats.queries_by_cl[size_t(options.get_consistency())] += batch_size;
-
-    auto audit_info = stmt->get_audit_info();
-    if (audit_info && audit_info->batch()) {
-        const auto& batch_infos = audit_info->batch_infos();
-        if (!batch_infos) {
-            on_internal_error(log, "batch statements need to return valid inner statements");
-        }
-        if (log.is_enabled(logging::log_level::trace)) {
-            std::ostringstream oss;
-            for (const audit::audit_info& inner : *batch_infos) {
-                oss << std::endl << inner.query();
-            }
-            log.trace("execute_batch({}): {}", batch_size, oss.str());
-        }
-    }
+    _stats.queries_by_cl[size_t(options.get_consistency())] += stmt->get_statements().size();
     stmt->validate(*this, query_state.get_client_state());
     co_return co_await stmt->execute_without_checking_exception_message(*this, query_state, options, std::nullopt);
 }

--- a/cql3/query_processor.hh
+++ b/cql3/query_processor.hh
@@ -492,10 +492,9 @@ public:
     // The result_message::exception must be explicitly handled.
     future<::shared_ptr<cql_transport::messages::result_message>>
     execute_batch_without_checking_exception_message(
-            ::shared_ptr<cql_statement>,
+            ::shared_ptr<statements::batch_statement> stmt,
             service::query_state& query_state,
             query_options& options,
-            size_t batch_size,
             std::unordered_map<prepared_cache_key_type, authorized_prepared_statements_cache::value_type> pending_authorization_entries);
 
     // Splits given `mapreduce_request` and distributes execution of resulting subrequests across a cluster.

--- a/cql3/statements/batch_statement.cc
+++ b/cql3/statements/batch_statement.cc
@@ -497,13 +497,7 @@ batch_statement::prepare(data_dictionary::database db, cql_stats& stats, const c
 
     shared_ptr<cql_statement> statement;
     if (first_ks && strong_consistency::is_strongly_consistent(db, *first_ks)) {
-        // The inner statements are already strongly consistent - prepare() builds
-        // them that way for a strongly consistent keyspace - so they only need to
-        // be moved into the batch's own element type.
-        auto sc_statements = statements | std::views::as_rvalue | std::views::transform([] (auto&& s) {
-            return strong_consistency::batch_statement::single_statement{std::move(s.statement), s.needs_authorization};
-        }) | std::ranges::to<std::vector>();
-        statement = ::make_shared<strong_consistency::batch_statement>(meta.bound_variables_size(), _type, std::move(sc_statements), std::move(prep_attrs));
+        statement = ::make_shared<strong_consistency::batch_statement>(meta.bound_variables_size(), _type, std::move(statements), std::move(prep_attrs), stats);
     } else {
         statement = ::make_shared<cql3::statements::batch_statement>(meta.bound_variables_size(), _type, std::move(statements), std::move(prep_attrs), stats);
     }

--- a/cql3/statements/batch_statement.cc
+++ b/cql3/statements/batch_statement.cc
@@ -154,7 +154,7 @@ void batch_statement::validate(query_processor& qp, const service::client_state&
     }
 }
 
-const std::vector<batch_statement::single_statement>& batch_statement::get_statements()
+const std::vector<batch_statement::single_statement>& batch_statement::get_statements() const
 {
     return _statements;
 }

--- a/cql3/statements/batch_statement.cc
+++ b/cql3/statements/batch_statement.cc
@@ -250,6 +250,36 @@ future<shared_ptr<cql_transport::messages::result_message>> batch_statement::exe
                        seastar::cref(options), false, options.get_timestamp(state));
 }
 
+std::optional<sstring> batch_statement::begin_execution(query_processor& qp, const query_options& options) const {
+    const auto cl = options.get_consistency();
+    const query_processor::write_consistency_guardrail_state guardrail_state = qp.check_write_consistency_levels_guardrail(cl);
+    if (guardrail_state == query_processor::write_consistency_guardrail_state::FAIL) {
+        throw exceptions::invalid_request_exception(
+                format("Write consistency level {} is forbidden by the current configuration "
+                       "setting of write_consistency_levels_disallowed. Please use a different "
+                       "consistency level, or remove {} from write_consistency_levels_disallowed "
+                       "set in the configuration.", cl, cl));
+    }
+
+    for (size_t i = 0; i < _statements.size(); ++i) {
+        _statements[i].statement->restrictions().validate_primary_key(options.for_statement(i));
+    }
+
+    if (_has_conditions) {
+        ++_stats.cas_batches;
+        _stats.statements_in_cas_batches += _statements.size();
+    } else {
+        ++_stats.batches;
+        _stats.statements_in_batches += _statements.size();
+    }
+
+    if (guardrail_state == query_processor::write_consistency_guardrail_state::WARN) {
+        return format("Using write consistency level {} listed on the "
+                      "write_consistency_levels_warned is not recommended.", cl);
+    }
+    return std::nullopt;
+}
+
 future<shared_ptr<cql_transport::messages::result_message>> batch_statement::do_execute(
         query_processor& qp,
         service::query_state& query_state, const query_options& options,
@@ -263,35 +293,17 @@ future<shared_ptr<cql_transport::messages::result_message>> batch_statement::do_
         throw new InvalidRequestException("Invalid empty serial consistency level");
 #endif
 
+    auto warning = begin_execution(qp, options);
     const auto cl = options.get_consistency();
-    const query_processor::write_consistency_guardrail_state guardrail_state = qp.check_write_consistency_levels_guardrail(cl);
-    if (guardrail_state == query_processor::write_consistency_guardrail_state::FAIL) {
-        return make_exception_future<shared_ptr<cql_transport::messages::result_message>>(
-                exceptions::invalid_request_exception(
-                        format("Write consistency level {} is forbidden by the current configuration "
-                               "setting of write_consistency_levels_disallowed. Please use a different "
-                               "consistency level, or remove {} from write_consistency_levels_disallowed "
-                               "set in the configuration.", cl, cl)));
-    }
-
-    for (size_t i = 0; i < _statements.size(); ++i) {
-        _statements[i].statement->restrictions().validate_primary_key(options.for_statement(i));
-    }
 
     if (_has_conditions) {
-        ++_stats.cas_batches;
-        _stats.statements_in_cas_batches += _statements.size();
-        return execute_with_conditions(qp, options, query_state).then([guardrail_state, cl] (auto result) {
-            if (guardrail_state == query_processor::write_consistency_guardrail_state::WARN) {
-                result->add_warning(format("Using write consistency level {} listed on the "
-                                           "write_consistency_levels_warned is not recommended.", cl));
+        return execute_with_conditions(qp, options, query_state).then([warning = std::move(warning)] (auto result) mutable {
+            if (warning) {
+                result->add_warning(std::move(*warning));
             }
             return result;
         });
     }
-
-    ++_stats.batches;
-    _stats.statements_in_batches += _statements.size();
 
     auto timeout = db::timeout_clock::now() + get_timeout(query_state.get_client_state(), options);
     auto violations = make_lw_shared<db::large_data_violation_type>(db::large_data_violation_type::none);
@@ -299,15 +311,14 @@ future<shared_ptr<cql_transport::messages::result_message>> batch_statement::do_
     return get_mutations(qp, options, timeout, local, now, query_state).then([this, &qp, cl, timeout, tr_state = query_state.get_trace_state(),
                     permit = query_state.get_permit(), violations] (utils::chunked_vector<mutation> ms) mutable {
         return execute_without_conditions(qp, std::move(ms), cl, timeout, std::move(tr_state), std::move(permit), violations.get());
-    }).then([guardrail_state, cl, violations] (coordinator_result<> res) {
+    }).then([warning = std::move(warning), violations] (coordinator_result<> res) mutable {
         if (!res) {
             return make_ready_future<shared_ptr<cql_transport::messages::result_message>>(
                     seastar::make_shared<cql_transport::messages::result_message::exception>(std::move(res).assume_error()));
         }
         auto result = make_shared<cql_transport::messages::result_message::void_message>();
-        if (guardrail_state == query_processor::write_consistency_guardrail_state::WARN) {
-            result->add_warning(format("Using write consistency level {} listed on the "
-                                       "write_consistency_levels_warned is not recommended.", cl));
+        if (warning) {
+            result->add_warning(std::move(*warning));
         }
         if (auto warning = db::large_data_soft_violation_warning(*violations); !warning.empty()) [[unlikely]] {
             result->add_warning(std::move(warning));

--- a/cql3/statements/batch_statement.cc
+++ b/cql3/statements/batch_statement.cc
@@ -497,6 +497,9 @@ batch_statement::prepare(data_dictionary::database db, cql_stats& stats, const c
 
     shared_ptr<cql_statement> statement;
     if (first_ks && strong_consistency::is_strongly_consistent(db, *first_ks)) {
+        // The inner statements are already strongly consistent - prepare() builds
+        // them that way for a strongly consistent keyspace - so they only need to
+        // be moved into the batch's own element type.
         auto sc_statements = statements | std::views::as_rvalue | std::views::transform([] (auto&& s) {
             return strong_consistency::batch_statement::single_statement{std::move(s.statement), s.needs_authorization};
         }) | std::ranges::to<std::vector>();

--- a/cql3/statements/batch_statement.cc
+++ b/cql3/statements/batch_statement.cc
@@ -498,7 +498,7 @@ batch_statement::prepare(data_dictionary::database db, cql_stats& stats, const c
     shared_ptr<cql_statement> statement;
     if (first_ks && strong_consistency::is_strongly_consistent(db, *first_ks)) {
         auto sc_statements = statements | std::views::as_rvalue | std::views::transform([] (auto&& s) {
-            return strong_consistency::batch_statement::single_statement{::make_shared<strong_consistency::modification_statement>(std::move(s.statement))};
+            return strong_consistency::batch_statement::single_statement{std::move(s.statement), s.needs_authorization};
         }) | std::ranges::to<std::vector>();
         statement = ::make_shared<strong_consistency::batch_statement>(meta.bound_variables_size(), _type, std::move(sc_statements), std::move(prep_attrs));
     } else {

--- a/cql3/statements/batch_statement.cc
+++ b/cql3/statements/batch_statement.cc
@@ -21,7 +21,6 @@
 #include "db/large_data_handler.hh"
 #include "tracing/trace_state.hh"
 #include "utils/unique_view.hh"
-#include "cql3/statements/strong_consistency/statement_helpers.hh"
 #include "cql3/statements/strong_consistency/batch_statement.hh"
 
 template<typename T = void>
@@ -492,8 +491,16 @@ batch_statement::prepare(data_dictionary::database db, cql_stats& stats, const c
         partition_key_bind_indices = meta.get_partition_key_bind_indexes(*statements[0].statement->s);
     }
 
+    // Asking the prepared statements rather than the keyspace of the first one,
+    // which says nothing about the keyspaces of the rest.
+    const auto sc_count = std::ranges::count_if(statements,
+            [] (auto&& s) { return s.statement->is_strongly_consistent(); });
+    if (sc_count != 0 && size_t(sc_count) != statements.size()) {
+        throw exceptions::invalid_request_exception("Cannot mix strongly consistent and eventually consistent statements in a batch");
+    }
+
     shared_ptr<cql_statement> statement;
-    if (first_ks && strong_consistency::is_strongly_consistent(db, *first_ks)) {
+    if (sc_count != 0) {
         statement = ::make_shared<strong_consistency::batch_statement>(meta.bound_variables_size(), _type, std::move(statements), std::move(prep_attrs), stats);
     } else {
         statement = ::make_shared<cql3::statements::batch_statement>(meta.bound_variables_size(), _type, std::move(statements), std::move(prep_attrs), stats);

--- a/cql3/statements/batch_statement.cc
+++ b/cql3/statements/batch_statement.cc
@@ -468,8 +468,6 @@ batch_statement::prepare(data_dictionary::database db, cql_stats& stats, const c
 
     std::vector<cql3::statements::batch_statement::single_statement> statements;
     statements.reserve(_parsed_statements.size());
-    std::vector<std::reference_wrapper<const audit::audit_info>> batch_audit_infos;
-    batch_audit_infos.reserve(_parsed_statements.size());
 
     for (auto&& parsed : _parsed_statements) {
         if (!first_ks) {
@@ -482,7 +480,6 @@ batch_statement::prepare(data_dictionary::database db, cql_stats& stats, const c
         auto statement = parsed->prepare(db, meta, stats);
         if (auto* audit_info = statement->get_audit_info()) {
             audit_info->set_query_string(parsed->get_raw_cql());
-            batch_audit_infos.emplace_back(*audit_info);
         }
         statements.emplace_back(std::move(statement));
     }
@@ -502,12 +499,7 @@ batch_statement::prepare(data_dictionary::database db, cql_stats& stats, const c
         statement = ::make_shared<cql3::statements::batch_statement>(meta.bound_variables_size(), _type, std::move(statements), std::move(prep_attrs), stats);
     }
 
-    auto ai = audit_info();
-    if (ai) {
-        ai->set_batch_infos(std::move(batch_audit_infos));
-    }
-
-    return std::make_unique<prepared_statement>(std::move(ai), std::move(statement),
+    return std::make_unique<prepared_statement>(audit_info(), std::move(statement),
                                                       meta.get_variable_specifications(),
                                                       std::move(partition_key_bind_indices));
 }

--- a/cql3/statements/batch_statement.hh
+++ b/cql3/statements/batch_statement.hh
@@ -142,6 +142,14 @@ protected:
             service::query_state& query_state, const query_options& options,
             bool local, api::timestamp_type now) const;
 
+    // The part of do_execute() which does not depend on the storage backend:
+    // the write consistency guardrail, primary key validation of every
+    // statement and the batch counters. Every do_execute() implementation
+    // calls it first. Throws when the guardrail forbids the consistency level;
+    // returns the warning to attach to the result when the guardrail merely
+    // warns.
+    std::optional<sstring> begin_execution(query_processor& qp, const query_options& options) const;
+
 private:
     friend class batch_statement_executor;
 

--- a/cql3/statements/batch_statement.hh
+++ b/cql3/statements/batch_statement.hh
@@ -54,7 +54,7 @@ public:
             , needs_authorization(na)
         {}
     };
-private:
+protected:
     int _bound_terms;
     type _type;
     std::vector<single_statement> _statements;
@@ -114,7 +114,7 @@ public:
     //   or in QueryProcessor.processBatch() - for native protocol batches.
     virtual void validate(query_processor& qp, const service::client_state& state) const override;
 
-    const std::vector<single_statement>& get_statements();
+    const std::vector<single_statement>& get_statements() const;
 private:
     future<utils::chunked_vector<mutation>> get_mutations(query_processor& qp, const query_options& options, db::timeout_clock::time_point timeout,
             bool local, api::timestamp_type now, service::query_state& query_state) const;
@@ -133,12 +133,17 @@ public:
             query_processor& qp, service::query_state& state, const query_options& options, std::optional<service::group0_guard> guard) const override;
 
     db::timeout_clock::duration get_timeout(const service::client_state& state, const query_options& options) const;
-private:
-    friend class batch_statement_executor;
-    future<shared_ptr<cql_transport::messages::result_message>> do_execute(
+protected:
+    // Performs the write itself. Overridable so that a subclass can commit the
+    // batch differently while inheriting the rest of the statement, the way
+    // modification_statement::do_execute already works.
+    virtual future<shared_ptr<cql_transport::messages::result_message>> do_execute(
             query_processor& qp,
             service::query_state& query_state, const query_options& options,
             bool local, api::timestamp_type now) const;
+
+private:
+    friend class batch_statement_executor;
 
     future<exceptions::coordinator_result<>> execute_without_conditions(
             query_processor& qp,

--- a/cql3/statements/delete_statement.cc
+++ b/cql3/statements/delete_statement.cc
@@ -13,6 +13,7 @@
 #include "data_dictionary/data_dictionary.hh"
 #include "delete_statement.hh"
 #include "raw/delete_statement.hh"
+#include "cql3/statements/strong_consistency/modification_statement.hh"
 #include "mutation/mutation.hh"
 #include "cql3/expr/expression.hh"
 #include "cql3/expr/expr-utils.hh"
@@ -61,7 +62,7 @@ namespace raw {
 ::shared_ptr<cql3::statements::modification_statement>
 delete_statement::prepare_internal(data_dictionary::database db, schema_ptr schema, prepare_context& ctx,
         std::unique_ptr<attributes> attrs, cql_stats& stats) const {
-    auto stmt = ::make_shared<cql3::statements::delete_statement>(audit_info(), statement_type::DELETE, ctx.bound_variables_size(), schema, std::move(attrs), stats);
+    auto stmt = strong_consistency::make_modification<cql3::statements::delete_statement>(db, schema, audit_info(), statement_type::DELETE, ctx.bound_variables_size(), schema, std::move(attrs), stats);
 
     for (auto&& deletion : _deletions) {
         auto&& id = deletion->affected_column().prepare_column_identifier(*schema);

--- a/cql3/statements/modification_statement.cc
+++ b/cql3/statements/modification_statement.cc
@@ -641,12 +641,7 @@ modification_statement::prepare(data_dictionary::database db, prepare_context& c
 
     auto prepared_stmt = prepare_internal(db, schema, ctx, std::move(prepared_attributes), stats);
     if (strong_consistency::is_strongly_consistent(db, schema->ks_name())) {
-        if (prepared_stmt->requires_read()) {
-            throw exceptions::invalid_request_exception("Strongly consistent updates don't support data prefetch");
-        }
-        if (prepared_stmt->is_timestamp_set()) {
-            throw exceptions::invalid_request_exception("Strongly consistent queries don't support user-provided timestamps");
-        }
+        strong_consistency::validate_modification_support(*prepared_stmt);
     }
 
     // At this point the prepare context instance should have a list of

--- a/cql3/statements/modification_statement.cc
+++ b/cql3/statements/modification_statement.cc
@@ -29,7 +29,6 @@
 #include "cql3/query_processor.hh"
 #include "service/storage_proxy.hh"
 #include "db/large_data_handler.hh"
-#include "cql3/statements/strong_consistency/modification_statement.hh"
 #include "cql3/statements/strong_consistency/statement_helpers.hh"
 
 #include <boost/lexical_cast.hpp>
@@ -617,15 +616,7 @@ modification_statement::prepare(data_dictionary::database db, cql_stats& stats, 
     schema_ptr schema = validation::validate_column_family(db, keyspace(), column_family());
     auto meta = get_prepare_context();
 
-    auto statement = std::invoke([&] -> shared_ptr<cql_statement> {
-        auto result = prepare(db, meta, stats);
-
-        if (strong_consistency::is_strongly_consistent(db, schema->ks_name())) {
-            return ::make_shared<strong_consistency::modification_statement>(std::move(result));
-        }
-
-        return result;
-    });
+    auto statement = prepare(db, meta, stats);
 
     auto partition_key_bind_indices = meta.get_partition_key_bind_indexes(*schema);
     return std::make_unique<prepared_statement>(audit_info(), std::move(statement), meta, 
@@ -640,7 +631,7 @@ modification_statement::prepare(data_dictionary::database db, prepare_context& c
     prepared_attributes->fill_prepare_context(ctx);
 
     auto prepared_stmt = prepare_internal(db, schema, ctx, std::move(prepared_attributes), stats);
-    if (strong_consistency::is_strongly_consistent(db, schema->ks_name())) {
+    if (prepared_stmt->is_strongly_consistent()) {
         strong_consistency::validate_modification_support(*prepared_stmt);
     }
 

--- a/cql3/statements/modification_statement.cc
+++ b/cql3/statements/modification_statement.cc
@@ -331,17 +331,7 @@ modification_statement::do_execute(query_processor& qp, service::query_state& qs
     if (keys_size_one && _may_use_token_aware_routing && table.uses_tablets()) {
         auto erm = table.get_effective_replication_map();
         if (qs.get_client_state().is_protocol_extension_set(cql_transport::cql_protocol_extension::TABLETS_ROUTING_V2_EXPERIMENTAL)) {
-            if (!options.get_tablet_version_block().has_value()) {
-                // V2 is negotiated but no block was parsed. process_execute_internal()
-                // reads the block unconditionally whenever the V2 extension is set and
-                // rejects the request with a protocol_exception if the byte is missing,
-                // so the block is guaranteed present here. Reaching this point is a
-                // server-side invariant violation, not a client error, hence on_internal_error.
-                utils::on_internal_error(
-                    "The protocol extension tablets-routing-v2 requires that every EXECUTE request "
-                    "carry a tablet_version_block");
-            }
-            auto tablet_info_v2 = erm->check_tablet_version(token, *options.get_tablet_version_block());
+            auto tablet_info_v2 = erm->check_tablet_version(token, options.get_negotiated_tablet_version_block());
             if (tablet_info_v2) {
                 result->add_tablet_info_v2(std::move(*tablet_info_v2));
             }

--- a/cql3/statements/modification_statement.cc
+++ b/cql3/statements/modification_statement.cc
@@ -265,12 +265,10 @@ modification_statement::execute_without_checking_exception_message(query_process
     return modify_stage(this, seastar::ref(qp), seastar::ref(qs), seastar::cref(options));
 }
 
-future<::shared_ptr<cql_transport::messages::result_message>>
-modification_statement::do_execute(query_processor& qp, service::query_state& qs, const query_options& options) const {
+std::optional<sstring>
+modification_statement::begin_execution(query_processor& qp, service::query_state& qs, const query_options& options) const {
     if (!qp.db().try_find_table(s->id())) {
-        co_return coroutine::exception(
-                std::make_exception_ptr(exceptions::invalid_request_exception(
-                        format("unconfigured table {}", column_family()))));
+        throw exceptions::invalid_request_exception(format("unconfigured table {}", column_family()));
     }
 
     tracing::add_table_name(qs.get_trace_state(), keyspace(), column_family());
@@ -280,21 +278,30 @@ modification_statement::do_execute(query_processor& qp, service::query_state& qs
     const auto cl = options.get_consistency();
     const query_processor::write_consistency_guardrail_state guardrail_state = qp.check_write_consistency_levels_guardrail(cl);
     if (guardrail_state == query_processor::write_consistency_guardrail_state::FAIL) {
-        co_return coroutine::exception(
-                std::make_exception_ptr(exceptions::invalid_request_exception(
-                        format("Write consistency level {} is forbidden by the current configuration "
-                               "setting of write_consistency_levels_disallowed. Please use a different "
-                               "consistency level, or remove {} from write_consistency_levels_disallowed "
-                               "set in the configuration.", cl, cl))));
+        throw exceptions::invalid_request_exception(
+                format("Write consistency level {} is forbidden by the current configuration "
+                       "setting of write_consistency_levels_disallowed. Please use a different "
+                       "consistency level, or remove {} from write_consistency_levels_disallowed "
+                       "set in the configuration.", cl, cl));
     }
 
     _restrictions->validate_primary_key(options);
 
+    if (guardrail_state == query_processor::write_consistency_guardrail_state::WARN) {
+        return format("Using write consistency level {} listed on the "
+                      "write_consistency_levels_warned is not recommended.", cl);
+    }
+    return std::nullopt;
+}
+
+future<::shared_ptr<cql_transport::messages::result_message>>
+modification_statement::do_execute(query_processor& qp, service::query_state& qs, const query_options& options) const {
+    auto warning = begin_execution(qp, qs, options);
+
     if (has_conditions()) {
         auto result = co_await execute_with_condition(qp, qs, options);
-        if (guardrail_state == query_processor::write_consistency_guardrail_state::WARN) {
-            result->add_warning(format("Using write consistency level {} listed on the "
-                                       "write_consistency_levels_warned is not recommended.", cl));
+        if (warning) {
+            result->add_warning(std::move(*warning));
         }
         co_return result;
     }
@@ -316,9 +323,8 @@ modification_statement::do_execute(query_processor& qp, service::query_state& qs
     }
 
     auto result = seastar::make_shared<cql_transport::messages::result_message::void_message>();
-    if (guardrail_state == query_processor::write_consistency_guardrail_state::WARN) {
-        result->add_warning(format("Using write consistency level {} listed on the "
-                                   "write_consistency_levels_warned is not recommended.", cl));
+    if (warning) {
+        result->add_warning(std::move(*warning));
     }
     // Surface any coordinator-side large data guardrail soft limit violations
     // detected during the write to the client as a CQL warning.

--- a/cql3/statements/modification_statement.hh
+++ b/cql3/statements/modification_statement.hh
@@ -236,6 +236,13 @@ protected:
     // different storage backend, e.g. by the strongly consistent statements.
     virtual future<::shared_ptr<cql_transport::messages::result_message>>
     do_execute(query_processor& qp, service::query_state& qs, const query_options& options) const;
+
+    // The part of do_execute() which does not depend on the storage backend:
+    // schema and primary key validation, tracing, statistics and the write
+    // consistency guardrail. Every do_execute() implementation calls it first.
+    // Throws when the guardrail forbids the consistency level; returns the
+    // warning to attach to the result when the guardrail merely warns.
+    std::optional<sstring> begin_execution(query_processor& qp, service::query_state& qs, const query_options& options) const;
 private:
     friend class modification_statement_executor;
 public:

--- a/cql3/statements/modification_statement.hh
+++ b/cql3/statements/modification_statement.hh
@@ -224,9 +224,12 @@ public:
      */
     bool applies_to(const selection::selection* selection, const update_parameters::prefetch_data::row* row, const query_options& options) const;
 
-private:
-    future<::shared_ptr<cql_transport::messages::result_message>>
+protected:
+    // Performs the actual write. Overridden to execute the statement against a
+    // different storage backend, e.g. by the strongly consistent statements.
+    virtual future<::shared_ptr<cql_transport::messages::result_message>>
     do_execute(query_processor& qp, service::query_state& qs, const query_options& options) const;
+private:
     friend class modification_statement_executor;
 public:
     // True if the statement has IF conditions. Pre-computed during prepare.

--- a/cql3/statements/modification_statement.hh
+++ b/cql3/statements/modification_statement.hh
@@ -126,6 +126,13 @@ public:
 
     bool is_view() const;
 
+    // True if this statement commits its mutation through Raft instead of
+    // storage_proxy. Lets callers which only see a modification_statement -
+    // notably the batch paths - tell the two apart without downcasting.
+    virtual bool is_strongly_consistent() const {
+        return false;
+    }
+
     int64_t get_timestamp(int64_t now, const query_options& options) const;
 
     bool is_timestamp_set() const;

--- a/cql3/statements/select_statement.cc
+++ b/cql3/statements/select_statement.cc
@@ -500,17 +500,7 @@ select_statement::do_execute(query_processor& qp,
         auto erm = table.get_effective_replication_map();
 
         if (state.get_client_state().is_protocol_extension_set(cql_transport::cql_protocol_extension::TABLETS_ROUTING_V2_EXPERIMENTAL)) {
-            if (!options.get_tablet_version_block().has_value()) {
-                // V2 is negotiated but no block was parsed. process_execute_internal()
-                // reads the block unconditionally whenever the V2 extension is set and
-                // rejects the request with a protocol_exception if the byte is missing,
-                // so the block is guaranteed present here. Reaching this point is a
-                // server-side invariant violation, not a client error, hence on_internal_error.
-                utils::on_internal_error(
-                    "The protocol extension tablets-routing-v2 requires that every EXECUTE request "
-                    "carry a tablet_version_block");
-            }
-            tablet_info_v2 = erm->check_tablet_version(token, *options.get_tablet_version_block());
+            tablet_info_v2 = erm->check_tablet_version(token, options.get_negotiated_tablet_version_block());
         } else if (state.get_client_state().is_protocol_extension_set(cql_transport::cql_protocol_extension::TABLETS_ROUTING_V1)) {
             tablet_info = erm->check_locality(token, state.get_client_state().get_original_shard());
         }

--- a/cql3/statements/strong_consistency/batch_statement.cc
+++ b/cql3/statements/strong_consistency/batch_statement.cc
@@ -63,12 +63,13 @@ future<shared_ptr<result_message>> batch_statement::do_execute(
     // The local and timestamp arguments are unused: the batch is always
     // committed through the Raft group which owns the partition, and that
     // group assigns the timestamp.
+    auto warning = begin_execution(qp, options);
+    validate_write_consistency_level(options.get_consistency());
+
     const auto& statements = get_statements();
     if (statements.empty()) {
         co_return seastar::make_shared<result_message::void_message>();
     }
-
-    validate_write_consistency_level(options.get_consistency());
 
     auto timeout = db::timeout_clock::now() + get_timeout(qs.get_client_state(), options);
 
@@ -143,7 +144,11 @@ future<shared_ptr<result_message>> batch_statement::do_execute(
         co_return co_await redirect_statement(qp, options, redirect->target, timeout, is_write, coordinator.get().get_stats(), std::move(redirect->on_forwarding_finished));
     }
 
-    co_return seastar::make_shared<result_message::void_message>();
+    auto result = seastar::make_shared<result_message::void_message>();
+    if (warning) {
+        result->add_warning(std::move(*warning));
+    }
+    co_return result;
 }
 
 }

--- a/cql3/statements/strong_consistency/batch_statement.cc
+++ b/cql3/statements/strong_consistency/batch_statement.cc
@@ -66,7 +66,7 @@ future<shared_ptr<result_message>> batch_statement::execute_without_checking_exc
     all_keys.reserve(_statements.size());
 
     for (size_t i = 0; i < _statements.size(); ++i) {
-        const auto& stmt = _statements[i].statement->inner_statement();
+        const auto& stmt = *_statements[i].statement;
         const auto& statement_options = options.for_statement(i);
         auto json_cache = stmt.maybe_prepare_json_cache(statement_options);
         auto keys = stmt.build_partition_keys(statement_options, json_cache);
@@ -93,8 +93,18 @@ future<shared_ptr<result_message>> batch_statement::execute_without_checking_exc
         [&](api::timestamp_type ts) {
             std::optional<mutation> merged;
             for (size_t i = 0; i < _statements.size(); ++i) {
+                const auto& stmt = *_statements[i].statement;
                 const auto& statement_options = options.for_statement(i);
-                auto m = _statements[i].statement->get_mutation(statement_options, ts, all_keys[i].json_cache, all_keys[i].keys);
+                const auto prefetch_data = update_parameters::prefetch_data(stmt.s);
+                const auto ttl = stmt.get_time_to_live(statement_options);
+                const auto params = update_parameters(stmt.s, statement_options, ts, ttl, prefetch_data);
+                const auto ranges = stmt.create_clustering_ranges(statement_options, all_keys[i].json_cache);
+                auto muts = stmt.apply_updates(all_keys[i].keys, ranges, params, all_keys[i].json_cache);
+                if (muts.size() != 1) {
+                    on_internal_error(logger, ::format("statement {} on {}.{} has unexpected number of mutations {}",
+                        i, stmt.keyspace(), stmt.column_family(), muts.size()));
+                }
+                auto& m = *muts.begin();
                 if (!merged) {
                     merged = std::move(m);
                 } else {
@@ -141,7 +151,7 @@ void batch_statement::validate() const {
 
     schema_ptr batch_schema;
     for (const auto& s: _statements) {
-        const auto& stmt = s.statement->inner_statement();
+        const auto& stmt = *s.statement;
         if (!batch_schema) {
             batch_schema = stmt.s;
         } else if (batch_schema != stmt.s) {

--- a/cql3/statements/strong_consistency/batch_statement.cc
+++ b/cql3/statements/strong_consistency/batch_statement.cc
@@ -6,12 +6,12 @@
  * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
  */
 
-#include "cql3/statements/modification_statement.hh"
 #include "batch_statement.hh"
 
 #include "db/timeout_clock.hh"
 #include "transport/messages/result_message.hh"
 #include "cql3/query_processor.hh"
+#include "cql3/statements/modification_statement.hh"
 #include "service/strong_consistency/coordinator.hh"
 #include "cql3/statements/strong_consistency/statement_helpers.hh"
 #include "exceptions/exceptions.hh"
@@ -20,39 +20,49 @@ namespace cql3::statements::strong_consistency {
 
 static logging::logger logger("sc_batch_statement");
 
-batch_statement::batch_statement(int bound_terms, type type_, std::vector<single_statement> statements, std::unique_ptr<attributes> attrs)
-    : cql_statement(&timeout_config::write_timeout)
-    , _bound_terms(bound_terms)
-    , _type(type_)
-    , _statements(std::move(statements))
-    , _attrs(std::move(attrs))
-{
-    validate();
-}
-
-batch_statement::batch_statement(type type_, std::vector<single_statement> statements, std::unique_ptr<attributes> attrs)
-    : batch_statement(-1, type_, std::move(statements), std::move(attrs))
-{
-}
-
 using result_message = cql_transport::messages::result_message;
 
-future<shared_ptr<result_message>> batch_statement::execute(query_processor& qp, service::query_state& qs,
-    const query_options& options, std::optional<service::group0_guard> guard) const
+batch_statement::batch_statement(int bound_terms, type type_, std::vector<single_statement> statements,
+        std::unique_ptr<attributes> attrs, cql_stats& stats)
+    : cql3::statements::batch_statement(bound_terms, type_, std::move(statements), std::move(attrs), stats)
 {
-    return execute_without_checking_exception_message(qp, qs, options, std::move(guard))
-            .then(cql_transport::messages::propagate_exception_as_future<shared_ptr<result_message>>);
+    validate_strongly_consistent();
 }
 
-future<shared_ptr<result_message>> batch_statement::execute_without_checking_exception_message(
-        query_processor& qp, service::query_state& qs, const query_options& options,
-        std::optional<service::group0_guard> guard) const
+batch_statement::batch_statement(type type_, std::vector<single_statement> statements,
+        std::unique_ptr<attributes> attrs, cql_stats& stats)
+    : batch_statement(-1, type_, std::move(statements), std::move(attrs), stats)
 {
-    if (_statements.empty()) {
+}
+
+void batch_statement::validate_strongly_consistent() const {
+    if (_type == type::COUNTER) {
+        throw exceptions::invalid_request_exception("Counter batches are not supported with strongly consistent tables");
+    }
+
+    schema_ptr batch_schema;
+    for (const auto& s : get_statements()) {
+        if (!batch_schema) {
+            batch_schema = s.statement->s;
+        } else if (batch_schema != s.statement->s) {
+            throw exceptions::invalid_request_exception("All statements in a strongly consistent batch must target the same table");
+        }
+    }
+}
+
+future<shared_ptr<result_message>> batch_statement::do_execute(
+        query_processor& qp, service::query_state& qs, const query_options& options,
+        bool, api::timestamp_type) const
+{
+    // The local and timestamp arguments are unused: the batch is always
+    // committed through the Raft group which owns the partition, and that
+    // group assigns the timestamp.
+    const auto& statements = get_statements();
+    if (statements.empty()) {
         co_return seastar::make_shared<result_message::void_message>();
     }
 
-    auto timeout = db::timeout_clock::now() + (_attrs->is_timeout_set() ? _attrs->get_timeout(options) : qs.get_client_state().get_timeout_config().write_timeout);
+    auto timeout = db::timeout_clock::now() + get_timeout(qs.get_client_state(), options);
 
     // Build partition keys for all statements and validate they all target the same partition
     std::optional<dht::decorated_key> batch_key;
@@ -63,10 +73,10 @@ future<shared_ptr<result_message>> batch_statement::execute_without_checking_exc
         std::vector<dht::partition_range> keys;
     };
     std::vector<statement_keys> all_keys;
-    all_keys.reserve(_statements.size());
+    all_keys.reserve(statements.size());
 
-    for (size_t i = 0; i < _statements.size(); ++i) {
-        const auto& stmt = *_statements[i].statement;
+    for (size_t i = 0; i < statements.size(); ++i) {
+        const auto& stmt = *statements[i].statement;
         const auto& statement_options = options.for_statement(i);
         auto json_cache = stmt.maybe_prepare_json_cache(statement_options);
         auto keys = stmt.build_partition_keys(statement_options, json_cache);
@@ -88,12 +98,14 @@ future<shared_ptr<result_message>> batch_statement::execute_without_checking_exc
 
     auto [coordinator, holder] = qp.acquire_strongly_consistent_coordinator();
 
+    // The mutations are built inside the callback because the coordinator
+    // assigns the timestamp, and calls back again whenever it retries.
     auto mutate_result = co_await coordinator.get().mutate(batch_schema,
         batch_key->token(),
         [&](api::timestamp_type ts) {
             std::optional<mutation> merged;
-            for (size_t i = 0; i < _statements.size(); ++i) {
-                const auto& stmt = *_statements[i].statement;
+            for (size_t i = 0; i < statements.size(); ++i) {
+                const auto& stmt = *statements[i].statement;
                 const auto& statement_options = options.for_statement(i);
                 const auto prefetch_data = update_parameters::prefetch_data(stmt.s);
                 const auto ttl = stmt.get_time_to_live(statement_options);
@@ -124,46 +136,6 @@ future<shared_ptr<result_message>> batch_statement::execute_without_checking_exc
     }
 
     co_return seastar::make_shared<result_message::void_message>();
-}
-
-future<> batch_statement::check_access(query_processor& qp, const service::client_state& state) const {
-    return parallel_for_each(_statements.begin(), _statements.end(), [&qp, &state] (auto&& s) {
-        if (s.needs_authorization) {
-            return s.statement->check_access(qp, state);
-        } else {
-            return make_ready_future<>();
-        }
-    });
-}
-
-uint32_t batch_statement::get_bound_terms() const {
-    return _bound_terms;
-}
-
-bool batch_statement::depends_on(std::string_view ks_name, std::optional<std::string_view> cf_name) const {
-    return std::ranges::any_of(_statements, [&ks_name, &cf_name] (auto&& s) { return s.statement->depends_on(ks_name, cf_name); });
-}
-
-void batch_statement::validate() const {
-    if (_type == type::COUNTER) {
-        throw exceptions::invalid_request_exception("Counter batches are not supported with strongly consistent tables");
-    }
-
-    schema_ptr batch_schema;
-    for (const auto& s: _statements) {
-        const auto& stmt = *s.statement;
-        if (!batch_schema) {
-            batch_schema = stmt.s;
-        } else if (batch_schema != stmt.s) {
-            throw exceptions::invalid_request_exception("All statements in a strongly consistent batch must target the same table");
-        }
-    }
-}
-
-void batch_statement::validate(query_processor& qp, const service::client_state& state) const {
-    for (const auto& s: _statements) {
-        s.statement->validate(qp, state);
-    }
 }
 
 }

--- a/cql3/statements/strong_consistency/batch_statement.cc
+++ b/cql3/statements/strong_consistency/batch_statement.cc
@@ -62,6 +62,8 @@ future<shared_ptr<result_message>> batch_statement::do_execute(
         co_return seastar::make_shared<result_message::void_message>();
     }
 
+    validate_write_consistency_level(options.get_consistency());
+
     auto timeout = db::timeout_clock::now() + get_timeout(qs.get_client_state(), options);
 
     // Build partition keys for all statements and validate they all target the same partition

--- a/cql3/statements/strong_consistency/batch_statement.cc
+++ b/cql3/statements/strong_consistency/batch_statement.cc
@@ -39,6 +39,12 @@ void batch_statement::validate_strongly_consistent() const {
     if (_type == type::COUNTER) {
         throw exceptions::invalid_request_exception("Counter batches are not supported with strongly consistent tables");
     }
+    // The commit timestamp is assigned by the Raft coordinator, which also
+    // reassigns it on retry, so a user-provided one cannot be honoured. The
+    // same restriction is enforced on individual statements at prepare time.
+    if (_attrs->is_timestamp_set()) {
+        throw exceptions::invalid_request_exception("Strongly consistent batches don't support user-provided timestamps");
+    }
 
     schema_ptr batch_schema;
     for (const auto& s : get_statements()) {

--- a/cql3/statements/strong_consistency/batch_statement.hh
+++ b/cql3/statements/strong_consistency/batch_statement.hh
@@ -8,69 +8,37 @@
 
 #pragma once
 
-#include "cql3/cql_statement.hh"
-#include "cql3/attributes.hh"
 #include "cql3/statements/batch_statement.hh"
-#include "cql3/statements/modification_statement.hh"
 
 namespace cql3::statements::strong_consistency {
 
-class batch_statement : public cql_statement {
-    using result_message = cql_transport::messages::result_message;
+/*
+ * Turns a batch into a strongly consistent one, by merging the mutations of
+ * its statements into a single mutation and committing it through Raft instead
+ * of storage_proxy. Everything else - parsing state, mutation building, access
+ * control - is inherited unchanged.
+ *
+ * Merging into one mutation is what makes the batch atomic, and is also why
+ * every statement in it has to target the same partition.
+ */
+class batch_statement final : public cql3::statements::batch_statement {
 public:
-    using type = cql3::statements::batch_statement::type;
+    batch_statement(int bound_terms, type type_, std::vector<single_statement> statements,
+            std::unique_ptr<attributes> attrs, cql_stats& stats);
 
-    struct single_statement {
-        // A plain modification statement: the batch does not go through the
-        // statement's own write path, it builds the mutations itself. Spelled
-        // out, because unqualified name lookup from this namespace silently
-        // falls through to the enclosing one.
-        shared_ptr<cql3::statements::modification_statement> statement;
-        bool needs_authorization = true;
+    batch_statement(type type_, std::vector<single_statement> statements,
+            std::unique_ptr<attributes> attrs, cql_stats& stats);
 
-        single_statement(shared_ptr<cql3::statements::modification_statement> s)
-            : statement(std::move(s))
-        {}
-        single_statement(shared_ptr<cql3::statements::modification_statement> s, bool na)
-            : statement(std::move(s))
-            , needs_authorization(na)
-        {}
-    };
+protected:
+    future<shared_ptr<cql_transport::messages::result_message>> do_execute(
+            query_processor& qp, service::query_state& query_state, const query_options& options,
+            bool local, api::timestamp_type now) const override;
+
 private:
-    int _bound_terms;
-    type _type;
-    std::vector<single_statement> _statements;
-    std::unique_ptr<attributes> _attrs;
-
-public:
-    batch_statement(int bound_terms, type type_, std::vector<single_statement> statements, std::unique_ptr<attributes> attrs);
-
-    batch_statement(type type_, std::vector<single_statement> statements, std::unique_ptr<attributes> attrs);
-
-    virtual future<shared_ptr<result_message>> execute(query_processor& qp, service::query_state& state,
-        const query_options& options, std::optional<service::group0_guard> guard) const override;
-
-    virtual future<shared_ptr<result_message>> execute_without_checking_exception_message(query_processor& qp,
-        service::query_state& qs, const query_options& options,
-        std::optional<service::group0_guard> guard) const override;
-
-    virtual future<> check_access(query_processor& qp, const service::client_state& state) const override;
-
-    virtual uint32_t get_bound_terms() const override;
-
-    virtual bool depends_on(std::string_view ks_name, std::optional<std::string_view> cf_name) const override;
-
-    void validate() const;
-
-    virtual void validate(query_processor& qp, const service::client_state& state) const override;
-
-    const std::vector<single_statement>& get_statements() const {
-        return _statements;
-    }
-
-    bool should_reclassify_control_connection() const override {
-        return true;
-    }
+    // Rejects what the strongly consistent write path cannot honour. Runs from
+    // the constructor rather than as an override of the base validate(), which
+    // the base constructor calls before this class exists.
+    void validate_strongly_consistent() const;
 };
 
 }

--- a/cql3/statements/strong_consistency/batch_statement.hh
+++ b/cql3/statements/strong_consistency/batch_statement.hh
@@ -11,7 +11,7 @@
 #include "cql3/cql_statement.hh"
 #include "cql3/attributes.hh"
 #include "cql3/statements/batch_statement.hh"
-#include "cql3/statements/strong_consistency/modification_statement.hh"
+#include "cql3/statements/modification_statement.hh"
 
 namespace cql3::statements::strong_consistency {
 
@@ -21,13 +21,15 @@ public:
     using type = cql3::statements::batch_statement::type;
 
     struct single_statement {
-        shared_ptr<modification_statement> statement;
+        // A plain modification statement: the batch does not go through the
+        // statement's own write path, it builds the mutations itself.
+        shared_ptr<cql3::statements::modification_statement> statement;
         bool needs_authorization = true;
 
-        single_statement(shared_ptr<modification_statement> s)
+        single_statement(shared_ptr<cql3::statements::modification_statement> s)
             : statement(std::move(s))
         {}
-        single_statement(shared_ptr<modification_statement> s, bool na)
+        single_statement(shared_ptr<cql3::statements::modification_statement> s, bool na)
             : statement(std::move(s))
             , needs_authorization(na)
         {}

--- a/cql3/statements/strong_consistency/batch_statement.hh
+++ b/cql3/statements/strong_consistency/batch_statement.hh
@@ -22,7 +22,9 @@ public:
 
     struct single_statement {
         // A plain modification statement: the batch does not go through the
-        // statement's own write path, it builds the mutations itself.
+        // statement's own write path, it builds the mutations itself. Spelled
+        // out, because unqualified name lookup from this namespace silently
+        // falls through to the enclosing one.
         shared_ptr<cql3::statements::modification_statement> statement;
         bool needs_authorization = true;
 

--- a/cql3/statements/strong_consistency/modification_statement.cc
+++ b/cql3/statements/strong_consistency/modification_statement.cc
@@ -29,6 +29,7 @@ future<::shared_ptr<result_message>> strongly_consistent<Base>::do_execute(
     // narrow the access of the overrides used below.
     const cql3::statements::modification_statement& stmt = *this;
 
+    auto warning = this->begin_execution(qp, qs, options);
     validate_write_consistency_level(options.get_consistency());
 
     auto timeout = db::timeout_clock::now() + stmt.get_timeout(qs.get_client_state(), options);
@@ -68,6 +69,9 @@ future<::shared_ptr<result_message>> strongly_consistent<Base>::do_execute(
     });
 
     auto result = seastar::make_shared<result_message::void_message>();
+    if (warning) {
+        result->add_warning(std::move(*warning));
+    }
 
     if (qs.get_client_state().is_protocol_extension_set(cql_transport::cql_protocol_extension::TABLETS_ROUTING_V2_EXPERIMENTAL)) {
         const auto& groups_manager = coordinator.get().get_groups_manager();

--- a/cql3/statements/strong_consistency/modification_statement.cc
+++ b/cql3/statements/strong_consistency/modification_statement.cc
@@ -10,61 +10,34 @@
 
 #include "db/consistency_level_type.hh"
 #include "db/timeout_clock.hh"
-#include "service/strong_consistency/groups_manager.hh"
 #include "transport/messages/result_message.hh"
 #include "cql3/query_processor.hh"
 #include "service/strong_consistency/coordinator.hh"
-#include "cql3/statements/strong_consistency/statement_helpers.hh"
+#include "service/strong_consistency/groups_manager.hh"
 #include "exceptions/exceptions.hh"
 #include "utils/error_injection.hh"
 
 namespace cql3::statements::strong_consistency {
-static logging::logger logger("sc_modification_statement");
 
-modification_statement::modification_statement(shared_ptr<base_statement> statement)
-    : cql_statement(&timeout_config::write_timeout)
-    , _statement(std::move(statement))
-{
-}
+static logging::logger logger("sc_modification_statement");
 
 using result_message = cql_transport::messages::result_message;
 
-future<shared_ptr<result_message>> modification_statement::execute(query_processor& qp, service::query_state& qs, 
-    const query_options& options, std::optional<service::group0_guard> guard) const
-{
-    return execute_without_checking_exception_message(qp, qs, options, std::move(guard))
-            .then(cql_transport::messages::propagate_exception_as_future<shared_ptr<result_message>>);
-}
+template <typename Base>
+future<::shared_ptr<result_message>> strongly_consistent<Base>::do_execute(
+        query_processor& qp, service::query_state& qs, const query_options& options) const {
+    // Referred to through the base class, because some of the statement kinds
+    // narrow the access of the overrides used below.
+    const cql3::statements::modification_statement& stmt = *this;
 
-static void validate_consistency_level(const db::consistency_level& cl) {
+    const auto cl = options.get_consistency();
     if (cl != db::consistency_level::QUORUM && cl != db::consistency_level::LOCAL_QUORUM) {
         throw exceptions::invalid_request_exception("Strongly consistent writes must use QUORUM/LOCAL_QUORUM consistency level");
     }
-}
 
-mutation modification_statement::get_mutation(const query_options& options, api::timestamp_type ts,
-        base_statement::json_cache_opt& json_cache, const std::vector<dht::partition_range>& keys) const {
-    const auto prefetch_data = update_parameters::prefetch_data(_statement->s);
-    const auto ttl = _statement->get_time_to_live(options);
-    const auto params = update_parameters(_statement->s, options, ts, ttl, prefetch_data);
-    const auto ranges = _statement->create_clustering_ranges(options, json_cache);
-    auto muts = _statement->apply_updates(keys, ranges, params, json_cache);
-    if (muts.size() != 1) {
-        on_internal_error(logger, ::format("statement '{}' has unexpected number of mutations {}",
-            raw_cql_statement.linearize(), muts.size()));
-    }
-    return std::move(*muts.begin());
-}
-
-future<shared_ptr<result_message>> modification_statement::execute_without_checking_exception_message(
-        query_processor& qp, service::query_state& qs, const query_options& options,
-        std::optional<service::group0_guard> guard) const
-{
-    validate_consistency_level(options.get_consistency());
-
-    auto timeout = db::timeout_clock::now() + _statement->get_timeout(qs.get_client_state(), options);
-    auto json_cache = _statement->maybe_prepare_json_cache(options);
-    const auto keys = _statement->build_partition_keys(options, json_cache);
+    auto timeout = db::timeout_clock::now() + stmt.get_timeout(qs.get_client_state(), options);
+    auto json_cache = stmt.maybe_prepare_json_cache(options);
+    const auto keys = stmt.build_partition_keys(options, json_cache);
     if (keys.size() != 1 || !query::is_single_partition(keys[0])) {
         throw exceptions::invalid_request_exception("Strongly consistent queries can only target a single partition");
     }
@@ -72,10 +45,21 @@ future<shared_ptr<result_message>> modification_statement::execute_without_check
     auto [coordinator, holder] = qp.acquire_strongly_consistent_coordinator();
     const auto token = keys[0].start()->value().token();
 
-    auto mutate_result = co_await coordinator.get().mutate(_statement->s,
+    // The mutation is built inside the callback because the coordinator assigns
+    // the timestamp, and calls back again whenever it retries.
+    auto mutate_result = co_await coordinator.get().mutate(stmt.s,
         token,
         [&](api::timestamp_type ts) {
-            return get_mutation(options, ts, json_cache, keys);
+            const auto prefetch_data = update_parameters::prefetch_data(stmt.s);
+            const auto ttl = stmt.get_time_to_live(options);
+            const auto params = update_parameters(stmt.s, options, ts, ttl, prefetch_data);
+            const auto ranges = stmt.create_clustering_ranges(options, json_cache);
+            auto muts = stmt.apply_updates(keys, ranges, params, json_cache);
+            if (muts.size() != 1) {
+                on_internal_error(logger, ::format("statement on {}.{} has unexpected number of mutations {}",
+                    stmt.keyspace(), stmt.column_family(), muts.size()));
+            }
+            return std::move(*muts.begin());
         }, timeout, qs.get_client_state().get_abort_source());
 
     using namespace service::strong_consistency;
@@ -102,7 +86,7 @@ future<shared_ptr<result_message>> modification_statement::execute_without_check
         }
 
         const auto& groups_manager = coordinator.get().get_groups_manager();
-        const auto& table = _statement->s->table();
+        const auto& table = stmt.s->table();
 
         auto maybe_routing_info_v2 = groups_manager.check_tablet_version(table, token, *options.get_tablet_version_block());
         if (maybe_routing_info_v2) {
@@ -113,19 +97,8 @@ future<shared_ptr<result_message>> modification_statement::execute_without_check
     co_return std::move(result);
 }
 
-future<> modification_statement::check_access(query_processor& qp, const service::client_state& state) const {
-    return _statement->check_access(qp, state);
-}
+template class strongly_consistent<cql3::statements::update_statement>;
+template class strongly_consistent<cql3::statements::delete_statement>;
+template class strongly_consistent<cql3::statements::insert_prepared_json_statement>;
 
-void modification_statement::validate(query_processor& qp, const service::client_state& state) const {
-    _statement->validate(qp, state);
-}
-
-uint32_t modification_statement::get_bound_terms() const {
-    return _statement->get_bound_terms();
-}
-
-bool modification_statement::depends_on(std::string_view ks_name, std::optional<std::string_view> cf_name) const {
-    return _statement->depends_on(ks_name, cf_name);
-}
 }

--- a/cql3/statements/strong_consistency/modification_statement.cc
+++ b/cql3/statements/strong_consistency/modification_statement.cc
@@ -74,21 +74,10 @@ future<::shared_ptr<result_message>> strongly_consistent<Base>::do_execute(
     auto result = seastar::make_shared<result_message::void_message>();
 
     if (qs.get_client_state().is_protocol_extension_set(cql_transport::cql_protocol_extension::TABLETS_ROUTING_V2_EXPERIMENTAL)) {
-        if (!options.get_tablet_version_block().has_value()) {
-            // V2 is negotiated but no block was parsed. process_execute_internal()
-            // reads the block unconditionally whenever the V2 extension is set and
-            // rejects the request with a protocol_exception if the byte is missing,
-            // so the block is guaranteed present here. Reaching this point is a
-            // server-side invariant violation, not a client error, hence on_internal_error.
-            utils::on_internal_error(
-                "The protocol extension tablets-routing-v2 requires that every EXECUTE request "
-                "carry a tablet_version_block");
-        }
-
         const auto& groups_manager = coordinator.get().get_groups_manager();
         const auto& table = stmt.s->table();
 
-        auto maybe_routing_info_v2 = groups_manager.check_tablet_version(table, token, *options.get_tablet_version_block());
+        auto maybe_routing_info_v2 = groups_manager.check_tablet_version(table, token, options.get_negotiated_tablet_version_block());
         if (maybe_routing_info_v2) {
             result->add_tablet_info_v2(std::move(*maybe_routing_info_v2));
         }

--- a/cql3/statements/strong_consistency/modification_statement.cc
+++ b/cql3/statements/strong_consistency/modification_statement.cc
@@ -8,7 +8,6 @@
 
 #include "modification_statement.hh"
 
-#include "db/consistency_level_type.hh"
 #include "db/timeout_clock.hh"
 #include "transport/messages/result_message.hh"
 #include "cql3/query_processor.hh"
@@ -30,10 +29,7 @@ future<::shared_ptr<result_message>> strongly_consistent<Base>::do_execute(
     // narrow the access of the overrides used below.
     const cql3::statements::modification_statement& stmt = *this;
 
-    const auto cl = options.get_consistency();
-    if (cl != db::consistency_level::QUORUM && cl != db::consistency_level::LOCAL_QUORUM) {
-        throw exceptions::invalid_request_exception("Strongly consistent writes must use QUORUM/LOCAL_QUORUM consistency level");
-    }
+    validate_write_consistency_level(options.get_consistency());
 
     auto timeout = db::timeout_clock::now() + stmt.get_timeout(qs.get_client_state(), options);
     auto json_cache = stmt.maybe_prepare_json_cache(options);

--- a/cql3/statements/strong_consistency/modification_statement.hh
+++ b/cql3/statements/strong_consistency/modification_statement.hh
@@ -8,51 +8,48 @@
 
 #pragma once
 
-#include "cql3/cql_statement.hh"
-#include "cql3/expr/expression.hh"
 #include "cql3/statements/modification_statement.hh"
+#include "cql3/statements/update_statement.hh"
+#include "cql3/statements/delete_statement.hh"
+#include "cql3/statements/strong_consistency/statement_helpers.hh"
 
 namespace cql3::statements::strong_consistency {
 
-class modification_statement : public cql_statement {
-    using result_message = cql_transport::messages::result_message;
-    using base_statement = cql3::statements::modification_statement;
-
-    shared_ptr<base_statement> _statement;
+/*
+ * Turns a modification statement into a strongly consistent one, by committing
+ * its mutation through Raft instead of storage_proxy. Everything else - parsing
+ * state, mutation building, access control - is inherited unchanged.
+ *
+ * This is a mixin rather than a single class because the base modification
+ * statement is abstract: building the mutation for a given row is implemented
+ * per statement kind (update, delete, insert-json).
+ *
+ * Note that only do_execute() is replaced. A statement executed as part of a
+ * batch goes through get_mutations() instead, and so still takes the eventually
+ * consistent path, which is what batches did before this was introduced.
+ */
+template <typename Base>
+class strongly_consistent final : public Base {
 public:
-    modification_statement(shared_ptr<base_statement> statement);
+    using Base::Base;
 
-    shared_ptr<base_statement> inner() const {
-        return _statement;
+    bool is_strongly_consistent() const override {
+        return true;
     }
 
-    const base_statement& inner_statement() const {
-        return *_statement;
-    }
-
-    future<shared_ptr<result_message>> execute(query_processor& qp, service::query_state& state,
-        const query_options& options, std::optional<service::group0_guard> guard) const override;
-
-    future<shared_ptr<result_message>> execute_without_checking_exception_message(query_processor& qp,
-        service::query_state& qs, const query_options& options,
-        std::optional<service::group0_guard> guard) const override;
-
-    mutation get_mutation(const query_options& options, api::timestamp_type ts,
-            base_statement::json_cache_opt& json_cache, const std::vector<dht::partition_range>& keys) const;
-
-    future<> check_access(query_processor& qp, const service::client_state& state) const override;
-
-    void validate(query_processor& qp, const service::client_state& state) const override;
-
-    uint32_t get_bound_terms() const override;
-
-    bool depends_on(std::string_view ks_name, std::optional<std::string_view> cf_name) const override;
-
-    // Wraps a regular modification, so it carries user load exactly when the
-    // wrapped statement does.
-    bool should_reclassify_control_connection() const override {
-        return _statement->should_reclassify_control_connection();
-    }
+    future<::shared_ptr<cql_transport::messages::result_message>>
+    do_execute(query_processor& qp, service::query_state& qs, const query_options& options) const override;
 };
+
+// Builds either Stmt or its strongly consistent counterpart, depending on the
+// keyspace the statement targets.
+template <typename Stmt, typename... Args>
+::shared_ptr<cql3::statements::modification_statement>
+make_modification(data_dictionary::database db, const schema_ptr& s, Args&&... args) {
+    if (is_strongly_consistent(db, s->ks_name())) {
+        return ::make_shared<strongly_consistent<Stmt>>(std::forward<Args>(args)...);
+    }
+    return ::make_shared<Stmt>(std::forward<Args>(args)...);
+}
 
 }

--- a/cql3/statements/strong_consistency/modification_statement.hh
+++ b/cql3/statements/strong_consistency/modification_statement.hh
@@ -25,8 +25,8 @@ namespace cql3::statements::strong_consistency {
  * per statement kind (update, delete, insert-json).
  *
  * Note that only do_execute() is replaced. A statement executed as part of a
- * batch goes through get_mutations() instead, and so still takes the eventually
- * consistent path, which is what batches did before this was introduced.
+ * batch never gets there: the batch collects the mutations of its statements
+ * and commits them itself, see strong_consistency::batch_statement.
  */
 template <typename Base>
 class strongly_consistent final : public Base {

--- a/cql3/statements/strong_consistency/select_statement.cc
+++ b/cql3/statements/strong_consistency/select_statement.cc
@@ -72,22 +72,11 @@ future<::shared_ptr<result_message>> select_statement::do_execute(query_processo
         read_command, options, now);
 
     if (state.get_client_state().is_protocol_extension_set(cql_transport::cql_protocol_extension::TABLETS_ROUTING_V2_EXPERIMENTAL)) {
-        if (!options.get_tablet_version_block().has_value()) {
-            // V2 is negotiated but no block was parsed. process_execute_internal()
-            // reads the block unconditionally whenever the V2 extension is set and
-            // rejects the request with a protocol_exception if the byte is missing,
-            // so the block is guaranteed present here. Reaching this point is a
-            // server-side invariant violation, not a client error, hence on_internal_error.
-            utils::on_internal_error(
-                "The protocol extension tablets-routing-v2 requires that every EXECUTE request "
-                "carry a tablet_version_block");
-        }
-
         const auto& groups_manager = coordinator.get().get_groups_manager();
         const auto& table = _query_schema->table();
         const auto& token = key_ranges[0].start()->value().token();
 
-        auto maybe_routing_info_v2 = groups_manager.check_tablet_version(table, token, *options.get_tablet_version_block());
+        auto maybe_routing_info_v2 = groups_manager.check_tablet_version(table, token, options.get_negotiated_tablet_version_block());
         if (maybe_routing_info_v2) {
             result->add_tablet_info_v2(std::move(*maybe_routing_info_v2));
         }

--- a/cql3/statements/strong_consistency/statement_helpers.cc
+++ b/cql3/statements/strong_consistency/statement_helpers.cc
@@ -10,6 +10,7 @@
 
 #include "transport/messages/result_message_base.hh"
 #include "cql3/query_processor.hh"
+#include "cql3/statements/modification_statement.hh"
 #include "replica/database.hh"
 #include "locator/tablet_replication_strategy.hh"
 #include "service/strong_consistency/coordinator.hh"
@@ -36,6 +37,18 @@ future<::shared_ptr<cql_transport::messages::result_message>> redirect_statement
 bool is_strongly_consistent(data_dictionary::database db, std::string_view ks_name) {
     const auto* tablet_aware_rs = db.find_keyspace(ks_name).get_replication_strategy().maybe_as_tablet_aware();
     return tablet_aware_rs && tablet_aware_rs->get_consistency() != data_dictionary::consistency_config_option::eventual;
+}
+
+void validate_modification_support(const cql3::statements::modification_statement& stmt) {
+    if (stmt.has_conditions()) {
+        throw exceptions::invalid_request_exception("Strongly consistent updates don't support conditions");
+    }
+    if (stmt.requires_read()) {
+        throw exceptions::invalid_request_exception("Strongly consistent updates don't support data prefetch");
+    }
+    if (stmt.is_timestamp_set()) {
+        throw exceptions::invalid_request_exception("Strongly consistent queries don't support user-provided timestamps");
+    }
 }
 
 }

--- a/cql3/statements/strong_consistency/statement_helpers.cc
+++ b/cql3/statements/strong_consistency/statement_helpers.cc
@@ -51,4 +51,10 @@ void validate_modification_support(const cql3::statements::modification_statemen
     }
 }
 
+void validate_write_consistency_level(db::consistency_level cl) {
+    if (cl != db::consistency_level::QUORUM && cl != db::consistency_level::LOCAL_QUORUM) {
+        throw exceptions::invalid_request_exception("Strongly consistent writes must use QUORUM/LOCAL_QUORUM consistency level");
+    }
+}
+
 }

--- a/cql3/statements/strong_consistency/statement_helpers.hh
+++ b/cql3/statements/strong_consistency/statement_helpers.hh
@@ -13,6 +13,8 @@
 
 namespace service::strong_consistency { struct stats; }
 
+namespace cql3::statements { class modification_statement; }
+
 namespace cql3::statements::strong_consistency {
 
 future<::shared_ptr<cql_transport::messages::result_message>> redirect_statement(
@@ -25,5 +27,10 @@ future<::shared_ptr<cql_transport::messages::result_message>> redirect_statement
     locator::host_id_or_exception_callback on_forwarding_finished = {});
 
 bool is_strongly_consistent(data_dictionary::database db, std::string_view ks_name);
+
+// Rejects CQL constructs that the strongly consistent write path cannot honour.
+// Called at prepare time, so that unsupported statements fail early rather than
+// being silently mis-executed.
+void validate_modification_support(const cql3::statements::modification_statement& stmt);
 
 }

--- a/cql3/statements/strong_consistency/statement_helpers.hh
+++ b/cql3/statements/strong_consistency/statement_helpers.hh
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "cql3/cql_statement.hh"
+#include "db/consistency_level_type.hh"
 #include "locator/tablets.hh"
 
 namespace service::strong_consistency { struct stats; }
@@ -32,5 +33,9 @@ bool is_strongly_consistent(data_dictionary::database db, std::string_view ks_na
 // Called at prepare time, so that unsupported statements fail early rather than
 // being silently mis-executed.
 void validate_modification_support(const cql3::statements::modification_statement& stmt);
+
+// A weaker level cannot be honoured: strongly consistent writes are committed
+// by a Raft group, which always replicates to a quorum.
+void validate_write_consistency_level(db::consistency_level cl);
 
 }

--- a/cql3/statements/update_statement.cc
+++ b/cql3/statements/update_statement.cc
@@ -14,6 +14,7 @@
 #include "cql3/expr/evaluate.hh"
 #include "cql3/expr/expr-utils.hh"
 #include "raw/update_statement.hh"
+#include "cql3/statements/strong_consistency/modification_statement.hh"
 
 #include "raw/insert_statement.hh"
 #include "unimplemented.hh"
@@ -287,7 +288,7 @@ insert_statement::insert_statement(cf_name name,
 insert_statement::prepare_internal(data_dictionary::database db, schema_ptr schema,
     prepare_context& ctx, std::unique_ptr<attributes> attrs, cql_stats& stats) const
 {
-    auto stmt = ::make_shared<cql3::statements::update_statement>(audit_info(), statement_type::INSERT, ctx.bound_variables_size(), schema, std::move(attrs), stats);
+    auto stmt = strong_consistency::make_modification<cql3::statements::update_statement>(db, schema, audit_info(), statement_type::INSERT, ctx.bound_variables_size(), schema, std::move(attrs), stats);
 
     // Created from an INSERT
     if (stmt->is_counter()) {
@@ -353,7 +354,7 @@ insert_json_statement::prepare_internal(data_dictionary::database db, schema_ptr
     auto prepared_json_value = prepare_expression(_json_value, db, "", nullptr, make_lw_shared<column_specification>("", "", json_column_placeholder, utf8_type));
     expr::verify_no_aggregate_functions(prepared_json_value, "JSON clause");
     expr::fill_prepare_context(prepared_json_value, ctx);
-    auto stmt = ::make_shared<cql3::statements::insert_prepared_json_statement>(audit_info(), ctx.bound_variables_size(), schema, std::move(attrs), stats, std::move(prepared_json_value), _default_unset);
+    auto stmt = strong_consistency::make_modification<cql3::statements::insert_prepared_json_statement>(db, schema, audit_info(), ctx.bound_variables_size(), schema, std::move(attrs), stats, std::move(prepared_json_value), _default_unset);
     prepare_conditions(db, *schema, ctx, *stmt);
     return stmt;
 }
@@ -372,7 +373,7 @@ update_statement::update_statement(cf_name name,
 update_statement::prepare_internal(data_dictionary::database db, schema_ptr schema,
     prepare_context& ctx, std::unique_ptr<attributes> attrs, cql_stats& stats) const
 {
-    auto stmt = ::make_shared<cql3::statements::update_statement>(audit_info(), statement_type::UPDATE, ctx.bound_variables_size(), schema, std::move(attrs), stats);
+    auto stmt = strong_consistency::make_modification<cql3::statements::update_statement>(db, schema, audit_info(), statement_type::UPDATE, ctx.bound_variables_size(), schema, std::move(attrs), stats);
 
     // FIXME: quadratic
     for (size_t i = 0; i < _updates.size(); ++i) {

--- a/test/cqlpy/strong_consistency/test_strong_consistency.py
+++ b/test/cqlpy/strong_consistency/test_strong_consistency.py
@@ -238,6 +238,18 @@ def test_batch(cql, sc_keyspace, batch_mode):
                         APPLY BATCH
                     """)
 
+        # A batch level USING TIMESTAMP used to be accepted and then
+        # silently ignored, because the Raft coordinator assigns the commit
+        # timestamp and reassigns it on every retry. Only the text path can
+        # express it; the native protocol path has no batch attributes.
+        if batch_mode == "text":
+            with pytest.raises(InvalidRequest, match="don't support user-provided timestamps"):
+                cql.execute(f"""
+                    BEGIN UNLOGGED BATCH USING TIMESTAMP 1234
+                    INSERT INTO {table} (pk, ck, v) VALUES (1, 1, 10);
+                    APPLY BATCH
+                """)
+
     with new_test_table(cql, sc_keyspace, "pk int PRIMARY KEY, c counter") as table:
         run_counter_batch = _make_batch_runner(table, counter_table=True)
 

--- a/test/cqlpy/strong_consistency/test_strong_consistency.py
+++ b/test/cqlpy/strong_consistency/test_strong_consistency.py
@@ -12,8 +12,9 @@
 #############################################################################
 
 import pytest
+from cassandra import ConsistencyLevel
 from cassandra.protocol import ConfigurationException, InvalidRequest
-from cassandra.query import BatchStatement, BatchType
+from cassandra.query import BatchStatement, BatchType, SimpleStatement
 
 from test.pylib.skip_types import skip_env
 
@@ -105,6 +106,7 @@ def test_batch(cql, sc_keyspace, batch_mode):
     - batch touching multiple tables,
     - batch touching multiple partitions,
     - statement touching multiple partition keys,
+    - batch at a weaker consistency level,
     - counter batch.
     """
 
@@ -206,6 +208,20 @@ def test_batch(cql, sc_keyspace, batch_mode):
             run_batch([
                 ("delete_in", (1, 2, 1)),
             ], kind="unlogged")
+
+        # A Raft group always replicates to a quorum, so a weaker
+        # consistency level cannot be honoured.
+        with pytest.raises(InvalidRequest, match="must use QUORUM/LOCAL_QUORUM"):
+            if batch_mode == "prepared":
+                batch = BatchStatement(batch_type=BatchType.UNLOGGED, consistency_level=ConsistencyLevel.ONE)
+                batch.add(cql.prepare(f"INSERT INTO {table} (pk, ck, v) VALUES (?, ?, ?)"), (1, 1, 10))
+                cql.execute(batch)
+            else:
+                cql.execute(SimpleStatement(f"""
+                    BEGIN UNLOGGED BATCH
+                    INSERT INTO {table} (pk, ck, v) VALUES (1, 1, 10);
+                    APPLY BATCH
+                """, consistency_level=ConsistencyLevel.ONE))
 
         with new_test_table(cql, sc_keyspace, "pk int, ck int, v int, PRIMARY KEY (pk, ck)") as other_table:
             with pytest.raises(InvalidRequest, match="same table"):

--- a/test/cqlpy/strong_consistency/test_strong_consistency.py
+++ b/test/cqlpy/strong_consistency/test_strong_consistency.py
@@ -68,6 +68,28 @@ def test_reject_user_provided_timestamps(cql, sc_keyspace):
         #   APPLY BATCH
 
 
+def test_reject_conditions(cql, sc_keyspace):
+    """
+    Conditional updates (LWT) are not supported on strongly consistent tables.
+    They must be rejected at prepare time - previously they were accepted and
+    the condition was silently never evaluated.
+    """
+    with new_test_table(cql, sc_keyspace, "pk int PRIMARY KEY, v int") as table:
+        error_msg = "Strongly consistent updates don't support conditions"
+        with pytest.raises(InvalidRequest, match=error_msg):
+            cql.execute(f"INSERT INTO {table} (pk, v) VALUES (0, 13) IF NOT EXISTS")
+        with pytest.raises(InvalidRequest, match=error_msg):
+            cql.execute(f"UPDATE {table} SET v = 13 WHERE pk = 0 IF EXISTS")
+        with pytest.raises(InvalidRequest, match=error_msg):
+            cql.execute(f"UPDATE {table} SET v = 13 WHERE pk = 0 IF v = 1")
+        with pytest.raises(InvalidRequest, match=error_msg):
+            cql.execute(f"DELETE FROM {table} WHERE pk = 0 IF EXISTS")
+        # A statement inside a batch is prepared through a different entry
+        # point, which used to skip the check.
+        with pytest.raises(InvalidRequest, match=error_msg):
+            cql.execute(f"BEGIN BATCH INSERT INTO {table} (pk, v) VALUES (0, 13) IF NOT EXISTS APPLY BATCH")
+
+
 @pytest.mark.parametrize("batch_mode", ["text", "prepared"], ids=["text", "prepared"])
 def test_batch(cql, sc_keyspace, batch_mode):
     """

--- a/test/cqlpy/strong_consistency/test_strong_consistency.py
+++ b/test/cqlpy/strong_consistency/test_strong_consistency.py
@@ -18,7 +18,7 @@ from cassandra.query import BatchStatement, BatchType, SimpleStatement
 
 from test.pylib.skip_types import skip_env
 
-from ..util import new_test_table, unique_name
+from ..util import new_test_keyspace, new_test_table, unique_name
 
 
 # A keyspace whose tables are strongly consistent. Cassandra and the --vnodes
@@ -237,6 +237,28 @@ def test_batch(cql, sc_keyspace, batch_mode):
                         INSERT INTO {other_table} (pk, ck, v) VALUES (1, 1, 20);
                         APPLY BATCH
                     """)
+
+        # A batch which mixes strongly and eventually consistent statements
+        # is rejected. The text path used to pick the batch kind from the
+        # keyspace of the first statement alone, so with the eventually
+        # consistent one first it built an eventually consistent batch, and
+        # committed the strongly consistent write through storage_proxy
+        # instead of Raft.
+        with new_test_keyspace(cql, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 1}") as ec_ks:
+            with new_test_table(cql, ec_ks, "pk int, ck int, v int, PRIMARY KEY (pk, ck)") as ec_table:
+                with pytest.raises(InvalidRequest, match="Cannot mix strongly consistent and eventually consistent statements"):
+                    if batch_mode == "prepared":
+                        batch = BatchStatement(batch_type=BatchType.UNLOGGED)
+                        batch.add(cql.prepare(f"INSERT INTO {ec_table} (pk, ck, v) VALUES (?, ?, ?)"), (1, 1, 10))
+                        batch.add(cql.prepare(f"INSERT INTO {table} (pk, ck, v) VALUES (?, ?, ?)"), (1, 1, 20))
+                        cql.execute(batch)
+                    else:
+                        cql.execute(f"""
+                            BEGIN UNLOGGED BATCH
+                            INSERT INTO {ec_table} (pk, ck, v) VALUES (1, 1, 10);
+                            INSERT INTO {table} (pk, ck, v) VALUES (1, 1, 20);
+                            APPLY BATCH
+                        """)
 
         # A batch level USING TIMESTAMP used to be accepted and then
         # silently ignored, because the Raft coordinator assigns the commit

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -1323,7 +1323,7 @@ public:
             local_qp().get_cql_stats());
         auto qs = make_query_state();
         auto& lqo = *qo;
-        return local_qp().execute_batch_without_checking_exception_message(batch, *qs, lqo, batch->get_statements().size(), {}).then([qs, batch, qo = std::move(qo)] (auto msg) {
+        return local_qp().execute_batch_without_checking_exception_message(batch, *qs, lqo, {}).then([qs, batch, qo = std::move(qo)] (auto msg) {
             return cql_transport::messages::propagate_exception_as_future(std::move(msg));
         });
     }

--- a/transport/server.cc
+++ b/transport/server.cc
@@ -2092,7 +2092,7 @@ process_batch_internal(service::client_state& client_state, sharded<cql3::query_
             return make_exception_future<cql_server::process_fn_return_type>(
                 exceptions::invalid_request_exception("Cannot mix strongly consistent and eventually consistent statements in a batch"));
         }
-        statement = ::make_shared<cql3::statements::strong_consistency::batch_statement>(cql3::statements::batch_statement::type(type.assume_value()), std::move(sc_modifications), cql3::attributes::none());
+        statement = ::make_shared<cql3::statements::strong_consistency::batch_statement>(cql3::statements::batch_statement::type(type.assume_value()), std::move(sc_modifications), cql3::attributes::none(), qp.local().get_cql_stats());
     } else {
         statement = ::make_shared<cql3::statements::batch_statement>(cql3::statements::batch_statement::type(type.assume_value()), std::move(modifications), cql3::attributes::none(), qp.local().get_cql_stats());
     }

--- a/transport/server.cc
+++ b/transport/server.cc
@@ -11,8 +11,6 @@
 #include "cql3/statements/batch_statement.hh"
 #include "cql3/statements/modification_statement.hh"
 #include "cql3/statements/strong_consistency/batch_statement.hh"
-#include "cql3/statements/strong_consistency/modification_statement.hh"
-#include "cql3/statements/strong_consistency/statement_helpers.hh"
 #include <seastar/core/scheduling.hh>
 #include <seastar/core/semaphore.hh>
 #include <seastar/coroutine/switch_to.hh>
@@ -1952,16 +1950,13 @@ process_batch_internal(service::client_state& client_state, sharded<cql3::query_
         return make_exception_future<cql_server::process_fn_return_type>(std::move(n).assume_error());
     }
 
-    size_t batch_size = 0;
-    std::vector<cql3::statements::batch_statement::single_statement> modifications; // used only for EC batches
-    std::vector<cql3::statements::strong_consistency::batch_statement::single_statement> sc_modifications; // used only for SC batches
+    std::vector<cql3::statements::batch_statement::single_statement> modifications;
     std::vector<cql3::raw_value_view_vector_with_unset> values;
     std::unordered_map<cql3::prepared_cache_key_type, cql3::authorized_prepared_statements_cache::value_type> pending_authorization_entries;
 
     modifications.reserve(n.assume_value());
-    sc_modifications.reserve(n.assume_value());
     values.reserve(n.assume_value());
-    bool is_sc = false;
+    size_t sc_count = 0;
 
     if (init_trace && trace_state) {
         tracing::begin(trace_state, "Execute batch of CQL3 queries", client_state.get_client_address());
@@ -2024,19 +2019,13 @@ process_batch_internal(service::client_state& client_state, sharded<cql3::query_
         if (!modif_statement_ptr) {
             return make_exception_future<cql_server::process_fn_return_type>(exceptions::invalid_request_exception("Invalid statement in batch: only UPDATE, INSERT and DELETE statements are allowed."));
         }
-        const bool statement_is_sc = modif_statement_ptr->is_strongly_consistent();
-        is_sc |= statement_is_sc;
+        sc_count += modif_statement_ptr->is_strongly_consistent();
 
         if (init_trace && trace_state) {
             tracing::add_table_name(trace_state, modif_statement_ptr->keyspace(), modif_statement_ptr->column_family());
             tracing::add_prepared_statement(trace_state, ps);
         }
-        if (statement_is_sc) {
-            sc_modifications.emplace_back(std::move(modif_statement_ptr), needs_authorization);
-        } else {
-            modifications.emplace_back(std::move(modif_statement_ptr), needs_authorization);
-        }
-        ++batch_size;
+        modifications.emplace_back(std::move(modif_statement_ptr), needs_authorization);
 
         std::vector<cql3::raw_value_view> tmp;
         cql3::unset_bind_variable_vector unset;
@@ -2077,15 +2066,16 @@ process_batch_internal(service::client_state& client_state, sharded<cql3::query_
     }
 
     auto ai = audit::audit::create_audit_info(audit::statement_category::DML, sstring(), sstring(), true);
+    if (sc_count != 0 && sc_count != modifications.size()) {
+        return make_exception_future<cql_server::process_fn_return_type>(
+            exceptions::invalid_request_exception("Cannot mix strongly consistent and eventually consistent statements in a batch"));
+    }
+    const auto batch_type = cql3::statements::batch_statement::type(type.assume_value());
     ::shared_ptr<cql3::statements::batch_statement> statement;
-    if (is_sc) {
-        if (sc_modifications.size() != batch_size) {
-            return make_exception_future<cql_server::process_fn_return_type>(
-                exceptions::invalid_request_exception("Cannot mix strongly consistent and eventually consistent statements in a batch"));
-        }
-        statement = ::make_shared<cql3::statements::strong_consistency::batch_statement>(cql3::statements::batch_statement::type(type.assume_value()), std::move(sc_modifications), cql3::attributes::none(), qp.local().get_cql_stats());
+    if (sc_count != 0) {
+        statement = ::make_shared<cql3::statements::strong_consistency::batch_statement>(batch_type, std::move(modifications), cql3::attributes::none(), qp.local().get_cql_stats());
     } else {
-        statement = ::make_shared<cql3::statements::batch_statement>(cql3::statements::batch_statement::type(type.assume_value()), std::move(modifications), cql3::attributes::none(), qp.local().get_cql_stats());
+        statement = ::make_shared<cql3::statements::batch_statement>(batch_type, std::move(modifications), cql3::attributes::none(), qp.local().get_cql_stats());
     }
     statement->set_audit_info(std::move(ai));
 

--- a/transport/server.cc
+++ b/transport/server.cc
@@ -2086,7 +2086,7 @@ process_batch_internal(service::client_state& client_state, sharded<cql3::query_
     if (ai) {
         ai->set_batch_infos(std::move(batch_audit_infos));
     }
-    ::shared_ptr<cql3::cql_statement> statement;
+    ::shared_ptr<cql3::statements::batch_statement> statement;
     if (is_sc) {
         if (sc_modifications.size() != batch_size) {
             return make_exception_future<cql_server::process_fn_return_type>(
@@ -2100,10 +2100,10 @@ process_batch_internal(service::client_state& client_state, sharded<cql3::query_
 
     auto execute_fut = reclassifying_control_connection_needs_user_service_level(*statement, query_state)
             ? query_state.get_service_level_controller().with_user_service_level(query_state.get_client_state().user(),
-                    [&qp, &query_state, &options, statement = std::move(statement), pending_authorization_entries = std::move(pending_authorization_entries), batch_size] () mutable {
-                return qp.local().execute_batch_without_checking_exception_message(std::move(statement), query_state, options, batch_size, std::move(pending_authorization_entries));
+                    [&qp, &query_state, &options, statement = std::move(statement), pending_authorization_entries = std::move(pending_authorization_entries)] () mutable {
+                return qp.local().execute_batch_without_checking_exception_message(std::move(statement), query_state, options, std::move(pending_authorization_entries));
             })
-            : qp.local().execute_batch_without_checking_exception_message(std::move(statement), query_state, options, batch_size, std::move(pending_authorization_entries));
+            : qp.local().execute_batch_without_checking_exception_message(std::move(statement), query_state, options, std::move(pending_authorization_entries));
     return std::move(execute_fut).then([stream, q_state = std::move(q_state), trace_state = query_state.get_trace_state(), version] (auto msg) {
         if (msg->as_bounce()) {
             return cql_server::process_fn_return_type(make_foreign(static_pointer_cast<messages::result_message::bounce>(msg)));

--- a/transport/server.cc
+++ b/transport/server.cc
@@ -2038,7 +2038,7 @@ process_batch_internal(service::client_state& client_state, sharded<cql3::query_
         }
 
         if (sc_statement) {
-            sc_modifications.emplace_back(std::move(sc_statement), needs_authorization);
+            sc_modifications.emplace_back(std::move(modif_statement_ptr), needs_authorization);
         } else {
             modifications.emplace_back(std::move(modif_statement_ptr), needs_authorization);
         }

--- a/transport/server.cc
+++ b/transport/server.cc
@@ -2022,13 +2022,13 @@ process_batch_internal(service::client_state& client_state, sharded<cql3::query_
                             + std::to_string(int(kind.assume_value()))));
         }
 
-        auto sc_statement = dynamic_pointer_cast<cql3::statements::strong_consistency::modification_statement>(ps->statement);
-        is_sc |= bool(sc_statement);
-
-        auto modif_statement_ptr = sc_statement ? sc_statement->inner() : dynamic_pointer_cast<cql3::statements::modification_statement>(ps->statement);
+        auto modif_statement_ptr = dynamic_pointer_cast<cql3::statements::modification_statement>(ps->statement);
         if (!modif_statement_ptr) {
             return make_exception_future<cql_server::process_fn_return_type>(exceptions::invalid_request_exception("Invalid statement in batch: only UPDATE, INSERT and DELETE statements are allowed."));
         }
+        const bool statement_is_sc = modif_statement_ptr->is_strongly_consistent();
+        is_sc |= statement_is_sc;
+
         if (init_trace && trace_state) {
             tracing::add_table_name(trace_state, modif_statement_ptr->keyspace(), modif_statement_ptr->column_family());
             tracing::add_prepared_statement(trace_state, ps);
@@ -2037,7 +2037,7 @@ process_batch_internal(service::client_state& client_state, sharded<cql3::query_
             batch_audit_infos.emplace_back(*inner_ai);
         }
 
-        if (sc_statement) {
+        if (statement_is_sc) {
             sc_modifications.emplace_back(std::move(modif_statement_ptr), needs_authorization);
         } else {
             modifications.emplace_back(std::move(modif_statement_ptr), needs_authorization);

--- a/transport/server.cc
+++ b/transport/server.cc
@@ -1955,13 +1955,11 @@ process_batch_internal(service::client_state& client_state, sharded<cql3::query_
     size_t batch_size = 0;
     std::vector<cql3::statements::batch_statement::single_statement> modifications; // used only for EC batches
     std::vector<cql3::statements::strong_consistency::batch_statement::single_statement> sc_modifications; // used only for SC batches
-    std::vector<std::reference_wrapper<const audit::audit_info>> batch_audit_infos;
     std::vector<cql3::raw_value_view_vector_with_unset> values;
     std::unordered_map<cql3::prepared_cache_key_type, cql3::authorized_prepared_statements_cache::value_type> pending_authorization_entries;
 
     modifications.reserve(n.assume_value());
     sc_modifications.reserve(n.assume_value());
-    batch_audit_infos.reserve(n.assume_value());
     values.reserve(n.assume_value());
     bool is_sc = false;
 
@@ -2033,10 +2031,6 @@ process_batch_internal(service::client_state& client_state, sharded<cql3::query_
             tracing::add_table_name(trace_state, modif_statement_ptr->keyspace(), modif_statement_ptr->column_family());
             tracing::add_prepared_statement(trace_state, ps);
         }
-        if (auto* inner_ai = ps->statement->get_audit_info()) {
-            batch_audit_infos.emplace_back(*inner_ai);
-        }
-
         if (statement_is_sc) {
             sc_modifications.emplace_back(std::move(modif_statement_ptr), needs_authorization);
         } else {
@@ -2083,9 +2077,6 @@ process_batch_internal(service::client_state& client_state, sharded<cql3::query_
     }
 
     auto ai = audit::audit::create_audit_info(audit::statement_category::DML, sstring(), sstring(), true);
-    if (ai) {
-        ai->set_batch_infos(std::move(batch_audit_infos));
-    }
     ::shared_ptr<cql3::statements::batch_statement> statement;
     if (is_sc) {
         if (sc_modifications.size() != batch_size) {


### PR DESCRIPTION
Strongly consistent statements were built as decorators: a
strong_consistency::modification_statement held a regular modification
statement, and a strong_consistency::batch_statement held a list of those
wrappers. Neither was an instance of the type it wrapped, so each had to
forward the cql_statement interface by hand and no caller could see through
it. This series makes both subclasses that replace only do_execute(), and
removes the workarounds that forced: execute_batch() taking a bare
cql_statement plus a separate batch size, audit's list of non-owning
references to the inner statements' audit_info, the second statement vector
in the native protocol path, and the wrapping of statements the strongly
consistent batch never writes through anyway.

It also fixes four constructs that were accepted and then silently did
nothing: IF conditions, BEGIN BATCH USING TIMESTAMP (the Raft coordinator
assigns the commit timestamp and reassigns it on retry), the checks for
conditions, prefetch and user timestamps being skipped for a statement inside
a batch, and a batch mixing consistency modes being committed through
storage_proxy instead of Raft.

Strongly consistent writes now also go through the modification execution
stage, which the decorator bypassed.

Tests: new test/cluster/test_strong_consistency.py cases for rejected
conditions, batch level timestamps and mixed batches.

Backport: no, it's a refactor