### PR TITLE
groundwork for pluggable storage formats

### DIFF
--- a/cql3/statements/select_statement.cc
+++ b/cql3/statements/select_statement.cc
@@ -219,6 +219,10 @@ select_statement::select_statement(schema_ptr schema,
 {
     _opts = _selection->get_query_options();
     _opts.set_if<query::partition_slice::option::bypass_cache>(_parameters->bypass_cache());
+    // may_project_columns is deliberately NOT set here. It would travel to replicas in the read
+    // command, and enum_set::from_mask() *throws* on a bit it does not know -- so during a rolling
+    // upgrade a new coordinator would break every `SELECT ... BYPASS CACHE` on an old replica. The
+    // permission is derived replica-side instead, in table::query(); see the note there.
     _opts.set_if<query::partition_slice::option::distinct>(_parameters->is_distinct());
     _opts.set_if<query::partition_slice::option::reversed>(_is_reversed);
     detect_range_scan();

--- a/db/schema_tables.cc
+++ b/db/schema_tables.cc
@@ -322,6 +322,8 @@ schema_ptr scylla_tables(schema_features features) {
         sb.with_column("tablets", map_type_impl::get_instance(utf8_type, utf8_type, false));
 
         sb.with_column("storage_engine", utf8_type);
+        sb.with_column("storage_format", utf8_type);
+        sb.with_column("parquet", map_type_impl::get_instance(utf8_type, utf8_type, false));
         sb.with_column("large_data_guardrails_enabled", boolean_type);
 
         sb.with_hash_version();
@@ -1693,6 +1695,26 @@ mutation make_scylla_tables_mutation(schema_ptr table, api::timestamp_type times
     if (table->logstor_enabled()) {
         m.set_clustered_cell(ckey, "storage_engine", "logstor", timestamp);
     }
+    // Written whenever the property was explicitly set -- including when it was
+    // set back to 'sstable', so that reverting actually takes effect rather than
+    // leaving the previous value in place. A table that never mentioned the
+    // property writes no cell at all, so existing schemas keep their digest.
+    // Same shape as the `tablets` column above, and the property can only be set
+    // once PARQUET_SSTABLE_FORMAT is enabled (see cf_prop_defs::validate).
+    if (!table->parquet_options().empty()) {
+        store_map(m, ckey, "parquet", timestamp, table->parquet_options());
+    } else if (table->has_storage_format()) {
+        // Clearing the options must actually clear them: without a tombstone the
+        // previously-stored collection survives and is restored on reload. Same
+        // shape as the `tablets` column above. Gated on has_storage_format() so a
+        // table that never used the feature keeps writing no cell at all.
+        auto& cdef = *scylla_tables()->get_column_definition("parquet");
+        m.set_clustered_cell(ckey, cdef, atomic_cell::make_dead(timestamp, gc_clock::now()));
+    }
+    if (table->has_storage_format()) {
+        m.set_clustered_cell(ckey, "storage_format",
+                storage_format_type_to_sstring(table->storage_format()), timestamp);
+    }
     // Write the large_data_guardrails_enabled column only when enabled.
     // When disabled (the default), omit the cell entirely so that old nodes
     // that don't know this column can still read the SSTable during rolling
@@ -2211,6 +2233,12 @@ static void prepare_builder_from_scylla_tables_row(const schema_ctxt& ctxt, sche
     if (auto opt_map = get_map<sstring, sstring>(table_row, "tablets")) {
         auto tablet_options = db::tablet_options(*opt_map);
         builder.set_tablet_options(tablet_options.to_map());
+    }
+    if (auto map = get_map<sstring, sstring>(table_row, "parquet")) {
+        builder.set_parquet_options(*map);
+    }
+    if (auto storage_format = table_row.get<sstring>("storage_format")) {
+        builder.set_storage_format(sstring_to_storage_format_type(*storage_format));
     }
     if (auto storage_engine = table_row.get<sstring>("storage_engine")) {
         if (*storage_engine == "logstor") {

--- a/gms/feature_service.hh
+++ b/gms/feature_service.hh
@@ -160,6 +160,7 @@ public:
     gms::feature tablet_options { *this, "TABLET_OPTIONS"sv };
     gms::feature tablet_load_stats_v2 { *this, "TABLET_LOAD_STATS_V2"sv };
     gms::feature sstable_compression_dicts { *this, "SSTABLE_COMPRESSION_DICTS"sv };
+    gms::feature parquet_sstable_format { *this, "PARQUET_SSTABLE_FORMAT"sv };
     gms::feature repair_based_tablet_rebuild { *this, "REPAIR_BASED_TABLET_REBUILD"sv };
     gms::feature enforced_raft_rpc_scheduling_group { *this, "ENFORCED_RAFT_RPC_SCHEDULING_GROUP"sv };
     gms::feature load_and_stream_abort_rpc_message { *this, "LOAD_AND_STREAM_ABORT_RPC_MESSAGE"sv };

--- a/query/query-request.hh
+++ b/query/query-request.hh
@@ -209,6 +209,18 @@ public:
         // timestamps and expiries to support WRITETIME(col[key])/TTL(col[key])
         // and WRITETIME(col.field)/TTL(col.field) selectors.
         send_collection_timestamps,
+        // The consumer of this read projects to `regular_columns` itself, so a storage engine that
+        // can cheaply skip the other columns is permitted to.
+        //
+        // Deliberately *not* implied by bypass_cache, which is what it looks like it should be.
+        // bypass_cache means "do not use the row cache" and is set by
+        // table::stream_view_replica_updates() and replica/mutation_dump.cc as well as by a client
+        // `BYPASS CACHE` -- and a view update computed from a partially-read base row produces wrong
+        // view rows. The two questions are unrelated, so they get separate flags.
+        //
+        // Storage engines are free to ignore it; the row format does, reading every regular column
+        // and projecting afterwards.
+        may_project_columns,
     };
     using option_set = enum_set<super_enum<option,
         option::send_clustering_key,
@@ -225,7 +237,8 @@ public:
         option::always_return_static_content,
         option::range_scan_data_variant,
         option::allow_mutation_read_page_without_live_row,
-        option::send_collection_timestamps>>;
+        option::send_collection_timestamps,
+        option::may_project_columns>>;
     clustering_row_ranges _row_ranges;
 public:
     column_id_vector static_columns; // TODO: consider using bitmap

--- a/schema/schema.cc
+++ b/schema/schema.cc
@@ -609,6 +609,8 @@ bool operator==(const schema::user_properties& lhs, const schema::user_propertie
         && lhs.compaction_strategy_options == rhs.compaction_strategy_options
         && lhs.compaction_enabled == rhs.compaction_enabled
         && lhs.storage_engine == rhs.storage_engine
+        && lhs.storage_format == rhs.storage_format
+        && lhs.parquet_options == rhs.parquet_options
         && lhs.caching_options == rhs.caching_options
         && lhs.tablet_options == rhs.tablet_options
         && lhs.get_paxos_grace_seconds() == rhs.get_paxos_grace_seconds()
@@ -716,6 +718,8 @@ table_schema_version schema::calculate_digest(const schema::raw_schema& r) {
     feed_hash(h, r._indices_by_name);
     feed_hash(h, r._is_counter);
     feed_hash(h, r._props.storage_engine);
+    feed_hash(h, r._props.storage_format);
+    feed_hash(h, r._props.parquet_options);
 
     for (auto&& [name, ext] : r._props.extensions) {
         feed_hash(h, name);
@@ -906,6 +910,9 @@ auto fmt::formatter<schema>::format(const schema& s, fmt::format_context& ctx) c
     out = fmt::format_to(out, ",minIndexInterval={}", s._raw._props.min_index_interval);
     out = fmt::format_to(out, ",maxIndexInterval={}", s._raw._props.max_index_interval);
     out = fmt::format_to(out, ",speculativeRetry={}", s._raw._props.speculative_retry.to_sstring());
+    if (s.has_storage_format() && s.storage_format() != storage_format_type::sstable) {
+        out = fmt::format_to(out, ",storage_format={}", storage_format_type_to_sstring(s.storage_format()));
+    }
     if (s.storage_engine() != storage_engine_type::normal) {
         out = fmt::format_to(out, ",storage_engine={}", storage_engine_type_to_sstring(s.storage_engine()));
     }
@@ -1253,8 +1260,28 @@ fragmented_ostringstream& schema::schema_properties(const schema_describe_helper
     os << "\n    AND memtable_flush_period_in_ms = " << fmt::to_string(memtable_flush_period());
     os << "\n    AND min_index_interval = " << fmt::to_string(min_index_interval());
     os << "\n    AND speculative_retry = '" << speculative_retry().to_sstring() << "'";
+    // Emitted unconditionally, including at the 'sstable' default. Every other property in this
+    // function prints at its default too -- bloom_filter_fp_chance = 0.01, default_time_to_live = 0,
+    // crc_check_chance = 1 -- so suppressing only this one made storage_format the single property
+    // whose absence was ambiguous: a table described without it could be an explicit 'sstable', or
+    // a server that does not know the property at all. Since which storage format a table uses is
+    // the whole subject of this feature, that is the last property that should be guessed at.
+    // has_storage_format() still gates it, so a table predating the feature prints nothing.
+    if (has_storage_format()) {
+        os << "\n    AND storage_format = '" << storage_format_type_to_sstring(storage_format()) << "'";
+    }
     if (storage_engine() != storage_engine_type::normal) {
         os << "\n    AND storage_engine = '" << storage_engine_type_to_sstring(storage_engine()) << "'";
+    }
+    // Emitted verbatim rather than through parquet_parameters::to_map(). The stored map is what the
+    // user wrote and was already validated at CREATE/ALTER time, so echoing it keeps DESCRIBE
+    // reproducible without pulling the sstables writer into schema.cc. Without this the per-column
+    // `encoding.<col>` settings -- and every other parquet sub-option -- were absent from DESCRIBE,
+    // so a table recreated from its own description silently lost them.
+    if (!parquet_options().empty()) {
+        os << "\n    AND parquet = {";
+        map_as_cql_param(os, parquet_options());
+        os << "}";
     }
 
     if (has_tablet_options()) {

--- a/schema/schema.hh
+++ b/schema/schema.hh
@@ -181,6 +181,32 @@ enum class storage_engine_type {
     logstor,
 };
 
+// Encoding of the SSTable Data component: how a table's rows are laid out on
+// disk. A property of the table, never of a tablet -- see
+// docs/dev/parquet-storage-format.md section 6.1.
+enum class storage_format_type {
+    sstable,    // the native row format (default)
+    parquet,    // columnar, every SSTable
+    hybrid,     // native in the upper LSM tiers, columnar in the bottom tier
+};
+
+inline sstring storage_format_type_to_sstring(storage_format_type t) {
+    switch (t) {
+    case storage_format_type::sstable: return "sstable";
+    case storage_format_type::parquet: return "parquet";
+    case storage_format_type::hybrid:  return "hybrid";
+    }
+    throw std::invalid_argument(format("unknown storage format type: {:d}\n", uint8_t(t)));
+}
+
+inline storage_format_type sstring_to_storage_format_type(std::string_view s) {
+    if (s == "sstable") { return storage_format_type::sstable; }
+    if (s == "parquet") { return storage_format_type::parquet; }
+    if (s == "hybrid")  { return storage_format_type::hybrid; }
+    throw std::invalid_argument(format("unknown storage format '{}' "
+        "(expected one of: sstable, parquet, hybrid)", s));
+}
+
 inline sstring storage_engine_type_to_sstring(storage_engine_type t) {
     switch (t) {
     case storage_engine_type::normal:
@@ -547,8 +573,18 @@ public:
         // This is the compaction strategy that will be used by default on tables which don't have one explicitly specified.
         compaction::compaction_strategy_type compaction_strategy = compaction::compaction_strategy_type::incremental;
         std::map<sstring, sstring> compaction_strategy_options;
+        // The validated `parquet = {...}` property. Held as the raw map rather than a
+        // parquet_parameters so that schema does not have to depend on the sstable
+        // layer above it; validation already happened at CREATE/ALTER time, and the
+        // writer reconstitutes the object from this.
+        std::map<sstring, sstring> parquet_options;
         bool compaction_enabled = true;
         storage_engine_type storage_engine = storage_engine_type::normal;
+        // Unset means the user never mentioned the property. That is distinct
+        // from explicitly choosing 'sstable', and the difference matters: a
+        // table that never opted in must not gain a schema cell, or every
+        // existing table's digest changes on upgrade. Mirrors tablet_options.
+        std::optional<storage_format_type> storage_format;
         ::caching_options caching_options;
         std::optional<std::map<sstring, sstring>> tablet_options;
 
@@ -765,6 +801,21 @@ public:
         return _raw._props.compaction_enabled;
     }
 
+    storage_format_type storage_format() const {
+        return _raw._props.storage_format.value_or(storage_format_type::sstable);
+    }
+    // True only if the property was explicitly set, which is what decides whether
+    // a schema cell is written at all.
+    bool has_storage_format() const {
+        return _raw._props.storage_format.has_value();
+    }
+    const std::map<sstring, sstring>& parquet_options() const {
+        return _raw._props.parquet_options;
+    }
+    // True when any SSTable of this table may be Parquet-encoded.
+    bool uses_parquet_format() const {
+        return storage_format() != storage_format_type::sstable;
+    }
     storage_engine_type storage_engine() const {
         return _raw._props.storage_engine;
     }

--- a/schema/schema_builder.hh
+++ b/schema/schema_builder.hh
@@ -279,6 +279,16 @@ public:
         enable_schema_commitlog();
     }
 
+    schema_builder& set_parquet_options(std::map<sstring, sstring> opts) {
+        _raw._props.parquet_options = std::move(opts);
+        return *this;
+    }
+
+    schema_builder& set_storage_format(storage_format_type t) {
+        _raw._props.storage_format = t;
+        return *this;
+    }
+
     schema_builder& set_logstor() {
         _raw._props.storage_engine = storage_engine_type::logstor;
         return *this;

--- a/sstables/mx/writer.cc
+++ b/sstables/mx/writer.cc
@@ -381,6 +381,14 @@ struct sstable_schema {
 };
 
 static
+sstable_schema make_sstable_schema(const schema& s, const encoding_stats& enc_stats, const sstable_writer_config& cfg);
+
+serialization_header make_serialization_header(const schema& s, const encoding_stats& enc_stats,
+        const sstable_writer_config& cfg) {
+    return make_sstable_schema(s, enc_stats, cfg).header;
+}
+
+static
 sstable_schema make_sstable_schema(const schema& s, const encoding_stats& enc_stats, const sstable_writer_config& cfg) {
     sstable_schema sst_sch;
     serialization_header& header = sst_sch.header;

--- a/sstables/mx/writer.hh
+++ b/sstables/mx/writer.hh
@@ -15,6 +15,15 @@
 namespace sstables {
 namespace mc {
 
+// The mc serialization header for a schema. Exposed because `pq` needs it too:
+// it writes mc-shaped index entries, and the index *parser* decides between the
+// mc and legacy layouts by asking whether the column translation -- which comes
+// from this header -- is empty. Without it a pq index parses as ka/la and every
+// lookup misses.
+serialization_header make_serialization_header(const schema& s,
+    const encoding_stats& enc_stats,
+    const sstable_writer_config& cfg);
+
 std::unique_ptr<sstable_writer::writer_impl> make_writer(sstable& sst,
     const schema& s,
     uint64_t estimated_partitions,

--- a/sstables/sstable_set.cc
+++ b/sstables/sstable_set.cc
@@ -89,6 +89,10 @@ uint64_t sstable_run::data_size() const {
     return std::ranges::fold_left(_all | std::views::transform(std::mem_fn(&sstable::data_size)), uint64_t(0), std::plus{});
 }
 
+uint64_t sstable_run::ondisk_data_size() const {
+    return std::ranges::fold_left(_all | std::views::transform(std::mem_fn(&sstable::ondisk_data_size)), uint64_t(0), std::plus{});
+}
+
 double sstable_run::estimate_droppable_tombstone_ratio(const gc_clock::time_point& compaction_time, const tombstone_gc_state& gc_state, const schema_ptr& s) const {
     auto estimate_sum = std::ranges::fold_left(_all | std::views::transform(std::bind(&sstable::estimate_droppable_tombstone_ratio, std::placeholders::_1, compaction_time, gc_state, s)), double(0), std::plus{});
     return _all.size() ? estimate_sum / _all.size() : double(0);

--- a/sstables/sstable_set.hh
+++ b/sstables/sstable_set.hh
@@ -54,6 +54,10 @@ public:
     }
     // Data size of the whole run, meaning it's a sum of the data size of all its fragments.
     uint64_t data_size() const;
+    // Same, but the bytes actually occupied on disk. The two differ by the compression ratio for a
+    // compressed native sstable and not at all for a `pq` one, so this is the only one of the two
+    // that is comparable across a run holding both formats.
+    uint64_t ondisk_data_size() const;
     const sstable_set& all() const { return _all; }
     double estimate_droppable_tombstone_ratio(const gc_clock::time_point& compaction_time, const tombstone_gc_state& gc_state, const schema_ptr& s) const;
     run_id run_identifier() const;

--- a/test/boost/schema_changes_test.cc
+++ b/test/boost/schema_changes_test.cc
@@ -91,3 +91,34 @@ SEASTAR_TEST_CASE(test_schema_changes_ms) {
 SEASTAR_TEST_CASE(test_schema_changes_mt) {
     return test_schema_changes_int(sstable_version_types::mt);
 }
+
+// Changing only a parquet option must change both schema equality and the digest.
+// user_properties::operator== and calculate_digest once covered storage_format but
+// not parquet_options, so an options-only ALTER compared equal and hashed the same.
+//
+// Both halves need care to actually reach the code under test, and the first
+// version of this test reached neither: schemas built without an explicit id
+// differ at the _id clause before properties are compared, and the default
+// version mode is a time UUID, which differs on every build whatever the digest
+// does. Hence the shared table_id and with_hash_version().
+SEASTAR_THREAD_TEST_CASE(test_parquet_options_affect_schema_equality_and_digest) {
+    const auto id = table_id(utils::UUID_gen::get_time_UUID());
+    auto make = [&] (const char* rows) {
+        return schema_builder(1, "ks", "parquet_options_digest", id)
+            .with_column("pk", int32_type, column_kind::partition_key)
+            .with_column("v", int32_type)
+            .set_storage_format(storage_format_type::parquet)
+            .set_parquet_options({{"rows_per_row_group", rows}})
+            .with_hash_version()
+            .build();
+    };
+    auto s1 = make("5000");
+    auto s2 = make("9000");
+    // The version is the digest here, so this is digest coverage.
+    BOOST_REQUIRE(s1->version() != s2->version());
+
+    // Same id, same (pinned) version: only the options differ, so this is
+    // equality coverage.
+    auto s2_pinned = schema_builder(s2).with_version(s1->version()).build();
+    BOOST_REQUIRE(!(*s1 == *s2_pinned));
+}

--- a/test/lib/index_reader_assertions.hh
+++ b/test/lib/index_reader_assertions.hh
@@ -46,9 +46,20 @@ public:
           }
 
           if (auto* r = dynamic_cast<sstables::index_reader*>(_r.get())) {
+            // A null cursor means this partition has no promoted index, which is a
+            // normal return -- index_reader itself handles it that way. It happens
+            // for partitions too small to earn one, and always for `pq`, whose
+            // writer emits a zero-size promoted index because Parquet's ColumnIndex
+            // already provides intra-partition seeking. There is nothing to check,
+            // and dereferencing it here used to segfault, taking down every case
+            // after this one in the same binary.
             sstables::clustered_index_cursor* cur = r->current_clustered_cursor();
             std::optional<sstables::promoted_index_block_position> prev_end;
-            while (auto ei_opt = cur->next_entry().get()) {
+            while (cur) {
+                auto ei_opt = cur->next_entry().get();
+                if (!ei_opt) {
+                    break;
+                }
                 sstables::clustered_index_cursor::entry_info& ei = *ei_opt;
                 if (prev_end && pos_cmp(ei.start, sstables::to_view(*prev_end))) {
                     BOOST_FAIL(seastar::format("Index blocks are not monotonic: {} > {}", *prev_end, ei.start));

--- a/test/lib/sstable_utils.cc
+++ b/test/lib/sstable_utils.cc
@@ -77,14 +77,30 @@ future<sstables::shared_sstable> make_sstable_containing(sstables::shared_sstabl
 
         // validate the sstable
         auto rd = sst->as_mutation_source().make_mutation_reader(s, sem.make_tracking_only_permit(nullptr, "test", db::no_timeout, {}));
-        for (auto&& m : merged) {
-            auto mo = co_await read_mutation_from_mutation_reader(rd);
-            BOOST_REQUIRE(mo);
-            assert_that(*mo).is_equal_to_compacted(m);
-            co_await coroutine::maybe_yield();
+        // The comparison below fails by *throwing* -- BOOST_REQUIRE and BOOST_FAIL both abort that
+        // way -- and until 2026-08-21 that exception unwound straight past `rd.close()`. The reader's
+        // permit was then destroyed unclosed, which seastar treats as fatal, so every validation
+        // mismatch killed the process with "permit ... was not closed before destruction" on top of
+        // a hundred-line backtrace, burying the assertion that had actually failed and stopping the
+        // test case at the first failing fixture. Closing on the exception path instead lets the
+        // mismatch propagate as an ordinary Boost failure, which is what a caller iterating over
+        // fixtures needs in order to report *which* of them failed rather than only the first.
+        std::exception_ptr ex;
+        try {
+            for (auto&& m : merged) {
+                auto mo = co_await read_mutation_from_mutation_reader(rd);
+                BOOST_REQUIRE(mo);
+                assert_that(*mo).is_equal_to_compacted(m);
+                co_await coroutine::maybe_yield();
+            }
+        } catch (...) {
+            ex = std::current_exception();
         }
         co_await rd.close();
         co_await sem.stop();
+        if (ex) {
+            std::rethrow_exception(ex);
+        }
     }
     co_return sst;
 }


### PR DESCRIPTION
Part 2/5 of the parquet storage format series (#31556); stacked on part 1.

Groundwork with no behavior change:

* a `storage_format` table property (`sstable` | `parquet` | `hybrid`) with a
  format-options extension map, persisted in the schema tables and gated on a
  cluster feature - nothing consumes it yet. Unset is distinct from an explicit
  'sstable': a table that never opted in gains no schema cell, so existing
  tables' schema digests do not move on upgrade;
* a `may_project_columns` partition-slice option declaring that the consumer
  discards columns outside the slice, so a storage engine may skip reading
  them. Never sent on the wire (an unknown enum-set bit throws on an older
  replica); a replica derives it locally in part 4. The row format ignores it;
* mx serialization-header construction exposed for reuse, and
  `sstable_run::ondisk_data_size()`;
* test-lib hardening for sstable formats without an index component - two cases
  where one test failure turned into a process death that hid the assertion.

Testing: schema equality and digest coverage for the new property and options map
(an options-only ALTER must change both); the DDL surface, the feature-gate
enforcement and the persistence round-trip are exercised by part 4's suites, where
the consumers land.

---
The stack: #31330 (fixes) → #31331 (groundwork) → #31332 (parquet) → #31333 (hooks) → #31334 (docs). Tracking: #31556.
