### PR TITLE
audit: mark audit_syslog_write_buffer_size as unused

### DIFF
--- a/db/config.cc
+++ b/db/config.cc
@@ -1745,7 +1745,7 @@ db::config::config(std::shared_ptr<db::extensions> exts)
     , audit_tables(this, "audit_tables", liveness::LiveUpdate, value_status::Used, "", "Comma separated list of table names (<keyspace>.<table>) that will be audited.")
     , audit_keyspaces(this, "audit_keyspaces", liveness::LiveUpdate, value_status::Used, "", "Comma separated list of keyspaces that will be audited. All tables in those keyspaces will be audited")
     , audit_unix_socket_path(this, "audit_unix_socket_path", value_status::Used, "/dev/log", "The path to the unix socket used for writing to syslog. Only applicable when audit is set to syslog.")
-    , audit_syslog_write_buffer_size(this, "audit_syslog_write_buffer_size", value_status::Used, 1048576, "The size (in bytes) of a write buffer used when writing to syslog socket.")
+    , audit_syslog_write_buffer_size(this, "audit_syslog_write_buffer_size", value_status::Unused, 1048576, "The size (in bytes) of a write buffer used when writing to syslog socket.")
      , audit_rules(this, "audit_rules", liveness::LiveUpdate, value_status::Used, {},
         "List of granular audit rules. Each rule has: sinks, categories, qualified_table_names, roles. "
         "When non-empty, these rules extend audit_categories, audit_tables, and audit_keyspaces; "

--- a/test/cluster/test_audit.py
+++ b/test/cluster/test_audit.py
@@ -1962,7 +1962,7 @@ class CQLAuditTester(AuditTester):
     async def _test_config_no_liveupdate(self, helper_class, audit_config_changer):
         """
         Test audit config parameters that don't allow config changes.
-        Modification of "audit", "audit_unix_socket_path", and "audit_syslog_write_buffer_size" should be forbidden.
+        Modification of "audit" and "audit_unix_socket_path" should be forbidden.
         """
         with helper_class() as helper, audit_config_changer() as config_changer:
             session = await self.prepare(helper=helper)
@@ -1980,10 +1980,9 @@ class CQLAuditTester(AuditTester):
             auditted_query = SimpleStatement("INSERT INTO test_config_no_lifeupdate (userid, password, name) VALUES ('user2', 'password2', 'second user');", consistency_level=ConsistencyLevel.QUORUM)
             expected_new_entries = [AuditEntry(category="DML", statement=auditted_query.query_string, table="test_config_no_lifeupdate", ks="ks", user="anonymous", cl="QUORUM", error=False)]
 
-            # Modifications of "audit", "audit_unix_socket_path", "audit_syslog_write_buffer_size" are forbidden and will fail
+            # Modifications of "audit" and "audit_unix_socket_path" are forbidden and will fail
             await config_changer.change_config(self, {"audit": "none"}, expected_result=self.AuditConfigChanger.ExpectedResult.FAILURE_UNUPDATABLE_PARAM)
             await config_changer.change_config(self, {"audit_unix_socket_path": "/path/"}, expected_result=self.AuditConfigChanger.ExpectedResult.FAILURE_UNUPDATABLE_PARAM)
-            await config_changer.change_config(self, {"audit_syslog_write_buffer_size": "123123123"}, expected_result=self.AuditConfigChanger.ExpectedResult.FAILURE_UNUPDATABLE_PARAM)
 
             # Despite unsuccesful attempts to change config, audit works as expected
             with self.assert_entries_were_added(session, expected_new_entries, merge_duplicate_rows=False):
@@ -2690,7 +2689,7 @@ _composite = functools.partial(AuditBackendComposite, socket_path=syslog_socket_
     pytest.param(_composite, CQLAuditTester.AuditCqlConfigChanger, id="composite-cql"),
 ])
 async def test_config_no_liveupdate(manager: ScyllaClusterManager, helper_class, config_changer):
-    """Non-live audit config params (audit, audit_unix_socket_path, audit_syslog_write_buffer_size) must be unmodifiable."""
+    """Non-live audit config params (audit, audit_unix_socket_path) must be unmodifiable."""
     await CQLAuditTester(manager)._test_config_no_liveupdate(helper_class, config_changer)
 
 


### PR DESCRIPTION
The option has never been read since it was introduced. Mark it unused so it stops being published in the configuration reference, and drop it from the liveupdate test.

Fixes: SCYLLADB-4000
Backport: no, minor improvements