### PR TITLE
reshard: fix crash on tablets tables in shard_based_splitting_mutation_writer

### DIFF
--- a/compaction/compaction.cc
+++ b/compaction/compaction.cc
@@ -2061,7 +2061,7 @@ public:
 
     mutation_reader_consumer make_interposer_consumer(mutation_reader_consumer end_consumer) override {
         auto owned_ranges = _reshard_vnodes ? _owned_ranges : nullptr;
-        return [end_consumer = std::move(end_consumer), owned_ranges = std::move(owned_ranges)] (mutation_reader reader) mutable -> future<> {
+        return [this, end_consumer = std::move(end_consumer), owned_ranges = std::move(owned_ranges)] (mutation_reader reader) mutable -> future<> {
             if (owned_ranges) {
                 auto classify = [owned_ranges, it = owned_ranges->begin(), idx = mutation_writer::token_group_id(0)] (dht::token t) mutable -> mutation_writer::token_group_id {
                     dht::token_comparator cmp;
@@ -2077,7 +2077,7 @@ public:
                 };
                 return mutation_writer::segregate_by_token_group(std::move(reader), std::move(classify), std::move(end_consumer));
             } else {
-                return mutation_writer::segregate_by_shard(std::move(reader), std::move(end_consumer));
+                return mutation_writer::segregate_by_shard(std::move(reader), *_sharder, std::move(end_consumer));
             }
         };
     }

--- a/mutation_writer/shard_based_splitting_writer.cc
+++ b/mutation_writer/shard_based_splitting_writer.cc
@@ -20,6 +20,7 @@ class shard_based_splitting_mutation_writer {
 private:
     schema_ptr _schema;
     reader_permit _permit;
+    const dht::sharder& _sharder;
     mutation_reader_consumer _consumer;
     unsigned _current_shard;
     std::vector<std::optional<shard_writer>> _shards;
@@ -29,15 +30,16 @@ private:
         return writer.consume(std::move(mf));
     }
 public:
-    shard_based_splitting_mutation_writer(schema_ptr schema, reader_permit permit, mutation_reader_consumer consumer)
+    shard_based_splitting_mutation_writer(schema_ptr schema, reader_permit permit, const dht::sharder& sharder, mutation_reader_consumer consumer)
         : _schema(std::move(schema))
         , _permit(std::move(permit))
+        , _sharder(sharder)
         , _consumer(std::move(consumer))
         , _shards(this_smp_shard_count())
     {}
 
     future<> consume(partition_start&& ps) {
-        _current_shard = dht::static_shard_of(*_schema, ps.key().token()); // FIXME: Use table sharder
+        _current_shard = _sharder.shard_for_reads(ps.key().token());
         if (!_shards[_current_shard]) {
             _shards[_current_shard] = shard_writer(_schema, _permit, _consumer);
         }
@@ -82,11 +84,11 @@ public:
     }
 };
 
-future<> segregate_by_shard(mutation_reader producer, mutation_reader_consumer consumer) {
+future<> segregate_by_shard(mutation_reader producer, const dht::sharder& sharder, mutation_reader_consumer consumer) {
     auto schema = producer.schema();
     auto permit = producer.permit();
     return feed_writer(
         std::move(producer),
-        shard_based_splitting_mutation_writer(std::move(schema), std::move(permit), std::move(consumer)));
+        shard_based_splitting_mutation_writer(std::move(schema), std::move(permit), sharder, std::move(consumer)));
 }
 } // namespace mutation_writer

--- a/mutation_writer/shard_based_splitting_writer.hh
+++ b/mutation_writer/shard_based_splitting_writer.hh
@@ -9,13 +9,12 @@
 #pragma once
 
 #include "readers/mutation_reader.hh"
+#include "dht/i_partitioner_fwd.hh"
 
 namespace mutation_writer {
 
-// Given a producer that may contain data for all shards, consume it in a per-shard
-// manner. This is useful, for instance, in the resharding process where a user changes
-// the amount of CPU assigned to Scylla and we have to rewrite the SSTables to their new
-// owners.
-future<> segregate_by_shard(mutation_reader producer, mutation_reader_consumer consumer);
+// Splits a producer's data by shard, e.g. for resharding. `sharder` decides ownership
+// per-partition; it must outlive the returned future.
+future<> segregate_by_shard(mutation_reader producer, const dht::sharder& sharder, mutation_reader_consumer consumer);
 
 } // namespace mutation_writer

--- a/test/boost/sstable_directory_test.cc
+++ b/test/boost/sstable_directory_test.cc
@@ -644,6 +644,77 @@ SEASTAR_TEST_CASE(sstable_directory_shared_sstables_reshard_correctly) {
     });
 }
 
+// Like make_sstable_for_all_shards(), but works for tablets too (no static sharder needed).
+sstables::shared_sstable
+make_unsharded_sstable_spanning_all_shards(replica::table& table, sstables::sstable_state state, sstables::generation_type generation) {
+    auto s = table.schema();
+    auto mt = make_lw_shared<replica::memtable>(s);
+    auto keys = tests::generate_partition_keys(std::max<size_t>(1000, this_smp_shard_count() * 100), s, std::optional<shard_id>(std::nullopt));
+    for (auto& key : keys) {
+        mutation m(s, key);
+        m.set_clustered_cell(clustering_key::make_empty(), bytes("c"), data_value(int32_t(0)), api::timestamp_type(0));
+        mt->apply(std::move(m));
+    }
+    auto sst = table.get_sstables_manager().make_sstable(s, table.get_storage_options(), generation, state);
+    write_memtable_to_sstable(*mt, sst).get();
+    mt->clear_gently().get();
+    // Pretend it came from Cassandra: we can't write a badly-sharded sstable ourselves.
+    sstables::test(sst).remove_component(sstables::component_type::Scylla).get();
+    sstables::test(sst).rewrite_toc_without_component(sstables::component_type::Scylla);
+    return sst;
+}
+
+// Regression test: reshard() must not assume static (vnode) sharding.
+SEASTAR_TEST_CASE(sstable_directory_reshard_works_for_tablets) {
+    if (this_smp_shard_count() == 1) {
+        fmt::print("Skipping sstable_directory_reshard_works_for_tablets, smp == 1\n");
+        return make_ready_future<>();
+    }
+
+    cql_test_config cfg;
+    cfg.initial_tablets = this_smp_shard_count() * 4;
+
+    return do_with_cql_env_thread([] (cql_test_env& e) {
+        e.execute_cql("create table cf (p text PRIMARY KEY, c int)").get();
+        auto& cf = e.local_db().find_column_family("ks", "cf");
+
+        e.db().invoke_on_all([] (replica::database& db) {
+            auto& cf = db.find_column_family("ks", "cf");
+            return cf.disable_auto_compaction();
+        }).get();
+
+        unsigned num_sstables = 4;
+
+        sharded<sstables::sstable_generation_generator> sharded_gen;
+        sharded_gen.start().get();
+        auto stop_generator = deferred_stop(sharded_gen);
+
+        for (unsigned nr = 0; nr < num_sstables; ++nr) {
+            auto generation = sharded_gen.invoke_on(nr % this_smp_shard_count(), [] (auto& gen) {
+                return gen();
+            }).get();
+            make_unsharded_sstable_spanning_all_shards(cf, sstables::sstable_state::upload, generation);
+        }
+
+      with_sstable_directory(e.db(), "ks", "cf", sstables::sstable_state::upload, [&] (sharded<sstables::sstable_directory>& sstdir) {
+        distributed_loader_for_tests::process_sstable_dir(sstdir, { .throw_on_missing_toc = true }).get();
+
+        sharded<sstables::sstable_generation_generator> sharded_gen;
+        sharded_gen.start().get();
+        auto stop_generator = deferred_stop(sharded_gen);
+
+        auto make_sstable = [&e, &sharded_gen] (shard_id shard) {
+            auto generation = sharded_gen.invoke_on(shard, [] (auto& gen) {
+                return gen();
+            }).get();
+            auto& cf = e.local_db().find_column_family("ks", "cf");
+            return cf.get_sstables_manager().make_sstable(cf.schema(), cf.get_storage_options(), generation, sstables::sstable_state::upload);
+        };
+        distributed_loader_for_tests::reshard(sstdir, e.db(), "ks", "cf", std::move(make_sstable)).get();
+      });
+    }, cfg);
+}
+
 // Regression test for #14618 - resharding with non-empty owned_ranges_ptr.
 SEASTAR_TEST_CASE(sstable_directory_shared_sstables_reshard_correctly_with_owned_ranges) {
     if (this_smp_shard_count() == 1) {


### PR DESCRIPTION
## Motivation

Follow-up to #31358. That PR fixed reshard() crashing on tablets tables via `table::try_get_compaction_group_view_with_static_sharding()`; that fix is already on master (63399951dfede8f5ffadad6b9e4addbf9dc7fd8c).

Once that crash is fixed, resharding a tablets table still aborts one step later: `shard_based_splitting_mutation_writer` (used by `resharding_compaction::make_interposer_consumer()`) hardcoded `dht::static_shard_of()` to route partitions to their destination shard. That call goes through `schema::get_sharder()`, which calls `on_internal_error()` for any non-statically-sharded (tablets) table — even though the correct, tablets-aware sharder is already available as `compaction_descriptor::sharder` and threaded into the `compaction` base class as `_sharder`.

This affects `nodetool refresh` and node startup whenever leftover sstables need resharding, with no shard count/topology change involved.

## Changes

- `mutation_writer::shard_based_splitting_mutation_writer` now takes a `const dht::sharder&` and uses `shard_for_reads()` instead of `dht::static_shard_of()`.
- `resharding_compaction::make_interposer_consumer()` passes `*_sharder` through to `segregate_by_shard()`.
- The `vnodes_resharding`/`segregate_by_token_group` branch is untouched.

## Tests

Added `sstable_directory_reshard_works_for_tablets` in `test/boost/sstable_directory_test.cc`: creates a tablets-based table, writes sstables spanning multiple shards/tablets, and resharding them. Without this fix it aborts (`on_internal_error`, exit 139); with it, it passes.

## Results

- New test passes.
- Existing reshard tests (`sstable_directory_shared_sstables_reshard_correctly`, `..._with_owned_ranges`, `..._distributes_well_even_if_files_are_not_well_distributed`, `..._respect_max_threshold`) still pass — no regression for vnode resharding.