### PR TITLE
mutation: drop the dead type parameter from atomic_cell_or_collection::external_memory_usage()

### DIFF
--- a/mutation/atomic_cell.cc
+++ b/mutation/atomic_cell.cc
@@ -171,7 +171,7 @@ bool atomic_cell_or_collection::equals(const abstract_type& type, const atomic_c
     }
 }
 
-size_t atomic_cell_or_collection::external_memory_usage(const abstract_type& t) const
+size_t atomic_cell_or_collection::external_memory_usage() const
 {
     return _data.external_memory_usage();
 }

--- a/mutation/atomic_cell_or_collection.hh
+++ b/mutation/atomic_cell_or_collection.hh
@@ -43,7 +43,7 @@ public:
     collection_mutation_view as_collection_mutation() const;
     bytes_view serialize() const;
     bool equals(const abstract_type& type, const atomic_cell_or_collection& other) const;
-    size_t external_memory_usage(const abstract_type&) const;
+    size_t external_memory_usage() const;
 
     class printer {
         const column_definition& _cdef;

--- a/mutation/mutation_partition.cc
+++ b/mutation/mutation_partition.cc
@@ -1214,10 +1214,11 @@ row::find_cell(column_id id) const {
     return c_a_h ? &c_a_h->cell : nullptr;
 }
 
-size_t row::external_memory_usage(const schema& s, column_kind kind) const {
-    return _cells.memory_usage([&] (column_id id, const cell_and_hash& cah) noexcept {
-            auto& cdef = s.column_at(kind, id);
-            return cah.cell.external_memory_usage(*cdef.type);
+// The schema and kind are unused, but kept for a uniform signature across
+// fragment types (see mutation_fragment_v2::external_memory_usage()).
+size_t row::external_memory_usage(const schema&, column_kind) const {
+    return _cells.memory_usage([] (column_id, const cell_and_hash& cah) noexcept {
+            return cah.cell.external_memory_usage();
     });
 }
 

--- a/test/boost/mutation_test.cc
+++ b/test/boost/mutation_test.cc
@@ -2729,7 +2729,7 @@ SEASTAR_THREAD_TEST_CASE(test_cell_external_memory_usage) {
             auto before = alloc.allocated_bytes();
             auto ac = atomic_cell_or_collection(atomic_cell::make_live(*dt, 1, bv));
             auto after = alloc.allocated_bytes();
-            BOOST_CHECK_EQUAL(ac.external_memory_usage(*dt), after - before);
+            BOOST_CHECK_EQUAL(ac.external_memory_usage(), after - before);
         });
     };
 
@@ -2756,8 +2756,8 @@ SEASTAR_THREAD_TEST_CASE(test_cell_external_memory_usage) {
             auto before = alloc.allocated_bytes();
             auto cell2 = cell.copy(*collection_type);
             auto after = alloc.allocated_bytes();
-            BOOST_CHECK_EQUAL(cell2.external_memory_usage(*collection_type), cell.external_memory_usage(*collection_type));
-            BOOST_CHECK_EQUAL(cell2.external_memory_usage(*collection_type), after - before);
+            BOOST_CHECK_EQUAL(cell2.external_memory_usage(), cell.external_memory_usage());
+            BOOST_CHECK_EQUAL(cell2.external_memory_usage(), after - before);
         });
     };
 


### PR DESCRIPTION
## Motivation

`atomic_cell_or_collection::external_memory_usage(const abstract_type&)` has ignored its parameter since the IMR removal (`ba7a9d2ac3`, 2020-10-30); the body is a one-line forward to `_data.external_memory_usage()`. Passing it forced `row::external_memory_usage()` into an out-of-line `schema::column_at()` lookup — two bounds checks — **per cell**, on every path that computes fragment memory usage, i.e. every fragment from every reader, plus `compacting_reader`'s accounting recompute. Direct precedent: `6926375c4d` "mutation/atomic_cell: drop unused type param from from_bytes()".

## Changes

Drop the parameter and the `column_at()` call; update all four callers (one production, three in `mutation_test.cc`).

`row::external_memory_usage()` keeps its own `(schema, kind)` parameters: the generic fragment visitor passes the schema uniformly to every fragment type and siblings such as `range_tombstone::external_memory_usage(const schema&)` already ignore it; cascading their removal is a separable, churny follow-up with no perf content.

## Tests

Build clean (proves caller completeness tree-wide); `mutation_test` 77/77 cases.

## Results

Measured (release, both arms sharing the identical PR #31131 harness base, `--smp 1`, `taskset -c 3` on an idle machine, 5 interleaved reps/arm, `perf_simple_query --write`, default no-clustering-key schema):

| | baseline insns/op (median) | fix insns/op (median) | Δ |
|---|---|---|---|
| median-of-5 | 49,466.00 | 49,385.53 | **−80.47 (−0.163%)** |

The delta exceeds the run-to-run spread of both arms (baseline range 25.95, fix range 58.52 across the 5 reps). Small in absolute terms, as expected for removing one out-of-line bounds-checked lookup per cell against a workload dominated by CQL parsing, memtable insertion and query-plan overhead — but real and reproducible.

Methodology note: `bench-mode.sh` (governor/turbo pinning) was unavailable this session, so only `taskset -c 3` + `--smp 1` were used; the machine was otherwise idle (verified via `vmstat` immediately before the run).

---

Backport: no, improvement
