### PR TITLE
transport, alternator: hold gate during certificate reload

### DIFF
--- a/alternator/server.cc
+++ b/alternator/server.cc
@@ -1107,6 +1107,16 @@ future<> server::init(net::inet_address addr, std::optional<uint16_t> port, std:
 
             if (this_shard_id() == 0) {
                 _credentials = creds->build_reloadable_server_credentials([this](const tls::credentials_builder& b, const std::unordered_set<sstring>& files, std::exception_ptr ep) -> future<> {
+                    // A reload can fire while the server is being shut down, and
+                    // there is nothing left to reload into then. Holding the gate
+                    // keeps this server and its peers on the other shards alive
+                    // for the duration of the reload - sharded<> destroys the
+                    // instances only once stop() completed on all of them, and
+                    // stop() waits for the gate.
+                    if (_pending_requests.is_closed()) {
+                        co_return;
+                    }
+                    seastar::gate::holder holder(_pending_requests);
                     if (ep) {
                         slogger.warn("Exception loading {}: {}", files, ep);
                     } else {

--- a/message/messaging_service.cc
+++ b/message/messaging_service.cc
@@ -306,6 +306,15 @@ future<> messaging_service::start() {
     if (_credentials_builder && !_credentials) {
         if (this_shard_id() == 0) {
             _credentials = co_await _credentials_builder->build_reloadable_server_credentials([this](const tls::credentials_builder& b, const std::unordered_set<sstring>& files, std::exception_ptr ep) -> future<> {
+                // A reload can fire while the service is being shut down, and there
+                // is nothing left to reload into then. Holding the gate keeps this
+                // instance and its peers on the other shards alive for the duration
+                // of the reload - sharded<> destroys the instances only once stop()
+                // completed on all of them, and stop() waits for the gate.
+                if (_reload_gate.is_closed()) {
+                    co_return;
+                }
+                auto holder = _reload_gate.hold();
                 if (ep) {
                     mlogger.warn("Exception loading {}: {}", files, ep);
                 } else {
@@ -666,6 +675,7 @@ future<> messaging_service::shutdown() {
 }
 
 future<> messaging_service::stop() {
+    co_await _reload_gate.close();
     if (!_shutting_down) {
         co_await shutdown();
     }

--- a/message/messaging_service.hh
+++ b/message/messaging_service.hh
@@ -10,6 +10,7 @@
 
 #include "messaging_service_fwd.hh"
 #include "msg_addr.hh"
+#include <seastar/core/gate.hh>
 #include <seastar/core/sharded.hh>
 #include <seastar/core/sstring.hh>
 #include "gms/inet_address.hh"
@@ -363,6 +364,8 @@ private:
     std::vector<clients_map_host_id> _clients_with_host_id;
     uint64_t _dropped_messages[static_cast<int32_t>(messaging_verb::LAST)] = {};
     bool _shutting_down = false;
+    // Held while a TLS certificate reload is in progress; see start().
+    seastar::gate _reload_gate;
     connection_drop_signal_t _connection_dropped;
     scheduling_config _scheduling_config;
     std::vector<scheduling_info_for_connection_index> _scheduling_info_for_connection_index;

--- a/transport/generic_server.cc
+++ b/transport/generic_server.cc
@@ -323,6 +323,16 @@ server::listen(socket_address addr, std::shared_ptr<seastar::tls::credentials_bu
     if (builder && !_credentials) {
         if (!get_shard_instance || this_shard_id() == 0) {
             _credentials = co_await builder->build_reloadable_server_credentials([this, get_shard_instance = std::move(get_shard_instance)](const tls::credentials_builder& b, const std::unordered_set<sstring>& files, std::exception_ptr ep) -> future<> {
+                // A reload can fire while the server is being shut down, and
+                // there is nothing left to reload into then. Holding the gate
+                // keeps this server and its peers on the other shards alive for
+                // the duration of the reload - sharded<> destroys the instances
+                // only once stop() completed on all of them, and stop() waits
+                // for the gate.
+                if (_gate.is_closed()) {
+                    co_return;
+                }
+                seastar::gate::holder holder(_gate);
                 if (ep) {
                     _logger.warn("Exception loading {}: {}", files, ep);
                 } else {

--- a/vector_search/truststore.cc
+++ b/vector_search/truststore.cc
@@ -25,6 +25,14 @@ seastar::future<seastar::shared_ptr<seastar::tls::certificate_credentials>> trus
         if (this_shard_id() == 0) {
             _credentials = co_await builder.build_reloadable_certificate_credentials(
                     [this](const tls::credentials_builder& b, const std::unordered_set<sstring>& files, std::exception_ptr ep) -> future<> {
+                        // A reload can fire while we are being shut down, and there
+                        // is nothing left to reload into then. Holding the gate keeps
+                        // this instance and its peers on the other shards alive for
+                        // the duration of the reload - stop() waits for the gate.
+                        if (_gate.is_closed()) {
+                            co_return;
+                        }
+                        auto holder = _gate.hold();
                         if (ep) {
                             _logger.warn("Exception while reloading truststore {}: {}", files, ep);
                         } else {


### PR DESCRIPTION
Prevent crashes when certificate reload races with shutdown.

Not backporting. While this is a crash, certificate reload is extremely rare, while shutdown is somewhat rare. This will only happen in tests.