### PR TITLE
db: fix object storage endpoint config losing every endpoint on one bad entry

### DIFF
--- a/db/config.cc
+++ b/db/config.cc
@@ -601,6 +601,27 @@ struct convert<db::object_storage_endpoint_param> {
 };
 
 template<>
+struct convert<std::vector<db::object_storage_endpoint_param>> {
+    // Decode each entry on its own, so a malformed entry costs its own
+    // endpoint rather than the whole option.
+    static bool decode(const Node& node, std::vector<db::object_storage_endpoint_param>& endpoints) {
+        if (!node.IsSequence()) {
+            return false;
+        }
+
+        endpoints.clear();
+        for (size_t i = 0; i < node.size(); ++i) {
+            try {
+                endpoints.push_back(db::object_storage_endpoint_param::decode(node[i]));
+            } catch (const std::exception& e) {
+                cfglogger.error("Ignoring object_storage_endpoints entry {}: {}", i, e.what());
+            }
+        }
+        return true;
+    }
+};
+
+template<>
 struct convert<audit::audit_rule> {
     static bool decode(const Node& node, audit::audit_rule& rule) {
         if (!node.IsMap()) {

--- a/db/object_storage_endpoint_param.cc
+++ b/db/object_storage_endpoint_param.cc
@@ -139,7 +139,14 @@ db::object_storage_endpoint_param db::object_storage_endpoint_param::decode(cons
         }
 
         auto aws_region = node["aws_region"];
-        ep.region = aws_region ? aws_region.as<std::string>() : std::getenv("AWS_DEFAULT_REGION");
+        if (aws_region) {
+            ep.region = aws_region.as<std::string>();
+        } else if (const char* env_region = std::getenv("AWS_DEFAULT_REGION")) {
+            ep.region = env_region;
+        }
+        if (ep.region.empty()) {
+            throw std::invalid_argument(fmt::format("Endpoint {} has no region, set aws_region or AWS_DEFAULT_REGION", ep.endpoint));
+        }
         ep.iam_role_arn = get_opt(node, "iam_role_arn", ""s);
 
         return object_storage_endpoint_param{std::move(ep)};

--- a/docs/operating-scylla/admin.rst
+++ b/docs/operating-scylla/admin.rst
@@ -112,7 +112,7 @@ should follow this format:
 
    object_storage_endpoints:
      - name: http[s]://<endpoint_address_or_domain_name>[:<port_number>]
-       aws_region: <region_name> # optional, e.g. us-east-1
+       aws_region: <region_name> # required unless AWS_DEFAULT_REGION is set, e.g. us-east-1
        iam_role_arn: <iam_role> # optional
 
 
@@ -126,7 +126,9 @@ Example:
        iam_role_arn: arn:aws:iam::123456789012:instance-profile/my-instance-instance-profile
 
 The ``aws_region`` option can also be specified using 
-the ``AWS_DEFAULT_REGION`` environment variable.
+the ``AWS_DEFAULT_REGION`` environment variable. An S3 endpoint needs a region
+from one of the two. If neither supplies a non-empty value, ScyllaDB logs an
+error and ignores that endpoint.
 
 The AWS-related credentials options (``aws_access_key_id``,
 ``aws_secret_access_key``, ``aws_session_token``) can be configured using

--- a/test/boost/config_test.cc
+++ b/test/boost/config_test.cc
@@ -16,7 +16,9 @@
 #include "test/lib/test_utils.hh"
 #include <seastar/testing/thread_test_case.hh>
 #include <seastar/core/future-util.hh>
+#include <yaml-cpp/yaml.h>
 #include "db/config.hh"
+#include "db/object_storage_endpoint_param.hh"
 #include "utils/updateable_value.hh"
 
 using namespace db;
@@ -971,4 +973,62 @@ SEASTAR_TEST_CASE(test_parse_experimental_features_invalid) {
                            BOOST_CHECK(!cfg.check_experimental(ef::UDF));
                        });
     return make_ready_future();
+}
+
+SEASTAR_THREAD_TEST_CASE(test_object_storage_endpoint_region_from_environment) {
+    tests::tmp_set_env region_env("AWS_DEFAULT_REGION", "us-east-1");
+    auto ep = object_storage_endpoint_param::decode(YAML::Load("name: http://localhost:9000\n"));
+    BOOST_REQUIRE(ep.is_s3_storage());
+    BOOST_CHECK_EQUAL(ep.get_s3_storage().region, "us-east-1");
+}
+
+SEASTAR_THREAD_TEST_CASE(test_object_storage_endpoint_region_unresolvable) {
+    tests::tmp_unset_env no_region_env("AWS_DEFAULT_REGION");
+    // Neither source is available. The error has to name both of them, so that
+    // the operator knows where to put the region.
+    try {
+        object_storage_endpoint_param::decode(YAML::Load("name: http://localhost:9000\n"));
+        BOOST_FAIL("expected the missing region to be reported");
+    } catch (const std::invalid_argument& e) {
+        const sstring msg = e.what();
+        BOOST_REQUIRE_NE(msg.find("aws_region"), msg.npos);
+        BOOST_REQUIRE_NE(msg.find("AWS_DEFAULT_REGION"), msg.npos);
+    }
+}
+
+SEASTAR_THREAD_TEST_CASE(test_object_storage_endpoint_region_empty) {
+    // An empty region is the same broken state as an absent one - it signs
+    // requests with an empty credential scope - so neither source may resolve
+    // to it.
+    {
+        tests::tmp_unset_env no_region_env("AWS_DEFAULT_REGION");
+        BOOST_REQUIRE_THROW(object_storage_endpoint_param::decode(
+                YAML::Load("name: http://localhost:9000\naws_region: \"\"\n")),
+            std::invalid_argument);
+    }
+    {
+        tests::tmp_set_env empty_region_env("AWS_DEFAULT_REGION", "");
+        BOOST_REQUIRE_THROW(object_storage_endpoint_param::decode(
+                YAML::Load("name: http://localhost:9000\n")),
+            std::invalid_argument);
+    }
+}
+
+SEASTAR_THREAD_TEST_CASE(test_parse_object_storage_endpoints_one_entry_broken) {
+    tests::tmp_unset_env no_region_env("AWS_DEFAULT_REGION");
+    auto cfg_ptr = std::make_unique<config>();
+    config& cfg = *cfg_ptr;
+
+    // The first entry cannot resolve a region. It must cost its own endpoint
+    // only - the correctly configured GCS entry below it has to survive.
+    cfg.read_from_yaml(R"foo(object_storage_endpoints:
+    - name: http://localhost:9000
+    - name: https://storage.googleapis.com
+      type: gs
+)foo", throw_on_error);
+
+    const auto& endpoints = cfg.object_storage_endpoints();
+    BOOST_REQUIRE_EQUAL(endpoints.size(), 1);
+    BOOST_CHECK(endpoints.front().is_gs_storage());
+    BOOST_CHECK_EQUAL(endpoints.front().key(), "https://storage.googleapis.com");
 }

--- a/test/lib/test_utils.cc
+++ b/test/lib/test_utils.cc
@@ -97,6 +97,22 @@ tmp_set_env::~tmp_set_env() {
     }
 }
 
+tmp_unset_env::tmp_unset_env(std::string_view var)
+    : _var(var)
+    , _old(getenv_or_default(_var))
+    , _was_set(std::getenv(_var.c_str()) != nullptr)
+{
+    ::unsetenv(_var.c_str());
+}
+
+tmp_unset_env::tmp_unset_env(tmp_unset_env&&) = default;
+
+tmp_unset_env::~tmp_unset_env() {
+    if (_was_set) {
+        ::setenv(_var.c_str(), _old.c_str(), 1);
+    }
+}
+
 bool check_run_test(std::string_view var, bool defval) {
     auto do_test = getenv_or_default(var, std::to_string(defval));
 

--- a/test/lib/test_utils.hh
+++ b/test/lib/test_utils.hh
@@ -107,6 +107,19 @@ public:
     ~tmp_set_env();
 };
 
+// Removes a variable from the environment for the lifetime of the object.
+// Setting one to the empty string is not the same thing: getenv() still
+// reports it as present.
+class tmp_unset_env {
+    std::string _var, _old;
+    bool _was_set;
+public:
+    explicit tmp_unset_env(std::string_view var);
+    tmp_unset_env(tmp_unset_env&&);
+    tmp_unset_env(const tmp_unset_env&) = delete;
+    ~tmp_unset_env();
+};
+
 bool check_run_test(std::string_view var, bool defval = false);
 
 inline auto check_run_test_decorator(std::string_view test_var, bool def = false) {


### PR DESCRIPTION
An S3 endpoint with no resolvable region silently disables **all** object storage on the node. `object_storage_endpoint_param::decode()` resolved the region as `aws_region ? aws_region.as<std::string>() : std::getenv("AWS_DEFAULT_REGION")`, whose common type is `std::string`, so an absent `aws_region` key fed a possibly-null pointer to the `std::string` constructor. With `AWS_DEFAULT_REGION` unset libstdc++ throws `basic_string: construction from null is not valid`, and `config_file::read_from_yaml()` reports a bad option value through the error handler rather than failing, so the node logs one line and starts normally with `object_storage_endpoints` left at its empty default.

The damage is not limited to the offending entry. `object_storage_endpoints` is a `std::vector<object_storage_endpoint_param>` assigned as a single value, and the stock yaml-cpp sequence conversion lets the first exception escape the loop, so `set_value()` never completes and every endpoint is discarded — including correctly configured endpoints of a different backend. A GCS-only deployment can be disabled by an unrelated, unused S3 entry. `CREATE KEYSPACE ... STORAGE = {...}` then fails with "endpoint not found", and the startup message names neither `aws_region` nor `AWS_DEFAULT_REGION`, so it offers no route to the cause.

### Changes

The region is resolved from the two sources in separate branches and validated once. An empty region is rejected along with an absent one: it reaches the signer, which builds a credential scope of the form `<key>/<date>//s3/aws4_request` that S3 rejects, so accepting it only defers the failure to an opaque signature error. The GCS credential loader already guards its own environment variable the same way, checking both for null and for length (`utils/gcp/gcp_credentials.cc:200`).

The sequence is converted entry by entry, so a malformed entry costs its own endpoint rather than the whole option, and the log names which entry was dropped and why. This covers the other decode failures too — a legacy-form entry with no `port` discarded the list the same way.

Tests cover the region taken from `AWS_DEFAULT_REGION`, the two ways it can fail to resolve, and a list whose first entry cannot be decoded keeping the entries that can. Every existing test sets `aws_region` (`test/pylib/minio_server.py`), so none of these paths were exercised. `tests::tmp_unset_env` is added because `tmp_set_env` can only put a variable into the "present" state, and only a genuinely absent variable makes `getenv` return the null pointer this bug is about.

The `aws_region` documentation is corrected: it was marked "optional" unqualified.

### Backward compatibility

**Old behavior:** `aws_region: ""`, or an empty `AWS_DEFAULT_REGION`, produced an endpoint with an empty region. **New behavior:** that endpoint is rejected and dropped, with an error naming both settings. **To restore:** set `aws_region` to the endpoint's region, or to any non-empty placeholder for a backend that ignores it.

Such an endpoint could only ever have worked against a backend that ignores the region; against AWS it was already failing with a signature error. The node still starts either way — only the offending endpoint is dropped, which is what the second change guarantees.

Fixes: https://scylladb.atlassian.net/browse/SCYLLADB-3978

Backport to 2026.1, 2026.2 and 2026.3: this is a bug fix that silently disables object storage. The defect also reaches back to `branch-2025.2`, but 2025.2-2025.4 are EOL.