### PR TITLE
repair: Reduce log verbosity for tablet repair

### DIFF
--- a/repair/repair.cc
+++ b/repair/repair.cc
@@ -497,7 +497,7 @@ future<std::tuple<bool, bool, gc_clock::time_point>> repair_service::flush_hints
                 co_return std::make_tuple(needs_flush_before_repair, hints_batchlog_flushed, flush_time);
             }
             co_await parallel_for_each(waiting_nodes, [this, uuid, start_time, &times, &req] (locator::host_id node) -> future<> {
-                rlogger.info("repair[{}]: Sending repair_flush_hints_batchlog to node={}, started",
+                rlogger.debug("repair[{}]: Sending repair_flush_hints_batchlog to node={}, started",
                         uuid, node);
                 try {
                     auto& ms = get_messaging();
@@ -521,12 +521,12 @@ future<std::tuple<bool, bool, gc_clock::time_point>> repair_service::flush_hints
             }
             hints_batchlog_flushed = true;
             auto duration = std::chrono::duration<float>(gc_clock::now() - start_time);
-            rlogger.info("repair[{}]: Finished repair_flush_hints_batchlog flush_times={} flush_time={} flush_duration={}", uuid, times, flush_time, duration);
+            rlogger.debug("repair[{}]: Finished repair_flush_hints_batchlog flush_times={} flush_time={} flush_duration={}", uuid, times, flush_time, duration);
         } catch (...) {
             rlogger.warn("repair[{}]: Sending repair_flush_hints_batchlog failed, continue to run repair", uuid);
         }
     } else {
-        rlogger.info("repair[{}]: Skipped sending repair_flush_hints_batchlog", uuid);
+        rlogger.debug("repair[{}]: Skipped sending repair_flush_hints_batchlog", uuid);
     }
     co_return std::make_tuple(needs_flush_before_repair, hints_batchlog_flushed, flush_time);
 }

--- a/repair/row_level.cc
+++ b/repair/row_level.cc
@@ -2672,7 +2672,7 @@ future<repair_flush_hints_batchlog_response> repair_service::repair_flush_hints_
             return rs.repair_flush_hints_batchlog_handler(from, std::move(req));
         });
     }
-    rlogger.info("repair[{}]: Started to process repair_flush_hints_batchlog_request from node={} hints_timeout={}s batchlog_timeout={}s",
+    rlogger.debug("repair[{}]: Started to process repair_flush_hints_batchlog_request from node={} hints_timeout={}s batchlog_timeout={}s",
             req.repair_uuid, from, req.hints_timeout.count(), req.batchlog_timeout.count());
     auto permit = co_await seastar::get_units(_flush_hints_batchlog_sem, 1);
     bool updated = false;
@@ -2742,7 +2742,11 @@ future<repair_flush_hints_batchlog_response> repair_service::repair_flush_hints_
         updated = true;
     }
     auto duration = std::chrono::duration<float>(gc_clock::now() - now);
-    rlogger.info("repair[{}]: Finished to process repair_flush_hints_batchlog_request from node={} updated={} flush_hints_batchlog_time={} flush_cache_time={} flush_duration={}",
+    // Log at info level only when a flush was actually performed, which is
+    // bounded by the flush cache time. The cache hit path is logged at debug
+    // level since it is performed for each tablet repair and can flood the log.
+    auto level = updated ? seastar::log_level::info : seastar::log_level::debug;
+    rlogger.log(level, "repair[{}]: Finished to process repair_flush_hints_batchlog_request from node={} updated={} flush_hints_batchlog_time={} flush_cache_time={} flush_duration={}",
             req.repair_uuid, from, updated, _flush_hints_batchlog_time, cache_time, duration);
     repair_flush_hints_batchlog_response resp{ .flush_time = _flush_hints_batchlog_time };
     co_return resp;
@@ -2954,7 +2958,7 @@ future<> repair_service::init_ms_handlers() {
             auto range = tmap.get_token_range(gid.tablet);
             co_await table.clear_being_repaired_for_range(range);
             auto removed = local_repair._repair_compaction_locks.erase(gid);
-            rlogger.info("Got repair_update_compaction_ctrl gid={} session_id={} removed={}", gid, topo_guard, removed);
+            rlogger.debug("Got repair_update_compaction_ctrl gid={} session_id={} removed={}", gid, topo_guard, removed);
         });
     });
 


### PR DESCRIPTION
During tablet repair, two groups of info level messages flood the log and overload the journal, causing message suppression:

- "Got repair_update_compaction_ctrl": the handler runs on all shards via invoke_on_all and logs on each of them, and the RPC is sent once per migrating tablet. With O(nr_shards) migrating tablets this prints O(nr_shards^2) messages.

- "Started/Finished to process repair_flush_hints_batchlog_request": tablet repair calls flush_hints once per tablet and sends the request to all nodes, so each node logs O(nr_tablets x nr_nodes) messages. The same holds for the sender side messages "Sending repair_flush_hints_batchlog", "Finished repair_flush_hints_batchlog" and "Skipped sending repair_flush_hints_batchlog".

Demote those per-shard and per-request messages to debug level. The messages that report an actual hints or batchlog flush are kept at info level, since the flush cache (repair_hints_batchlog_flush_cache_time_in_ms, 60s by default) bounds how often they can be printed. The "Finished to process" message on the handler side is kept at info level only when a flush was actually performed, so the resulting flush time remains visible in the log.

Fixes https://scylladb.atlassian.net/browse/SCYLLADB-3968

Improvement. No backport. 