### PR TITLE
query/result: drop dead reduce_chunk_count() calls on a moved-from buffer

### DIFF
--- a/query/query-result.hh
+++ b/query/query-result.hh
@@ -324,6 +324,8 @@ public:
     friend class result_merger;
 
     result();
+    // The result buffer is deliberately left as-is, not linearized: it is parsed at most
+    // once, sequentially, and is serialized to the wire fragment by fragment.
     result(bytes_ostream&& w, short_read sr, std::optional<uint32_t> c_low_bits, std::optional<uint32_t> pc,
            std::optional<uint32_t> c_high_bits, std::optional<full_position> last_position, result_memory_tracker memory_tracker = { })
         : _w(std::move(w))
@@ -333,9 +335,7 @@ public:
         , _partition_count(pc)
         , _row_count_high_bits(c_high_bits)
         , _last_position(std::move(last_position))
-    {
-        w.reduce_chunk_count();
-    }
+    { }
     result(bytes_ostream&& w, std::optional<result_digest> d, api::timestamp_type last_modified,
            short_read sr, std::optional<uint32_t> c_low_bits, std::optional<uint32_t> pc, std::optional<uint32_t> c_high_bits,
            std::optional<full_position> last_position, result_memory_tracker memory_tracker = { })
@@ -348,9 +348,7 @@ public:
         , _partition_count(pc)
         , _row_count_high_bits(c_high_bits)
         , _last_position(std::move(last_position))
-    {
-        w.reduce_chunk_count();
-    }
+    { }
     result(bytes_ostream&& w, short_read sr, uint64_t c, std::optional<uint32_t> pc,
            std::optional<full_position> last_position, result_memory_tracker memory_tracker = { })
         : _w(std::move(w))
@@ -360,9 +358,7 @@ public:
         , _partition_count(pc)
         , _row_count_high_bits(static_cast<uint32_t>(c >> 32))
         , _last_position(std::move(last_position))
-    {
-        w.reduce_chunk_count();
-    }
+    { }
     result(bytes_ostream&& w, std::optional<result_digest> d, api::timestamp_type last_modified,
            short_read sr, uint64_t c, std::optional<uint32_t> pc, std::optional<full_position> last_position, result_memory_tracker memory_tracker = { })
         : _w(std::move(w))
@@ -374,9 +370,7 @@ public:
         , _partition_count(pc)
         , _row_count_high_bits(static_cast<uint32_t>(c >> 32))
         , _last_position(std::move(last_position))
-    {
-        w.reduce_chunk_count();
-    }
+    { }
     result(result&&) = default;
     result& operator=(result&&) = default;
 


### PR DESCRIPTION
## Motivation

All four `query::result` constructors end with `w.reduce_chunk_count()` where `w` was already moved from on the initializer list.
`bytes_ostream`'s move constructor zeroes the source, so the call sees `size() == 0`, forwards to `linearize()`, and returns immediately because `is_linearized()` is true for a null `_begin`.
The call was born dead in `cb2a557cf7` (2016) and has never executed. The code claims to do something it doesn't, which misleads readers and invites "fixes".

## Changes

Delete the four dead calls. Deliberately do **not** "fix" them by linearizing `_w` instead: small results already fit one chunk (builder starts at 512 B), medium results are parsed exactly once sequentially into the CQL response, replicas serialize the buffer to RPC fragment by fragment without parsing, and the coordinator's receive side already compacts via `deserialized_bytes_proxy::operator bytes_ostream() &&`.
A comment in the header records this so the calls are not reintroduced.

## Tests

Build clean; `mutation_query_test` 10/10, `result_utils_test` 15/15, `mutation_test` 77/77 cases.

## Results

None to claim, by design: the change deletes provably-dead code, so generated behaviour is identical (the no-op proof chain is in the commit message).
Per the measurement methodology used elsewhere in this series, no numbers are manufactured for a change with no behavioral or performance delta.

---

Backport: no, improvement
