### PR TITLE
Stop load-and-stream from flooding the global topology request queue

### DIFF
--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -2368,6 +2368,8 @@ future<> storage_service::stop() {
     co_await _global_topology_requests_module->stop();
     co_await _vnodes_to_tablets_migration_module->stop();
     co_await _async_gate.close();
+    // The quiesce action runs detached from its callers, so it can outlive the gate.
+    co_await _quiesce_topology.join();
     _tablet_split_monitor_event.signal();
     co_await std::move(_tablet_split_monitor);
 }
@@ -6372,6 +6374,29 @@ future<utils::UUID> storage_service::submit_quiesce_topology_request() {
     }
 }
 
+// Submit a topology request and retry until the coordinator observes an empty tablet
+// balance plan with fresh stats. Runs as _quiesce_topology, so at most one of these is
+// in flight at a time, see await_topology_quiesced().
+future<> storage_service::do_await_topology_quiesced() {
+    while (true) {
+        auto request_id = co_await submit_quiesce_topology_request();
+        auto error = co_await wait_for_topology_request_completion(request_id);
+        if (error.empty()) {
+            co_return;
+        }
+        if (error.starts_with("quiesce request failed")) {
+            slogger.warn("quiesce request {}: {}", request_id, error);
+        } else {
+            slogger.debug("quiesce request {}: topology not idle: {}", request_id, error);
+        }
+        // Wait locally for topology to settle before resubmitting.
+        co_await _topology_state_machine.await_not_busy();
+        co_await _topology_state_machine.event.when([this] {
+            return get_token_metadata_ptr()->tablets().is_idle();
+        });
+    }
+}
+
 future<> storage_service::await_topology_quiesced() {
     auto holder = _async_gate.hold();
 
@@ -6391,25 +6416,16 @@ future<> storage_service::await_topology_quiesced() {
         co_return;
     }
 
-    // New behavior — submit a topology request and retry until the
-    // coordinator observes an empty tablet balance plan with fresh stats.
-    while (true) {
-        auto request_id = co_await submit_quiesce_topology_request();
-        auto error = co_await wait_for_topology_request_completion(request_id);
-        if (error.empty()) {
-            co_return;
-        }
-        if (error.starts_with("quiesce request failed")) {
-            slogger.warn("quiesce request {}: {}", request_id, error);
-        } else {
-            slogger.debug("quiesce request {}: topology not idle: {}", request_id, error);
-        }
-        // Wait locally for topology to settle before resubmitting.
-        co_await _topology_state_machine.await_not_busy();
-        co_await _topology_state_machine.event.when([this] {
-            return get_token_metadata_ptr()->tablets().is_idle();
-        });
-    }
+    // Whether the topology has quiesced is a question about the cluster, so concurrent
+    // callers all want the same answer. load_and_stream() asks it from every shard at
+    // once, which used to put smp::count requests into the cluster-wide group0 queue,
+    // each one costing the coordinator a load stats collection and a full balance.
+    //
+    // trigger_later() defers the run briefly so that callers forwarded from other shards
+    // join the same one. Callers which arrive once a run has already started are served
+    // by the next run rather than by that one, so nobody is given an answer which was
+    // computed before it asked.
+    co_await _quiesce_topology.trigger_later();
 }
 
 future<bool> storage_service::verify_topology_quiesced(token_metadata::version_t expected_version) {

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -6387,7 +6387,7 @@ future<> storage_service::do_await_topology_quiesced() {
         if (error.starts_with("quiesce request failed")) {
             slogger.warn("quiesce request {}: {}", request_id, error);
         } else {
-            slogger.debug("quiesce request {}: topology not idle: {}", request_id, error);
+            slogger.info("quiesce request {}: topology not idle: {}", request_id, error);
         }
         // Wait locally for topology to settle before resubmitting.
         co_await _topology_state_machine.await_not_busy();

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -50,6 +50,7 @@
 #include "utils/UUID.hh"
 #include "utils/user_provided_param.hh"
 #include "utils/sequenced_set.hh"
+#include "utils/serialized_action.hh"
 #include "service/topology_coordinator.hh"
 
 class node_ops_cmd_request;
@@ -885,6 +886,11 @@ public:
 private:
      // State machine that is responsible for topology change
     topology_state_machine& _topology_state_machine;
+
+    // Batches concurrent await_topology_quiesced() callers so that they share one
+    // group0 request instead of submitting one each. Only shard 0's instance is used,
+    // since that is where the other shards forward to.
+    serialized_action _quiesce_topology{[this] { return do_await_topology_quiesced(); }};
     db::view::view_building_state_machine& _view_building_state_machine;
 
     future<> _topology_change_coordinator = make_ready_future<>();
@@ -994,6 +1000,9 @@ public:
     future<> set_tablet_balancing_enabled(bool);
 
     future<utils::UUID> submit_quiesce_topology_request();
+    // The body of await_topology_quiesced(), run through _quiesce_topology so that
+    // concurrent callers share a single request. Shard 0 only.
+    future<> do_await_topology_quiesced();
     future<> await_topology_quiesced();
     // Verifies topology is not busy, and also that topology version hasn't changed since the one provided
     // by the caller.

--- a/service/topology_coordinator.cc
+++ b/service/topology_coordinator.cc
@@ -1255,6 +1255,34 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
             group0_update_collector updates;
             bool requires_schema_changes = false;
 
+            // A quiesce request asks a question about the cluster as a whole, so several of them
+            // queued next to each other all have the same answer. Collapse the longest run of
+            // consecutive quiesce requests at the head of the queue and answer them from a single
+            // evaluation, instead of collecting load stats and balancing once per request.
+            //
+            // Only a prefix is collapsed, for two reasons: requests of other types keep their
+            // position in the queue, and every request in the batch was already queued before the
+            // evaluation below starts, so each still gets an answer computed after it was
+            // submitted. Attaching a request to an evaluation which started earlier would answer
+            // it with a stale observation.
+            std::vector<utils::UUID> batch{req_id};
+            const auto& queue = _topo_sm._topology.global_requests_queue;
+            for (size_t i = 1; i < queue.size(); i++) {
+                auto entry = co_await _sys_ks.get_topology_request_entry_opt(queue[i]);
+                if (!entry) {
+                    break;
+                }
+                auto* queued = std::get_if<global_topology_request>(&entry->request_type);
+                if (!queued || *queued != global_topology_request::quiesce) {
+                    break;
+                }
+                batch.push_back(queue[i]);
+            }
+            if (batch.size() > 1) {
+                rtlogger.debug("quiesce topology request: answering {} queued requests from one evaluation",
+                        batch.size());
+            }
+
             try {
                 rtlogger.debug("quiesce topology request: refreshing tablet load stats");
                 auto [load_stats, complete] = co_await collect_tablet_load_stats(require_live_nodes::yes);
@@ -1280,22 +1308,28 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
 
             updates.emplace_back(
                     topology_mutation_builder(guard.write_timestamp())
-                         .drop_first_global_topology_request_id(_topo_sm._topology.global_requests_queue, req_id)
+                         .drop_first_global_topology_request_ids(_topo_sm._topology.global_requests_queue, batch)
                          .build());
-            updates.emplace_back(
-                    topology_request_tracking_mutation_builder(req_id)
-                         .set("start_time", db_clock::now())
-                         .done(error)
-                         .build());
+            // One evaluation answered all of them, so stamp them with one time rather than
+            // letting each request pick up a slightly different db_clock::now().
+            const auto completion_time = db_clock::now();
+            for (const auto& id : batch) {
+                updates.emplace_back(
+                        topology_request_tracking_mutation_builder(id)
+                             .set("start_time", completion_time)
+                             .done(error, completion_time)
+                             .build());
+            }
             if (error) {
-                auto reason = fmt::format("quiesce request deferred: {}", *error);
+                auto reason = fmt::format("quiesce request deferred ({} request(s)): {}", batch.size(), *error);
                 if (requires_schema_changes) {
                     co_await update_topology_state_with_mixed_change(std::move(guard), std::move(updates), reason);
                 } else {
                     co_await update_topology_state(std::move(guard), std::move(updates), reason);
                 }
             } else {
-                co_await update_topology_state(std::move(guard), std::move(updates), "quiesce request completed");
+                co_await update_topology_state(std::move(guard), std::move(updates),
+                        fmt::format("quiesce request completed ({} request(s))", batch.size()));
             }
         }
         break;

--- a/service/topology_mutation.cc
+++ b/service/topology_mutation.cc
@@ -6,6 +6,7 @@
  * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
  */
 
+#include <algorithm>
 #include "utils/assert.hh"
 #include "db/system_keyspace.hh"
 #include "topology_mutation.hh"
@@ -267,6 +268,19 @@ topology_mutation_builder& topology_mutation_builder::drop_first_global_topology
     }
 }
 
+topology_mutation_builder& topology_mutation_builder::drop_first_global_topology_request_ids(const std::vector<utils::UUID>& queue,
+        const std::vector<utils::UUID>& ids) {
+    if (ids.empty()) {
+        return *this;
+    }
+    if (ids.size() > queue.size() || !std::equal(ids.begin(), ids.end(), queue.begin())) {
+        on_internal_error(rtlogger, fmt::format("global topology requests queue [{}] does not start with the completed requests [{}]",
+                fmt::join(queue, ", "), fmt::join(ids, ", ")));
+    }
+    return apply_set("global_requests", collection_apply_mode::overwrite,
+            std::span(queue.begin() + ids.size(), queue.size() - ids.size()));
+}
+
 topology_mutation_builder& topology_mutation_builder::pause_rf_change_request(const utils::UUID& id) {
     return apply_set("paused_rf_change_requests", collection_apply_mode::update, std::vector<data_value>{id});
 }
@@ -379,8 +393,9 @@ topology_request_tracking_mutation_builder& topology_request_tracking_mutation_b
     return set("error", error);
 }
 
-topology_request_tracking_mutation_builder& topology_request_tracking_mutation_builder::done(std::optional<sstring> error) {
-    set("end_time", db_clock::now());
+topology_request_tracking_mutation_builder& topology_request_tracking_mutation_builder::done(std::optional<sstring> error,
+        std::optional<db_clock::time_point> end_time) {
+    set("end_time", end_time.value_or(db_clock::now()));
     if (error) {
         set("error", *error);
     }

--- a/service/topology_mutation.hh
+++ b/service/topology_mutation.hh
@@ -130,6 +130,17 @@ public:
     topology_mutation_builder& del_global_topology_request_id();
     topology_mutation_builder& queue_global_topology_request_id(const utils::UUID& value);
     topology_mutation_builder& drop_first_global_topology_request_id(const std::vector<utils::UUID>&, const utils::UUID&);
+    // Drops `ids` from the front of the queue. The plural counterpart of the above, for
+    // when several queued requests are handled together, see handle_global_request().
+    //
+    // `queue` must start with `ids`, otherwise this is an internal error. Callers take the
+    // ids from the head of the queue under the same guard the mutation is written with,
+    // and that guard also excludes group0 command application, so the queue cannot move
+    // underneath them. Dropping the wrong entries would either lose a request nobody
+    // answered, or leave an answered one to be popped and answered again on every
+    // subsequent round, wedging the coordinator on it forever.
+    topology_mutation_builder& drop_first_global_topology_request_ids(const std::vector<utils::UUID>& queue,
+            const std::vector<utils::UUID>& ids);
     topology_mutation_builder& pause_rf_change_request(const utils::UUID&);
     topology_mutation_builder& resume_rf_change_request(const std::unordered_set<utils::UUID>&, const utils::UUID&);
     topology_mutation_builder& start_rf_change_migrations(const utils::UUID&);
@@ -161,7 +172,10 @@ public:
     topology_request_tracking_mutation_builder& set(const char* cell, topology_request value);
     topology_request_tracking_mutation_builder& set(const char* cell, global_topology_request value);
     topology_request_tracking_mutation_builder& abort(sstring error);
-    topology_request_tracking_mutation_builder& done(std::optional<sstring> error = std::nullopt);
+    // `end_time` defaults to now. Pass it explicitly when several requests are completed
+    // together, so that they are all stamped with the same time.
+    topology_request_tracking_mutation_builder& done(std::optional<sstring> error = std::nullopt,
+            std::optional<db_clock::time_point> end_time = std::nullopt);
     topology_request_tracking_mutation_builder& set_truncate_table_data(const table_id& table_id);
     topology_request_tracking_mutation_builder& set_new_keyspace_rf_change_data(const sstring& ks_name, const std::map<sstring, sstring>& rf_per_dc);
     topology_request_tracking_mutation_builder& set_snapshot_tables_data(const std::unordered_set<table_id>&, const sstring& tag, bool);


### PR DESCRIPTION
Problem

Whether the topology has quiesced is a question about the cluster as a whole, but sstables_loader asks it once per shard. `load_new_sstables()` and `download_task_impl::run()` fan out with `invoke_on_all()`, and each shard's `load_and_stream()` opens with `await_topology_quiesced_and_get_erm()`.

Since `QUIESCE_TOPOLOGY_ENHANCED` that wait is no longer a local check: it submits a global topology request to group0. Non-zero shards forward to shard 0, where each caller runs an independent instance of the retry loop and mints its own request id, so nothing coalesces them. A single `POST /storage_service/sstables/<ks>?cf=<cf>&load_and_stream=true` therefore puts `smp::count` requests into the queue.

Each entry is expensive, and not read-only:

- it forces `collect_tablet_load_stats(require_live_nodes::yes)`, an RPC fan-out to every node, plus a full `balance_tablets()` over every table;
- on a non-empty plan it commits the migrations it just computed and sets `tstate = tablet_migration`. `handle_topology_transition()` checks `tstate` before the queue, so the next entry cannot even be looked at until that whole migration round has drained through a global barrier.

This series does not change what quiesce promises — the whole cluster being balanced is the intended contract. It reduces how many times that question is asked.

Solution

On the caller side the submit-and-retry loop moves behind a `serialized_action`. Concurrent callers on shard 0, including those forwarded from the other shards, share a single run instead of each submitting a request of its own, and the
action's semaphore of one means a node has at most one quiesce request in flight at any moment. The run is deferred briefly so that shards arriving a little later still join it rather than starting a second one.

A `serialized_action` and not a `shared_future`, because the freshness of the answer matters. `trigger()` guarantees a run which starts after the call, so a caller which arrives while a run is already going is served by the next run. A `shared_future` would attach it to an observation older than its own request, and "the topology was quiesced at some point" is a weaker statement than "the topology was quiesced after I asked".

On the coordinator side a run of consecutive quiesce requests at the head of the queue is answered from one evaluation, with the same result and the same completion time written to every request's tracking row. The requests keep their own ids and their own rows; only the load stats collection and the balance are shared. All of it lands in a single group0 command, so a batch is either answered and dequeued as a whole or not at all.

Only a prefix is collapsed, which is what keeps the answer honest. Every request in the batch was already queued before the evaluation begins, so each still gets an answer computed after it was submitted. Reaching past a request of another
type would reorder that request and would answer whatever sits behind it from an observation taken before it ran.

Fixes: https://scylladb.atlassian.net/browse/SCYLLADB-4035

**The QUIESCE_TOPOLOGY_ENHANCED has been introduced in 2026.3. Thus it needs a backport there.**