### PR TITLE
sstables: Add mechanism to detect leaked SSTables

### DIFF
--- a/main.cc
+++ b/main.cc
@@ -2187,6 +2187,10 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
             checkpoint(stop_signal, "loading non-system sstables");
             replica::distributed_loader::init_non_system_keyspaces(db, proxy, sys_ks).get();
 
+            // Loading is over, so from now on a sstable is only released after
+            // being unlinked, and the leakage detector can be armed.
+            db.invoke_on_all(&replica::database::enable_sstable_leakage_detection).get();
+
             checkpoint(stop_signal, "recovering logstor");
             db.invoke_on_all([] (replica::database& db) {
                 return db.recover_logstor();

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -2840,8 +2840,15 @@ future<> database::start(sharded<qos::service_level_controller>& sl_controller, 
     }
 }
 
+void database::enable_sstable_leakage_detection() noexcept {
+    _user_sstables_manager->enable_leakage_detection();
+    _system_sstables_manager->enable_leakage_detection();
+}
+
 future<> database::shutdown() {
     _shutdown = true;
+    _user_sstables_manager->disable_leakage_detection();
+    _system_sstables_manager->disable_leakage_detection();
     auto b = defer([this] noexcept { _stop_barrier.abort(); });
     co_await _stop_barrier.arrive_and_wait();
     b.cancel();

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -2012,6 +2012,10 @@ public:
     /// the normal concurrency.
     void revert_initial_system_read_concurrency_boost();
     future<> start(sharded<qos::service_level_controller>&, utils::disk_space_monitor* dsm);
+    // Arms the sstable leakage detector, see sstables_manager::detect_leakage().
+    // Called once sstable loading is over, so that boot doesn't trip it.
+    void enable_sstable_leakage_detection() noexcept;
+
     future<> shutdown();
     future<> stop();
     future<> close_tables(table_kind kind_to_close);

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -685,6 +685,9 @@ public:
     bool has_component(component_type f) const;
     sstables_manager& manager() { return _manager; }
     const sstables_manager& manager() const { return _manager; }
+    bool opened_for_reading() const {
+        return _open_mode && _open_mode.value() == open_flags::ro;
+    }
 
     static future<std::pair<std::vector<sstring>, uint32_t>> read_and_parse_toc(file f);
 private:

--- a/sstables/sstables_manager.cc
+++ b/sstables/sstables_manager.cc
@@ -8,6 +8,8 @@
 
 #include <seastar/coroutine/parallel_for_each.hh>
 #include <seastar/coroutine/switch_to.hh>
+#include <seastar/util/backtrace.hh>
+#include <seastar/core/on_internal_error.hh>
 #include <cctype>
 #include <ranges>
 #include <unordered_map>
@@ -55,6 +57,15 @@ atomic_deletion::atomic_deletion(std::vector<shared_sstable> ssts)
 future<> atomic_deletion::commit() {
     if (empty()) {
         co_return;
+    }
+    // The caller detached these sstables before asking for the deletion and will
+    // not put them back, so they are condemned from here on, however this deletion
+    // ends. Mark them before anything can fail: sstable::destroy() then removes
+    // them when the last reference is dropped, so a failure below neither leaves
+    // their files behind until the next startup nor looks like a leak to
+    // sstables_manager::detect_leakage().
+    for (auto& sst : _ssts) {
+        sst->mark_for_deletion();
     }
     if (utils::get_local_injector().enter("delete_atomically_before_prepare")) {
         throw std::runtime_error("delete_atomically_before_prepare");
@@ -431,7 +442,36 @@ void sstables_manager::add(sstable* sst) {
     _active.push_back(*sst);
 }
 
+void sstables_manager::detect_leakage(sstable* sst) {
+    if (!_detect_leakage) {
+        return;
+    }
+    if (_leakage_detection_paused.contains(sst->get_schema()->id())) {
+        return;
+    }
+    if (sst->unlinked_at()) {
+        return;
+    }
+    // A sstable marked for deletion is unlinked by sstable::destroy(), which
+    // runs right after deactivation, so it isn't leaked.
+    if (sst->marked_for_deletion()) {
+        return;
+    }
+    // During boot, a sstable can be partially loaded for determining shard
+    // ownership and then discarded. Also, a partially written sstable can
+    // be discarded without being unlinked, but will be GC'ed on restart.
+    // Either way, detector shouldn't misfire.
+    if (!sst->opened_for_reading()) {
+        return;
+    }
+    // Deactivation runs from lw_shared_ptr's deleter, i.e. from a noexcept
+    // context, so throwing when abort_on_internal_error is unset would terminate.
+    on_internal_error_noexcept(smlogger, fmt::format("Detected leakage of sstable {} of origin {} and state {}",
+                                            sst->get_filename(), sst->get_origin(), sst->state()));
+}
+
 void sstables_manager::deactivate(sstable* sst) {
+    detect_leakage(sst);
     // Drop reclaimable components if they are still in memory
     // and remove SSTable from the reclaimable memory tracking
     reclaim_memory_and_stop_tracking_sstable(sst);

--- a/sstables/sstables_manager.hh
+++ b/sstables/sstables_manager.hh
@@ -183,6 +183,11 @@ private:
     future<> _components_reloader_status = make_ready_future<>();
 
     bool _closing = false;
+    // Leakage detection is off until the owner explicitly arms it. See
+    // detect_leakage().
+    bool _detect_leakage = false;
+    // Per-table nesting count of pause_leakage_detection() holders.
+    std::unordered_map<table_id, unsigned> _leakage_detection_paused;
     promise<> _done;
     cache_tracker& _cache_tracker;
 
@@ -321,6 +326,28 @@ public:
 
     const abort_source& get_abort_source() const noexcept { return _abort; }
 
+    // To be called by the owner once it is done loading sstables, and again,
+    // to disable, before it starts closing its tables. See detect_leakage().
+    void enable_leakage_detection() noexcept { _detect_leakage = true; }
+    void disable_leakage_detection() noexcept { _detect_leakage = false; }
+
+    // Suppresses leakage detection for one table while an operation that
+    // legitimately releases live sstables is in progress. The holder must
+    // outlive whatever owns those sstables.
+    using leakage_detection_pause = deferred_action<noncopyable_function<void () noexcept>>;
+
+    [[nodiscard]] leakage_detection_pause pause_leakage_detection(table_id id) {
+        ++_leakage_detection_paused[id];
+        return leakage_detection_pause([this, id] () noexcept {
+            // Look the entry up rather than indexing it, so the destructor
+            // doesn't allocate.
+            auto it = _leakage_detection_paused.find(id);
+            if (it != _leakage_detection_paused.end() && !--it->second) {
+                _leakage_detection_paused.erase(it);
+            }
+        });
+    }
+
     // To be called by the sstable to signal its unlinking
     void on_unlink(sstable* sst);
 
@@ -358,6 +385,16 @@ private:
     // The method is idempotent and for an sstable that is deleted, it is called both
     // during unlink and during deactivation.
     void reclaim_memory_and_stop_tracking_sstable(sstable* sst);
+    // The sstable will be reported as leaked if the system is no longer referencing
+    // the sstable, but it's still alive in the storage.
+    //
+    // Only owners that arm the detector via enable_leakage_detection() are checked.
+    // It stays off while sstables are being loaded, since loading legitimately
+    // releases live sstables (e.g. a shared sstable is handed over as open info,
+    // see sstable_directory::process_descriptor()), and it is turned off again
+    // when closing tables on shutdown. Managers owned by tools and tests never arm
+    // it.
+    void detect_leakage(sstable* sst);
 private:
     db::large_data_handler& get_large_data_handler() const {
         return _large_data_handler;

--- a/sstables_loader.cc
+++ b/sstables_loader.cc
@@ -656,6 +656,13 @@ future<> sstables_loader::load_and_stream(sstring ks_name, sstring cf_name,
     auto& tbl = _db.local().find_column_family(table_id);
     auto stream_guard = tbl.stream_in_progress();
 
+    // The streamer unlinks the sstables only if it was asked to and only if
+    // streaming succeeded: on failure, or for tablets outside the stream scope,
+    // their files are left in place on purpose so the operation can be retried.
+    // So releasing a live sstable is expected here. Declared before the streamer,
+    // which owns the sstables, so that it outlives them.
+    auto leakage_pause = tbl.get_sstables_manager().pause_leakage_detection(table_id);
+
     std::unique_ptr<sstable_streamer> streamer;
     if (tbl.uses_tablets()) {
         streamer =
@@ -986,6 +993,9 @@ future<> sstables_loader::download_tablet_sstables(locator::global_tablet_id tid
     sstring snapshot_name = trinfo->snapshot_name;
 
     auto s = _db.local().find_schema(tid.table);
+    // The downloaded sstables are traded for a minimal_sst_info descriptor and
+    // released while their files stay in place, so this isn't a leak either.
+    auto leakage_pause = _db.local().get_sstables_manager(*s).pause_leakage_detection(tid.table);
     auto tablet_range = tmap.get_token_range(tid.tablet);
     const auto& topo = guard.get_token_metadata()->get_topology();
     auto keyspace_name = s->ks_name();


### PR DESCRIPTION
A sstable is leaked if it's still alive in the storage but the system is no longer referencing it anywhere.

There are different areas of the system where a sstable can be leaked, usually it involves new sstables being generated. It happened in streaming, compaction. But we made a long way since then. See commit c5a0f7eb4e83e50 for an example.

A leaked sstable can potentially cause silent data resurrection, since it might contain live data that was later deleted, and the tombstone is gone by the time the leaked sstable is reintegrated on restart.

A leaked sstable wouldn't only be reintegrated if the underlying tablet was migrated to a remote node, or splits and merges happened so the sstable is no longer fully contained within a single local tablet replica.

We cannot rely on luck, so a new mechanism is being added that will generate an internal error whenever a sstable is leaked, allowing the operator to intervene. On production, it means that the operation that leaked the sstable will fail (that could be compaction, repair, etc).

Example of leakage report:
```
ERROR 2026-08-30 19:18:47,485 [shard 0:comp] sstables_manager - Detected leakage of sstable /home/raphaelsc/tmp/1/system_schema/keyspaces-abac5682dea631c5b535b3d6cffd0fb6/mt-3h3e_1pzb_2edkg2g1m09sn6m4mw-big-Data.db of origin compaction and state , at: /home/raphaelsc/scylla/build/dev/seastar/libseastar.so+0x61abac /home/raphaelsc/scylla/build/dev/seastar/libseastar.so+0x61aeb0 /home/raphaelsc/scylla/build/dev/seastar/libseastar.so+0x61b1d8 /home/raphaelsc/scylla/build/dev/seastar/libseastar.so+0x42de7e 0x2195ba5 0x2195be1 0x22ca282 0x23ae0fc 0x23db29a /home/raphaelsc/scylla/build/dev/seastar/libseastar.so+0x493ff4 /home/raphaelsc/scylla/build/dev/seastar/libseastar.so+0x4951b7 /home/raphaelsc/scylla/build/dev/seastar/libseastar.so+0x495013 /home/raphaelsc/scylla/build/dev/seastar/libseastar.so+0x496193 /home/raphaelsc/scylla/build/dev/seastar/libseastar.so+0x495428 /home/raphaelsc/scylla/build/dev/seastar/libseastar.so+0x3d5157 /home/raphaelsc/scylla/build/dev/seastar/libseastar.so+0x3d44a2 0x169e6f3 0x169d401 /lib64/libc.so.6+0x3574 /lib64/libc.so.6+0x3627 0x169bb64 (BuildId: 8f09c1b15b635ea0b1dbdd213cff5d43158cad3f)
   --------
   compaction/compaction_manager.cc:1586:21
   seastar::internal::coroutine_traits_base<std::optional<compaction::compaction_stats> >::promise_type
   --------
   seastar::shared_future<std::optional<compaction::compaction_stats> >::shared_state
```

Fixes https://scylladb.atlassian.net/browse/SCYLLADB-4021.

Not backporting, since it's a new tool that needs to cook.