### PR TITLE
service: rate-limit and demote per-barrier topology logging

### DIFF
--- a/service/session.cc
+++ b/service/session.cc
@@ -58,6 +58,11 @@ void session_manager::initiate_close_of_sessions_except(const std::unordered_set
     }
 }
 
+// Called on every shard for every raft_topology_cmd::barrier_and_drain, so on a
+// cluster with a heavy stream of tablet migrations this runs constantly and has
+// nothing to do most of the time. All of the routine progress is therefore
+// logged at debug level; a session that fails to close is still reported by the
+// periodic warnings below, and the barrier itself is reported by its caller.
 future<> session_manager::drain_closing_sessions() {
     slogger.debug("drain_closing_sessions: waiting for lock");
     seastar::timer<lowres_clock> lock_timer([this] {
@@ -84,7 +89,7 @@ future<> session_manager::drain_closing_sessions() {
         co_await s.close();
         warn_timer.reset();
         if (_sessions.erase(id)) {
-            slogger.info("drain_closing_sessions: session {} closed", id);
+            slogger.debug("drain_closing_sessions: session {} closed", id);
         }
     }
     slogger.debug("drain_closing_sessions: done");

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -4845,9 +4845,18 @@ future<> storage_service::local_topology_barrier() {
 
     co_await container().invoke_on_all([version] (storage_service& ss) -> future<> {
         const auto current_version = ss._shared_token_metadata.get()->get_version();
-        rtlogger.info("Got raft_topology_cmd::barrier_and_drain, version {}, "
-                      "current version {}, stale versions (version: use_count): {}",
-                      version, current_version, ss._shared_token_metadata.describe_stale_versions());
+        // This handler runs on every shard of every node for every barrier, so
+        // under a heavy stream of tablet migrations it dominates the log. Keep
+        // the arrival line at info level, since it carries the version
+        // diagnostics, but rate-limit it; the progress lines below are traces
+        // and carry nothing in the common case where the barrier completes
+        // immediately, so they are logged at debug level. A barrier that does
+        // get stuck is still reported by the periodic warning below.
+        static thread_local logging::logger::rate_limit rate_limit{std::chrono::seconds(1)};
+        rtlogger.log(logging::log_level::info, rate_limit,
+                     "Got raft_topology_cmd::barrier_and_drain, version {}, "
+                     "current version {}, stale versions (version: use_count): {}",
+                     version, current_version, ss._shared_token_metadata.describe_stale_versions());
 
         // This shouldn't happen under normal operation, it's only plausible
         // if the topology change coordinator has
@@ -4864,7 +4873,7 @@ future<> storage_service::local_topology_barrier() {
                              version, current_version)));
         }
 
-        rtlogger.info("raft_topology_cmd::barrier_and_drain version {}: waiting for stale token metadata versions to be released", version);
+        rtlogger.debug("raft_topology_cmd::barrier_and_drain version {}: waiting for stale token metadata versions to be released", version);
         {
             seastar::timer<lowres_clock> warn_timer([&ss, version] {
                 rtlogger.warn("raft_topology_cmd::barrier_and_drain version {}: still waiting for stale versions, "
@@ -4874,10 +4883,10 @@ future<> storage_service::local_topology_barrier() {
             warn_timer.arm_periodic(std::chrono::minutes(5));
             co_await ss._shared_token_metadata.stale_versions_in_use();
         }
-        rtlogger.info("raft_topology_cmd::barrier_and_drain version {}: stale versions released, draining closing sessions", version);
+        rtlogger.debug("raft_topology_cmd::barrier_and_drain version {}: stale versions released, draining closing sessions", version);
         co_await get_topology_session_manager().drain_closing_sessions();
 
-        rtlogger.info("raft_topology_cmd::barrier_and_drain version {}: done", version);
+        rtlogger.debug("raft_topology_cmd::barrier_and_drain version {}: done", version);
     });
 }
 


### PR DESCRIPTION
`raft_topology_cmd::barrier_and_drain` is handled on every shard of every node, and every tablet migration triggers one. Its handler emits four `info`-level lines per shard per barrier, so a cluster with a heavy stream of tablet migrations spends most of its log on barrier bookkeeping.

Measured on a 14-shard node during the SCYLLADB-3939 run, over 80 minutes:

| | |
|---|---|
| `barrier_and_drain` invocations | 201 838 |
| info lines from this handler | 807 352 |
| total lines for the node | 2 127 887 |
| sustained log rate | 443 lines/s |

At that rate the log costs real disk and CPU and, worse, buries whatever else was going wrong — in that run, the actual failure.

## Change

Of the four lines, only the first carries information: the topology version, the current version, and the stale versions in use. The other three are progress traces that say nothing in the common case where the barrier completes immediately.

- Keep the arrival line at `info` but rate-limit it to one line per second per shard. Ordinary topology operations stay fully logged, while a migration storm is capped; the rate limiter annotates how many similar messages it dropped, so the real rate remains visible.
- Log the three progress lines at `debug`.
- In `drain_closing_sessions()`, demote the last remaining `info` line to `debug`, for consistency with the rest of that function which already logs progress at `debug`.

A barrier that actually gets stuck is unaffected: the periodic warnings for stale versions still not released and for sessions still not closed are untouched, as is the version-mismatch exception.

No functional change — logging only.

## Testing

Compile-checked `service/storage_service.cc` and `service/session.cc` (`-fsyntax-only`, dev config, in `dbuild`). No test added: logging levels are not asserted anywhere in the suite.

Refs SCYLLADB-3939