### PR TITLE
docs: stop hand-copying audit config defaults

### DIFF
--- a/docs/operating-scylla/security/auditing.rst
+++ b/docs/operating-scylla/security/auditing.rst
@@ -42,6 +42,12 @@ audit_keyspaces     Comma-separated list of keyspaces that should be audited. Yo
                     If you leave this option empty, no keyspace will be audited.
 ==================  ========================================================================================================================
 
+The default value and liveness of each option are listed in
+:doc:`/reference/configuration-parameters`: see
+:ref:`audit_categories <confprop_audit_categories>`,
+:ref:`audit_tables <confprop_audit_tables>` and
+:ref:`audit_keyspaces <confprop_audit_keyspaces>`.
+
 To audit all the tables in a keyspace, set the ``audit_keyspaces`` with the keyspace you want to audit and leave ``audit_tables`` empty.
 
 You can use DCL, AUTH, and ADMIN audit categories without including any keyspace or table.

--- a/docs/operating-scylla/security/auditing.rst
+++ b/docs/operating-scylla/security/auditing.rst
@@ -29,18 +29,18 @@ Configuring Audit
 
 The audit can be tuned using the following flags or ``scylla.yaml`` entries:
 
-==================  ==================================  ========================================================================================================================
-Flag                Default Value                       Description
-==================  ==================================  ========================================================================================================================
-audit_categories    "DCL,AUTH,ADMIN"                                  Comma-separated list of statement categories that should be audited
-------------------  ----------------------------------  ------------------------------------------------------------------------------------------------------------------------
-audit_tables        “”                                  Comma-separated list of table names that should be audited, in the format ``<keyspace_name>.<table_name>``.
-                                                        
-                                                        For Alternator tables use the ``alternator.<table_name>`` format (see :ref:`alternator-auditing`).
-------------------  ----------------------------------  ------------------------------------------------------------------------------------------------------------------------
-audit_keyspaces     “”                                  Comma-separated list of keyspaces that should be audited. You must specify at least one keyspace.
-                                                        If you leave this option empty, no keyspace will be audited.
-==================  ==================================  ========================================================================================================================
+==================  ========================================================================================================================
+Flag                Description
+==================  ========================================================================================================================
+audit_categories    Comma-separated list of statement categories that should be audited
+------------------  ------------------------------------------------------------------------------------------------------------------------
+audit_tables        Comma-separated list of table names that should be audited, in the format ``<keyspace_name>.<table_name>``.
+
+                    For Alternator tables use the ``alternator.<table_name>`` format (see :ref:`alternator-auditing`).
+------------------  ------------------------------------------------------------------------------------------------------------------------
+audit_keyspaces     Comma-separated list of keyspaces that should be audited. You must specify at least one keyspace.
+                    If you leave this option empty, no keyspace will be audited.
+==================  ========================================================================================================================
 
 To audit all the tables in a keyspace, set the ``audit_keyspaces`` with the keyspace you want to audit and leave ``audit_tables`` empty.
 


### PR DESCRIPTION
The audit options table hand-copied defaults from db/config.cc and had drifted. Drop the column and point at the generated configuration reference instead.

Fixes: SCYLLADB-3999
Backport: 2025.1, 2026.1, 2026.2, 2026.3 - the audit options table misstates the default `audit_categories` on every maintained branch (2025.1 and 2026.1 list ADMIN, which is not in those branches' default; 2026.2 and 2026.3 omit DDL)
