### PR TITLE
idl: generate a single-pass read_all() for writable views

### DIFF
--- a/idl-compiler.py
+++ b/idl-compiler.py
@@ -1471,7 +1471,13 @@ def add_view(cout, cls):
 
     skip = "" if cls.final else "ser::skip(in, std::type_identity<size_type>());"
     local_names = {}
-    for m in members:
+    # Single-pass reader (read_all()) accumulators; see emit below.
+    all_types = []
+    all_body = []
+    all_locals = []
+    all_local_names = {}
+    for idx, m in enumerate(members):
+        is_last = idx == len(members) - 1
         name = get_member_name(m.name)
         local_names[name] = "this->" + name + "()"
         full_type = param_view_type(m.type)
@@ -1507,6 +1513,50 @@ def add_view(cout, cls):
             """).format(f=DESERIALIZER, **locals()))
 
         skip = skip + f"\n       ser::skip(in, std::type_identity<{full_type}>());"
+
+        # read_all(): single walk in member order, avoiding per-accessor re-skips.
+        local = "__all_" + name
+        if is_vector(m.type):
+            elem_type = element_type(m.type)
+            all_types.append(f"vector_deserializer<{elem_type}>")
+            # A vector is read from a saved position, so `in` only needs advancing past it if a member follows.
+            if m.attribute:
+                if is_last:
+                    all_body.append(f"auto {local} = (in.size()>0) ? vector_deserializer<{elem_type}>(in) : vector_deserializer<{elem_type}>();")
+                else:
+                    all_body.append(
+                        f"bool {local}_present = in.size() > 0;\n"
+                        f"       auto {local}_in = in;\n"
+                        f"       if ({local}_present) {{ ser::skip(in, std::type_identity<{full_type}>()); }}\n"
+                        f"       auto {local} = {local}_present ? vector_deserializer<{elem_type}>({local}_in) : vector_deserializer<{elem_type}>();")
+            elif is_last:
+                all_body.append(f"auto {local} = vector_deserializer<{elem_type}>(in);")
+            else:
+                all_body.append(f"auto {local}_in = in;\n       ser::skip(in, std::type_identity<{full_type}>());\n       auto {local} = vector_deserializer<{elem_type}>({local}_in);")
+        else:
+            all_types.append(f"decltype({DESERIALIZER}(std::declval<utils::input_stream&>(), std::type_identity<{full_type}>()))")
+            if m.attribute:
+                deflt = m.default_value if m.default_value else param_type(m.type) + "()"
+                deflt = all_local_names.get(deflt, deflt)
+                all_body.append(f"auto {local} = (in.size()>0) ? {DESERIALIZER}(in, std::type_identity<{full_type}>()) : {deflt};")
+            else:
+                all_body.append(f"auto {local} = {DESERIALIZER}(in, std::type_identity<{full_type}>());")
+        all_locals.append(f"std::move({local})")
+        all_local_names[name] = local
+
+    if members:
+        head_skip = "" if cls.final else "ser::skip(in, std::type_identity<size_type>());"
+        body = ("\n       ".join([head_skip] + all_body)).strip()
+        fprintln(cout, reindent(4, """
+            using all_type = std::tuple<{types}>;
+            all_type read_all() const {{
+              return seastar::with_serialized_stream(v, [] (auto& v) -> all_type {{
+               auto in = v;
+               {body}
+               return all_type({locals});
+              }});
+            }}
+        """).format(types=", ".join(all_types), body=body, locals=", ".join(all_locals)))
 
     fprintln(cout, "};")
     skip_impl = "auto& in = v;\n       " + skip if cls.final else "v.skip(read_frame_size(v));"

--- a/mutation/mutation_partition_view.cc
+++ b/mutation/mutation_partition_view.cc
@@ -90,7 +90,7 @@ template<typename Visitor>
 void read_and_visit_row(ser::row_view rv, const column_mapping& cm, column_kind kind, Visitor&& visitor)
 {
     for (auto&& cv : rv.columns()) {
-        auto id = cv.id();
+        auto [id, cell] = cv.read_all();
         auto& col = cm.column_at(kind, id);
 
         class atomic_cell_or_collection_visitor : public boost::static_visitor<> {
@@ -117,7 +117,6 @@ void read_and_visit_row(ser::row_view rv, const column_mapping& cm, column_kind 
                 throw std::runtime_error("Trying to deserialize unknown cell type");
             }
         };
-        auto&& cell = cv.c();
         boost::apply_visitor(atomic_cell_or_collection_visitor(visitor, id, col), cell);
     }
 }
@@ -171,8 +170,9 @@ void mutation_partition_view::do_accept(const column_mapping& cm, Visitor& visit
     }
 
     for (auto&& cr : mpv.rows()) {
-        auto t = row_tombstone(cr.deleted_at(), shadowable_tombstone(cr.shadowable_deleted_at()));
-        visitor.accept_row(position_in_partition_view::for_key(cr.key()), t, read_row_marker(cr.marker()), is_dummy::no, is_continuous::yes);
+        auto [key, marker, deleted_at, cells, shadowable_deleted_at] = cr.read_all();
+        auto t = row_tombstone(deleted_at, shadowable_tombstone(shadowable_deleted_at));
+        visitor.accept_row(position_in_partition_view::for_key(key), t, read_row_marker(marker), is_dummy::no, is_continuous::yes);
 
         struct cell_visitor {
             Visitor& _visitor;
@@ -184,7 +184,7 @@ void mutation_partition_view::do_accept(const column_mapping& cm, Visitor& visit
                _visitor.accept_row_cell(id, std::move(cm));
             }
         };
-        read_and_visit_row(cr.cells(), cm, column_kind::regular_column, cell_visitor{visitor});
+        read_and_visit_row(cells, cm, column_kind::regular_column, cell_visitor{visitor});
     }
 }
 
@@ -215,9 +215,9 @@ future<> mutation_partition_view::do_accept_gently(const column_mapping& cm, Vis
     }
 
     for (auto cr : mpv.rows()) {
-        auto t = row_tombstone(cr.deleted_at(), shadowable_tombstone(cr.shadowable_deleted_at()));
-        auto key = cr.key();
-        visitor.accept_row(position_in_partition_view::for_key(key), t, read_row_marker(cr.marker()), is_dummy::no, is_continuous::yes);
+        auto [key, marker, deleted_at, cells, shadowable_deleted_at] = cr.read_all();
+        auto t = row_tombstone(deleted_at, shadowable_tombstone(shadowable_deleted_at));
+        visitor.accept_row(position_in_partition_view::for_key(key), t, read_row_marker(marker), is_dummy::no, is_continuous::yes);
 
         struct cell_visitor {
             Visitor& _visitor;
@@ -229,7 +229,7 @@ future<> mutation_partition_view::do_accept_gently(const column_mapping& cm, Vis
                _visitor.accept_row_cell(id, std::move(cm));
             }
         };
-        read_and_visit_row(cr.cells(), cm, column_kind::regular_column, cell_visitor{visitor});
+        read_and_visit_row(cells, cm, column_kind::regular_column, cell_visitor{visitor});
         co_await coroutine::maybe_yield();
     }
 }
@@ -260,9 +260,9 @@ future<> mutation_partition_view::do_accept_gently(const column_mapping& cm, Asy
     }
 
     for (auto cr : mpv.rows()) {
-        auto t = row_tombstone(cr.deleted_at(), shadowable_tombstone(cr.shadowable_deleted_at()));
-        auto key = cr.key();
-        co_await visitor.accept_row(position_in_partition_view::for_key(key), t, read_row_marker(cr.marker()), is_dummy::no, is_continuous::yes);
+        auto [key, marker, deleted_at, cells, shadowable_deleted_at] = cr.read_all();
+        auto t = row_tombstone(deleted_at, shadowable_tombstone(shadowable_deleted_at));
+        co_await visitor.accept_row(position_in_partition_view::for_key(key), t, read_row_marker(marker), is_dummy::no, is_continuous::yes);
 
         struct cell_visitor {
             AsyncVisitor& _visitor;
@@ -274,7 +274,7 @@ future<> mutation_partition_view::do_accept_gently(const column_mapping& cm, Asy
                _visitor.accept_row_cell(id, std::move(cm));
             }
         };
-        read_and_visit_row(cr.cells(), cm, column_kind::regular_column, cell_visitor{visitor});
+        read_and_visit_row(cells, cm, column_kind::regular_column, cell_visitor{visitor});
         co_await coroutine::maybe_yield();
     }
 
@@ -476,10 +476,10 @@ clustering_row read_clustered_row(const schema& s, ser::clustering_row_view crv)
         clustering_row get() && { return std::move(_row); }
     };
 
-    auto cr = crv.row();
-    auto t = row_tombstone(cr.deleted_at(), shadowable_tombstone(cr.shadowable_deleted_at()));
-    clustering_row_builder builder(cr.key(), std::move(t), read_row_marker(cr.marker()));
-    read_and_visit_row(cr.cells(), s.get_column_mapping(), column_kind::regular_column, builder);
+    auto [key, marker, deleted_at, cells, shadowable_deleted_at] = crv.row().read_all();
+    auto t = row_tombstone(deleted_at, shadowable_tombstone(shadowable_deleted_at));
+    clustering_row_builder builder(std::move(key), std::move(t), read_row_marker(marker));
+    read_and_visit_row(cells, s.get_column_mapping(), column_kind::regular_column, builder);
     return std::move(builder).get();
 }
 


### PR DESCRIPTION
## Motivation

`mutation_partition_view::do_accept()` and its `_gently` variants are the frozen-mutation apply path: every replica write, hint replay, commitlog replay, streaming/repair apply and `canonical_mutation::to_mutation()` goes through them.
For each clustered row they call five `deletable_row_view` accessors and, for each cell, two `column_view` accessors - and each generated accessor re-walks the frame from its head.
Per row that's 15 `ser::skip()` calls where a single pass needs one, plus 3 per column instead of 1.

## Changes

- `idl-compiler.py`: emit, alongside the existing per-member accessors, a `read_all()` returning a `std::tuple` of every member deserialized in one linear pass.
Purely additive - existing accessors are untouched, so single-member call sites are unaffected.
42 view types across 6 IDL files gain the method; the wire format is unchanged.
- `idl-compiler.py`: `read_all()`'s last member no longer gets a needless trailing `ser::skip()` when it's a `std::vector<...>`. Not hit by this PR's call sites (both end in a scalar); verified via synthetic IDL across all four codegen branches.
- `mutation/mutation_partition_view.cc`: switch `do_accept()`/`_gently` to use `read_all()` for `deletable_row_view` and `column_view` (4 call sites). `do_accept_ordered()` keeps the per-accessor calls since its caller already deserializes the clustering key separately.

## Tests

All pass (release, x86_64): `mutation_test`, `idl_test`, `frozen_mutation_test`, `canonical_mutation_test`, `mutation_fragment_test`, `mutation_query_test`, `sstable_mutation_test`, `cache_mutation_reader_test`, `serialization_test`, `keys_test`.

Also rebuilt (dev, x86_64) and re-ran the same 11 suites; all still pass.

## Results

`test/perf/perf_canonical_mutation`, `--smp 1`, pinned core, 1000 rows × 8 byte values, 5 interleaved reps (instruction counts identical across reps); raw per-op counts divided by the 1000-row workload size:

| columns | to_mutation instr/row | | other-schema-version instr/row | |
|---|---|---|---|---|
| 1 | 4,455 → 3,996 | -10.3% | 11,408 → 10,951 | -4.0% |
| 5 | 9,235 → 8,717 | -5.6% | 19,319 → 18,822 | -2.6% |
| 20 | 27,365 → 26,622 | -2.7% | 49,549 → 48,901 | -1.3% |

~445 instructions saved per clustered row plus ~15 per cell, independent of row width. Allocation counts unchanged.

