### PR TITLE
DO NOT MERGE: raft/group0: bug-hunt findings (4 reproducers + 1 fix)

### DIFF
--- a/service/raft/raft_group0_client.cc
+++ b/service/raft/raft_group0_client.cc
@@ -194,6 +194,11 @@ future<> raft_group0_client::add_entry(group0_command group0_cmd, group0_guard g
                 // Just fail the operation by propagating the error.
                 logger.error("add_entry: unexpected `not_a_leader` error: \"{}\". Please file an issue.", e);
                 throw;
+            } catch (const raft_operation_timeout_error& e) {
+                // A per-operation deadline expiry, not a hard raft error: fall through
+                // to the applied/GC-window classification below instead of propagating
+                // an opaque error the caller has no way to retry safely.
+                logger.warn("add_entry: {}", e);
             }
 
             // Thanks to the `prev_state_id` check in `group0_state_machine::apply`, the command is idempotent.

--- a/test/boost/group0_cmd_merge_test.cc
+++ b/test/boost/group0_cmd_merge_test.cc
@@ -77,6 +77,46 @@ SEASTAR_TEST_CASE(test_group0_state_machine_merger_timeuuid_order) {
     BOOST_REQUIRE_EQUAL(merger.last_id(), t1);
 }
 
+// Reproducer: merge() never resets _size, so a post-flush can_merge()
+// measures against sizes from already-flushed batches.
+SEASTAR_TEST_CASE(test_group0_state_machine_merger_size_reset_after_flush) {
+    auto [db, db_impl] = cql3::expr::test_utils::make_data_dictionary_database(db::system_keyspace::group0_history());
+
+    semaphore s{1};
+    auto mutex_holder = co_await get_units(s, 1);
+
+    constexpr size_t max_command_size = 100;
+    service::group0_state_machine_merger merger{OLD_TIMEUUID, std::move(mutex_holder), max_command_size, db};
+
+    // First batch: a single size-60 command.
+    auto cmd_a = create_command(utils::UUID_gen::get_time_UUID());
+    merger.add(std::move(cmd_a), 60);
+
+    // 60 + 60 > 100: the caller must flush, as apply()'s merge loop does.
+    auto cmd_b = create_command(utils::UUID_gen::get_time_UUID());
+    BOOST_REQUIRE(!merger.can_merge(cmd_b, 60));
+    merger.merge(); // flush; result content is irrelevant here
+    BOOST_REQUIRE(merger.empty());
+
+    // Fresh batch: correctly-reset _size is 60, buggy carryover makes 120.
+    merger.add(std::move(cmd_b), 60);
+
+    auto cmd_c = create_command(utils::UUID_gen::get_time_UUID());
+
+    // Control: the fresh batch's own 60 still counts (60 + 41 > 100).
+    BOOST_REQUIRE(!merger.can_merge(cmd_c, 41));
+
+    // The bug: 61 <= 100 must merge, but the stale carryover says 121 > 100.
+    BOOST_REQUIRE_MESSAGE(merger.can_merge(cmd_c, 1),
+            "merger should accept merging a tiny command into a 60-sized fresh batch (61 <= 100), "
+            "but can_merge() is measuring against size left over from the previous (already flushed) batch");
+
+    // Control: in-batch accumulation still works (61 + 40 > 100 rejects).
+    merger.add(std::move(cmd_c), 1);
+    auto cmd_d = create_command(utils::UUID_gen::get_time_UUID());
+    BOOST_REQUIRE(!merger.can_merge(cmd_d, 40));
+}
+
 SEASTAR_TEST_CASE(test_group0_cmd_merge) {
 #ifndef SCYLLA_ENABLE_ERROR_INJECTION
     fmt::print("Skipping test as it depends on error injection. Please run in mode where it's enabled (debug,dev).\n");

--- a/test/boost/group0_test.cc
+++ b/test/boost/group0_test.cc
@@ -10,6 +10,8 @@
 #include <seastar/testing/test_case.hh>
 #include "test/lib/cql_assertions.hh"
 #include <seastar/core/coroutine.hh>
+#include <seastar/core/sleep.hh>
+#include <seastar/core/timer.hh>
 #include <seastar/util/defer.hh>
 
 #include "clocks-impl.hh"
@@ -566,6 +568,112 @@ SEASTAR_TEST_CASE(test_group0_hard_timeout_history_absent_after_real_gc_is_hard_
         BOOST_CHECK_EXCEPTION(co_await std::move(mc_a).commit(rclient, as, ::service::raft_timeout{}),
                 service::group0_hard_timeout, [] (const service::group0_hard_timeout&) { return true; });
     });
+}
+
+// Reproducer: a raft_timeout expiry in add_entry() escapes as opaque
+// raft_operation_timeout_error, bypassing the applied/retryable
+// classification every other timeout path gets. See commit message.
+SEASTAR_TEST_CASE(test_group0_add_entry_timeout_in_flight_is_concurrent_modification) {
+#ifndef SCYLLA_ENABLE_ERROR_INJECTION
+    std::cerr << "Skipping test as it depends on error injection. Please run in mode where it's enabled (debug,dev).\n";
+    return make_ready_future<>();
+#else
+    return do_with_cql_env([] (cql_test_env& e) -> future<> {
+        auto& rclient = e.get_raft_group0_client();
+        abort_source as;
+
+        schema_builder::register_schema_initializer([](schema_builder& builder) {
+            if (builder.cf_name() == "test_group0_timeout_bypass") {
+                builder.set_is_group0_table();
+            }
+        });
+
+        co_await e.execute_cql("CREATE TABLE test_group0_timeout_bypass (key int PRIMARY KEY)");
+
+        // Pin the GC window so the expected classification can't flip if the
+        // default ever changes.
+        rclient.set_history_gc_duration(std::chrono::hours{1});
+
+        auto guard = co_await rclient.start_operation(as);
+        auto muts = co_await e.get_modification_mutations("INSERT INTO test_group0_timeout_bypass (key) VALUES (1)");
+        service::group0_batch mc(std::move(guard));
+        mc.add_mutation(muts[0]);
+
+        // Stall the group0 io_fiber (shard 0, same as this test; enable() is
+        // shard-local) so add_entry can never observe "applied".
+        utils::get_local_injector().enable("poll_fsm_output/pause");
+        auto resume_polling = defer([] noexcept { utils::get_local_injector().disable("poll_fsm_output/pause"); });
+
+        // Already-past deadline: expiry fires without a real 60s op timeout.
+        ::service::raft_timeout past_deadline{.value = seastar::lowres_clock::now() - std::chrono::seconds{1}};
+
+        // Bound the test: a fix that retries instead would loop forever here.
+        seastar::timer<seastar::lowres_clock> watchdog([&as] () noexcept { as.request_abort(); });
+        watchdog.arm(std::chrono::minutes{2});
+
+        // The bug: a raft_operation_timeout_error escapes instead of the
+        // retry-safe classification (concurrent_modification/hard_timeout).
+        BOOST_CHECK_EXCEPTION(co_await std::move(mc).commit(rclient, as, past_deadline),
+                service::group0_concurrent_modification, [] (const service::group0_concurrent_modification&) { return true; });
+        watchdog.cancel();
+
+        resume_polling.cancel();
+        utils::get_local_injector().disable("poll_fsm_output/pause");
+        // The "failed" write lands once polling resumes: the entry was merely
+        // in flight, which is why the retryable classification is right.
+        for (int i = 0; (co_await fetch_rows(e, "SELECT key FROM test_group0_timeout_bypass")).empty(); ++i) {
+            BOOST_REQUIRE_MESSAGE(i < 600, "stalled entry never applied after polling resumed");
+            co_await seastar::sleep(std::chrono::milliseconds{100});
+        }
+    });
+#endif
+}
+
+// Companion: same stalled add_entry timeout, but with the state id already
+// past the GC window -- ambiguous, so it must be group0_hard_timeout. Pins
+// the other classification branch against a blind timeout->retryable map.
+SEASTAR_TEST_CASE(test_group0_add_entry_timeout_past_gc_window_is_hard_timeout) {
+#ifndef SCYLLA_ENABLE_ERROR_INJECTION
+    std::cerr << "Skipping test as it depends on error injection. Please run in mode where it's enabled (debug,dev).\n";
+    return make_ready_future<>();
+#else
+    return do_with_cql_env([] (cql_test_env& e) -> future<> {
+        auto& rclient = e.get_raft_group0_client();
+        abort_source as;
+
+        schema_builder::register_schema_initializer([](schema_builder& builder) {
+            if (builder.cf_name() == "test_group0_timeout_bypass_gc") {
+                builder.set_is_group0_table();
+            }
+        });
+
+        co_await e.execute_cql("CREATE TABLE test_group0_timeout_bypass_gc (key int PRIMARY KEY)");
+
+        auto guard = co_await rclient.start_operation(as);
+        auto muts = co_await e.get_modification_mutations("INSERT INTO test_group0_timeout_bypass_gc (key) VALUES (1)");
+        service::group0_batch mc(std::move(guard));
+        mc.add_mutation(muts[0]);
+
+        // Make the guard's state id GC-eligible before the commit.
+        auto gc_dur = rclient.get_history_gc_duration();
+        forward_jump_clocks(gc_dur + std::chrono::seconds{1});
+        auto restore_clocks = defer([gc_dur] noexcept { forward_jump_clocks(-(gc_dur + std::chrono::seconds{1})); });
+
+        utils::get_local_injector().enable("poll_fsm_output/pause");
+        auto resume_polling = defer([] noexcept { utils::get_local_injector().disable("poll_fsm_output/pause"); });
+
+        ::service::raft_timeout past_deadline{.value = seastar::lowres_clock::now() - std::chrono::seconds{1}};
+
+        // Bound the test: a fix that retries instead would loop forever here.
+        seastar::timer<seastar::lowres_clock> watchdog([&as] () noexcept { as.request_abort(); });
+        watchdog.arm(std::chrono::minutes{2});
+
+        // Row absent and past the GC window is ambiguous: never a retry.
+        BOOST_CHECK_EXCEPTION(co_await std::move(mc).commit(rclient, as, past_deadline),
+                service::group0_hard_timeout, [] (const service::group0_hard_timeout&) { return true; });
+        watchdog.cancel();
+    });
+#endif
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/boost/group0_voter_calculator_test.cc
+++ b/test/boost/group0_voter_calculator_test.cc
@@ -1110,4 +1110,56 @@ BOOST_AUTO_TEST_CASE(enforces_odd_number_of_voters_for_multiple_dc) {
     BOOST_CHECK_EQUAL(seen_dcs.size(), 3);
 }
 
+
+// Reproducer: the DC-level "no half of the voters" cap has no rack-level
+// equivalent, so one rack can absorb a voter majority. See commit message.
+BOOST_AUTO_TEST_CASE(rack_cannot_have_half_or_more_of_voters) {
+
+    // Arrange: one DC (the DC cap constrains nothing), one large rack and
+    // two single-node racks.
+
+    constexpr size_t max_voters = 5;
+
+    const service::group0_voter_calculator voter_calc{max_voters};
+
+    std::vector<raft::server_id> big_rack_ids;
+    for (int i = 0; i < 10; ++i) {
+        big_rack_ids.push_back(raft::server_id::create_random_id());
+    }
+    const auto small_rack_b_id = raft::server_id::create_random_id();
+    const auto small_rack_c_id = raft::server_id::create_random_id();
+
+    service::group0_voter_calculator::nodes_list_t nodes;
+    for (const auto& id : big_rack_ids) {
+        nodes.emplace(id, service::group0_voter_calculator::node_descriptor{
+                .datacenter = "dc", .rack = "rack-a", .is_voter = is_voter::no, .is_alive = true});
+    }
+    nodes.emplace(small_rack_b_id, service::group0_voter_calculator::node_descriptor{
+            .datacenter = "dc", .rack = "rack-b", .is_voter = is_voter::no, .is_alive = true});
+    nodes.emplace(small_rack_c_id, service::group0_voter_calculator::node_descriptor{
+            .datacenter = "dc", .rack = "rack-c", .is_voter = is_voter::no, .is_alive = true});
+
+    // Act: Distribute the voters.
+
+    const auto& voters = voter_calc.distribute_voters(nodes);
+
+    // Assert: no rack holds >= half the actual voters. Unsatisfiable with 5
+    // voters here, so a correct implementation must reduce the count.
+
+    BOOST_CHECK_LE(voters.size(), max_voters);
+    BOOST_CHECK_GE(voters.size(), 3);
+
+    std::unordered_map<sstring, size_t> voters_per_rack;
+    for (const auto id : voters) {
+        ++voters_per_rack[nodes.at(id).rack];
+    }
+
+    const size_t total = voters.size();
+    for (const auto& [rack, count] : voters_per_rack) {
+        BOOST_CHECK_MESSAGE(2 * count < total,
+                fmt::format("Rack {} has {} of {} voters, i.e. at least half, which the class contract says must "
+                            "not happen when there are 3 or more racks", rack, count, total));
+    }
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/raft/fsm_test.cc
+++ b/test/raft/fsm_test.cc
@@ -128,6 +128,25 @@ BOOST_AUTO_TEST_CASE(test_votes) {
     BOOST_CHECK_EQUAL(votes.tally_votes(), raft::vote_result::WON);
 }
 
+// Reproducer: tally_votes() masks a decisive LOST in the new config as
+// UNKNOWN while the old config is pending. See commit message.
+BOOST_AUTO_TEST_CASE(test_joint_consensus_reports_lost_in_new_config_while_old_pending) {
+    auto id1 = id(), id2 = id(); // new/current config {id1, id2}, majority 2
+    auto id3 = id(), id4 = id(); // previous config {id3, id4}, majority 2
+
+    raft::votes votes(raft::configuration(config_set({id1, id2}), config_set({id3, id4})));
+
+    // A majority of the new config votes "no": decisive LOST for _current.
+    votes.register_vote(id1, false);
+    votes.register_vote(id2, false);
+
+    // Pins ctor argument order: has_responded() consults _current only.
+    BOOST_CHECK(votes.has_responded(id1) && votes.has_responded(id2));
+
+    // The bug: _previous is UNKNOWN and masks _current's decisive LOST.
+    BOOST_CHECK_EQUAL(votes.tally_votes(), raft::vote_result::LOST);
+}
+
 BOOST_AUTO_TEST_CASE(test_tracker) {
     auto id1 = id();
     raft::tracker tracker;
@@ -624,6 +643,67 @@ BOOST_AUTO_TEST_CASE(test_election_two_nodes_prevote) {
     BOOST_CHECK(msg.current_term == term_t{4} && msg.vote_granted);
     // But fsm current term stays the same
     BOOST_CHECK_EQUAL(fsm.get_current_term(), term_t{3});
+}
+
+// Reproducer: maybe_resend_vote_request() stamps a prevote resend with the
+// raw _current_term, one lower than the original. See commit message.
+BOOST_AUTO_TEST_CASE(test_prevote_resend_carries_campaign_term) {
+    server_id A_id = id(), B_id = id();
+    raft::configuration cfg = config_from_ids({A_id, B_id});
+    raft::log log(raft::snapshot_descriptor{.config = cfg});
+
+    fsm_debug A(A_id, term_t{}, server_id{}, std::move(log), trivial_failure_detector, fsm_cfg_pre);
+
+    // A prevote candidate does not bump its real term.
+    election_timeout(A);
+    BOOST_CHECK(A.is_prevote_candidate());
+    BOOST_CHECK_EQUAL(A.get_current_term(), term_t{0});
+
+    // Consume the original prevote request (simulating it being lost).
+    auto output = A.get_output();
+    BOOST_REQUIRE_EQUAL(output.messages.size(), 1);
+    auto original = std::get<raft::vote_request>(output.messages.back().second);
+    BOOST_CHECK(original.is_prevote);
+    BOOST_CHECK_EQUAL(original.current_term, term_t{1});
+
+    // A ping-style append_reply at A's own term triggers the resend path.
+    A.step(B_id, raft::append_reply{term_t{0}, index_t{0},
+            raft::append_reply::rejected{index_t{0}, index_t{0}}});
+
+    output = A.get_output();
+    bool found_resend = false;
+    for (auto& [to, msg] : output.messages) {
+        if (auto* vr = std::get_if<raft::vote_request>(&msg)) {
+            BOOST_CHECK_EQUAL(to, B_id);
+            BOOST_CHECK(vr->is_prevote);
+            // The bug: the resend must carry the original campaign term.
+            BOOST_CHECK_EQUAL(vr->current_term, original.current_term);
+            found_resend = true;
+        }
+    }
+    BOOST_CHECK(found_resend);
+
+    // Control: for a *real* candidate the raw _current_term is the correct
+    // stamp -- guards against a "fix" that adds 1 unconditionally.
+    A.step(B_id, raft::vote_reply{original.current_term, true, true});
+    BOOST_CHECK(A.is_candidate() && !A.is_prevote_candidate());
+    BOOST_CHECK_EQUAL(A.get_current_term(), term_t{1});
+    (void)A.get_output(); // consume the real-vote request
+
+    A.step(B_id, raft::append_reply{term_t{0}, index_t{0},
+            raft::append_reply::rejected{index_t{0}, index_t{0}}});
+
+    output = A.get_output();
+    found_resend = false;
+    for (auto& [to, msg] : output.messages) {
+        if (auto* vr = std::get_if<raft::vote_request>(&msg)) {
+            BOOST_CHECK_EQUAL(to, B_id);
+            BOOST_CHECK(!vr->is_prevote);
+            BOOST_CHECK_EQUAL(vr->current_term, term_t{1});
+            found_resend = true;
+        }
+    }
+    BOOST_CHECK(found_resend);
 }
 
 BOOST_AUTO_TEST_CASE(test_election_four_nodes_prevote) {

--- a/test/raft/raft_server_test.cc
+++ b/test/raft/raft_server_test.cc
@@ -5,6 +5,7 @@
 #include "test/lib/error_injection.hh"
 #include <seastar/util/defer.hh>
 #include <seastar/core/when_all.hh>
+#include <seastar/core/with_timeout.hh>
 
 #ifdef SEASTAR_DEBUG
 // Increase tick time to allow debug to process messages
@@ -589,4 +590,45 @@ SEASTAR_THREAD_TEST_CASE(test_add_entry_preserves_submission_order) {
     for (int v = 0; v < n; ++v) {
         BOOST_REQUIRE_EQUAL((*applied)[v], v);
     }
+}
+
+// Reproducer: abort() fails every other pending waiter but never touches
+// _stepdown_promise, leaving stepdown()'s future unresolved forever.
+SEASTAR_THREAD_TEST_CASE(test_abort_resolves_pending_stepdown) {
+    auto cluster = get_default_cluster(test_case{ .nodes = 2 });
+    cluster.start_all().get();
+    // The is_alive() guard avoids double-aborting node 0 on the happy path
+    // while still stopping it if an assertion unwinds before the stop below.
+    auto stop = defer([&cluster] noexcept {
+        if (cluster.get_server(0).is_alive()) {
+            cluster.stop_server(0).get();
+        }
+        cluster.stop_server(1).get();
+    });
+
+    auto& leader = cluster.get_server(0);
+    BOOST_REQUIRE(leader.is_leader());
+
+    // No ticks and no timeout_now delivery: the transfer can neither
+    // complete nor time out, so node 0 deterministically stays leader.
+    cluster.pause_tickers();
+    cluster.block_receive(1, 0);
+
+    auto stepdown_fut = leader.stepdown(raft::logical_clock::duration{1000});
+
+    // Park the io_fiber while node 0 is still leader: a woken one would run
+    // process_fsm_output() once more and resolve the promise with success.
+    // Two sleeps: a starved reactor could defer the wake-up past one window.
+    seastar::sleep(50ms).get();
+    seastar::sleep(50ms).get();
+    BOOST_REQUIRE(leader.is_leader());
+
+    cluster.stop_server(0, "test abort during stepdown").get();
+
+    // The bug: stepdown_fut is left unresolved; bound the wait.
+    auto bounded = with_timeout(std::chrono::steady_clock::now() + 5s, std::move(stepdown_fut));
+    BOOST_CHECK_EXCEPTION(bounded.get(), raft::stopped_error,
+            [] (const raft::stopped_error& e) {
+        return sstring(e.what()) == sstring("Raft instance is stopped, reason: \"test abort during stepdown\"");
+    });
 }


### PR DESCRIPTION
## Summary

This is a **bug-hunting series**, not a ready-to-merge fix set. It contains 5 commits: 4 add a standalone reproduction test for a distinct bug found while auditing the raft/group0 code paths (no fix yet), and 1 adds both a reproduction test and its fix, squashed together.

**Do not merge.** The reproducer-only commits are here so the bugs are documented and reproducible while proper fixes are designed and reviewed; each will get its own dedicated PR once fixed.

## Why 4 reproducers with no fix?

Each of the 4 fix-less bugs needs a design decision beyond "patch the one broken line," so a fix wasn't rushed just to close them out here:

- **Rack-level voter majority** needs a real bound in `rack_info::has_more_candidates()` analogous to the existing per-DC cap, not just a tweak to the round-robin order.
- **`group0_state_machine_merger` size leak** needs to decide where `_size` should be reset (end of `merge()`? per top-level `apply()` call?) without breaking the merge-across-flushes behavior it's there for.
- **`stepdown()` promise leak** touches the `abort()` / `fsm::stop()` / `io_fiber` shutdown sequence, which is easy to get wrong in ways that reintroduce a hang or a double-resolve.
- **Vote-tallying liveness bugs** are two independent issues in `tally_votes()` and `maybe_resend_vote_request()`; each fix needs to be checked against the config-change and pre-vote protocols so it doesn't trade a liveness bug for a safety one.

## Commits

1. **`test: raft: reproduce two liveness bugs in vote tallying`**
   `votes::tally_votes()` only consults the new/current config's tally once the old config resolves to `WON`, so a decisive `LOST` in the new config is masked while the old config is still `UNKNOWN`. Separately, `fsm::maybe_resend_vote_request()` resends at `_current_term` unconditionally, which is one term stale for a pre-vote candidate (whose `_current_term` never bumps), so peers who already voted this term wrongly reject the resent pre-vote. Both are liveness-only (delayed election), not safety violations.

2. **`test: raft: reproduce stepdown() promise leak on abort()`**
   `server_impl::stepdown()`'s `_stepdown_promise` is only resolved from `process_fsm_output` on specific branches. `abort()` resolves every other pending waiter with `stopped_error` but never touches `_stepdown_promise`, and its call to `fsm::stop()` plus `_events.broken()` means `io_fiber` exits without a final `process_fsm_output()` that could resolve it. A `stepdown()` in flight when `abort()` runs hangs forever instead of failing.

3. **`test: raft: reproduce group0_state_machine_merger size leak across flushes`**
   `group0_state_machine_merger::merge()` clears `_cmd_to_merge` and `_merged_history_mutation` but never resets `_size`. Since one merger instance is reused across every flush within a single `group0_state_machine::apply()` call, `_size` accumulates for the whole call; once it exceeds `_max_command_size`, `can_merge()` permanently rejects merging into any later batch in that call — defeating the merger for the large-backlog case it exists for.

4. **`test: raft: reproduce rack-level voter majority violation`**
   `group0_voter_calculator`'s invariant is that no single DC or rack holds ≥half of group0's voters with 3+ DCs/racks. The DC level enforces this with a hard cap, but `rack_info::has_more_candidates()` has no equivalent bound — once smaller racks in a DC run out of candidates, the remaining rack absorbs every further pick. Racks sized 10/1/1 with `voters_max=5` assign the big rack 3 of 5 voters, a strict majority; losing that one rack costs group0 its quorum.

5. **`raft: fix and test group0 add_entry timeout bypassing classification`** (fix + test, squashed)
   `raft_group0_client::add_entry()` only caught `raft::dropped_entry`, `raft::commit_status_unknown`, and `raft::not_a_leader` before falling through to `group0_history_contains()` classification (retryable `group0_concurrent_modification` vs. terminal `group0_hard_timeout`). But `run_with_timeout()` reclassifies its own internal per-operation-deadline `raft::request_aborted` into a bare `raft_operation_timeout_error`, a type `add_entry`'s catches didn't match — so it escaped classification entirely, and since CQL's DDL retry loop only catches `group0_concurrent_modification`, a stalled-leader timeout on virtually any group0 write surfaced as an opaque error instead of a proper retry-or-fail signal. Fix: catch `raft_operation_timeout_error` alongside the other raft-layer errors and fall through to the existing classification. Verified: `test.py --mode=dev test/boost/group0_test.cc` — 11/11 passed.

## Test plan

- [x] Full clean build under `dbuild` (`ninja -j4 build/dev/test/boost/combined_tests`)
- [x] `./tools/toolchain/dbuild ./test.py --mode=dev test/boost/group0_test.cc` — 11 passed
- [ ] Fixes for the 4 reproducer-only bugs, each in its own follow-up PR