### PR TITLE
[DO NOT MERGE][2026.1] reshard: fix crashes on tablet-based tables during nodetool refresh / startup

### DIFF
--- a/compaction/compaction.cc
+++ b/compaction/compaction.cc
@@ -2021,8 +2021,8 @@ public:
     }
 
     mutation_reader_consumer make_interposer_consumer(mutation_reader_consumer end_consumer) override {
-        return [end_consumer = std::move(end_consumer)] (mutation_reader reader) mutable -> future<> {
-            return mutation_writer::segregate_by_shard(std::move(reader), std::move(end_consumer));
+        return [this, end_consumer = std::move(end_consumer)] (mutation_reader reader) mutable -> future<> {
+            return mutation_writer::segregate_by_shard(std::move(reader), *_sharder, std::move(end_consumer));
         };
     }
 

--- a/compaction/task_manager_module.cc
+++ b/compaction/task_manager_module.cc
@@ -160,7 +160,16 @@ future<> reshard(sstables::sstable_directory& dir, sstables::sstable_directory::
     // There is a semaphore inside the compaction manager in run_resharding_jobs. So we
     // parallel_for_each so the statistics about pending jobs are updated to reflect all
     // jobs. But only one will run in parallel at a time
-    auto& t = table.try_get_compaction_group_view_with_static_sharding();
+    //
+    // The compaction group view is used here only for job registration and gate-holding;
+    // resharding never reads or writes the group's own SSTables. With static (vnode)
+    // sharding there is exactly one group per shard; with tablets there may be many.
+    // In either case, any registered group suffices.
+    auto* cg = table.get_any_compaction_group();
+    if (!cg) {
+        on_internal_error(tasks::tmlogger, format("No compaction group found for table {}.{}", table.schema()->ks_name(), table.schema()->cf_name()));
+    }
+    auto& t = cg->view_for_unrepaired_data();
     // Resharding is mandatory for SSTable loading — if it cannot proceed (e.g. due to
     // out-of-space prevention disabling compaction), we must fail loudly rather than
     // silently skipping and leaving SSTables orphaned.

--- a/mutation_writer/shard_based_splitting_writer.cc
+++ b/mutation_writer/shard_based_splitting_writer.cc
@@ -20,6 +20,7 @@ class shard_based_splitting_mutation_writer {
 private:
     schema_ptr _schema;
     reader_permit _permit;
+    const dht::sharder& _sharder;
     mutation_reader_consumer _consumer;
     unsigned _current_shard;
     std::vector<std::optional<shard_writer>> _shards;
@@ -29,15 +30,16 @@ private:
         return writer.consume(std::move(mf));
     }
 public:
-    shard_based_splitting_mutation_writer(schema_ptr schema, reader_permit permit, mutation_reader_consumer consumer)
+    shard_based_splitting_mutation_writer(schema_ptr schema, reader_permit permit, const dht::sharder& sharder, mutation_reader_consumer consumer)
         : _schema(std::move(schema))
         , _permit(std::move(permit))
+        , _sharder(sharder)
         , _consumer(std::move(consumer))
         , _shards(smp::count)
     {}
 
     future<> consume(partition_start&& ps) {
-        _current_shard = dht::static_shard_of(*_schema, ps.key().token()); // FIXME: Use table sharder
+        _current_shard = _sharder.shard_for_reads(ps.key().token());
         if (!_shards[_current_shard]) {
             _shards[_current_shard] = shard_writer(_schema, _permit, _consumer);
         }
@@ -82,11 +84,11 @@ public:
     }
 };
 
-future<> segregate_by_shard(mutation_reader producer, mutation_reader_consumer consumer) {
+future<> segregate_by_shard(mutation_reader producer, const dht::sharder& sharder, mutation_reader_consumer consumer) {
     auto schema = producer.schema();
     auto permit = producer.permit();
     return feed_writer(
         std::move(producer),
-        shard_based_splitting_mutation_writer(std::move(schema), std::move(permit), std::move(consumer)));
+        shard_based_splitting_mutation_writer(std::move(schema), std::move(permit), sharder, std::move(consumer)));
 }
 } // namespace mutation_writer

--- a/mutation_writer/shard_based_splitting_writer.hh
+++ b/mutation_writer/shard_based_splitting_writer.hh
@@ -9,13 +9,18 @@
 #pragma once
 
 #include "readers/mutation_reader.hh"
+#include "dht/i_partitioner_fwd.hh"
 
 namespace mutation_writer {
 
 // Given a producer that may contain data for all shards, consume it in a per-shard
 // manner. This is useful, for instance, in the resharding process where a user changes
 // the amount of CPU assigned to Scylla and we have to rewrite the SSTables to their new
-// owners.
-future<> segregate_by_shard(mutation_reader producer, mutation_reader_consumer consumer);
+// owners, or when tablet sstables loaded from a foreign shard need to be split by their
+// current owning shard.
+//
+// `sharder` determines the owning shard of each partition. Its lifetime must extend
+// until the returned future resolves.
+future<> segregate_by_shard(mutation_reader producer, const dht::sharder& sharder, mutation_reader_consumer consumer);
 
 } // namespace mutation_writer

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -716,6 +716,9 @@ private:
 
     std::unique_ptr<storage_group_manager> make_storage_group_manager();
     compaction_group* get_compaction_group(size_t id) const;
+public:
+    compaction_group* get_any_compaction_group() const;
+private:
     // NOTE: all readers must only operate on storage groups, which can provide all data belonging to
     // a given tablet replica. Interfaces below should only be used in the context of writes, for
     // example, to append data to memtable. Iterating on compaction groups is susceptible to races

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -1249,6 +1249,14 @@ compaction_group* table::get_compaction_group(size_t id) const {
     return storage_group_for_id(id).main_compaction_group().get();
 }
 
+compaction_group* table::get_any_compaction_group() const {
+    auto& groups = _sg_manager->storage_groups();
+    if (groups.empty()) {
+        return nullptr;
+    }
+    return groups.begin()->second->main_compaction_group().get();
+}
+
 storage_group& table::storage_group_for_token(dht::token token) const {
     return _sg_manager->storage_group_for_token(token);
 }

--- a/test/boost/sstable_directory_test.cc
+++ b/test/boost/sstable_directory_test.cc
@@ -598,6 +598,83 @@ SEASTAR_TEST_CASE(sstable_directory_shared_sstables_reshard_correctly) {
     });
 }
 
+// Like make_sstable_for_all_shards(), but doesn't require a static sharder (i.e. works for
+// tablet-based tables too): keys aren't filtered per-shard, they just need to span multiple
+// shards so that sstable_directory sees the sstable as "shared" and routes it through reshard().
+sstables::shared_sstable
+make_unsharded_sstable_spanning_all_shards(replica::table& table, sstables::sstable_state state, sstables::generation_type generation) {
+    auto s = table.schema();
+    auto mt = make_lw_shared<replica::memtable>(s);
+    auto keys = tests::generate_partition_keys(std::max<size_t>(1000, smp::count * 100), s, std::optional<shard_id>(std::nullopt));
+    for (auto& key : keys) {
+        mutation m(s, key);
+        m.set_clustered_cell(clustering_key::make_empty(), bytes("c"), data_value(int32_t(0)), api::timestamp_type(0));
+        mt->apply(std::move(m));
+    }
+    auto sst = table.get_sstables_manager().make_sstable(s, table.get_storage_options(), generation, state);
+    write_memtable_to_sstable(*mt, sst).get();
+    mt->clear_gently().get();
+    // We can't write an SSTable with bad sharding, so pretend it came from Cassandra.
+    sstables::test(sst).remove_component(sstables::component_type::Scylla).get();
+    sstables::test(sst).rewrite_toc_without_component(sstables::component_type::Scylla);
+    return sst;
+}
+
+// Regression test: reshard() must not assume static (vnode) sharding. It used to call
+// try_get_compaction_group_view_with_static_sharding() unconditionally, which throws
+// "Getting table state is allowed only with static sharding" for any tablet-based table,
+// even though no shard count/topology change is involved -- e.g. on `nodetool refresh`
+// or node startup when leftover sstables need resharding.
+SEASTAR_TEST_CASE(sstable_directory_reshard_works_for_tablets) {
+    if (smp::count == 1) {
+        fmt::print("Skipping sstable_directory_reshard_works_for_tablets, smp == 1\n");
+        return make_ready_future<>();
+    }
+
+    cql_test_config cfg;
+    cfg.initial_tablets = smp::count * 4;
+
+    return do_with_cql_env_thread([] (cql_test_env& e) {
+        e.execute_cql("create table cf (p text PRIMARY KEY, c int)").get();
+        auto& cf = e.local_db().find_column_family("ks", "cf");
+
+        e.db().invoke_on_all([] (replica::database& db) {
+            auto& cf = db.find_column_family("ks", "cf");
+            return cf.disable_auto_compaction();
+        }).get();
+
+        unsigned num_sstables = 4;
+
+        sharded<sstables::sstable_generation_generator> sharded_gen;
+        sharded_gen.start().get();
+        auto stop_generator = deferred_stop(sharded_gen);
+
+        for (unsigned nr = 0; nr < num_sstables; ++nr) {
+            auto generation = sharded_gen.invoke_on(nr % smp::count, [] (auto& gen) {
+                return gen();
+            }).get();
+            make_unsharded_sstable_spanning_all_shards(cf, sstables::sstable_state::upload, generation);
+        }
+
+      with_sstable_directory(e.db(), "ks", "cf", sstables::sstable_state::upload, [&] (sharded<sstables::sstable_directory>& sstdir) {
+        distributed_loader_for_tests::process_sstable_dir(sstdir, { .throw_on_missing_toc = true }).get();
+
+        sharded<sstables::sstable_generation_generator> sharded_gen;
+        sharded_gen.start().get();
+        auto stop_generator = deferred_stop(sharded_gen);
+
+        auto make_sstable = [&e, &sharded_gen] (shard_id shard) {
+            auto generation = sharded_gen.invoke_on(shard, [] (auto& gen) {
+                return gen();
+            }).get();
+            auto& cf = e.local_db().find_column_family("ks", "cf");
+            return cf.get_sstables_manager().make_sstable(cf.schema(), cf.get_storage_options(), generation, sstables::sstable_state::upload);
+        };
+        distributed_loader_for_tests::reshard(sstdir, e.db(), "ks", "cf", std::move(make_sstable)).get();
+      });
+    }, cfg);
+}
+
 // Regression test for #14618 - resharding with non-empty owned_ranges_ptr.
 SEASTAR_TEST_CASE(sstable_directory_shared_sstables_reshard_correctly_with_owned_ranges) {
     if (smp::count == 1) {


### PR DESCRIPTION
## Motivation

`std::runtime_error("Getting table state is allowed only with static sharding")` is thrown on 2026.1 whenever `distributed_loader::reshard()` runs against a tablets-based table with sstables that span more than one shard's ownership - no cluster resize or shard-count change required.
This function is invoked by `nodetool refresh` (loading sstables from the upload dir) and by node startup's `table_populator::populate_subdir()` when leftover sstables need resharding (due to https://github.com/scylladb/scylladb/pull/31032 ) 

Root cause: `reshard()` unconditionally called `table::try_get_compaction_group_view_with_static_sharding()`, which throws whenever the table isn't vnode-based - i.e. every tablets table, the default replication mode in this release.

While reproducing and fixing this, a second, deeper crash in the same code path was found:
once the first throw is fixed, resharding proceeds into `compact_sstables()`, whose interposer consumer (`shard_based_splitting_mutation_writer`) called `dht::static_shard_of()` (marked `// FIXME: Use table sharder`) instead of the already-available effective-replication-map sharder.
That call reaches `schema::get_sharder()`, which aborts via `on_internal_error()` for any non-statically-sharded (tablets) table.

** NOTE this second bug is still present on `master` as of this PR. **

## Changes

1. `replica: Pick any compaction group for resharding` (cherry-picked from upstream master `63399951df`, already merged there) - `reshard()` now uses `table::get_any_compaction_group()` instead of assuming exactly one static-sharding compaction group.
2. The compaction group is only used for job registration/gate-holding here, not for reading/writing its own sstables, so any group works for both vnode tables (one group per shard) and tablet tables (one group per tablet).
3. `mutation_writer: use table sharder in shard_based_splitting_writer` (new, not yet on master) - threads the effective-replication-map sharder (`compaction_descriptor::sharder`, already correctly computed by the caller) through `segregate_by_shard()` into `shard_based_splitting_mutation_writer`, replacing the hardcoded `dht::static_shard_of()` call with `sharder.shard_for_reads()`. This is what actually makes resharding-on-load complete successfully for tablet-based tables.

## Tests

Added `sstable_directory_reshard_works_for_tablets` to `test/boost/sstable_directory_test.cc`: creates a tablets-enabled table (`cfg.initial_tablets = smp::count * 4`), writes sstables containing keys spread across the full token range (so some genuinely span multiple tablets/shards), and calls `distributed_loader::reshard()` 
— the same function `nodetool refresh` and startup use — expecting it to complete without throwing. No shard-count or topology change is involved.

Also re-ran the existing vnode-based reshard tests in `sstable_directory_test.cc` (`sstable_directory_shared_sstables_reshard_correctly[_with_owned_ranges]`, `..._distributes_well_even_if_files_are_not_well_distributed`, `..._respect_max_threshold`) to confirm no regression.

## Results

- Before either fix: new test crashes with `std::runtime_error("Getting table state is allowed only with static sharding")`.
- After fix 1 only: new test crashes differently — `on_internal_error` abort (`"Attempted to obtain static sharder for table ks.cf"`) inside `shard_based_splitting_mutation_writer`.
- After both fixes: new test passes; resharding completes normally (`Resharding 256kB for ks.cf` / `Resharded 256kB for ks.cf in 0.01 seconds`).
- All 4 existing vnode-based reshard tests still pass unmodified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)