### PR TITLE
service: storage_service: make a non-quiescing topology wait visible

### DIFF
--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -6431,16 +6431,47 @@ future<> storage_service::await_topology_quiesced() {
 
     // New behavior — submit a topology request and retry until the
     // coordinator observes an empty tablet balance plan with fresh stats.
+    //
+    // This loop can retry for a long time: on a cluster whose tablet load
+    // never settles within size_based_balance_threshold_percentage, the
+    // coordinator keeps deferring the request and the caller (e.g.
+    // load-and-stream) makes no progress at all. Report that at info level so
+    // the wait is diagnosable from a default-level log rather than only from
+    // the coordinator's own deferral messages.
+    const auto start_time = lowres_clock::now();
+    unsigned attempts = 0;
+    auto elapsed_s = [start_time] {
+        return std::chrono::duration_cast<std::chrono::seconds>(lowres_clock::now() - start_time).count();
+    };
     while (true) {
+        ++attempts;
         auto request_id = co_await submit_quiesce_topology_request();
         auto error = co_await wait_for_topology_request_completion(request_id);
         if (error.empty()) {
+            if (attempts > 1) {
+                slogger.info("quiesce request {}: topology quiesced after {} attempts in {} s",
+                             request_id, attempts, elapsed_s());
+            }
             co_return;
         }
         if (error.starts_with("quiesce request failed")) {
             slogger.warn("quiesce request {}: {}", request_id, error);
+        } else if (attempts == 1) {
+            // Always report the first attempt of a wait. The rate limiter below
+            // is shared by every wait on this shard, so an unconditional line
+            // here is what guarantees that each wait is recorded as having
+            // started; otherwise a fresh wait could be silently swallowed by
+            // the tail of a preceding one.
+            slogger.info("quiesce request {}: topology not idle: {}", request_id, error);
         } else {
-            slogger.debug("quiesce request {}: topology not idle: {}", request_id, error);
+            // Retries are rate-limited, and add the attempt count and elapsed
+            // time: a bare "not idle" line is not actionable, whereas
+            // "attempt 812, waiting for 2700 s" tells an operator that the
+            // topology is never going to quiesce.
+            static thread_local logging::logger::rate_limit rate_limit{std::chrono::seconds(30)};
+            slogger.log(logging::log_level::info, rate_limit,
+                        "quiesce request {}: topology not idle: {} (attempt {}, waiting for {} s)",
+                        request_id, error, attempts, elapsed_s());
         }
         // Wait locally for topology to settle before resubmitting.
         co_await _topology_state_machine.await_not_busy();


### PR DESCRIPTION
`await_topology_quiesced()` retries until the topology coordinator answers a quiesce request without deferring it. That can go on indefinitely: on a cluster whose tablet load never settles within `size_based_balance_threshold_percentage`, the balancer keeps producing a non-empty plan, the coordinator keeps deferring, and the caller makes no progress at all.

Today the only trace of that on the waiting node is a `debug`-level line, so with default logging the wait is invisible. In the SCYLLADB-3939 run, a load-and-stream blocked here emitted its `Loading new SSTables` line and then nothing whatsoever for 67 minutes on all three target nodes. The condition was diagnosable only by correlating the coordinator's own `quiesce request deferred` messages against the loader's silence.

## Change

- Log the deferral at `info` level, rate-limited to one line every 30s so a migration storm cannot flood the log.
- Include the attempt count and elapsed time. A bare "topology not idle" line is not actionable; `attempt 812, waiting for 2700 s` tells an operator that the topology is never going to quiesce.
- Log once when a wait that needed more than one attempt finally succeeds, so the cost of the wait is visible in the good case too.

No functional change — logging only.

## Testing

Compile-checked `service/storage_service.cc` (`-fsyntax-only`, dev config, in `dbuild`). No test added: the change is logging-only and the retry path it annotates has no existing test hook.

Refs SCYLLADB-3939