### PR TITLE
API: Move compaction-task related endpoints from storage_service block

### DIFF
--- a/api/api.cc
+++ b/api/api.cc
@@ -377,13 +377,13 @@ future<> set_server_service_levels(http_context &ctx, cql_transport::controller&
     });
 }
 
-future<> set_server_tasks_compaction_module(http_context& ctx, sharded<replica::database>& db, sharded<db::snapshot_ctl>& snap_ctl) {
+future<> set_server_tasks_compaction_module(http_context& ctx, sharded<replica::database>& db, sharded<db::snapshot_ctl>& snap_ctl, sharded<service::storage_service>& ss) {
     auto rb = std::make_shared < api_registry_builder > (ctx.api_doc);
 
-    return ctx.http_server.set_routes([rb, &ctx, &db, &snap_ctl](routes& r) {
+    return ctx.http_server.set_routes([rb, &ctx, &db, &snap_ctl, &ss](routes& r) {
         rb->register_function(r, "tasks",
                 "The tasks API");
-        set_tasks_compaction_module(ctx, r, db, snap_ctl);
+        set_tasks_compaction_module(ctx, r, db, snap_ctl, ss);
     });
 }
 

--- a/api/api_init.hh
+++ b/api/api_init.hh
@@ -143,7 +143,7 @@ future<> set_server_task_manager(http_context& ctx, sharded<tasks::task_manager>
 future<> unset_server_task_manager(http_context& ctx);
 future<> set_server_task_manager_test(http_context& ctx, sharded<tasks::task_manager>& tm);
 future<> unset_server_task_manager_test(http_context& ctx);
-future<> set_server_tasks_compaction_module(http_context& ctx, sharded<replica::database>& db, sharded<db::snapshot_ctl>& snap_ctl);
+future<> set_server_tasks_compaction_module(http_context& ctx, sharded<replica::database>& db, sharded<db::snapshot_ctl>& snap_ctl, sharded<service::storage_service>& ss);
 future<> unset_server_tasks_compaction_module(http_context& ctx);
 future<> set_server_raft(http_context&, sharded<service::raft_group_registry>&);
 future<> unset_server_raft(http_context&);

--- a/api/storage_service.cc
+++ b/api/storage_service.cc
@@ -773,27 +773,6 @@ rest_cdc_streams_check_and_repair(sharded<service::storage_service>& ss, std::un
         });
 }
 
-static future<shared_ptr<compaction::cleanup_keyspace_compaction_task_impl>> force_keyspace_cleanup(http_context& ctx, sharded<service::storage_service>& ss, std::unique_ptr<http::request> req) {
-        auto& db = ctx.db;
-        auto [keyspace, table_infos] = parse_table_infos(ctx, *req);
-        const auto& rs = db.local().find_keyspace(keyspace).get_replication_strategy();
-        if (rs.is_local() || !rs.is_vnode_based()) {
-            auto reason = rs.is_local() ? "require" : "support";
-            apilog.info("Keyspace {} does not {} cleanup", keyspace, reason);
-            co_return nullptr;
-        }
-        apilog.info("force_keyspace_cleanup: keyspace={} tables={}", keyspace, table_infos);
-        if (!co_await ss.local().is_vnodes_cleanup_allowed(keyspace)) {
-            auto msg = "Can not perform cleanup operation when topology changes";
-            apilog.warn("force_keyspace_cleanup: keyspace={} tables={}: {}", keyspace, table_infos, msg);
-            co_await coroutine::return_exception(std::runtime_error(msg));
-        }
-
-        auto& compaction_module = db.local().get_compaction_manager().get_task_manager_module();
-        co_return co_await compaction_module.make_and_start_task<compaction::cleanup_keyspace_compaction_task_impl>(
-            {}, std::move(keyspace), db, table_infos, compaction::flush_mode::all_tables, tasks::is_user_task::yes);
-}
-
 static
 future<json::json_return_type>
 rest_reset_cleanup_needed(http_context& ctx, sharded<service::storage_service>& ss, std::unique_ptr<http::request> req) {
@@ -1907,21 +1886,6 @@ void set_storage_service(http_context& ctx, routes& r, sharded<service::storage_
     ss::get_natural_endpoints_v2.set(r, gated(ss, rest_bind(rest_get_natural_endpoints_v2, ctx, ss)));
     ss::cdc_streams_check_and_repair.set(r, gated(ss, rest_bind(rest_cdc_streams_check_and_repair, ss)));
     ss::reset_cleanup_needed.set(r, gated(ss, rest_bind(rest_reset_cleanup_needed, ctx, ss)));
-    t::force_keyspace_cleanup_async.set(r, [&ctx, &ss](std::unique_ptr<http::request> req) -> future<json::json_return_type> {
-        tasks::task_id id = tasks::task_id::create_null_id();
-        auto task = co_await force_keyspace_cleanup(ctx, ss, std::move(req));
-        if (task) {
-            id = task->get_status().id;
-        }
-        co_return json::json_return_type(id.to_sstring());
-    });
-    ss::force_keyspace_cleanup.set(r, [&ctx, &ss](std::unique_ptr<http::request> req) -> future<json::json_return_type> {
-        auto task = co_await force_keyspace_cleanup(ctx, ss, std::move(req));
-        if (task) {
-            co_await task->done();
-        }
-        co_return json::json_return_type(0);
-    });
     ss::decommission.set(r, gated(ss, rest_bind(rest_decommission, ss, ssc)));
     ss::logstor_compaction.set(r, gated(ss, rest_bind(rest_logstor_compaction, ctx)));
     ss::logstor_flush.set(r, gated(ss, rest_bind(rest_logstor_flush, ctx)));
@@ -2002,8 +1966,6 @@ void unset_storage_service(http_context& ctx, routes& r) {
     ss::get_natural_endpoints.unset(r);
     ss::cdc_streams_check_and_repair.unset(r);
     ss::reset_cleanup_needed.unset(r);
-    t::force_keyspace_cleanup_async.unset(r);
-    ss::force_keyspace_cleanup.unset(r);
     ss::logstor_compaction.unset(r);
     ss::logstor_flush.unset(r);
     ss::decommission.unset(r);

--- a/api/storage_service.cc
+++ b/api/storage_service.cc
@@ -2243,33 +2243,6 @@ void set_snapshot(http_context& ctx, routes& r, sharded<db::snapshot_ctl>& snap_
         });
     });
 
-    ss::scrub.set(r, [&ctx, &snap_ctl] (std::unique_ptr<http::request> req) -> future<json::json_return_type> {
-        auto& db = ctx.db;
-        auto info = parse_scrub_options(ctx, std::move(req));
-
-        if (!info.snapshot_tag.empty()) {
-            db::snapshot_options opts = {.skip_flush = false};
-            co_await snap_ctl.local().take_column_family_snapshot(info.keyspace, info.column_families, info.snapshot_tag, opts);
-        }
-
-        compaction::compaction_stats stats;
-        auto& compaction_module = db.local().get_compaction_manager().get_task_manager_module();
-        auto task = co_await compaction_module.make_and_start_task<compaction::scrub_sstables_compaction_task_impl>({}, info.keyspace, db, info.column_families, info.opts, &stats);
-        try {
-            co_await task->done();
-            if (stats.validation_errors) {
-                co_return json::json_return_type(static_cast<int>(scrub_status::validation_errors));
-            }
-        } catch (const compaction::compaction_aborted_exception&) {
-            co_return json::json_return_type(static_cast<int>(scrub_status::aborted));
-        } catch (...) {
-            apilog.error("scrub keyspace={} tables={} failed: {}", info.keyspace, info.column_families, std::current_exception());
-            throw;
-        }
-
-        co_return json::json_return_type(static_cast<int>(scrub_status::successful));
-    });
-
     ss::start_backup.set(r, [&snap_ctl] (std::unique_ptr<http::request> req) -> future<json::json_return_type> {
         auto endpoint = req->get_query_param("endpoint");
         auto keyspace = req->get_query_param("keyspace");
@@ -2348,7 +2321,6 @@ void unset_snapshot(http_context& ctx, routes& r) {
     ss::take_snapshot.unset(r);
     ss::del_snapshot.unset(r);
     ss::true_snapshots_size.unset(r);
-    ss::scrub.unset(r);
     ss::start_backup.unset(r);
     cf::get_true_snapshots_size.unset(r);
     cf::get_all_true_snapshots_size.unset(r);

--- a/api/storage_service.cc
+++ b/api/storage_service.cc
@@ -773,36 +773,6 @@ rest_cdc_streams_check_and_repair(sharded<service::storage_service>& ss, std::un
         });
 }
 
-static
-future<json::json_return_type>
-rest_cleanup_all(http_context& ctx, sharded<service::storage_service>& ss, std::unique_ptr<http::request> req) {
-        bool global = true;
-        if (auto global_param = req->get_query_param("global"); !global_param.empty()) {
-            global = validate_bool(global_param);
-        }
-
-        apilog.info("cleanup_all global={}", global);
-
-        if (global) {
-            co_await ss.invoke_on(0, [] (service::storage_service& ss) -> future<> {
-                co_return co_await ss.do_clusterwide_vnodes_cleanup();
-            });
-            co_return json::json_return_type(0);
-        }
-        // fall back to the local cleanup if local cleanup is requested
-        auto& db = ctx.db;
-        auto& compaction_module = db.local().get_compaction_manager().get_task_manager_module();
-        auto task = co_await compaction_module.make_and_start_task<compaction::global_cleanup_compaction_task_impl>({}, db);
-        co_await task->done();
-
-        // Mark this node as clean
-        co_await ss.invoke_on(0, [] (service::storage_service& ss) -> future<> {
-            co_await ss.reset_cleanup_needed();
-        });
-
-        co_return json::json_return_type(0);
-}
-
 static future<shared_ptr<compaction::cleanup_keyspace_compaction_task_impl>> force_keyspace_cleanup(http_context& ctx, sharded<service::storage_service>& ss, std::unique_ptr<http::request> req) {
         auto& db = ctx.db;
         auto [keyspace, table_infos] = parse_table_infos(ctx, *req);
@@ -1936,7 +1906,6 @@ void set_storage_service(http_context& ctx, routes& r, sharded<service::storage_
     ss::get_natural_endpoints.set(r, gated(ss, rest_bind(rest_get_natural_endpoints, ctx, ss)));
     ss::get_natural_endpoints_v2.set(r, gated(ss, rest_bind(rest_get_natural_endpoints_v2, ctx, ss)));
     ss::cdc_streams_check_and_repair.set(r, gated(ss, rest_bind(rest_cdc_streams_check_and_repair, ss)));
-    ss::cleanup_all.set(r, gated(ss, rest_bind(rest_cleanup_all, ctx, ss)));
     ss::reset_cleanup_needed.set(r, gated(ss, rest_bind(rest_reset_cleanup_needed, ctx, ss)));
     t::force_keyspace_cleanup_async.set(r, [&ctx, &ss](std::unique_ptr<http::request> req) -> future<json::json_return_type> {
         tasks::task_id id = tasks::task_id::create_null_id();
@@ -2032,7 +2001,6 @@ void unset_storage_service(http_context& ctx, routes& r) {
     ss::get_current_generation_number.unset(r);
     ss::get_natural_endpoints.unset(r);
     ss::cdc_streams_check_and_repair.unset(r);
-    ss::cleanup_all.unset(r);
     ss::reset_cleanup_needed.unset(r);
     t::force_keyspace_cleanup_async.unset(r);
     ss::force_keyspace_cleanup.unset(r);

--- a/api/storage_service.cc
+++ b/api/storage_service.cc
@@ -230,69 +230,6 @@ seastar::future<json::json_return_type> run_toppartitions_query(db::toppartition
     });
 }
 
-scrub_info parse_scrub_options(const http_context& ctx, std::unique_ptr<http::request> req) {
-    scrub_info info;
-    auto [ keyspace, table_infos ] = parse_table_infos(ctx, *req, "cf");
-    info.keyspace = std::move(keyspace);
-    info.column_families = table_infos | std::views::transform(&table_info::name) | std::ranges::to<std::vector>();
-    auto scrub_mode_str = req->get_query_param("scrub_mode");
-    auto scrub_mode = compaction::compaction_type_options::scrub::mode::validate;
-
-    if (scrub_mode_str.empty()) {
-        const auto skip_corrupted = validate_bool_x(req->get_query_param("skip_corrupted"), false);
-
-        if (skip_corrupted) {
-            scrub_mode = compaction::compaction_type_options::scrub::mode::skip;
-        }
-    } else {
-        if (scrub_mode_str == "ABORT") {
-            scrub_mode = compaction::compaction_type_options::scrub::mode::abort;
-        } else if (scrub_mode_str == "SKIP") {
-            scrub_mode = compaction::compaction_type_options::scrub::mode::skip;
-        } else if (scrub_mode_str == "SEGREGATE") {
-            scrub_mode = compaction::compaction_type_options::scrub::mode::segregate;
-        } else if (scrub_mode_str == "VALIDATE") {
-            scrub_mode = compaction::compaction_type_options::scrub::mode::validate;
-        } else {
-            throw httpd::bad_param_exception(fmt::format("Unknown argument for 'scrub_mode' parameter: {}", scrub_mode_str));
-        }
-    }
-
-    if (!req_param<bool>(*req, "disable_snapshot", false) && !info.column_families.empty()) {
-        info.snapshot_tag = format("pre-scrub-{:d}", db_clock::now().time_since_epoch().count());
-    }
-
-    info.opts = {
-        .operation_mode = scrub_mode,
-    };
-    const sstring quarantine_mode_str = req_param<sstring>(*req, "quarantine_mode", "INCLUDE");
-    if (quarantine_mode_str == "INCLUDE") {
-        info.opts.quarantine_operation_mode = compaction::compaction_type_options::scrub::quarantine_mode::include;
-    } else if (quarantine_mode_str == "EXCLUDE") {
-        info.opts.quarantine_operation_mode = compaction::compaction_type_options::scrub::quarantine_mode::exclude;
-    } else if (quarantine_mode_str == "ONLY") {
-        info.opts.quarantine_operation_mode = compaction::compaction_type_options::scrub::quarantine_mode::only;
-    } else {
-        throw httpd::bad_param_exception(fmt::format("Unknown argument for 'quarantine_mode' parameter: {}", quarantine_mode_str));
-    }
-
-    if(req_param<bool>(*req, "drop_unfixable_sstables", false)) {
-        if(scrub_mode != compaction::compaction_type_options::scrub::mode::segregate) {
-            throw httpd::bad_param_exception("The 'drop_unfixable_sstables' parameter is only valid when 'scrub_mode' is 'SEGREGATE'");
-        }
-        info.opts.drop_unfixable = compaction::compaction_type_options::scrub::drop_unfixable_sstables::yes;
-    }
-
-    if (req->get_query_param("quarantine_invalid_sstables") != "") {
-        if (scrub_mode != compaction::compaction_type_options::scrub::mode::validate) {
-            throw httpd::bad_param_exception("The 'quarantine_invalid_sstables' parameter is only valid when 'scrub_mode' is 'VALIDATE'");
-        }
-        info.opts.quarantine_sstables = compaction::compaction_type_options::scrub::quarantine_invalid_sstables(req_param<bool>(*req, "quarantine_invalid_sstables", true));
-    }
-
-    return info;
-}
-
 void set_transport_controller(http_context& ctx, routes& r, cql_transport::controller& ctl) {
     ss::start_native_transport.set(r, [&ctl](std::unique_ptr<http::request> req) {
         return smp::submit_to(0, [&] {

--- a/api/storage_service.hh
+++ b/api/storage_service.hh
@@ -64,8 +64,6 @@ struct scrub_info {
     sstring snapshot_tag;
 };
 
-scrub_info parse_scrub_options(const http_context& ctx, std::unique_ptr<http::request> req);
-
 // TTL is given as a number with an optional a suffix of:
 // s - seconds (default)
 // m - minutes

--- a/api/tasks.cc
+++ b/api/tasks.cc
@@ -61,7 +61,7 @@ static future<shared_ptr<compaction::upgrade_sstables_compaction_task_impl>> upg
     return compaction_module.make_and_start_task<compaction::upgrade_sstables_compaction_task_impl>({}, std::move(keyspace), db, table_infos, exclude_current_version);
 }
 
-void set_tasks_compaction_module(http_context& ctx, routes& r, sharded<replica::database>& db, sharded<db::snapshot_ctl>& snap_ctl) {
+void set_tasks_compaction_module(http_context& ctx, routes& r, sharded<replica::database>& db, sharded<db::snapshot_ctl>& snap_ctl, sharded<service::storage_service>& ss) {
     t::force_keyspace_compaction_async.set(r, [&ctx, &db](std::unique_ptr<http::request> req) -> future<json::json_return_type> {
         auto task = co_await force_keyspace_compaction(ctx, db, std::move(req));
         co_return json::json_return_type(task->get_status().id.to_sstring());

--- a/api/tasks.cc
+++ b/api/tasks.cc
@@ -19,6 +19,7 @@
 #include "compaction/task_manager_module.hh"
 #include "tasks/task_manager.hh"
 #include "replica/database.hh"
+#include "service/storage_service.hh"
 
 using namespace seastar::httpd;
 
@@ -60,6 +61,33 @@ static future<shared_ptr<compaction::upgrade_sstables_compaction_task_impl>> upg
 
     auto& compaction_module = db.local().get_compaction_manager().get_task_manager_module();
     return compaction_module.make_and_start_task<compaction::upgrade_sstables_compaction_task_impl>({}, std::move(keyspace), db, table_infos, exclude_current_version);
+}
+
+static future<json::json_return_type> rest_cleanup_all(sharded<replica::database>& db, sharded<service::storage_service>& ss, std::unique_ptr<http::request> req) {
+    bool global = true;
+    if (auto global_param = req->get_query_param("global"); !global_param.empty()) {
+        global = validate_bool(global_param);
+    }
+
+    apilog.info("cleanup_all global={}", global);
+
+    if (global) {
+        co_await ss.invoke_on(0, [] (service::storage_service& ss) -> future<> {
+            co_return co_await ss.do_clusterwide_vnodes_cleanup();
+        });
+        co_return json::json_return_type(0);
+    }
+    // fall back to the local cleanup if local cleanup is requested
+    auto& compaction_module = db.local().get_compaction_manager().get_task_manager_module();
+    auto task = co_await compaction_module.make_and_start_task<compaction::global_cleanup_compaction_task_impl>({}, db);
+    co_await task->done();
+
+    // Mark this node as clean
+    co_await ss.invoke_on(0, [] (service::storage_service& ss) -> future<> {
+        co_await ss.reset_cleanup_needed();
+    });
+
+    co_return json::json_return_type(0);
 }
 
 void set_tasks_compaction_module(http_context& ctx, routes& r, sharded<replica::database>& db, sharded<db::snapshot_ctl>& snap_ctl, sharded<service::storage_service>& ss) {
@@ -142,6 +170,10 @@ void set_tasks_compaction_module(http_context& ctx, routes& r, sharded<replica::
         co_return json::json_return_type(static_cast<int>(scrub_status::successful));
     });
 
+    ss::cleanup_all.set(r, [&db, &ss] (std::unique_ptr<http::request> req) {
+        return rest_cleanup_all(db, ss, std::move(req));
+    });
+
     ss::force_compaction.set(r, [&db] (std::unique_ptr<http::request> req) -> future<json::json_return_type> {
         auto flush = validate_bool_x(req->get_query_param("flush_memtables"), true);
         auto consider_only_existing_data = validate_bool_x(req->get_query_param("consider_only_existing_data"), false);
@@ -167,6 +199,7 @@ void unset_tasks_compaction_module(http_context& ctx, httpd::routes& r) {
     ss::upgrade_sstables.unset(r);
     t::scrub_async.unset(r);
     ss::scrub.unset(r);
+    ss::cleanup_all.unset(r);
     ss::force_compaction.unset(r);
 }
 

--- a/api/tasks.cc
+++ b/api/tasks.cc
@@ -7,6 +7,7 @@
  */
 
 #include <seastar/core/coroutine.hh>
+#include <seastar/coroutine/exception.hh>
 #include <fmt/ranges.h>
 
 #include "api/api.hh"
@@ -88,6 +89,26 @@ static future<json::json_return_type> rest_cleanup_all(sharded<replica::database
     });
 
     co_return json::json_return_type(0);
+}
+
+static future<shared_ptr<compaction::cleanup_keyspace_compaction_task_impl>> force_keyspace_cleanup(http_context& ctx, sharded<replica::database>& db, sharded<service::storage_service>& ss, std::unique_ptr<http::request> req) {
+    auto [keyspace, table_infos] = parse_table_infos(ctx, *req);
+    const auto& rs = db.local().find_keyspace(keyspace).get_replication_strategy();
+    if (rs.is_local() || !rs.is_vnode_based()) {
+        auto reason = rs.is_local() ? "require" : "support";
+        apilog.info("Keyspace {} does not {} cleanup", keyspace, reason);
+        co_return nullptr;
+    }
+    apilog.info("force_keyspace_cleanup: keyspace={} tables={}", keyspace, table_infos);
+    if (!co_await ss.local().is_vnodes_cleanup_allowed(keyspace)) {
+        auto msg = "Can not perform cleanup operation when topology changes";
+        apilog.warn("force_keyspace_cleanup: keyspace={} tables={}: {}", keyspace, table_infos, msg);
+        co_await coroutine::return_exception(std::runtime_error(msg));
+    }
+
+    auto& compaction_module = db.local().get_compaction_manager().get_task_manager_module();
+    co_return co_await compaction_module.make_and_start_task<compaction::cleanup_keyspace_compaction_task_impl>(
+        {}, std::move(keyspace), db, table_infos, compaction::flush_mode::all_tables, tasks::is_user_task::yes);
 }
 
 void set_tasks_compaction_module(http_context& ctx, routes& r, sharded<replica::database>& db, sharded<db::snapshot_ctl>& snap_ctl, sharded<service::storage_service>& ss) {
@@ -174,6 +195,22 @@ void set_tasks_compaction_module(http_context& ctx, routes& r, sharded<replica::
         return rest_cleanup_all(db, ss, std::move(req));
     });
 
+    t::force_keyspace_cleanup_async.set(r, [&ctx, &db, &ss](std::unique_ptr<http::request> req) -> future<json::json_return_type> {
+        tasks::task_id id = tasks::task_id::create_null_id();
+        auto task = co_await force_keyspace_cleanup(ctx, db, ss, std::move(req));
+        if (task) {
+            id = task->get_status().id;
+        }
+        co_return json::json_return_type(id.to_sstring());
+    });
+    ss::force_keyspace_cleanup.set(r, [&ctx, &db, &ss](std::unique_ptr<http::request> req) -> future<json::json_return_type> {
+        auto task = co_await force_keyspace_cleanup(ctx, db, ss, std::move(req));
+        if (task) {
+            co_await task->done();
+        }
+        co_return json::json_return_type(0);
+    });
+
     ss::force_compaction.set(r, [&db] (std::unique_ptr<http::request> req) -> future<json::json_return_type> {
         auto flush = validate_bool_x(req->get_query_param("flush_memtables"), true);
         auto consider_only_existing_data = validate_bool_x(req->get_query_param("consider_only_existing_data"), false);
@@ -200,6 +237,8 @@ void unset_tasks_compaction_module(http_context& ctx, httpd::routes& r) {
     t::scrub_async.unset(r);
     ss::scrub.unset(r);
     ss::cleanup_all.unset(r);
+    t::force_keyspace_cleanup_async.unset(r);
+    ss::force_keyspace_cleanup.unset(r);
     ss::force_compaction.unset(r);
 }
 

--- a/api/tasks.cc
+++ b/api/tasks.cc
@@ -11,6 +11,7 @@
 
 #include "api/api.hh"
 #include "api/storage_service.hh"
+#include "api/scrub_status.hh"
 #include "api/validate.hh"
 #include "api/api-doc/tasks.json.hh"
 #include "api/api-doc/storage_service.json.hh"
@@ -115,6 +116,32 @@ void set_tasks_compaction_module(http_context& ctx, routes& r, sharded<replica::
         co_return json::json_return_type(task->get_status().id.to_sstring());
     });
 
+    ss::scrub.set(r, [&ctx, &db, &snap_ctl] (std::unique_ptr<http::request> req) -> future<json::json_return_type> {
+        auto info = parse_scrub_options(ctx, std::move(req));
+
+        if (!info.snapshot_tag.empty()) {
+            db::snapshot_options opts = {.skip_flush = false};
+            co_await snap_ctl.local().take_column_family_snapshot(info.keyspace, info.column_families, info.snapshot_tag, opts);
+        }
+
+        compaction::compaction_stats stats;
+        auto& compaction_module = db.local().get_compaction_manager().get_task_manager_module();
+        auto task = co_await compaction_module.make_and_start_task<compaction::scrub_sstables_compaction_task_impl>({}, info.keyspace, db, info.column_families, info.opts, &stats);
+        try {
+            co_await task->done();
+            if (stats.validation_errors) {
+                co_return json::json_return_type(static_cast<int>(scrub_status::validation_errors));
+            }
+        } catch (const compaction::compaction_aborted_exception&) {
+            co_return json::json_return_type(static_cast<int>(scrub_status::aborted));
+        } catch (...) {
+            apilog.error("scrub keyspace={} tables={} failed: {}", info.keyspace, info.column_families, std::current_exception());
+            throw;
+        }
+
+        co_return json::json_return_type(static_cast<int>(scrub_status::successful));
+    });
+
     ss::force_compaction.set(r, [&db] (std::unique_ptr<http::request> req) -> future<json::json_return_type> {
         auto flush = validate_bool_x(req->get_query_param("flush_memtables"), true);
         auto consider_only_existing_data = validate_bool_x(req->get_query_param("consider_only_existing_data"), false);
@@ -139,6 +166,7 @@ void unset_tasks_compaction_module(http_context& ctx, httpd::routes& r) {
     t::upgrade_sstables_async.unset(r);
     ss::upgrade_sstables.unset(r);
     t::scrub_async.unset(r);
+    ss::scrub.unset(r);
     ss::force_compaction.unset(r);
 }
 

--- a/api/tasks.cc
+++ b/api/tasks.cc
@@ -111,6 +111,69 @@ static future<shared_ptr<compaction::cleanup_keyspace_compaction_task_impl>> for
         {}, std::move(keyspace), db, table_infos, compaction::flush_mode::all_tables, tasks::is_user_task::yes);
 }
 
+static scrub_info parse_scrub_options(const http_context& ctx, std::unique_ptr<http::request> req) {
+    scrub_info info;
+    auto [ keyspace, table_infos ] = parse_table_infos(ctx, *req, "cf");
+    info.keyspace = std::move(keyspace);
+    info.column_families = table_infos | std::views::transform(&table_info::name) | std::ranges::to<std::vector>();
+    auto scrub_mode_str = req->get_query_param("scrub_mode");
+    auto scrub_mode = compaction::compaction_type_options::scrub::mode::validate;
+
+    if (scrub_mode_str.empty()) {
+        const auto skip_corrupted = validate_bool_x(req->get_query_param("skip_corrupted"), false);
+
+        if (skip_corrupted) {
+            scrub_mode = compaction::compaction_type_options::scrub::mode::skip;
+        }
+    } else {
+        if (scrub_mode_str == "ABORT") {
+            scrub_mode = compaction::compaction_type_options::scrub::mode::abort;
+        } else if (scrub_mode_str == "SKIP") {
+            scrub_mode = compaction::compaction_type_options::scrub::mode::skip;
+        } else if (scrub_mode_str == "SEGREGATE") {
+            scrub_mode = compaction::compaction_type_options::scrub::mode::segregate;
+        } else if (scrub_mode_str == "VALIDATE") {
+            scrub_mode = compaction::compaction_type_options::scrub::mode::validate;
+        } else {
+            throw httpd::bad_param_exception(fmt::format("Unknown argument for 'scrub_mode' parameter: {}", scrub_mode_str));
+        }
+    }
+
+    if (!req_param<bool>(*req, "disable_snapshot", false) && !info.column_families.empty()) {
+        info.snapshot_tag = format("pre-scrub-{:d}", db_clock::now().time_since_epoch().count());
+    }
+
+    info.opts = {
+        .operation_mode = scrub_mode,
+    };
+    const sstring quarantine_mode_str = req_param<sstring>(*req, "quarantine_mode", "INCLUDE");
+    if (quarantine_mode_str == "INCLUDE") {
+        info.opts.quarantine_operation_mode = compaction::compaction_type_options::scrub::quarantine_mode::include;
+    } else if (quarantine_mode_str == "EXCLUDE") {
+        info.opts.quarantine_operation_mode = compaction::compaction_type_options::scrub::quarantine_mode::exclude;
+    } else if (quarantine_mode_str == "ONLY") {
+        info.opts.quarantine_operation_mode = compaction::compaction_type_options::scrub::quarantine_mode::only;
+    } else {
+        throw httpd::bad_param_exception(fmt::format("Unknown argument for 'quarantine_mode' parameter: {}", quarantine_mode_str));
+    }
+
+    if(req_param<bool>(*req, "drop_unfixable_sstables", false)) {
+        if(scrub_mode != compaction::compaction_type_options::scrub::mode::segregate) {
+            throw httpd::bad_param_exception("The 'drop_unfixable_sstables' parameter is only valid when 'scrub_mode' is 'SEGREGATE'");
+        }
+        info.opts.drop_unfixable = compaction::compaction_type_options::scrub::drop_unfixable_sstables::yes;
+    }
+
+    if (req->get_query_param("quarantine_invalid_sstables") != "") {
+        if (scrub_mode != compaction::compaction_type_options::scrub::mode::validate) {
+            throw httpd::bad_param_exception("The 'quarantine_invalid_sstables' parameter is only valid when 'scrub_mode' is 'VALIDATE'");
+        }
+        info.opts.quarantine_sstables = compaction::compaction_type_options::scrub::quarantine_invalid_sstables(req_param<bool>(*req, "quarantine_invalid_sstables", true));
+    }
+
+    return info;
+}
+
 void set_tasks_compaction_module(http_context& ctx, routes& r, sharded<replica::database>& db, sharded<db::snapshot_ctl>& snap_ctl, sharded<service::storage_service>& ss) {
     t::force_keyspace_compaction_async.set(r, [&ctx, &db](std::unique_ptr<http::request> req) -> future<json::json_return_type> {
         auto task = co_await force_keyspace_compaction(ctx, db, std::move(req));

--- a/api/tasks.hh
+++ b/api/tasks.hh
@@ -19,10 +19,14 @@ namespace replica {
 class database;
 }
 
+namespace service {
+class storage_service;
+}
+
 namespace api {
 
 struct http_context;
-void set_tasks_compaction_module(http_context& ctx, httpd::routes& r, sharded<replica::database>& db, sharded<db::snapshot_ctl>& snap_ctl);
+void set_tasks_compaction_module(http_context& ctx, httpd::routes& r, sharded<replica::database>& db, sharded<db::snapshot_ctl>& snap_ctl, sharded<service::storage_service>& ss);
 void unset_tasks_compaction_module(http_context& ctx, httpd::routes& r);
 
 }

--- a/main.cc
+++ b/main.cc
@@ -2390,7 +2390,7 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
                 api::unset_server_snapshot(ctx).get();
             });
 
-            api::set_server_tasks_compaction_module(ctx, db, snapshot_ctl).get();
+            api::set_server_tasks_compaction_module(ctx, db, snapshot_ctl, ss).get();
             auto stop_tasks_api = defer_verbose_shutdown("tasks API", [&ctx] {
                 api::unset_server_tasks_compaction_module(ctx).get();
             });


### PR DESCRIPTION
The api::http_context is going to stop carrying sharded<replica::database>& reference in favor of a data_dictionary::database, but some endpoint still use it.

This PR moves several endpoints, whose work is to start compaction manager task, from storage_service.cc into tasks.cc where the database reference is available as captured parameter. Also, for some of them, the sync/async sibling alreay exists in tasks.cc so this move also improves the code harmony :lotus_position: 

Improving components inter-dependencies, not backporting