### PR TITLE
keys: serialize keys without exploding them twice (less insn/op, less allocs/op) [ hand-written, or ai-written serialization ]

### DIFF
--- a/idl/keys.idl.hh
+++ b/idl/keys.idl.hh
@@ -6,10 +6,9 @@
  * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
  */
 
-class clustering_key_prefix {
-    std::vector<bytes> explode();
-};
-
-class partition_key {
-    std::vector<bytes> explode();
-};
+// The serializers for partition_key and clustering_key_prefix are hand-written
+// rather than generated: the generated writer exploded each key into a
+// std::vector<bytes> twice per write (once for sizing, once for the write).
+// This file only pulls the replacement in so that keys.dist.hh keeps providing
+// ser::serializer<> for both keys, as every other IDL module expects.
+#include "keys/keys_serializer.hh"

--- a/keys/keys_serializer.hh
+++ b/keys/keys_serializer.hh
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2016-present ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
+ */
+
+#pragma once
+
+#include "keys/keys.hh"
+#include "serializer.hh"
+#include "serializer_impl.hh"
+#include "utils/fragment_range.hh"
+
+// Wire format matches the old generated single-vector<bytes> serializer;
+// size now comes from one components() walk instead of two explode() calls.
+
+namespace ser {
+
+namespace impl {
+
+struct compound_key_layout {
+    size_type count = 0;
+    uint64_t size = sizeof(size_type) /* frame size */ + sizeof(size_type) /* component count */;
+};
+
+// Frame size and component count, from a single walk over the key's components.
+template <typename Key>
+compound_key_layout measure_compound_key(const Key& key) {
+    compound_key_layout l;
+    for (managed_bytes_view c : key.components()) {
+        ++l.count;
+        l.size += sizeof(size_type) + c.size_bytes();
+    }
+    // Same limit and wording as get_sizeof(), which this replaces.
+    if (l.size > std::numeric_limits<size_type>::max()) {
+        throw std::runtime_error("Object is too big for get_sizeof");
+    }
+    return l;
+}
+
+template <typename Output, typename Key>
+void write_compound_key(Output& out, const Key& key) {
+    auto l = measure_compound_key(key);
+    if constexpr (std::is_same_v<Output, seastar::measuring_output_stream>) {
+        // Filler bytes only; l.size already has the real total.
+        serialize(out, size_type(0));
+        serialize(out, l.count);
+        out.write(nullptr, l.size - 2 * sizeof(size_type));
+    } else {
+        serialize(out, size_type(l.size));
+        serialize(out, l.count);
+        for (managed_bytes_view c : key.components()) {
+            safe_serialize_as_uint32(out, c.size_bytes());
+            for (bytes_view frag : fragment_range(c)) {
+                out.write(reinterpret_cast<const char*>(frag.data()), frag.size());
+            }
+        }
+    }
+}
+
+template <typename Key, typename Input>
+Key read_compound_key(Input& buf) {
+    return seastar::with_serialized_stream(buf, [] (auto& buf) {
+        size_type size = deserialize(buf, std::type_identity<size_type>());
+        auto in = buf.read_substream(size - sizeof(size_type));
+        auto components = deserialize(in, std::type_identity<std::vector<bytes>>());
+        return Key(std::move(components));
+    });
+}
+
+template <typename Input>
+void skip_compound_key(Input& buf) {
+    seastar::with_serialized_stream(buf, [] (auto& buf) {
+        size_type size = deserialize(buf, std::type_identity<size_type>());
+        buf.skip(size - sizeof(size_type));
+    });
+}
+
+} // namespace impl
+
+template <>
+struct serializer<clustering_key_prefix> {
+    template <typename Output>
+    static void write(Output& buf, const clustering_key_prefix& v) {
+        impl::write_compound_key(buf, v);
+    }
+
+    template <typename Input>
+    static clustering_key_prefix read(Input& buf) {
+        return impl::read_compound_key<clustering_key_prefix>(buf);
+    }
+
+    template <typename Input>
+    static void skip(Input& buf) {
+        impl::skip_compound_key(buf);
+    }
+};
+
+template <>
+struct serializer<const clustering_key_prefix> : public serializer<clustering_key_prefix>
+{};
+
+template <>
+struct serializer<partition_key> {
+    template <typename Output>
+    static void write(Output& buf, const partition_key& v) {
+        impl::write_compound_key(buf, v);
+    }
+
+    template <typename Input>
+    static partition_key read(Input& buf) {
+        return impl::read_compound_key<partition_key>(buf);
+    }
+
+    template <typename Input>
+    static void skip(Input& buf) {
+        impl::skip_compound_key(buf);
+    }
+};
+
+template <>
+struct serializer<const partition_key> : public serializer<partition_key>
+{};
+
+} // namespace ser


### PR DESCRIPTION
## Motivation

`idl/keys.idl.hh` declared `partition_key` and `clustering_key_prefix` as a single `std::vector<bytes>` member obtained from `explode()`, so writing a key ran `explode()` twice: once inside `set_size()`, which re-runs the whole writer against a measuring stream just to learn the frame size, and once for the write itself.
Each call heap-allocates a `std::vector<bytes>` grown by `emplace_back` (1, 3 and 4 allocations for 1, 3 and 5 components) and copies every component out of the key's already-contiguous representation.
Keys are written on every mutation, frozen mutation, canonical mutation and query result page, so this is on the hot path of essentially all inter-shard and inter-node traffic.

## Changes

Replace the generated serializers with a hand-written `keys/keys_serializer.hh`. The frame size and the component count come from a single walk over `components()`; the components are then written straight out of the key's representation, with nothing allocated.
The measuring pass (`set_size()`) doesn't re-walk `components()` either - the analytically-derived size already gives the exact byte width it needs to advance a measuring stream by.
The wire format is unchanged (uint32 frame size, uint32 component count, then uint32 length plus data per component - exactly what the generated code emitted for one `vector<bytes>` member), and `read()`/`skip()` are the generated code verbatim.

`idl/keys.idl.hh` is reduced to an `#include` of that header. That's unusual but deliberate: a plain `#include` in an IDL file passes through to the generated `keys.dist.hh`, so every module that pulls in `keys.dist.hh` keeps getting `ser::serializer<>` for both key types with no other change.

Known limitation, not addressed here: that `#include` makes `keys.dist.hh` (otherwise a light, forward-declaration-only header) pull in `keys/keys.hh`'s full dependency chain, since `idl-compiler.py` has no way to route a raw `#include` into a module's heavy `.dist.impl.hh` only.
A split attempt (declarations in `keys.dist.hh`, definitions trailing off `keys.hh`) was tried and reverted: it moved the heavy include onto `keys/keys.hh`, which 41 files include directly versus 8 for `idl/keys.idl.hh` - a larger blast radius, not a smaller one - and broke `utils/gcp/object_storage.cc`'s build.
Fixing this properly needs an `idl-compiler.py` change - I'm not sure I'll attend to it now or not.

## Tests

Unit (release, x86_64): `keys_test`, `serialization_test`, `idl_test`, `frozen_mutation_test`, `canonical_mutation_test`, `mutation_test`, `mutation_fragment_test`, `hint_test`, `mutation_query_test`, `sstable_mutation_test`, `cache_mutation_reader_test` all pass.

## Results

Measured with `perf_simple_query` reading whole 1024-row partitions with the clustering key columns projected, `--smp 1`, pinned to one core, five interleaved runs per arm, medians:

| clustering columns | insns/op | allocs/row saved | tps |
|---|---|---|---|
| 1 | -4.7% | 2 | +6.2% |
| 3 | -10.8% | 6 | +11.1% |
| 5 | -14.6% | 8 | +16.2% |


Backport: no, it's an improvement.