### PR TITLE
Update seastar submodule

### DIFF
--- a/db/paxos_grace_seconds_extension.hh
+++ b/db/paxos_grace_seconds_extension.hh
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <cstdint>
+
 #include <seastar/core/on_internal_error.hh>
 
 #include "serializer.hh"

--- a/keys/compound_compat.hh
+++ b/keys/compound_compat.hh
@@ -10,6 +10,7 @@
 
 #include <ranges>
 #include <compare>
+#include <cstdint>
 #include <seastar/core/on_internal_error.hh>
 #include "compound.hh"
 #include "schema/schema.hh"

--- a/tasks/task_manager.hh
+++ b/tasks/task_manager.hh
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <list>
 #include <ranges>
 #include <seastar/core/on_internal_error.hh>

--- a/test/boost/encrypted_file_test.cc
+++ b/test/boost/encrypted_file_test.cc
@@ -8,6 +8,7 @@
 #include <stdint.h>
 #include <random>
 
+#include <seastar/core/align.hh>
 #include <seastar/core/future-util.hh>
 #include <seastar/core/seastar.hh>
 #include <seastar/core/shared_ptr.hh>

--- a/test/boost/logalloc_test.cc
+++ b/test/boost/logalloc_test.cc
@@ -12,6 +12,7 @@
 #include <algorithm>
 #include <deque>
 
+#include <seastar/core/chunked_fifo.hh>
 #include <seastar/core/circular_buffer.hh>
 #include <seastar/core/format.hh>
 #include <seastar/core/thread.hh>

--- a/test/lib/exception_utils.hh
+++ b/test/lib/exception_utils.hh
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <functional>
+#include <source_location>
 #include <seastar/core/sstring.hh>
 
 #include "seastarx.hh"

--- a/utils/hashing.hh
+++ b/utils/hashing.hh
@@ -12,6 +12,7 @@
 #include <map>
 #include <optional>
 #include <memory>
+#include <chrono>
 #include <seastar/core/byteorder.hh>
 #include <seastar/core/sstring.hh>
 #include "seastarx.hh"


### PR DESCRIPTION
A few #includes added to adjust for loss of transitive includes.

* seastar 1c05d41f...9135cbf4 (11):
  > thread: allow a thread to switch its own scheduling group
  > net/tcp: fix incorrect congestion window handling in can_send()
  > util: %u -> %d for signed int formatting in assert_fail
  > util: move assert_fail to assert.cc
  > coroutine: Remove deprecated exception helpers
  > Merge 'replace boost range utilities with stdlib' from crackcomm (#3637)
    net,rpc: use std views instead of boost range utilities Replace boost::adaptors/map_keys and make_iterator_range with std::views::keys and std::ranges::subrange; drop dead boost includes in tls_gnutls.cc and net/config.cc.
    core,util: use std ranges instead of boost range utilities Replace boost range algorithms and adaptors with std equivalents, replace boost::combine with std::views::zip, and drop boost from the public header disk_params.hh.
    tests: replace boost range utilities with std ranges Replace boost::sort/reverse/equal/irange/copy_range/counting_iterator/ transformed/accumulate/split with std algorithm and std::views equivalents in unit tests.
  > Merge 'fixes for libc++' from crackcomm (#3636)
    tests: fix iterator invalidation in remove_existing_metrics
    tests: make exception_logging_test pass with libc++
    tests: use int distribution to fill random buffer in file_io_test
    core: add operator[] to circular_buffer_fixed_capacity iterator
    util: always include `<new>` header in `spinlock.hh`
  > Merge 'migrate tls_test helpers to coroutines' from crackcomm (#3640)
    tests: migrate tls_test's run_echo_test to coroutines
    tests: migrate tls_test's connect_to_ssl_addr to coroutines
  > treewide: cleanup unused includes
  > tests: run the TLS tests against every configured crypto provider (#3608)
  > tests: retry test_tls_cipher_suite_and_protocol_version on transient network errors

Routine submodule update with no important fixes, so not backporting.