### PR TITLE
test/alternator: add an error-injection handle

### DIFF
--- a/test/alternator/test_batch.py
+++ b/test/alternator/test_batch.py
@@ -627,6 +627,7 @@ def test_batch_get_item_full_failure(scylla_only, dynamodb, rest_api, test_table
                 'p': p, 'c': i, 'content': content})
     to_read = { test_table_sn.name: {'Keys': [{'p': p, 'c': c} for c in range(count)], 'ConsistentRead': True } }
     # The error injection is permanent, so it will fire for each batch read.
-    with scylla_inject_error(rest_api, "alternator_batch_get_item", one_shot=False):
+    with scylla_inject_error(rest_api, "alternator_batch_get_item", one_shot=False) as injection:
         with pytest.raises(ClientError, match="InternalServerError"):
             test_table_sn.meta.client.batch_get_item(RequestItems = to_read)
+        assert injection.enter_count() > 0

--- a/test/alternator/util.py
+++ b/test/alternator/util.py
@@ -250,21 +250,74 @@ def get_region(dynamodb):
     system_local = dynamodb.Table('.scylla.alternator.system.local')
     return system_local.scan(AttributesToGet=['data_center'])['Items'][0]['data_center']
 
+
+class _ScyllaErrorInjection:
+    request_timeout = 5
+
+    def __init__(self, rest_api, err):
+        self.err = err
+        self.url = f'{rest_api}/v2/error_injection/injection/{err}'
+
+    def enter_count(self, timeout=None):
+        response = requests.get(f'{self.url}/enters',
+                timeout=self.request_timeout if timeout is None else timeout)
+        response.raise_for_status()
+        return response.json()
+
+    def wait_for_enter(self, deadline, threshold=1):
+        delay = 0.1
+        while (remaining := deadline - time.monotonic()) > 0:
+            try:
+                count = self.enter_count(timeout=min(self.request_timeout, remaining))
+            except requests.Timeout:
+                pass
+            else:
+                if count >= threshold:
+                    return count
+            remaining = deadline - time.monotonic()
+            if remaining > 0:
+                time.sleep(min(delay, remaining))
+                delay = min(delay * 2, 0.5)
+        pytest.fail(f'Timed out waiting for error injection {self.err} to be entered')
+
+    def message(self):
+        response = requests.post(f'{self.url}/message', timeout=self.request_timeout)
+        response.raise_for_status()
+
+    def disable(self):
+        print("Disabling error injection", self.err)
+        response = requests.delete(self.url, timeout=self.request_timeout)
+        response.raise_for_status()
+
+
 # Tries to inject an error via Scylla REST API. It only works on Scylla,
 # and only in specific build modes (dev, debug, sanitize), so this function
-# will trigger a test to be skipped if it cannot be executed.
+# will trigger a test to be skipped if it cannot be executed. The yielded
+# handle can be used to wait for and send messages to the injected code.
 @contextmanager
-def scylla_inject_error(rest_api, err, one_shot=False, parameters={}):
-    requests.post(f'{rest_api}/v2/error_injection/injection/{err}?one_shot={one_shot}', json=parameters)
-    response = requests.get(f'{rest_api}/v2/error_injection/injection')
-    print("Enabled error injections:", response.content.decode('utf-8'))
-    if response.content.decode('utf-8') == "[]":
-        skip_env("Error injection not enabled in Scylla - try compiling in dev/debug/sanitize mode")
+def scylla_inject_error(rest_api, err, one_shot=False, parameters=None):
+    injection = _ScyllaErrorInjection(rest_api, err)
     try:
-        yield
-    finally:
-        print("Disabling error injection", err)
-        requests.delete(f'{rest_api}/v2/error_injection/injection/{err}')
+        response = requests.post(injection.url, params={'one_shot': one_shot},
+                json={} if parameters is None else parameters,
+                timeout=injection.request_timeout)
+        response.raise_for_status()
+        response = requests.get(f'{rest_api}/v2/error_injection/injection', timeout=injection.request_timeout)
+        response.raise_for_status()
+        enabled_injections = response.json()
+        print("Enabled error injections:", enabled_injections)
+        if err not in enabled_injections:
+            skip_env("Error injection not enabled in Scylla - try compiling in dev/debug/sanitize mode")
+        yield injection
+    except BaseException:
+        try:
+            injection.disable()
+        except Exception as cleanup_error:
+            print(f'Failed to disable error injection {err}: {cleanup_error}')
+        raise
+    else:
+        injection.disable()
+
 
 # Send a message to the Scylla log. E.g., we can write a message to the log
 # indicating that a test has started, which will make it easier to see which


### PR DESCRIPTION
## Problem

`scylla_inject_error()` is the only helper Alternator tests have for error injection, and it yields nothing. A test that needs to *synchronize* with the injection — wait until the injected code is actually reached, or unblock it with a message — has to hand-roll its own `requests` calls against the error-injection REST API. That polling loop gets copy-pasted into every such test.

The helper's own REST calls have further problems:

- **No timeouts.** Every `requests` call is unbounded, so a stalled or wedged test server hangs the test forever, and hangs it again in cleanup.
- **No status checks.** A failed enable is silently ignored; the test then fails later with a confusing, unrelated symptom instead of at the point of the actual failure.
- **Wrong skip detection.** The "is error injection compiled in?" check compared the enabled-injections list against the literal string `"[]"`. That only detects "no injection at all is enabled" — if any *other* injection happened to be registered, the check passed even when the requested one was never enabled.
- **Cleanup masks failures.** Disabling happened in a `finally`, so an exception from the `DELETE` replaced the original test failure with a cleanup error.
- **Mutable default argument** for `parameters={}`.

## Solution

Move the REST interaction into a handle object and yield it from the context manager, so the polling and messaging logic lives in one place instead of being reimplemented per test. Existing call sites are unaffected — they simply ignore the yielded value.

The remaining issues are fixed in passing, since they are all in the code being moved: requests get timeouts and status checks so failures surface where they happen rather than as a hang or a misleading later error; the skip check parses the response and looks for the specific injection, which is what it was always meant to mean; and cleanup no longer runs in a `finally`, so a failing test keeps its original traceback.

`test_batch.py::test_batch_get_item_full_failure` adopts the handle and asserts the injection actually fired, as a first user of the new API.
