### PR TITLE
logstor: disable logstor compaction only after truncate flush

### DIFF
--- a/replica/database.cc
+++ b/replica/database.cc
@@ -3146,13 +3146,7 @@ future<> database::truncate_table_on_all_shards(sharded<database>& sharded_db, s
                     st->cres.emplace_back(co_await cm.stop_and_disable_compaction("truncate", ts));
                 });
             });
-
-            if (cf.uses_logstor()) {
-                auto& logstor_cm = cf.get_logstor_compaction_manager();
-                co_await cf.parallel_foreach_logstor_compaction_group([&logstor_cm, &st] (replica::compaction_group& cg) -> future<> {
-                    st->logstor_cres.emplace_back(co_await logstor_cm.disable_compaction(cg.as_logstor_group()));
-                });
-            }
+            // for logstor tables, we disable compaction only after the flush. see below.
 
             co_return make_foreign(std::move(st));
         });
@@ -3186,7 +3180,15 @@ future<> database::truncate_table_on_all_shards(sharded<database>& sharded_db, s
         co_await coroutine::parallel_for_each(views, [&] (lw_shared_ptr<replica::table> v) -> future<> {
             co_await flush_or_clear(*v);
         });
-        co_await cf.flush_separator();
+        if (cf.uses_logstor()) {
+            // flush and only then disable the compaction. flush writes to new segments, and the compaction
+            // is what generates free segments for new writes.
+            co_await cf.flush_separator();
+            auto& logstor_cm = cf.get_logstor_compaction_manager();
+            co_await cf.parallel_foreach_logstor_compaction_group([&logstor_cm, &st] (replica::compaction_group& cg) -> future<> {
+                st.logstor_cres.emplace_back(co_await logstor_cm.disable_compaction(cg.as_logstor_group()));
+            });
+        }
         // Since writes could be appended to active memtable between getting low_mark above
         // and flush, the low_mark has to be adjusted to account for those writes, where
         // memtable was flushed with a higher replay position than the one obtained above.


### PR DESCRIPTION
database::truncate_table_on_all_shards() disabled logstor compaction for every compaction group of the table before the flush phase, and only then called flush_separator().

A separator flush writes a full segment, and a write that is not a compaction write is served from the segment pool only while the pool holds more than the segments reserved for compaction. Compaction is the only thing that puts segments back, so on a disk with no free segment left the flush waits for a segment that can never arrive and the truncate never completes.

Disable logstor compaction after the flushes instead. The reenablers are still kept in table_truncate_state, so compaction stays disabled for database::truncate() and the segment discarding it does, which is what needed the guard in the first place.

Fixes SCYLLADB-4010

backport - the issue may affect CI stability in existing releases although infrequently