### PR TITLE
seastar: update submodule for thread scheduling-group switching

### DIFF
--- a/utils/hashing.hh
+++ b/utils/hashing.hh
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include <chrono>
 #include <concepts>
 #include <map>
 #include <optional>


### PR DESCRIPTION
## Why

This update is a prerequisite for revising #31304 before it merges, not a follow-up. Making Alternator's JSON byte threshold effective sends normal large requests to its persistent parser worker. That worker must switch to each request's service-level scheduling group; otherwise parsing CPU is charged to the worker's construction group. Without the new Seastar API, #31304 must allocate a temporary thread and stack for every non-default service-level request.

## Changes

- Fast-forward Seastar from [`1c05d41f`](https://github.com/scylladb/seastar/commit/1c05d41f5271a1e9feb618f835776c34da734c19) to [`9135cbf4`](https://github.com/scylladb/seastar/commit/9135cbf41913381b1288a82cd13a53b0da18af5b), including merged [Seastar #3651](https://github.com/scylladb/seastar/pull/3651), which adds `seastar::thread::switch_to(scheduling_group)`.
- Add direct `<chrono>` and `<source_location>` includes exposed by Seastar's unused-header cleanup, keeping this single commit independently buildable.

The commit retains the generated 11-entry first-parent changelog. The [full Seastar comparison](https://github.com/scylladb/seastar/compare/1c05d41f5271a1e9feb618f835776c34da734c19...9135cbf41913381b1288a82cd13a53b0da18af5b) contains 24 commits including merged topic branches.

## Validation

- Full Dev `scylla` build passed.
- Debug/ASAN `alternator_unit_test` target build passed.
- Seastar `test_thread_switch_to`: 12/12 assertions passed.
- Seastar #3651 passed its upstream compiler, architecture, sanitizer, fuzz, DPDK, and module CI matrix.
- `git diff --check` passed.

No backport of the full Seastar roll is planned.

Refs #31304
Refs #31349
