### PR TITLE
keys: derive prefix lengths from the equal-prefix walk

### DIFF
--- a/keys/clustering_bounds_comparator.hh
+++ b/keys/clustering_bounds_comparator.hh
@@ -54,15 +54,17 @@ public:
         { }
         std::strong_ordering operator()(const clustering_key_prefix& p1, int32_t w1, const clustering_key_prefix& p2, int32_t w2) const {
             auto type = _s.get().clustering_key_prefix_type();
-            auto res = prefix_equality_tri_compare(type->types().begin(),
+            auto res = prefix_equality_tri_compare_with_exhaustion(type->types().begin(),
                 type->begin(p1.representation()), type->end(p1.representation()),
                 type->begin(p2.representation()), type->end(p2.representation()),
                 ::tri_compare);
-            if (res != 0) {
-                return res;
+            if (res.order != 0) {
+                return res.order;
             }
-            auto d1 = p1.size(_s);
-            auto d2 = p2.size(_s);
+            // The walk above stopped as soon as one prefix ran out, so
+            // exhausted1 == (d1 <= d2) and exhausted2 == (d2 <= d1), where dN
+            // is the component count of pN. Using the flags avoids two
+            // p.size() calls, each of which re-decodes every length header.
 
             /*
              * The logic below is
@@ -79,7 +81,7 @@ public:
              * helps compiler generate jump-less assembly.
              */
 
-            return ((d1 <= d2) ? w1 << 1 : 1) <=> ((d2 <= d1) ? w2 << 1 : 1);
+            return (res.exhausted1 ? w1 << 1 : 1) <=> (res.exhausted2 ? w2 << 1 : 1);
         }
         std::strong_ordering operator()(const bound_view b, const clustering_key_prefix& p) const {
             return operator()(b._prefix, weight(b._kind), p, 0);

--- a/test/boost/keys_test.cc
+++ b/test/boost/keys_test.cc
@@ -9,10 +9,13 @@
 #define BOOST_TEST_MODULE core
 
 #include <boost/test/unit_test.hpp>
+#include <random>
 #include "keys/keys.hh"
+#include "keys/clustering_bounds_comparator.hh"
 #include "schema/schema.hh"
 #include "schema/schema_builder.hh"
 #include "types/types.hh"
+#include "utils/lexicographical_compare.hh"
 
 #include "idl/keys.dist.hh"
 #include "serializer_impl.hh"
@@ -193,4 +196,167 @@ BOOST_AUTO_TEST_CASE(test_from_nodetool_style_string_composite_partition_key) {
 
     BOOST_REQUIRE_THROW(partition_key::from_nodetool_style_string(s2, "value1:value2:extra"), std::invalid_argument);
     BOOST_REQUIRE_THROW(partition_key::from_nodetool_style_string(s2, "value1"), std::invalid_argument);
+}
+
+// ---------------------------------------------------------------------------
+// Differential test for bound_view::tri_compare.
+//
+// bound_view::tri_compare derives the relative component counts of the two
+// prefixes from the exhaustion flags of the prefix walk. The implementation it
+// replaced called clustering_key_prefix::size() on both prefixes, which
+// re-decodes every component's length header. That older implementation is
+// kept below verbatim as a reference oracle, and the tests assert the two
+// agree bit-for-bit over a corpus that covers component counts 0..5 on both
+// sides, empty prefixes, genuine prefix-of relationships, mixed component
+// types and every weight combination.
+// ---------------------------------------------------------------------------
+
+namespace {
+
+// The pre-optimization body of bound_view::tri_compare::operator()(p1, w1, p2, w2).
+std::strong_ordering reference_bound_view_tri_compare(const schema& s,
+        const clustering_key_prefix& p1, int32_t w1,
+        const clustering_key_prefix& p2, int32_t w2) {
+    auto type = s.clustering_key_prefix_type();
+    auto res = prefix_equality_tri_compare(type->types().begin(),
+        type->begin(p1.representation()), type->end(p1.representation()),
+        type->begin(p2.representation()), type->end(p2.representation()),
+        ::tri_compare);
+    if (res != 0) {
+        return res;
+    }
+    auto d1 = p1.size(s);
+    auto d2 = p2.size(s);
+    return ((d1 <= d2) ? w1 << 1 : 1) <=> ((d2 <= d1) ? w2 << 1 : 1);
+}
+
+int to_int(std::strong_ordering o) {
+    return o < 0 ? -1 : (o > 0 ? 1 : 0);
+}
+
+constexpr size_t ck_columns = 5;
+
+// Mixed types, multi-component clustering key. Fixed-width (int32/long) and
+// variable-width (utf8/bytes) components exercise both length-header shapes.
+schema_ptr make_multi_component_ck_schema() {
+    return schema_builder(1, "ks", "cf")
+            .with_column("pk", bytes_type, column_kind::partition_key)
+            .with_column("c1", utf8_type, column_kind::clustering_key)
+            .with_column("c2", int32_type, column_kind::clustering_key)
+            .with_column("c3", bytes_type, column_kind::clustering_key)
+            .with_column("c4", long_type, column_kind::clustering_key)
+            .with_column("c5", utf8_type, column_kind::clustering_key)
+            .with_column("v", bytes_type)
+            .build();
+}
+
+// Deliberately tiny per-position alphabets, so that equal prefixes - the case
+// that reaches the length-comparing tail - are common rather than rare.
+std::vector<std::vector<bytes>> ck_candidate_values() {
+    return {
+        {bytes(), to_bytes("a"), to_bytes("b")},
+        {int32_type->decompose(int32_t(-1)), int32_type->decompose(int32_t(0)), int32_type->decompose(int32_t(7))},
+        {bytes(), to_bytes("x"), to_bytes("xy")},
+        {long_type->decompose(int64_t(0)), long_type->decompose(int64_t(-5)), long_type->decompose(int64_t(1) << 40)},
+        {bytes(), to_bytes("p"), to_bytes("q")},
+    };
+}
+
+// For every random full-length key, all of its prefixes are added, so
+// prefix-of pairs and the empty prefix are guaranteed present, not merely likely.
+std::vector<clustering_key_prefix> make_ck_pool(const schema& s, std::mt19937& rnd, size_t full_keys) {
+    auto candidates = ck_candidate_values();
+    std::vector<clustering_key_prefix> pool;
+    pool.reserve(full_keys * (ck_columns + 1));
+    for (size_t i = 0; i < full_keys; ++i) {
+        std::vector<bytes> full;
+        for (size_t c = 0; c < ck_columns; ++c) {
+            auto& values = candidates[c];
+            std::uniform_int_distribution<size_t> pick(0, values.size() - 1);
+            full.push_back(values[pick(rnd)]);
+        }
+        for (size_t n = 0; n <= ck_columns; ++n) {
+            pool.push_back(clustering_key_prefix::from_exploded(s, std::vector<bytes>(full.begin(), full.begin() + n)));
+        }
+    }
+    return pool;
+}
+
+constexpr int32_t bound_weights[] = {-1, 0, 1};
+
+// Compares every weight combination for one key pair; returns the mismatch count.
+size_t check_pair(const schema& s, const bound_view::tri_compare& cmp,
+        const clustering_key_prefix& p1, const clustering_key_prefix& p2) {
+    size_t mismatches = 0;
+    for (auto w1 : bound_weights) {
+        for (auto w2 : bound_weights) {
+            auto expected = reference_bound_view_tri_compare(s, p1, w1, p2, w2);
+            auto actual = cmp(p1, w1, p2, w2);
+            if (actual != expected) {
+                ++mismatches;
+                if (mismatches <= 8) {
+                    BOOST_ERROR(fmt::format("bound_view::tri_compare({}, {}, {}, {}) = {}, reference = {}",
+                            p1.with_schema(s), w1, p2.with_schema(s), w2, to_int(actual), to_int(expected)));
+                }
+            }
+        }
+    }
+    return mismatches;
+}
+
+}
+
+// Exhaustive over a small deterministic corpus: all prefixes of length 0..3
+// over a 2-symbol-per-position alphabet, every ordered pair, every weight pair.
+BOOST_AUTO_TEST_CASE(test_bound_view_tri_compare_exhaustive_small_corpus) {
+    auto s_ptr = make_multi_component_ck_schema();
+    const schema& s = *s_ptr;
+    bound_view::tri_compare cmp(s);
+
+    const std::vector<bytes> a0 = {bytes(), to_bytes("a")};
+    const std::vector<bytes> a1 = {int32_type->decompose(int32_t(0)), int32_type->decompose(int32_t(1))};
+    const std::vector<bytes> a2 = {bytes(), to_bytes("z")};
+
+    std::vector<clustering_key_prefix> keys;
+    keys.push_back(clustering_key_prefix::from_exploded(s, std::vector<bytes>{}));
+    for (auto& v0 : a0) {
+        keys.push_back(clustering_key_prefix::from_exploded(s, std::vector<bytes>{v0}));
+        for (auto& v1 : a1) {
+            keys.push_back(clustering_key_prefix::from_exploded(s, std::vector<bytes>{v0, v1}));
+            for (auto& v2 : a2) {
+                keys.push_back(clustering_key_prefix::from_exploded(s, std::vector<bytes>{v0, v1, v2}));
+            }
+        }
+    }
+    BOOST_REQUIRE_EQUAL(keys.size(), 15u);
+
+    size_t mismatches = 0;
+    for (auto& p1 : keys) {
+        for (auto& p2 : keys) {
+            mismatches += check_pair(s, cmp, p1, p2);
+        }
+    }
+    BOOST_REQUIRE_EQUAL(mismatches, 0u);
+}
+
+// Randomized corpus: component counts 0..5 on both sides, mixed types.
+BOOST_AUTO_TEST_CASE(test_bound_view_tri_compare_matches_reference_implementation) {
+    auto s_ptr = make_multi_component_ck_schema();
+    const schema& s = *s_ptr;
+    bound_view::tri_compare cmp(s);
+
+    std::mt19937 rnd(20260816);
+    auto pool = make_ck_pool(s, rnd, 400);
+    BOOST_REQUIRE_EQUAL(pool.size(), 400u * (ck_columns + 1));
+
+    constexpr size_t iterations = 200000;
+    std::uniform_int_distribution<size_t> pick(0, pool.size() - 1);
+
+    size_t mismatches = 0;
+    for (size_t i = 0; i < iterations; ++i) {
+        mismatches += check_pair(s, cmp, pool[pick(rnd)], pool[pick(rnd)]);
+    }
+    BOOST_TEST_MESSAGE(fmt::format("compared {} (key pair, weight pair) combinations",
+            iterations * std::size(bound_weights) * std::size(bound_weights)));
+    BOOST_REQUIRE_EQUAL(mismatches, 0u);
 }

--- a/test/boost/keys_test.cc
+++ b/test/boost/keys_test.cc
@@ -360,3 +360,39 @@ BOOST_AUTO_TEST_CASE(test_bound_view_tri_compare_matches_reference_implementatio
             iterations * std::size(bound_weights) * std::size(bound_weights)));
     BOOST_REQUIRE_EQUAL(mismatches, 0u);
 }
+
+// The equivalence the optimization rests on: after an equal prefix walk, the
+// exhaustion flags are exactly the d1<=d2 / d2<=d1 predicates.
+BOOST_AUTO_TEST_CASE(test_prefix_equality_exhaustion_flags_match_component_counts) {
+    auto s_ptr = make_multi_component_ck_schema();
+    const schema& s = *s_ptr;
+    auto type = s.clustering_key_prefix_type();
+
+    std::mt19937 rnd(4236);
+    auto pool = make_ck_pool(s, rnd, 100);
+
+    size_t mismatches = 0;
+    size_t equal_cases = 0;
+    for (auto& p1 : pool) {
+        for (auto& p2 : pool) {
+            auto res = prefix_equality_tri_compare_with_exhaustion(type->types().begin(),
+                type->begin(p1.representation()), type->end(p1.representation()),
+                type->begin(p2.representation()), type->end(p2.representation()),
+                ::tri_compare);
+            auto plain = prefix_equality_tri_compare(type->types().begin(),
+                type->begin(p1.representation()), type->end(p1.representation()),
+                type->begin(p2.representation()), type->end(p2.representation()),
+                ::tri_compare);
+            mismatches += (res.order != plain);
+            if (res.order == 0) {
+                ++equal_cases;
+                auto d1 = p1.size(s);
+                auto d2 = p2.size(s);
+                mismatches += (res.exhausted1 != (d1 <= d2));
+                mismatches += (res.exhausted2 != (d2 <= d1));
+            }
+        }
+    }
+    BOOST_REQUIRE_GT(equal_cases, 0u);
+    BOOST_REQUIRE_EQUAL(mismatches, 0u);
+}

--- a/utils/lexicographical_compare.hh
+++ b/utils/lexicographical_compare.hh
@@ -114,6 +114,37 @@ std::strong_ordering prefix_equality_tri_compare(TypesIterator types, InputIt1 f
     return std::strong_ordering::equal;
 }
 
+// Result of prefix_equality_tri_compare_with_exhaustion().
+struct prefix_equality_tri_compare_result {
+    std::strong_ordering order;
+    // Set only when order == equal. Then exhausted1 <=> len1 <= len2 and
+    // exhausted2 <=> len2 <= len1, because the walk consumes both sequences
+    // in lockstep and stops as soon as one of them runs out.
+    bool exhausted1;
+    bool exhausted2;
+};
+
+// Same ordering as prefix_equality_tri_compare(), but also reports which of
+// the sequences the lockstep walk exhausted. Lets the caller learn the
+// relative lengths without re-walking the sequences.
+template <typename TypesIterator, typename InputIt1, typename InputIt2, typename Compare>
+requires requires (TypesIterator ti, InputIt1 i1, InputIt2 i2, Compare c) {
+    { c(*ti, *i1, *i2) } -> std::same_as<std::strong_ordering>;
+}
+prefix_equality_tri_compare_result prefix_equality_tri_compare_with_exhaustion(TypesIterator types,
+        InputIt1 first1, InputIt1 last1, InputIt2 first2, InputIt2 last2, Compare comp) {
+    while (first1 != last1 && first2 != last2) {
+        auto c = comp(*types, *first1, *first2);
+        if (c != 0) {
+            return {c, false, false};
+        }
+        ++first1;
+        ++first2;
+        ++types;
+    }
+    return {std::strong_ordering::equal, first1 == last1, first2 == last2};
+}
+
 // Returns true iff the second sequence is a prefix of the first sequence
 // Equality is an abstract_type-aware equality checker which takes the type as first argument.
 template <typename TypesIterator, typename InputIt1, typename InputIt2, typename Equality>


### PR DESCRIPTION
## Motivation

`bound_view::tri_compare()` resolved the ordering of 2 prefixes that compare equal by calling `clustering_key_prefix::size()` on both - each a `std::distance(begin, end)` that re-decodes every component's length header, so each equal comparison walked both keys a second and third time.
The equal path is hot: the terminal compare of every successful `rows_entry` b-tree lookup, compares against same-key dummy entries in the cache, and against the empty-prefix `after_all_clustered_rows()` sentinel present in every MVCC partition version - typically 1–3 re-walk hits per lookup.
This comparator is the root of the whole family (`position_in_partition::tri_compare`, `rows_entry::tri_compare`, the rows b-tree, the cache cursor, the merging-reader heaps).

## Changes

The equal-prefix walk already establishes the answer: lockstep advance exits equal only when a side is exhausted, so `first1 == last1 ⟺ d1 <= d2` and symmetrically. Add `prefix_equality_tri_compare_with_exhaustion()` (same loop, returns `{ordering, exhausted1, exhausted2}`;
flags meaningful only on equal) and use the flags in place of both `size()` calls. The jump-less `<=>` tail is unchanged. `lexicographical_tri_compare()` in the same header already resolves relative lengths this way.

## Tests

Differential oracle committed first: a verbatim copy of the pre-change comparator plus two tests asserting bit-for-bit agreement - exhaustive over a deterministic corpus (component counts 0–5, empty prefixes, genuine prefixes of one another, mixed-type 5-component key, all nine weight combinations) 
and randomized over 200,000 key pairs.
Test: build clean; `keys_test` 11/11 (incl. the 2 differential tests), `mutation_test` 77/77, `mvcc_test` 24/24.

## Results

Measured (release, both arms carrying the PR #31131 harness commit, `--smp 1`, pinned core with idle SMT sibling, bench-mode on, 5 interleaved reps/arm, median insns/op via `perf_simple_query --clustering-columns`):

| clustering columns | baseline insns/op | C1 insns/op | Δ |
|---|---|---|---|
| 1 | 524,738 | 524,057 | **−681 (−0.13%)** |
| 3 | 562,998 | 561,937 | **−1,061 (−0.19%)** |
| 5 | 602,246 | 600,804 | **−1,442 (−0.24%)** |

Every delta exceeds the run-to-run spread of both arms, and the delta scales with component count exactly as removing an O(components) re-walk predicts - independent corroboration beyond magnitude.
Honest scope: 0.13–0.24% of a full CQL slice read over 64 rows; the workload spends most instructions in iteration/serialization, not the terminal compare. `cycles/op`/`tps` are directionally consistent but noisier (expected; `insns/op` is the trusted metric here).

Too low value? Unsure.

---

Backport: no, improvement
