### PR TITLE
test: view_build_test: skip if error injections are disabled

### DIFF
--- a/test/boost/view_build_test.cc
+++ b/test/boost/view_build_test.cc
@@ -690,6 +690,10 @@ SEASTAR_THREAD_TEST_CASE(test_view_update_generator_register_semaphore_unit_leak
 }
 
 SEASTAR_THREAD_TEST_CASE(test_view_update_generator_stop_during_process_staging_sstables) {
+#ifndef SCYLLA_ENABLE_ERROR_INJECTION
+    fmt::print("Skipping test as it depends on error injection. Please run in mode where it's enabled (debug,dev).\n");
+    return;
+#endif
     cql_test_config test_cfg;
     auto& db_cfg = *test_cfg.db_config;
 
@@ -729,9 +733,9 @@ SEASTAR_THREAD_TEST_CASE(test_view_update_generator_stop_during_process_staging_
         utils::get_local_injector().enable(injection);
         auto processing = view_update_generator.process_staging_sstables(table, {sst});
 
-        eventually_true([injection] {
+        BOOST_REQUIRE(eventually_true([injection] {
             return utils::get_local_injector().waiters(injection) > 0;
-        });
+        }));
 
         auto stop = view_update_generator.stop();
         utils::get_local_injector().receive_message(injection);


### PR DESCRIPTION
test_view_update_generator_stop_during_process_staging_sstables pauses process_staging_sstables() on the view_update_generator_pause_before_processing injection and waits for a fiber to park on it before calling stop().

In builds without SCYLLA_ENABLE_ERROR_INJECTION the injection is compiled away: enable() is a no-op and waiters() always returns 0. The wait therefore ran its full backoff - about 33 seconds - and returned false, but the result was discarded, so the test went on to stop() a generator that had never been paused and reported success without exercising the race it was written for. It cost 35s of every release run to test nothing.

Skip the test where injections are unavailable, following the idiom used by the other injection-dependent tests, and require the wait to succeed so that a fiber which never reaches the injection point fails the test instead of being silently ignored.

no backport - small improvement to test time