### PR TITLE
[DONT REVIEW] test: decouple test.py's scylla-driver from the frozen toolchain

### DIFF
--- a/docs/dev/testing.md
+++ b/docs/dev/testing.md
@@ -18,6 +18,14 @@ please manually install all Python modules it lists with `pip`.
 Additionally, `toolchain/dbuild` could be used to run `test.py`. In this
 case you don't need to run `./install-dependencies.sh`
 
+`test.py`'s own Python dependencies (scylla-driver and other test-only
+packages) are listed in `test/requirements.txt`, independent of the
+frozen toolchain image. On startup, `test.py` installs them into an
+isolated, per-requirements-file cache directory under `XDG_CACHE_HOME`
+(reused across runs once populated) and prepends it to `sys.path`, so
+bumping a version in `test/requirements.txt` takes effect immediately
+without having to rebuild the toolchain.
+
 By default `test.py` has `--gather-metrics` parameter, that is used to gather
 CPU/RAM usage during tests from the cgroup.
 This means that before execute `test.py` current terminal process should be located in

--- a/install-dependencies.sh
+++ b/install-dependencies.sh
@@ -180,18 +180,16 @@ fedora_python3_packages=(
 )
 
 # an associative array from packages to constrains
+#
+# These are packages also needed outside of test.py (e.g. by cqlsh, or by the
+# shipped python3 relocatable package / dist/common/scripts). test.py-only
+# packages live in test/requirements.txt instead, which test.py installs
+# itself so their versions stay decoupled from this frozen toolchain image.
 declare -A pip_packages=(
     [scylla-driver]="==$(cat tools/cqlsh/requirements.txt | grep scylla-driver | cut -d= -f3)"
     [geomet]=""
     [traceback-with-variables]=""
     [scylla-api-client]=""
-    [treelib]=""
-    [allure-pytest]=""
-    [pytest-xdist]=""
-    [pykmip]=""
-    [universalasync]=""
-    [boto3-stubs[dynamodb]]=""
-    [setuptools_scm]=""
 )
 
 pip_symlinks=(

--- a/test.py
+++ b/test.py
@@ -9,6 +9,73 @@
 
 from __future__ import annotations
 
+import pathlib
+import subprocess
+import sys
+
+
+def _ensure_test_requirements() -> None:
+    """Install test.py's own Python dependencies (scylla-driver and others) from
+    test/requirements.txt into an isolated, per-requirements-file cache
+    directory, and prepend it to sys.path, so test.py doesn't depend on
+    whatever happens to be frozen into the toolchain image.
+
+    Installing into an isolated --target dir (rather than the live
+    environment), keyed by a hash of the requirements file plus the
+    interpreter ABI, lets a populated cache from a previous run be reused (no
+    re-invoking pip on every run) while avoiding two concurrent test.py runs
+    -- e.g. different modes' stages landing on the same builder node at once
+    -- racing to install into a shared site-packages. A marker file is
+    written only after a full, successful install, and its presence (rather
+    than merely the target dir's) gates whether a run can skip straight to
+    reuse; a per-target-dir file lock serializes concurrent installs into the
+    same directory.
+    """
+    import fcntl
+    import hashlib
+    import importlib
+    import os
+    import shutil
+    import sysconfig
+
+    requirements_file = pathlib.Path(__file__).resolve().parent / "test" / "requirements.txt"
+    digest = hashlib.sha256(requirements_file.read_bytes()).hexdigest()[:16]
+
+    cache_home = pathlib.Path(os.environ.get("XDG_CACHE_HOME", pathlib.Path.home() / ".cache"))
+    cache_root = cache_home / "scylla-test-pip-packages"
+    target_dir = cache_root / f"{sysconfig.get_config_var('SOABI')}-{digest}"
+    marker = target_dir / ".install-complete"
+
+    sys.path.insert(0, str(target_dir))
+    if marker.exists():
+        return
+
+    cache_root.mkdir(parents=True, exist_ok=True)
+    with open(cache_root / f"{target_dir.name}.lock", "w") as lock_file:
+        fcntl.flock(lock_file, fcntl.LOCK_EX)
+        try:
+            if marker.exists():  # another process installed while we were waiting for the lock
+                return
+            # A directory left behind by a crashed install is missing the marker, so it
+            # would reach this point again -- but pip's --target only reliably behaves
+            # against an empty directory, so a stale partial install must be cleared first.
+            shutil.rmtree(target_dir, ignore_errors=True)
+            target_dir.mkdir(parents=True, exist_ok=True)
+            subprocess.check_call(
+                [sys.executable, "-m", "pip", "install", "--quiet",
+                 "--target", str(target_dir), "-r", str(requirements_file)])
+            # target_dir didn't exist yet when it was inserted into sys.path above; if anything
+            # probed an import through it before now, Python's import system would have cached
+            # its absence in sys.path_importer_cache, and the just-installed packages would stay
+            # unimportable without invalidating that cache.
+            importlib.invalidate_caches()
+            marker.touch()
+        finally:
+            fcntl.flock(lock_file, fcntl.LOCK_UN)
+
+
+_ensure_test_requirements()
+
 import argparse
 import asyncio
 import dataclasses
@@ -25,10 +92,7 @@ import itertools
 import logging
 import multiprocessing
 import os
-import pathlib
 import resource
-import subprocess
-import sys
 import time
 
 import humanfriendly

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -1,0 +1,15 @@
+# Python dependencies required to run test.py.
+#
+# scylla-driver's pin here is intentionally independent of both
+# tools/cqlsh/requirements.txt and install-dependencies.sh: test.py installs
+# from this file on its own (see _ensure_test_requirements() in test.py), so
+# bumping the version here takes effect immediately and does not require
+# rebuilding the frozen toolchain image.
+scylla-driver==3.29.7
+treelib
+allure-pytest
+pytest-xdist
+pykmip
+universalasync
+boto3-stubs[dynamodb]
+setuptools_scm


### PR DESCRIPTION
test.py's scylla-driver version was tied to whatever install-dependencies.sh baked into the frozen toolchain image, so bumping the driver required rebuilding the toolchain. Add test/requirements.txt with test.py-only pip dependencies, pinning scylla-driver independently, and have test.py install from it on startup so it self-corrects regardless of the toolchain image state. Packages also needed by cqlsh/the shipped python3 relocatable package (scylla-driver, geomet, traceback-with-variables, scylla-api-client) stay in install-dependencies.sh.

Fixes: https://scylladb.atlassian.net/browse/RELENG-760

**test.py improvement, no need for backport**