### PR TITLE
sstables: track reclaimed sstables by identity, not by filter size

### DIFF
--- a/sstables/sstables_manager.cc
+++ b/sstables/sstables_manager.cc
@@ -423,8 +423,14 @@ void sstables_manager::reclaim_memory_and_stop_tracking_sstable(sstable* sst) {
     // reclaim any remaining memory from the sstable
     sst->reclaim_memory_from_components();
     // disable further reload of components
-    _reclaimed.erase(*sst);
+    erase_from_reclaimed(sst);
     sst->disable_component_memory_reload();
+}
+
+void sstables_manager::erase_from_reclaimed(sstable* sst) noexcept {
+    if (sst->_manager_set_link.is_linked()) {
+        _reclaimed.erase(_reclaimed.iterator_to(*sst));
+    }
 }
 
 void sstables_manager::add(sstable* sst) {

--- a/sstables/sstables_manager.hh
+++ b/sstables/sstables_manager.hh
@@ -27,6 +27,7 @@
 #include "reader_concurrency_semaphore.hh"
 #include "utils/s3/creds.hh"
 #include <boost/intrusive/list.hpp>
+#include <boost/intrusive/set.hpp>
 #include "sstable_compressor_factory.hh"
 #include "sstables/sstables_manager_subscription.hh"
 
@@ -130,7 +131,7 @@ class sstables_manager {
     using list_type = boost::intrusive::list<sstable,
             boost::intrusive::member_hook<sstable, sstable::manager_list_link_type, &sstable::_manager_list_link>,
             boost::intrusive::constant_time_size<false>>;
-    using set_type = boost::intrusive::set<sstable,
+    using set_type = boost::intrusive::multiset<sstable,
             boost::intrusive::member_hook<sstable, sstable::manager_set_link_type, &sstable::_manager_set_link>,
             boost::intrusive::constant_time_size<false>,
             boost::intrusive::compare<sstable::lesser_reclaimed_memory>>;
@@ -358,6 +359,9 @@ private:
     // The method is idempotent and for an sstable that is deleted, it is called both
     // during unlink and during deactivation.
     void reclaim_memory_and_stop_tracking_sstable(sstable* sst);
+    // Unlink the sstable from _reclaimed, if it is linked. Erasing by key would
+    // remove an arbitrary sstable with the same total_memory_reclaimed().
+    void erase_from_reclaimed(sstable* sst) noexcept;
 private:
     db::large_data_handler& get_large_data_handler() const {
         return _large_data_handler;

--- a/test/boost/bloom_filter_test.cc
+++ b/test/boost/bloom_filter_test.cc
@@ -113,6 +113,83 @@ SEASTAR_TEST_CASE(test_sstable_manager_auto_reclaim_and_reload_of_bloom_filter) 
     });
 }
 
+// Reproducer for https://github.com/scylladb/scylladb/issues/31202.
+// Sstables with the same partition estimate have equally sized bloom filters,
+// so they share the key of the manager's reclaimed set. All of them have to be
+// tracked, otherwise their filters are never reloaded.
+SEASTAR_TEST_CASE(test_reclaim_and_reload_of_equal_sized_bloom_filters) {
+    return test_env::do_with_async([] (test_env& env) {
+        simple_schema ss;
+        auto schema_ptr = ss.schema();
+        auto& sst_mgr = env.manager();
+
+        auto [sst1, sst1_bf_memory] = create_sstable_with_bloom_filter(env, sst_mgr, schema_ptr, 70);
+        auto [sst2, sst2_bf_memory] = create_sstable_with_bloom_filter(env, sst_mgr, schema_ptr, 70);
+        BOOST_REQUIRE_EQUAL(sst1_bf_memory, sst2_bf_memory);
+        // both filters fit under the threshold
+        BOOST_REQUIRE_EQUAL(sst_mgr.get_total_memory_reclaimed(), 0);
+        BOOST_REQUIRE_EQUAL(sst_mgr.get_total_reclaimable_memory(), sst1_bf_memory + sst2_bf_memory);
+
+        // drop the threshold to reclaim both filters
+        env.db_config().components_memory_reclaim_threshold.set(0);
+        REQUIRE_EVENTUALLY_EQUAL<size_t>([&] { return sst_mgr.get_total_memory_reclaimed(); }, sst1_bf_memory + sst2_bf_memory);
+        BOOST_REQUIRE_EQUAL(sst_mgr.get_reclaimed_set().size(), 2);
+        BOOST_REQUIRE_EQUAL(sst1->filter_memory_size(), 0);
+        BOOST_REQUIRE_EQUAL(sst2->filter_memory_size(), 0);
+
+        // restore the threshold; both filters have to be reloaded
+        env.db_config().components_memory_reclaim_threshold.set(0.2);
+        REQUIRE_EVENTUALLY_EQUAL<size_t>([&] { return sst_mgr.get_total_memory_reclaimed(); }, 0);
+        BOOST_REQUIRE_EQUAL(sst_mgr.get_reclaimed_set().size(), 0);
+        BOOST_REQUIRE_EQUAL(sst1->filter_memory_size(), sst1_bf_memory);
+        BOOST_REQUIRE_EQUAL(sst2->filter_memory_size(), sst2_bf_memory);
+        BOOST_REQUIRE_EQUAL(sst_mgr.get_total_reclaimable_memory(), sst1_bf_memory + sst2_bf_memory);
+    }, {
+        // limit available memory to the sstables_manager to test reclaiming.
+        // this will set the reclaim threshold to 200 bytes.
+        .available_memory = 1000
+    });
+}
+
+// Reproducer for https://github.com/scylladb/scylladb/issues/31202.
+// Disposing an sstable reclaims its components, which gives it the same
+// reclaimed memory as an sstable already tracked in the reclaimed set. The
+// tracked sstable must not be evicted from the set by the disposal.
+SEASTAR_TEST_CASE(test_reclaimed_bloom_filter_survives_disposal_of_equal_sized_sstable) {
+    return test_env::do_with_async([] (test_env& env) {
+        simple_schema ss;
+        auto schema_ptr = ss.schema();
+        auto& sst_mgr = env.manager();
+
+        auto [sst1, sst1_bf_memory] = create_sstable_with_bloom_filter(env, sst_mgr, schema_ptr, 70);
+        auto [sst2, sst2_bf_memory] = create_sstable_with_bloom_filter(env, sst_mgr, schema_ptr, 70);
+        BOOST_REQUIRE_EQUAL(sst1_bf_memory, sst2_bf_memory);
+
+        // dropping one of the two equally sized filters brings the total memory
+        // usage back under the threshold, so exactly one of them is reclaimed.
+        REQUIRE_EVENTUALLY_EQUAL<size_t>([&] { return sst_mgr.get_total_memory_reclaimed(); }, sst1_bf_memory);
+        BOOST_REQUIRE_EQUAL(sst_mgr.get_reclaimed_set().size(), 1);
+        // the victim is chosen by the manager, so identify it instead of assuming it
+        const bool sst1_reclaimed = sst1->filter_memory_size() == 0;
+        auto& reclaimed_sst = sst1_reclaimed ? sst1 : sst2;
+        auto& loaded_sst = sst1_reclaimed ? sst2 : sst1;
+        BOOST_REQUIRE_EQUAL(loaded_sst->filter_memory_size(), sst1_bf_memory);
+
+        // The disposal reclaims the loaded sstable's filter, giving it the same
+        // reclaimed memory as its twin. The twin must remain in the set...
+        dispose_and_stop_tracking_bf_memory(std::move(loaded_sst), sst_mgr);
+        BOOST_REQUIRE_EQUAL(sst_mgr.get_reclaimed_set().size(), 1);
+        // ...and its filter must be reloaded once the disposal frees up memory.
+        REQUIRE_EVENTUALLY_EQUAL<size_t>([&] { return reclaimed_sst->filter_memory_size(); }, sst1_bf_memory);
+        REQUIRE_EVENTUALLY_EQUAL<size_t>([&] { return sst_mgr.get_total_memory_reclaimed(); }, 0);
+        BOOST_REQUIRE_EQUAL(sst_mgr.get_reclaimed_set().size(), 0);
+    }, {
+        // limit available memory to the sstables_manager to test reclaiming.
+        // this will set the reclaim threshold to 100 bytes.
+        .available_memory = 500
+    });
+}
+
 // Reproducer for https://github.com/scylladb/scylladb/issues/18398.
 SEASTAR_TEST_CASE(test_reclaimed_bloom_filter_deletion_from_disk) {
     return test_env::do_with_async([] (test_env& env) {

--- a/test/lib/sstable_test_env.hh
+++ b/test/lib/sstable_test_env.hh
@@ -69,7 +69,7 @@ public:
     }
 
     void remove_sst_from_reclaimed(sstable* sst) {
-        _reclaimed.erase(*sst);
+        sstables_manager::erase_from_reclaimed(sst);
     }
 
     auto& get_active_list() {


### PR DESCRIPTION
`sstables_manager::_reclaimed` holds the sstables whose bloom filters were dropped from memory, so that the filters can be reloaded once memory frees up again. It is a `boost::intrusive::set` ordered on `sstable::total_memory_reclaimed()`, the size of the dropped filter. That size is derived from the estimated partition count, so sstables of the same table routinely share it and the key is not unique. Two things break as a result.
`maybe_reclaim_components()` inserts into a unique set, so reclaiming a filter whose size is already present in the set is silently a no-op. The sstable is never tracked and its filter is never reloaded, while `_total_memory_reclaimed` still accounts for it, so the accounting drifts as well.
`reclaim_memory_and_stop_tracking_sstable()` erases by key. It reclaims the disposed sstable's filter just before the erase, which stamps that sstable with the same key as an unrelated sstable already in the set, so the erase removes that one instead and its filter is lost for good.
Make `_reclaimed` a `boost::intrusive::multiset` so that every reclaimed sstable is kept, and erase through the sstable's own hook so that removal is by identity.
Fixes #31202
## Tests
Two regression tests in `test/boost/bloom_filter_test.cc`, one per failure mode. Both fail without the fix and pass with it.
- `test_reclaim_and_reload_of_equal_sized_bloom_filters` covers the insert side. Two sstables with equally sized (52 byte) filters are both reclaimed. Without the fix the second insert collides with the first and is silently dropped, so the reclaimed set holds one entry instead of two (`[1 != 2]`) and only one of the two filters is ever reloaded.
- `test_reclaimed_bloom_filter_survives_disposal_of_equal_sized_sstable` covers the erase side. One of two equally sized sstables is reclaimed and the other, still holding its filter in memory, is then disposed. Without the fix the disposal erases the wrong entry, leaving the reclaimed set empty (`[0 != 1]`), so the surviving sstable's filter is never reloaded and `_total_memory_reclaimed` stays permanently inflated.
The whole of `test/boost/bloom_filter_test.cc` was run, and the two new cases were also run at 20 repeats each.
Tests: unit (dev)
## Backport
No backport labels added. The effect is a permanently lost bloom filter and inflated reclaim accounting, which degrades read performance rather than causing a crash or data loss, so I have left the backport decision to the maintainers.

hi @mykaul can u please review the changes?
