### PR TITLE
replica: fix dead pending_compaction gauge (the per table column_family_pending_compaction metric)

### DIFF
--- a/replica/database.hh
+++ b/replica/database.hh
@@ -1428,6 +1428,13 @@ private:
     timer<> _off_strategy_trigger;
     void do_update_off_strategy_trigger();
 
+    // Keeps _stats.pending_compactions (the "pending_compaction" gauge) fresh;
+    // estimate_pending_compactions() can yield, so it can't run in the gauge callback itself.
+    // Coalesced: a refresh already in flight absorbs later requests instead of racing with them.
+    bool _pending_compactions_refresh_in_progress = false;
+    bool _pending_compactions_refresh_requested = false;
+    void refresh_pending_compactions_stat();
+
     compaction_group* try_get_compaction_group_with_static_sharding() const;
 public:
     void update_off_strategy_trigger();

--- a/replica/distributed_loader.cc
+++ b/replica/distributed_loader.cc
@@ -467,6 +467,10 @@ future<> table_populator::populate_subdir(sharded<sstables::sstable_directory>& 
         if (do_allow_offstrategy_compaction) {
             _global_table->trigger_offstrategy_compaction();
         }
+        // Startup doesn't go through flush/compaction, so the gauge needs an explicit refresh here.
+        if (_global_table->_config.enable_metrics_reporting) {
+            _global_table->refresh_pending_compactions_stat();
+        }
     });
 }
 

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -9,6 +9,7 @@
 #include <seastar/core/seastar.hh>
 #include <seastar/core/shard_id.hh>
 #include <seastar/core/coroutine.hh>
+#include <seastar/core/loop.hh>
 #include <seastar/core/with_scheduling_group.hh>
 #include <seastar/coroutine/maybe_yield.hh>
 #include <seastar/coroutine/exception.hh>
@@ -2190,6 +2191,9 @@ table::try_flush_memtable_to_sstable(compaction_group& cg, lw_shared_ptr<memtabl
         co_await with_scheduling_group(_config.memtable_to_cache_scheduling_group, [this, old, &newtabs, &cg] {
             return update_cache(cg, old, newtabs);
         });
+        if (_config.enable_metrics_reporting) {
+            refresh_pending_compactions_stat();
+        }
 
         for (const auto& sst : newtabs) {
             _large_data_guardrail->register_sstable(sst);
@@ -2905,6 +2909,35 @@ future<unsigned> table::estimate_pending_compactions() const {
     co_return ret;
 }
 
+void table::refresh_pending_compactions_stat() {
+    // estimate_pending_compactions() yields, so it must run detached from its (synchronous) call sites.
+    // A refresh already in flight absorbs this request instead of racing it (unserialized
+    // refreshes could otherwise let a stale estimate overwrite a fresher one).
+    _pending_compactions_refresh_requested = true;
+    if (_pending_compactions_refresh_in_progress || _async_gate.is_closed()) {
+        return;
+    }
+    _pending_compactions_refresh_in_progress = true;
+    (void)with_gate(_async_gate, [this] {
+        return do_until(
+                [this] {
+                    return !_pending_compactions_refresh_requested;
+                },
+                [this] {
+                    _pending_compactions_refresh_requested = false;
+                    return estimate_pending_compactions().then([this](unsigned pending) {
+                        _stats.pending_compactions = pending;
+                    });
+                })
+                .handle_exception([this](std::exception_ptr ex) {
+                    tlogger.debug("Failed to refresh pending_compactions stat of {}.{}: {}", _schema->ks_name(), _schema->cf_name(), ex);
+                })
+                .finally([this] {
+                    _pending_compactions_refresh_in_progress = false;
+                });
+    });
+}
+
 void compaction_group::set_compaction_strategy_state(compaction::compaction_strategy_state compaction_strategy_state) noexcept {
     _compaction_strategy_state = std::move(compaction_strategy_state);
 }
@@ -3305,6 +3338,9 @@ public:
         co_await _cg.update_sstable_sets_on_compaction_completion(std::move(desc));
         if (offstrategy) {
             _cg.trigger_compaction();
+        }
+        if (_t._config.enable_metrics_reporting) {
+            _t.refresh_pending_compactions_stat();
         }
     }
     bool is_auto_compaction_disabled_by_user() const noexcept override {

--- a/test/boost/sstable_set_test.cc
+++ b/test/boost/sstable_set_test.cc
@@ -11,6 +11,7 @@
 #include <seastar/testing/test_case.hh>
 #include <seastar/core/abort_source.hh>
 #include <seastar/core/loop.hh>
+#include <seastar/core/metrics_api.hh>
 
 #include <fmt/ranges.h>
 #include "db/config.hh"
@@ -22,6 +23,7 @@
 #include "sstables/sstables.hh"
 #include "sstable_test.hh"
 #include "test/lib/cql_test_env.hh"
+#include "test/lib/eventually.hh"
 #include "test/lib/random_utils.hh"
 #include "test/lib/simple_schema.hh"
 #include "test/lib/sstable_utils.hh"
@@ -578,6 +580,59 @@ SEASTAR_TEST_CASE(test_tablet_sstable_set_preserves_arbitrary_boundaries) {
             BOOST_REQUIRE_MESSAGE(selected_from_copy == expected,
                                   fmt::format("select() mismatch for single-key range i={}", i));
         }
+    }, std::move(cfg));
+}
+
+// table_stats::pending_compactions (replica/database.hh) backs the "pending_compaction"
+// gauge (replica/table.cc); it must be refreshed on flush/compaction so the gauge tracks
+// table::estimate_pending_compactions().
+SEASTAR_TEST_CASE(test_pending_compaction_gauge_is_updated) {
+    cql_test_config cfg;
+    cfg.db_config->enable_keyspace_column_family_metrics(true);
+    return do_with_cql_env_thread([](cql_test_env& env) {
+        // Pin all tablets to shard 0 so the 4 flushed sstables land in one
+        // table's local view, regardless of the test binary's smp::count.
+        guarantee_all_tablet_replicas_on_shard0(env).get();
+
+        env.execute_cql("CREATE KEYSPACE pcg_ks WITH REPLICATION = "
+                         "{'class': 'NetworkTopologyStrategy', 'replication_factor': 1} "
+                         "AND TABLETS = {'enabled': true, 'initial': 1}").get();
+        env.execute_cql("CREATE TABLE pcg_ks.pcg_cf (pk int PRIMARY KEY, v int) "
+                        "WITH compaction = {'class': 'SizeTieredCompactionStrategy'}")
+                .get();
+
+        auto& table = env.local_db().find_column_family("pcg_ks", "pcg_cf");
+        table.disable_auto_compaction().get();
+
+        // Flush enough similarly-sized sstables to exceed min_threshold, so STCS
+        // reports a real pending-compaction backlog.
+        for (int i = 0; i < 4; i++) {
+            env.execute_cql(fmt::format("INSERT INTO pcg_ks.pcg_cf (pk, v) VALUES ({}, {})", i, i)).get();
+            table.flush().get();
+        }
+
+        auto real_backlog = table.estimate_pending_compactions().get();
+        BOOST_REQUIRE_GT(real_backlog, 0u);
+
+        auto scrape_gauge = [] {
+            const auto& value_map = seastar::metrics::impl::get_value_map();
+            const auto& metric_family = value_map.at("column_family_pending_compaction");
+            auto gauge_value = std::numeric_limits<double>::quiet_NaN();
+            for (const auto& [labels, reg] : metric_family) {
+                if (labels.labels().at("cf").value() == "pcg_cf" && labels.labels().at("ks").value() == "pcg_ks") {
+                    gauge_value = (*reg)().d();
+                    break;
+                }
+            }
+            return gauge_value;
+        };
+
+        // The refresh triggered by the last flush runs detached, so give it a chance to land.
+        eventually([&] {
+            auto gauge_value = scrape_gauge();
+            testlog.info("real estimated backlog={}, scraped gauge={}", real_backlog, gauge_value);
+            BOOST_REQUIRE_EQUAL(gauge_value, double(real_backlog));
+        });
     }, std::move(cfg));
 }
 


### PR DESCRIPTION
### Motivation
The per-table `column_family_pending_compaction` metrics gauge always read 0, regardless of the actual compaction backlog: `table_stats::pending_compactions`, which backs it, was never assigned anywhere in the code.

### Change
Added `table::refresh_pending_compactions_stat()`, which computes the backlog via the existing `table::estimate_pending_compactions()` and stores it into `_stats.pending_compactions`. Wired to run after a flush completes, after a compaction completes, and after sstables are populated at table startup (so idle tables with a pre-existing backlog report it correctly right after restart, not just after their first flush/compaction) — all gated on `enable_metrics_reporting` so it costs nothing when the gauge isn't exported.

### Tests
Added `test_pending_compaction_gauge_is_updated` in `test/boost/sstable_set_test.cc`: flushes 4 similarly-sized sstables under `SizeTieredCompactionStrategy` (exceeding `min_threshold`) and asserts the exported gauge converges to the real estimated backlog. Tablets are pinned to shard 0 via the existing `guarantee_all_tablet_replicas_on_shard0()` helper so the sstables land in a single table view regardless of `smp::count`.

### Results
`build/dev/test/boost/combined_tests -t sstable_set_test/test_pending_compaction_gauge_is_updated`: `real estimated backlog=1, scraped gauge=1`, `*** No errors detected`.

backport: none, improvement
