### PR TITLE
tasks: keep the task impl alive until its run fiber completes

### DIFF
--- a/tasks/task_manager.cc
+++ b/tasks/task_manager.cc
@@ -213,8 +213,8 @@ future<> task_manager::task::impl::done() const noexcept {
     return _done.get_shared_future();
 }
 
-void task_manager::task::impl::run_to_completion() {
-    (void)run().then([this] {
+future<> task_manager::task::impl::run_to_completion() {
+    return run().then([this] {
         _as.check();
         return finish();
     }).handle_exception([this] (std::exception_ptr ex) {
@@ -330,7 +330,7 @@ void task_manager::task::start() {
         });
         _impl->_as.check();
         _impl->_status.state = task_manager::task_state::running;
-        _impl->run_to_completion();
+        (void)_impl->run_to_completion().finally([impl = _impl] {});
     } catch (...) {
         (void)_impl->finish_failed(std::current_exception()).then([impl = _impl] {});
     }

--- a/tasks/task_manager.hh
+++ b/tasks/task_manager.hh
@@ -227,7 +227,7 @@ public:
             future<> done() const noexcept;
         protected:
             virtual future<> run() = 0;
-            void run_to_completion();
+            future<> run_to_completion();
             future<> maybe_fold_into_parent() const noexcept;
             future<> finish() noexcept;
             future<> finish_failed(std::exception_ptr ex, std::string error) noexcept;


### PR DESCRIPTION
The run fiber holds no reference to the task's impl, and finish() calls release_resources() after resolving _done - the point from which the task may be unregistered and destroyed. If release_resources() suspends, the task can be destroyed during the suspension and the fiber resumes on a dangling pointer.

Make the fiber keep the impl - but still not the task - alive until the run-finish-release chain completes.

Fixes: https://scylladb.atlassian.net/browse/SCYLLADB-4001.

Needs backport to all live version as they all have the bug