### PR TITLE
strong_consistency: wrap schema resolution into schema_store

### DIFF
--- a/db/commitlog/raft_commitlog_replay_buffer.cc
+++ b/db/commitlog/raft_commitlog_replay_buffer.cc
@@ -138,6 +138,11 @@ future<> raft_commitlog_replay_buffer::process_raft_replayed_items(replica::data
 
     logger.info("processing {} raft groups with {} total entries from commitlog replay", remaining_groups(), total_entries());
 
+    // Shared by all groups: it resolves the table from the mutation itself, and reusing
+    // it lets entries written with the same schema version resolve their schema only once.
+    // No barrier trigger during replay, since group0 is not started yet.
+    service::strong_consistency::schema_store schemas(db, sys_ks);
+
     for (auto& [group_id, entries_list] : _replayed_commitlog_entries_by_group) {
         if (entries_list.empty()) {
             continue;
@@ -179,11 +184,9 @@ future<> raft_commitlog_replay_buffer::process_raft_replayed_items(replica::data
             // only be deleted after the memtables are flushed. Therefore, the data will either
             // be persisted to SSTables or, in case of a crash, still be available in the old commitlog.
             if (entry->idx <= commit_idx && std::holds_alternative<raft::command>(entry->data)) {
-                utils::chunked_vector<frozen_mutation> muts;
-                muts.emplace_back(service::strong_consistency::detail::deserialize_to_frozen_mutation(entry));
-                // Resolve schema and upgrade mutation if needed (no barrier during replay).
-                auto schemas = co_await service::strong_consistency::resolve_and_upgrade_mutations(muts, table_id, db, sys_ks);
-                co_await db.apply_in_memory(muts[0], schemas[0], db::rp_handle(), db::no_timeout, db::noop_large_data_guardrail::instance());
+                auto mut = service::strong_consistency::detail::deserialize_to_frozen_mutation(entry);
+                auto schema = co_await schemas.resolve_and_upgrade(mut);
+                co_await db.apply_in_memory(mut, std::move(schema), db::rp_handle(), db::no_timeout, db::noop_large_data_guardrail::instance());
                 ++applied;
             }
 

--- a/service/strong_consistency/state_machine.cc
+++ b/service/strong_consistency/state_machine.cc
@@ -19,7 +19,6 @@
 #include "replica/database.hh"
 #include "service/migration_manager.hh"
 #include "db/system_keyspace.hh"
-#include "utils/loading_cache.hh"
 #include "utils/error_injection.hh"
 #include "schema/schema_registry.hh"
 #include "service/strong_consistency/raft_commitlog.hh"
@@ -60,34 +59,29 @@ public:
         static thread_local logging::logger::rate_limit rate_limit(std::chrono::seconds(10));
         try {
             co_await utils::get_local_injector().inject("strong_consistency_state_machine_wait_before_apply", utils::wait_for_message(20min));
-            // Collect mutations from the command list.
-            utils::chunked_vector<frozen_mutation> muts;
-            muts.reserve(command.size());
-            for (auto& log_entry : command) {
-                auto mutation = detail::deserialize_to_frozen_mutation(log_entry);
-                muts.emplace_back(std::move(mutation));
-            }
             // Get replay positions for the commands.
             auto replay_positions = _persistence.acquire_replay_position_handles_for(command);
             // Make sure we got replay positions for all commands.
             throwing_assert(replay_positions.size() == command.size());
-            // Get schemas for all mutations (also upgrades mutations to current schema if needed).
-            auto barrier = [this]() -> future<> {
+            // One store for the whole batch, so that commands written with the same
+            // schema version resolve their schema only once.
+            schema_store schemas(_db, _sys_ks, [this]() -> future<> {
                 if (utils::get_local_injector().enter("disable_raft_drop_append_entries_for_specified_group")) {
                     utils::get_local_injector().disable("raft_drop_incoming_append_entries_for_specified_group");
                 }
                 co_await _mm.get_group0_barrier().trigger(false, &_as);
-            };
-            auto schemas = co_await resolve_and_upgrade_mutations(muts, _tablet.table, _db, _sys_ks, barrier);
+            });
             // Apply mutations sequentially to preserve linearizability.
             // E.g., for writes A-B-C-D, a reader must observe
             // them in that order and never see A-C or A-D skipping intermediate values.
             for (size_t i = 0; i < command.size(); ++i) {
                 throwing_assert(replay_positions[i].index == command[i]->idx);
+                auto mut = detail::deserialize_to_frozen_mutation(command[i]);
+                auto schema = co_await schemas.resolve_and_upgrade(mut);
                 // Concurrent apply_in_memory() calls can complete out of order under memory pressure
                 // (suspended at run_when_memory_available()), making mutations visible out of Raft log order.
                 // Therefore we must await each apply_in_memory() sequentially to preserve Raft log order.
-                co_await _db.apply_in_memory(muts[i], schemas[i], std::move(replay_positions[i].replay_position_handle), db::no_timeout, db::noop_large_data_guardrail::instance());
+                co_await _db.apply_in_memory(mut, std::move(schema), std::move(replay_positions[i].replay_position_handle), db::no_timeout, db::noop_large_data_guardrail::instance());
             }
         } catch (replica::no_such_column_family&) {
             // If the table doesn't exist, it means it was already dropped.
@@ -98,7 +92,7 @@ public:
             logger.log(log_level::warn, rate_limit, "apply(): table {} was already dropped, ignoring mutations", _tablet.table);
         } catch (replica::no_such_keyspace&) {
             // Thrown when DROP KEYSPACE races with the raft applier fiber.
-            // The path: resolve_and_upgrade_mutations() calls
+            // The path: schema_store::resolve_and_upgrade() calls
             // local_schema_registry().get_or_null(schema_version), which may
             // trigger lazy unfreezing of a cached frozen_schema. Unfreezing
             // re-parses column types via cql_type_parser::parse(), which
@@ -109,7 +103,7 @@ public:
             // by schedule_raft_group_deletion() anyway.
             logger.log(log_level::warn, rate_limit, "apply(): keyspace for table {} was already dropped, ignoring mutations", _tablet.table);
         } catch (const abort_requested_exception& ex) {
-            // The exception can be thrown by get_schema_and_upgrade_mutations.
+            // The exception can be thrown by schema_store::resolve_and_upgrade.
             // It means that the Raft group is being removed.
             //
             // Technically, throwing an exception from a state machine
@@ -166,91 +160,77 @@ public:
     }
 };
 
-using column_mappings_cache = utils::loading_cache<table_schema_version, column_mapping>;
-using schema_entry = std::pair<schema_ptr, column_mappings_cache::value_ptr>;
+thread_local schema_store::column_mappings_cache schema_store::_column_mapping_cache(
+        std::numeric_limits<size_t>::max(), 1h, logger);
 
-future<std::vector<schema_ptr>> resolve_and_upgrade_mutations(utils::chunked_vector<frozen_mutation>& muts, table_id table, replica::database& db,
-        db::system_keyspace& sys_ks, std::function<future<>()> barrier_trigger) {
-    // Cache column mappings to avoid querying `system.scylla_table_schema_history` multiple times.
-    static thread_local column_mappings_cache column_mapping_cache(std::numeric_limits<size_t>::max(), 1h, logger);
-    using schema_store = std::unordered_map<table_schema_version, schema_entry>;
-    // Stores schema pointer and optional column mapping for each schema version present in the mutations
-    schema_store schema_mappings;
-    bool barrier_executed = false;
+future<schema_store::schema_entry> schema_store::get_schema(table_id table, table_schema_version schema_version) {
+    if (utils::get_local_injector().enter("sc_state_machine_return_empty_schema")) {
+        co_return schema_entry{nullptr, nullptr};
+    }
 
-    auto get_schema = [&] (table_schema_version schema_version) -> future<schema_entry> {
-        if (utils::get_local_injector().enter("sc_state_machine_return_empty_schema")) {
-            co_return schema_entry{nullptr, nullptr};
-        }
+    auto schema = local_schema_registry().get_or_null(schema_version);
+    if (schema) {
+        co_return schema_entry{std::move(schema), nullptr};
+    }
 
-        auto schema = local_schema_registry().get_or_null(schema_version);
-        if (schema) {
-            co_return schema_entry{std::move(schema), nullptr};
-        }
-
-        // `db.find_schema()` may throw `replica::no_such_column_family` if the table was already dropped.
-        schema = db.find_schema(table);
-        // The column mapping may be already present in the cache from another call
-        auto cm_ptr = column_mapping_cache.find(schema_version);
-        if (cm_ptr) {
-            co_return schema_entry{std::move(schema), std::move(cm_ptr)};
-        }
-
-        // We may not find the column mapping if the mutation schema is newer than the present schema.
-        // In this case, we should trigger the barrier to wait for the schema to be updated and then try again.
-        auto cm_opt = co_await db::schema_tables::get_column_mapping_if_exists(sys_ks, table, schema_version);
-        if (!cm_opt) {
-            co_return schema_entry{nullptr, nullptr};
-        }
-
-        cm_ptr = co_await column_mapping_cache.get_ptr(schema_version, [cm = std::move(*cm_opt)](auto schema_version) -> future<column_mapping> {
-            co_return std::move(cm);
-        });
+    // `db.find_schema()` may throw `replica::no_such_column_family` if the table was already dropped.
+    schema = _db.find_schema(table);
+    // The column mapping may be already present in the cache from another call
+    auto cm_ptr = _column_mapping_cache.find(schema_version);
+    if (cm_ptr) {
         co_return schema_entry{std::move(schema), std::move(cm_ptr)};
-    };
+    }
 
-    auto resolve_schema = [&] (const frozen_mutation& mut) -> future<const schema_store::mapped_type*> {
-        auto schema_version = mut.schema_version();
-        auto it = schema_mappings.find(schema_version);
-        if (it != schema_mappings.end()) {
-            co_return &it->second;
+    // We may not find the column mapping if the mutation schema is newer than the present schema.
+    // In this case, we should trigger the barrier to wait for the schema to be updated and then try again.
+    auto cm_opt = co_await db::schema_tables::get_column_mapping_if_exists(_sys_ks, table, schema_version);
+    if (!cm_opt) {
+        co_return schema_entry{nullptr, nullptr};
+    }
+
+    cm_ptr = co_await _column_mapping_cache.get_ptr(schema_version, [cm = std::move(*cm_opt)](auto schema_version) -> future<column_mapping> {
+        co_return std::move(cm);
+    });
+    co_return schema_entry{std::move(schema), std::move(cm_ptr)};
+}
+
+schema_store::schema_store(replica::database& db, db::system_keyspace& sys_ks, std::function<future<>()> barrier_trigger)
+    : _db(db)
+    , _sys_ks(sys_ks)
+    , _barrier_trigger(std::move(barrier_trigger))
+{
+}
+
+future<schema_ptr> schema_store::resolve_and_upgrade(frozen_mutation& m) {
+    const auto schema_version = m.schema_version();
+
+    auto it = _schema_mappings.find(schema_version);
+    if (it == _schema_mappings.end()) {
+        const auto table = m.column_family_id();
+        auto [schema, cm_ptr] = co_await get_schema(table, schema_version);
+        if (!schema) {
+            if (const auto trigger = std::exchange(_barrier_trigger, nullptr)) {
+                co_await trigger();
+                std::tie(schema, cm_ptr) = co_await get_schema(table, schema_version);
+            }
         }
-
-        auto schema_cm = co_await get_schema(schema_version);
-        if (!schema_cm.first && barrier_trigger && !barrier_executed) {
-            co_await barrier_trigger();
-            barrier_executed = true;
-            schema_cm = co_await get_schema(schema_version);
-        }
-
-        if (schema_cm.first) {
-            const auto [it, _] = schema_mappings.insert({schema_version, std::move(schema_cm)});
-            co_return &it->second;
-        }
-        co_return nullptr;
-    };
-
-    // Build parallel vector of schema pointers (one per mutation).
-    // We can't return the map keyed by schema_version because upgrade
-    // changes a mutation's schema_version to the current one.
-    std::vector<schema_ptr> result;
-    result.reserve(muts.size());
-    for (auto& m : muts) {
-        auto entry = co_await resolve_schema(m);
-        if (!entry) {
+        if (!schema) {
             // Old schema are TTLed after 10 days (see comment in `schema_applier::finalize_tables_and_views()`),
             // so this error theoretically may be triggered if a node is stuck longer than this.
             // But in practice we should do a snapshot much earlier, that's why `on_internal_error()` here.
             // And if the table or keyspace was already dropped, `no_such_column_family`
             // or `no_such_keyspace` will be thrown earlier.
-            on_internal_error(logger, fmt::format("couldn't find schema for table {} and mutation schema version {}", table, m.schema_version()));
+            on_internal_error(logger, fmt::format("couldn't find schema for table {} and mutation schema version {}",
+                    table, schema_version));
         }
-        if (entry->second) {
-            m = freeze(m.unfreeze_upgrading(entry->first, *entry->second));
-        }
-        result.push_back(entry->first);
+        it = _schema_mappings.insert({schema_version, {std::move(schema), cm_ptr}}).first;
     }
-    co_return std::move(result);
+
+    const auto& [schema, cm_ptr] = it->second;
+    if (cm_ptr) {
+        m = freeze(m.unfreeze_upgrading(schema, *cm_ptr));
+    }
+    co_return schema;
 }
 
 std::unique_ptr<raft_state_machine> make_state_machine(locator::global_tablet_id tablet,

--- a/service/strong_consistency/state_machine.hh
+++ b/service/strong_consistency/state_machine.hh
@@ -11,8 +11,10 @@
 #include "service/raft/raft_state_machine.hh"
 #include "mutation/frozen_mutation.hh"
 #include <functional>
+#include <unordered_map>
 #include "locator/tablets.hh"
 #include "service/strong_consistency/raft_groups_storage.hh"
+#include "utils/loading_cache.hh"
 
 namespace db {
 class system_keyspace;
@@ -35,21 +37,42 @@ std::unique_ptr<raft_state_machine> make_state_machine(locator::global_tablet_id
     db::system_keyspace& sys_ks,
     raft_groups_storage& storage);
 
-// Resolve schemas for frozen mutations and upgrade them to the current schema if needed.
-// For each mutation, looks up the schema version in the local schema registry. If the mutation
-// was written with an older schema, the column mapping is fetched from system.scylla_table_schema_history
-// and used to upgrade the mutation to the current schema.
-// Returns a parallel vector of schema_ptr (one per mutation, aligned by index).
+// Resolves schemas for frozen mutations and upgrades them to the current schema if needed.
 //
-// If `barrier_trigger` is provided, it is called as a last resort when a schema version cannot
-// be resolved locally (e.g., during normal operation, this triggers a group0 barrier to wait for
-// schema propagation). During replay, pass nullptr since group0 is not yet started.
-future<std::vector<schema_ptr>> resolve_and_upgrade_mutations(
-    utils::chunked_vector<frozen_mutation>& muts,
-    table_id table,
-    replica::database& db,
-    db::system_keyspace& sys_ks,
-    std::function<future<>()> barrier_trigger = nullptr);
+// One instance is meant to serve a batch of mutations: schemas resolved for a given
+// schema version are remembered, so mutations sharing a version are resolved only once.
+class schema_store {
+    using column_mappings_cache = utils::loading_cache<table_schema_version, column_mapping>;
+    // Schema to apply a mutation with, plus the column mapping needed to upgrade
+    // the mutation to that schema. The mapping is null when the mutation was
+    // written with exactly that schema and thus needs no upgrade.
+    using schema_entry = std::pair<schema_ptr, column_mappings_cache::value_ptr>;
+
+    // Cache of column mappings, shared by all instances on this shard, so that
+    // `system.scylla_table_schema_history` isn't queried for the same version repeatedly.
+    static thread_local column_mappings_cache _column_mapping_cache;
+
+    replica::database& _db;
+    db::system_keyspace& _sys_ks;
+    // Called as a last resort when a schema version cannot be resolved locally.
+    // During normal operation this triggers a group0 barrier to wait for schema
+    // propagation; during commitlog replay it is null, since group0 isn't started yet.
+    std::function<future<>()> _barrier_trigger;
+
+    // Resolved schemas, keyed by the schema version found in the mutations.
+    std::unordered_map<table_schema_version, schema_entry> _schema_mappings;
+
+    future<schema_entry> get_schema(table_id table, table_schema_version schema_version);
+
+public:
+    schema_store(replica::database& db, db::system_keyspace& sys_ks,
+        std::function<future<>()> barrier_trigger = nullptr);
+
+    // Returns the schema that `m` should be applied with. If `m` was written with an
+    // older schema, it is upgraded in place to the returned schema, using the column
+    // mapping fetched from `system.scylla_table_schema_history`.
+    future<schema_ptr> resolve_and_upgrade(frozen_mutation& m);
+};
 
 namespace detail {
 // Deserialize a frozen_mutation from a raft::log_entry_ptr.


### PR DESCRIPTION
This is a small refactoring PR.

`resolve_and_upgrade_mutations()` took a chunked_vector of mutations and returned a parallel vector of schemas. The commitlog replay path has a single mutation at hand and had to wrap it into a one-element vector just to make the call.

Turn the function into a class schema_store with a single-mutation resolve_and_upgrade() method. The per-batch state that used to live in locals -- the resolved schemas map, the "barrier already triggered" flag -- becomes fields, and the column mapping cache becomes a static member. The table id is taken from frozen_mutation::column_family_id() instead of being passed in.

state_machine::apply() now creates one store per batch and resolves each command right before applying it, so the intermediate mutation vector is gone. process_raft_replayed_items() creates one store for all groups, which also lets entries sharing a schema version resolve it only once.

No functional change intended, except that apply() may now trigger the group0 barrier after applying earlier commands of the same batch rather than before applying any of them. Applies are sequential either way.

Fixes SCYLLADB-2480

backport: no need -- strong consistency is experimental