### PR TITLE
docs: Fix incremental backup directory layout description

### DIFF
--- a/docs/operating-scylla/procedures/backup-restore/backup.rst
+++ b/docs/operating-scylla/procedures/backup-restore/backup.rst
@@ -77,12 +77,12 @@ Incremental Backup
 
 **Procedure**
 
-| 1. In the ``/etc/scylla/scylla.yaml`` file set the ``incremental backups`` parameters to ``true`` and restart the ScyllaDB service. Snapshot are created under ScyllaDB data directory ``/var/lib/scylla/data``
-| with the following structure:
-| ``keyspace_name/table_name-UUID/backups/backups_name``
+| 1. In the ``/etc/scylla/scylla.yaml`` file set the ``incremental_backups`` parameter to ``true`` and restart the ScyllaDB service. From now on, flushed SSTables are hard-linked under ScyllaDB data directory ``/var/lib/scylla/data``
+| into a directory with the following structure:
+| ``keyspace_name/table_name-UUID/backups``
 
 | For example:
-| ``/mykeyspace/team_roster-91cd2060f99d11e6a47a000000000000/backups/1437827672721``
+| ``/mykeyspace/team_roster-91cd2060f99d11e6a47a000000000000/backups``
 
 
 Additional Resources


### PR DESCRIPTION
The backup procedure claims that incremental backups are created in per-backup subdirectories, backups/<backups_name>, apparently mirroring the snapshots/<snapshot_name> layout of full backups. In fact, flushed SSTables are hard-linked directly into the flat backups directory. Also fix the enabling option name -- it's incremental_backups.

Fixes SCYLLADB-3996

The text is there since being imported from docs repo. Probably worth backporting