### PR TITLE
test/pylib: remove unused "unstable" pytest marker

### DIFF
--- a/test/pylib/runner.py
+++ b/test/pylib/runner.py
@@ -801,7 +801,7 @@ def modify_pytest_item(item: pytest.Item, run_ids: defaultdict[tuple[str, str], 
             and not any(mark.name == "tier2" for mark in item.iter_markers("tier2"))):
         item.add_marker(pytest.mark.tier2)
 
-    if (any(mark.name in ("perf", "manual", "unstable", "no_parallel") for mark in item.iter_markers())
+    if (any(mark.name in ("perf", "manual", "no_parallel") for mark in item.iter_markers())
             and not any(mark.name == "non_gating" for mark in item.iter_markers("non_gating"))):
         item.add_marker(pytest.mark.non_gating)
 

--- a/test/pytest.ini
+++ b/test/pytest.ini
@@ -34,7 +34,6 @@ markers =
     cluster_options: specify cluster options used to initialize a cluster (dtest only)
     perf: mark for performance tests, these tests will automatically apply non_gating marker
     manual: to mark manual test cases, these tests will automatically apply non_gating marker
-    unstable: mark for unstable tests that may pass may fail, these tests will continue to run every night and generate up-to-date statistics with failures without failing the “Main” verification path(scylla-ci, Next), these tests will automatically apply non_gating marker
     no_parallel: for genuinely heavy tests that must not run in parallel with other tests, they run in a separate step of the Nightly pipeline with parallelization 1, these tests will automatically apply non_gating marker
     non_gating: tests that are not run in CI/Next/Nightly verification, but can be run manually or on special job when needed
     tier2: for tests that are quite old, stable, and test functionality that rather not be changed or affected by other features, are partially covered in other tests, verify non-critical functionality, have not found any issues or regressions, too long to run on every PR,  and can be popped out from the CI run, but will continue run in Next/Nightly verification


### PR DESCRIPTION
## What

Removes the `unstable` pytest marker: its declaration in `test/pytest.ini`
and the corresponding `non_gating` auto-marking in `test/pylib/runner.py`.

## Why — and the actual question for this PR

The marker was added as part of the `nightly_unstable` stage idea. The
motivation was real: at that time we had three bad options for a flaky test,
and all of them hide the problem rather than solve it.

- **dtest**: move the test out of `scylla-ci`, but keep running it in `Next`.
- **test.py**: turn a failure into a skip during the run, e.g.
  `pytest.skip('Failed to verify tracing')` — the test can now pass or skip,
  but never fail, so it burns cloud resources without telling us anything.
- **Just disable it** — dead code in the repo that never runs and rots.

`nightly_unstable` was supposed to be the fix: keep such tests running, keep
generating up-to-date failure statistics, but out of the "Main" verification
path (scylla-ci, Next), so they stop producing noise that someone has to
triage as "known or not known". The Core QA team agreed to babysit the group
— watch its size, analyse the statistics, manage the issues — with an
explicit target of driving it to zero.

**In practice the marker was used exactly once:**

| Date | Commit | Change |
|---|---|---|
| 2025-07-14 | `4b975668f6` | `@pytest.mark.unstable` added to `test_alternator_enforce_authorization_true` (`test/cluster/test_alternator.py`)
| 2026-07-01 | `9aa25e6a80` | removed, after the test was actually deflaked |

One use, one removal, and nothing since. So the tooling exists, but nobody
reaches for it.

## The question

The intent behind the marker was to give us a way to **be tolerant of
unstable / raw tests** — to keep them alive and observable instead of
skipped or deleted. Based on the usage above, that does not look like the
way it plays out in practice: people either deflake the test or disable it,
and the "tolerated" middle state is not something the team uses.

So, before this gets merged, I'd like a decision from management rather than
just quietly dropping it:

 **Do we still want this approach at all?** Is a "tolerated unstable"
   category is something we want to support in test.py or not (for example, dirig probably future migration test.py to python-rs driver )?

## Testing

No test behaviour changes: no test in the tree carries the marker, and
`grep -rn unstable test/` shows no remaining references.