### PR TITLE
metrics: export shard's CPU location

### DIFF
--- a/replica/database.cc
+++ b/replica/database.cc
@@ -6,6 +6,7 @@
  * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
  */
 
+#include <sched.h>
 #include <algorithm>
 
 #include <exception>
@@ -597,12 +598,25 @@ database::sum_read_concurrency_sem_stat(std::invocable<reader_concurrency_semaph
     return _reader_concurrency_semaphores_group.sum_read_concurrency_sem_var([&] (reader_concurrency_semaphore& rcs) { return std::invoke(stats_member, rcs.get_stats()); });
 }
 
+// Returns -1 when unknown, which cannot be mistaken for a real cpu.
+static int current_cpu_id() {
+    return sched_getcpu();
+}
+
 void
 database::setup_metrics() {
     _dirty_memory_manager.setup_collectd("regular");
     _system_dirty_memory_manager.setup_collectd("system");
 
     namespace sm = seastar::metrics;
+
+    // The value is 1 so that cpu label can be applied to node metrics by joining them with this
+    // metric using multiplication and "group_left" on (instance, cpu).
+    _metrics.add_group("location", {
+        sm::make_gauge("shard", [] { return 1; },
+                       sm::description("The host CPU this shard's reactor runs on, in the cpu label."),
+                       {sm::label_instance("cpu", current_cpu_id()), basic_level}),
+    });
 
     _metrics.add_group("memory", {
         sm::make_gauge("dirty_bytes", [this] { return _dirty_memory_manager.real_dirty_memory() + _system_dirty_memory_manager.real_dirty_memory(); },


### PR DESCRIPTION
Per-shard metrics cannot be correlated with the host's per-cpu counters, as nothing reports which cpu a shard's reactor runs on, and the mapping is not easily guessable.

Add scylla_location_shard, a constant metric whose payload is its labels, like scylla_scylladb_current_version. Joining on the cpu gives a host counter a shard label, so it can be filtered and aggregated like any other per-shard metric:

    rate(node_cpu_seconds_total{mode="steal"}[4m])
        * on (instance, cpu) group_left(shard) scylla_location_shard

This will also allow agents to map scylla metrics to node metrics automatically using thanos.  

scylla-monitoring PR: https://github.com/scylladb/scylla-monitoring/pull/2897
