### PR TITLE
alternator: preserve BatchGetItem read accounting

### DIFF
--- a/alternator/executor_read.cc
+++ b/alternator/executor_read.cc
@@ -42,6 +42,7 @@
 #include "vector_search/vector_store_client.hh"
 #include <seastar/core/abort_on_expiry.hh>
 #include <seastar/core/coroutine.hh>
+#include <seastar/coroutine/as_future.hh>
 #include <seastar/coroutine/maybe_yield.hh>
 #include <boost/range/algorithm/find_end.hpp>
 #include <charconv>
@@ -2239,55 +2240,81 @@ future<executor::request_return_type> executor::batch_get_item(client_state& cli
     // requests for the different partitions all in parallel.
     using batch_get_item_result = service::storage_proxy::result<std::vector<rjson::value>>;
     std::vector<future<batch_get_item_result>> response_futures;
+    response_futures.reserve(batch_size);
+    std::vector<std::exception_ptr> response_exceptions(batch_size);
     std::vector<uint64_t> consumed_rcu_half_units_per_table(requests.size());
+    std::vector<lw_shared_ptr<stats>> batch_get_stats;
+    batch_get_stats.reserve(requests.size());
+    // Finish potentially throwing per-table setup before launching reads.
+    for (const table_requests& rs : requests) {
+        auto per_table_stats = get_stats_from_schema(_proxy, *rs.schema);
+        per_table_stats->api_operations.batch_get_item_histogram.add(rs.requests.size());
+        batch_get_stats.push_back(std::move(per_table_stats));
+    }
     for (size_t i = 0; i < requests.size(); i++) {
         const table_requests& rs = requests[i];
         bool is_quorum = rs.cl == db::consistency_level::LOCAL_QUORUM;
-        lw_shared_ptr<stats> per_table_stats = get_stats_from_schema(_proxy, *rs.schema);
-        per_table_stats->api_operations.batch_get_item_histogram.add(rs.requests.size());
+        auto per_table_stats = batch_get_stats[i];
         for (const auto& [pk, cks] : rs.requests) {
-            dht::partition_range_vector partition_ranges{dht::partition_range(dht::decorate_key(*rs.schema, pk))};
-            std::vector<query::clustering_range> bounds;
-            if (rs.schema->clustering_key_size() == 0) {
-                bounds.push_back(query::clustering_range::make_open_ended_both_sides());
-            } else {
-                for (auto& ck : cks) {
-                    bounds.push_back(query::clustering_range::make_singular(ck.first));
+            try {
+                dht::partition_range_vector partition_ranges{dht::partition_range(dht::decorate_key(*rs.schema, pk))};
+                std::vector<query::clustering_range> bounds;
+                if (rs.schema->clustering_key_size() == 0) {
+                    bounds.push_back(query::clustering_range::make_open_ended_both_sides());
+                } else {
+                    for (auto& ck : cks) {
+                        bounds.push_back(query::clustering_range::make_singular(ck.first));
+                    }
                 }
-            }
-            auto regular_columns =
-                    rs.schema->regular_columns() | std::views::transform(&column_definition::id)
-                    | std::ranges::to<query::column_id_vector>();
-            auto selection = cql3::selection::selection::wildcard(rs.schema);
-            auto partition_slice = query::partition_slice(std::move(bounds), {}, std::move(regular_columns), selection->get_query_options());
-            auto command = ::make_lw_shared<query::read_command>(rs.schema->id(), rs.schema->version(), partition_slice, _proxy.get_max_result_size(partition_slice),
-                    query::tombstone_limit(_proxy.get_tombstone_limit()));
-            command->allow_limit = db::allow_per_partition_rate_limit::yes;
-            const auto item_callback = [is_quorum, per_table_stats, &rcus_per_table = consumed_rcu_half_units_per_table[i]](uint64_t size) {
-                rcus_per_table += rcu_consumed_capacity_counter::get_half_units(size, is_quorum);
-                // Update item size only if the item exists.
-                if (size > 0) {
-                    per_table_stats->operation_sizes.batch_get_item_op_size_kb.add(bytes_to_kb_ceil(size));
-                }
-            };
-            future<batch_get_item_result> f = 
-                    _proxy.query_result(rs.schema, std::move(command), std::move(partition_ranges), rs.cl,
+                auto regular_columns =
+                        rs.schema->regular_columns() | std::views::transform(&column_definition::id)
+                        | std::ranges::to<query::column_id_vector>();
+                auto selection = cql3::selection::selection::wildcard(rs.schema);
+                auto partition_slice = query::partition_slice(std::move(bounds), {}, std::move(regular_columns), selection->get_query_options());
+                auto command = ::make_lw_shared<query::read_command>(rs.schema->id(), rs.schema->version(), partition_slice, _proxy.get_max_result_size(partition_slice),
+                        query::tombstone_limit(_proxy.get_tombstone_limit()));
+                command->allow_limit = db::allow_per_partition_rate_limit::yes;
+                const auto item_callback = [is_quorum, per_table_stats, &rcus_per_table = consumed_rcu_half_units_per_table[i]](uint64_t size) {
+                    rcus_per_table += rcu_consumed_capacity_counter::get_half_units(size, is_quorum);
+                    // Update item size only if the item exists.
+                    if (size > 0) {
+                        per_table_stats->operation_sizes.batch_get_item_op_size_kb.add(bytes_to_kb_ceil(size));
+                    }
+                };
+                auto f = _proxy.query_result(rs.schema, std::move(command), std::move(partition_ranges), rs.cl,
                         service::storage_proxy::coordinator_query_options(executor::default_timeout(), permit, client_state, trace_state)).then(
-                    [schema = rs.schema, partition_slice = std::move(partition_slice), selection = std::move(selection), attrs_to_get = rs.attrs_to_get, item_callback = std::move(item_callback)] (service::storage_proxy::result<service::storage_proxy::coordinator_query_result> rqr) mutable -> future<batch_get_item_result> {
-                if (!rqr) {
-                    return make_ready_future<batch_get_item_result>(std::move(rqr).as_failure());
-                }
-                auto qr = std::move(rqr).assume_value();
-                utils::get_local_injector().inject("alternator_batch_get_item", [] { throw std::runtime_error("batch_get_item injection"); });
-                return describe_multi_item(std::move(schema), std::move(partition_slice), std::move(selection), std::move(qr.query_result), std::move(attrs_to_get), std::move(item_callback)).then([] (std::vector<rjson::value> result) {
-                    return make_ready_future<batch_get_item_result>(std::move(result));
+                        [schema = rs.schema, partition_slice = std::move(partition_slice), selection = std::move(selection),
+                                attrs_to_get = rs.attrs_to_get, item_callback = std::move(item_callback)]
+                        (service::storage_proxy::result<service::storage_proxy::coordinator_query_result> rqr) mutable -> future<batch_get_item_result> {
+                    if (!rqr) {
+                        return make_ready_future<batch_get_item_result>(std::move(rqr).as_failure());
+                    }
+                    auto qr = std::move(rqr).assume_value();
+                    utils::get_local_injector().inject("alternator_batch_get_item", [] { throw std::runtime_error("batch_get_item injection"); });
+                    return describe_multi_item(std::move(schema), std::move(partition_slice), std::move(selection), std::move(qr.query_result), std::move(attrs_to_get), std::move(item_callback)).then([] (std::vector<rjson::value> result) {
+                        return make_ready_future<batch_get_item_result>(std::move(result));
+                    });
                 });
-            });
-            response_futures.push_back(std::move(f));
+                response_futures.push_back(std::move(f));
+            } catch (...) {
+                response_futures.push_back(current_exception_as_future<batch_get_item_result>());
+            }
         }
     }
 
-    // Wait for all requests to complete, and then return the response.
+    // Keep referenced request state alive until every read has completed. Drain
+    // futures individually: a range-based when_all() can fail its allocation
+    // after reads have launched but before it starts draining them. Consume
+    // exceptions now as well, so later response-building failures cannot
+    // discard unobserved exceptional futures.
+    for (size_t i = 0; i < response_futures.size(); ++i) {
+        response_futures[i] = co_await coroutine::as_future(std::move(response_futures[i]));
+        if (response_futures[i].failed()) {
+            response_exceptions[i] = response_futures[i].get_exception();
+        }
+    }
+
+    // Process completed requests and build the response.
     // In case of full failure (no reads succeeded), an arbitrary error
     // from one of the operations will be returned.
     bool some_succeeded = false;
@@ -2300,6 +2327,7 @@ future<executor::request_return_type> executor::batch_get_item(client_state& cli
     rjson::add(response, "Responses", rjson::empty_object());
     rjson::add(response, "UnprocessedKeys", rjson::empty_object());
     auto fut_it = response_futures.begin();
+    auto exception_it = response_exceptions.begin();
     rjson::value consumed_capacity = rjson::empty_array();
     auto add_unprocessed_keys = [&] (const std::string& table, const auto& cks) {
         // Read failed on item represented by `cks` key(s), we need to add it to UnprocessedKeys field in reply object.
@@ -2335,6 +2363,13 @@ future<executor::request_return_type> executor::batch_get_item(client_state& cli
         for (const auto& [_, cks] : rs.requests) {
             auto& fut = *fut_it;
             ++fut_it;
+            auto read_exception = *exception_it;
+            ++exception_it;
+            if (read_exception) {
+                eptr = std::move(read_exception);
+                add_unprocessed_keys(table, cks);
+                continue;
+            }
             try {
                 // The future here (`storage_proxy::result`, which is a `bo::result`) might contain an error as value
                 // or it might contain an exception (which will be rethrown on `co_await` call).

--- a/alternator/executor_read.cc
+++ b/alternator/executor_read.cc
@@ -2226,15 +2226,18 @@ future<executor::request_return_type> executor::batch_get_item(client_state& cli
     bool should_add_rcu = rcu_consumed_capacity_counter::should_add_capacity(request);
     struct table_requests {
         schema_ptr schema;
+        lw_shared_ptr<stats> per_table_stats;
         db::consistency_level cl;
         ::shared_ptr<const std::optional<alternator::attrs_to_get>> attrs_to_get;
+        uint64_t consumed_rcu_half_units = 0;
         // clustering_keys keeps a sorted set of clustering keys. It must
         // be sorted for the read below (see #10827). Additionally each
         // clustering key is mapped to the original rjson::value "Key".
         using clustering_keys = std::map<clustering_key, rjson::value*, clustering_key::less_compare>;
         std::unordered_map<partition_key, clustering_keys, partition_key::hashing, partition_key::equality> requests;
-        table_requests(schema_ptr s)
+        table_requests(schema_ptr s, lw_shared_ptr<stats> stats)
             : schema(std::move(s))
+            , per_table_stats(std::move(stats))
             , requests(8, partition_key::hashing(*schema), partition_key::equality(*schema))
         {}
         void add(rjson::value& key) {
@@ -2252,9 +2255,10 @@ future<executor::request_return_type> executor::batch_get_item(client_state& cli
     std::vector<table_requests> requests;
     uint batch_size = 0;
     for (auto it = request_items.MemberBegin(); it != request_items.MemberEnd(); ++it) {
-        table_requests rs(get_table_from_batch_request(_proxy, it));
-        lw_shared_ptr<stats> per_table_stats = get_stats_from_schema(_proxy, *rs.schema);
-        per_table_stats->api_operations.batch_get_item++;
+        auto schema = get_table_from_batch_request(_proxy, it);
+        auto per_table_stats = get_stats_from_schema(_proxy, *schema);
+        table_requests rs(std::move(schema), std::move(per_table_stats));
+        rs.per_table_stats->api_operations.batch_get_item++;
         tracing::add_alternator_table_name(trace_state, rs.schema->cf_name());
         rs.cl = get_read_consistency(it->value);
         std::unordered_set<std::string> used_attribute_names;
@@ -2282,19 +2286,14 @@ future<executor::request_return_type> executor::batch_get_item(client_state& cli
     std::vector<future<batch_get_item_result>> response_futures;
     response_futures.reserve(batch_size);
     std::vector<std::exception_ptr> response_exceptions(batch_size);
-    std::vector<uint64_t> consumed_rcu_half_units_per_table(requests.size());
-    std::vector<lw_shared_ptr<stats>> batch_get_stats;
-    batch_get_stats.reserve(requests.size());
     // Finish potentially throwing per-table setup before launching reads.
     for (const table_requests& rs : requests) {
-        auto per_table_stats = get_stats_from_schema(_proxy, *rs.schema);
-        per_table_stats->api_operations.batch_get_item_histogram.add(rs.requests.size());
-        batch_get_stats.push_back(std::move(per_table_stats));
+        rs.per_table_stats->api_operations.batch_get_item_histogram.add(rs.requests.size());
     }
     for (size_t i = 0; i < requests.size(); i++) {
-        const table_requests& rs = requests[i];
+        table_requests& rs = requests[i];
         bool is_quorum = rs.cl == db::consistency_level::LOCAL_QUORUM;
-        auto per_table_stats = batch_get_stats[i];
+        auto per_table_stats = rs.per_table_stats;
         for (const auto& [pk, cks] : rs.requests) {
             try {
                 dht::partition_range_vector partition_ranges{dht::partition_range(dht::decorate_key(*rs.schema, pk))};
@@ -2314,7 +2313,7 @@ future<executor::request_return_type> executor::batch_get_item(client_state& cli
                 auto command = ::make_lw_shared<query::read_command>(rs.schema->id(), rs.schema->version(), partition_slice, _proxy.get_max_result_size(partition_slice),
                         query::tombstone_limit(_proxy.get_tombstone_limit()));
                 command->allow_limit = db::allow_per_partition_rate_limit::yes;
-                const auto item_callback = [is_quorum, per_table_stats, &rcus_per_table = consumed_rcu_half_units_per_table[i]](uint64_t size) {
+                const auto item_callback = [is_quorum, per_table_stats, &rcus_per_table = rs.consumed_rcu_half_units](uint64_t size) {
                     rcus_per_table += rcu_consumed_capacity_counter::get_half_units(size, is_quorum);
                     // Update item size only if the item exists.
                     if (size > 0) {
@@ -2356,6 +2355,12 @@ future<executor::request_return_type> executor::batch_get_item(client_state& cli
         if (response_futures[i].failed()) {
             response_exceptions[i] = response_futures[i].get_exception();
         }
+    }
+    // Account for completed reads before response construction, which can fail
+    // after the work and its capacity consumption have already occurred.
+    for (const table_requests& rs : requests) {
+        _stats.rcu_half_units_total += rs.consumed_rcu_half_units;
+        rs.per_table_stats->rcu_half_units_total += rs.consumed_rcu_half_units;
     }
     if (const auto table_name = utils::get_local_injector().inject_parameter<std::string_view>(
                 batch_get_item_response_failure_injection, "table_name");
@@ -2448,14 +2453,10 @@ future<executor::request_return_type> executor::batch_get_item(client_state& cli
                 add_unprocessed_keys(table, cks);
             }
         }
-        uint64_t rcu_half_units = consumed_rcu_half_units_per_table[i];
-        _stats.rcu_half_units_total += rcu_half_units;
-        lw_shared_ptr<stats> per_table_stats = get_stats_from_schema(_proxy, *rs.schema);
-        per_table_stats->rcu_half_units_total += rcu_half_units;
         if (should_add_rcu) {
             rjson::value entry = rjson::empty_object();
             rjson::add(entry, "TableName", table);
-            rjson::add(entry, "CapacityUnits", rcu_half_units*0.5);
+            rjson::add(entry, "CapacityUnits", rs.consumed_rcu_half_units*0.5);
             rjson::push_back(consumed_capacity, std::move(entry));
         }
     }
@@ -2486,8 +2487,7 @@ future<executor::request_return_type> executor::batch_get_item(client_state& cli
     auto duration = std::chrono::steady_clock::now() - start_time;
     _stats.api_operations.batch_get_item_latency.mark(duration);
     for (const table_requests& rs : requests) {
-        lw_shared_ptr<stats> per_table_stats = get_stats_from_schema(_proxy, *rs.schema);
-        per_table_stats->api_operations.batch_get_item_latency.mark(duration);
+        rs.per_table_stats->api_operations.batch_get_item_latency.mark(duration);
     }
     if (is_big(response)) {
         co_return make_streamed(std::move(response));

--- a/alternator/executor_read.cc
+++ b/alternator/executor_read.cc
@@ -2165,6 +2165,46 @@ future<executor::request_return_type> executor::get_item(client_state& client_st
     co_return rjson::print(std::move(res));
 }
 
+static constexpr std::string_view batch_get_item_launch_failure_injection = "alternator_batch_get_item_launch_failure";
+static constexpr std::string_view batch_get_item_pause_read_injection = "alternator_batch_get_item_pause_read";
+static constexpr std::string_view batch_get_item_response_failure_injection = "alternator_batch_get_item_response_failure";
+
+static void maybe_inject_batch_get_item_launch_failure(const schema& table_schema, bool previous_read_was_launched) {
+    if (!previous_read_was_launched) {
+        return;
+    }
+    const auto table_name = utils::get_local_injector().inject_parameter<std::string_view>(
+            batch_get_item_launch_failure_injection, "table_name");
+    if (table_name && *table_name == table_schema.cf_name()) {
+        utils::get_local_injector().inject(batch_get_item_launch_failure_injection, [] {
+            throw std::runtime_error("batch_get_item launch injection");
+        });
+    }
+}
+
+static bool should_pause_batch_get_item_read(const schema& table_schema, bool first_read) {
+    const auto table_name = utils::get_local_injector().inject_parameter<std::string_view>(
+            batch_get_item_pause_read_injection, "table_name");
+    const auto position = utils::get_local_injector().inject_parameter<std::string_view>(
+            batch_get_item_pause_read_injection, "position");
+    return table_name && *table_name == table_schema.cf_name()
+            && position && *position == (first_read ? "first" : "later");
+}
+
+template <typename T>
+static future<T> maybe_pause_batch_get_item_read(future<T> read, bool pause_read) {
+    if (!pause_read) {
+        return std::move(read);
+    }
+    return std::move(read).then([] (T result) {
+        return utils::get_local_injector().inject(
+                batch_get_item_pause_read_injection, utils::wait_for_message(5min)).then(
+                [result = std::move(result)] () mutable {
+            return std::move(result);
+        });
+    });
+}
+
 future<executor::request_return_type> executor::batch_get_item(client_state& client_state, tracing::trace_state_ptr trace_state, service_permit permit, rjson::value request, std::unique_ptr<audit::audit_info_alternator>& audit_info) {
     // FIXME: In this implementation, an unbounded batch size can cause
     // unbounded response JSON object to be buffered in memory, unbounded
@@ -2281,8 +2321,8 @@ future<executor::request_return_type> executor::batch_get_item(client_state& cli
                         per_table_stats->operation_sizes.batch_get_item_op_size_kb.add(bytes_to_kb_ceil(size));
                     }
                 };
-                auto f = _proxy.query_result(rs.schema, std::move(command), std::move(partition_ranges), rs.cl,
-                        service::storage_proxy::coordinator_query_options(executor::default_timeout(), permit, client_state, trace_state)).then(
+                maybe_inject_batch_get_item_launch_failure(*rs.schema, !response_futures.empty());
+                auto process_query_result =
                         [schema = rs.schema, partition_slice = std::move(partition_slice), selection = std::move(selection),
                                 attrs_to_get = rs.attrs_to_get, item_callback = std::move(item_callback)]
                         (service::storage_proxy::result<service::storage_proxy::coordinator_query_result> rqr) mutable -> future<batch_get_item_result> {
@@ -2294,7 +2334,11 @@ future<executor::request_return_type> executor::batch_get_item(client_state& cli
                     return describe_multi_item(std::move(schema), std::move(partition_slice), std::move(selection), std::move(qr.query_result), std::move(attrs_to_get), std::move(item_callback)).then([] (std::vector<rjson::value> result) {
                         return make_ready_future<batch_get_item_result>(std::move(result));
                     });
-                });
+                };
+                const bool pause_read = should_pause_batch_get_item_read(*rs.schema, response_futures.empty());
+                auto query_result_future = _proxy.query_result(rs.schema, std::move(command), std::move(partition_ranges), rs.cl,
+                        service::storage_proxy::coordinator_query_options(executor::default_timeout(), permit, client_state, trace_state));
+                auto f = maybe_pause_batch_get_item_read(std::move(query_result_future), pause_read).then(std::move(process_query_result));
                 response_futures.push_back(std::move(f));
             } catch (...) {
                 response_futures.push_back(current_exception_as_future<batch_get_item_result>());
@@ -2312,6 +2356,15 @@ future<executor::request_return_type> executor::batch_get_item(client_state& cli
         if (response_futures[i].failed()) {
             response_exceptions[i] = response_futures[i].get_exception();
         }
+    }
+    if (const auto table_name = utils::get_local_injector().inject_parameter<std::string_view>(
+                batch_get_item_response_failure_injection, "table_name");
+            table_name && std::ranges::any_of(requests, [&] (const table_requests& rs) {
+                return *table_name == rs.schema->cf_name();
+            })) {
+        utils::get_local_injector().inject(batch_get_item_response_failure_injection, [] {
+            throw std::runtime_error("batch_get_item response injection");
+        });
     }
 
     // Process completed requests and build the response.

--- a/test/alternator/test_batch.py
+++ b/test/alternator/test_batch.py
@@ -17,6 +17,7 @@ import requests
 import urllib3
 from botocore.exceptions import ClientError, HTTPClientError
 
+from test.alternator.test_metrics import check_increases_metric_exact, metrics
 from test.alternator.util import random_string, full_query, multiset, scylla_inject_error, client_no_transform
 
 
@@ -679,7 +680,7 @@ def test_batch_get_item_launch_failure(scylla_only, rest_api, test_table_sn):
 
 # Response processing must wait for every read, because it can throw while a
 # later read still references request-owned state. Reproduces #31295.
-def test_batch_get_item_response_failure_drains_reads(scylla_only, rest_api, test_table_sn):
+def test_batch_get_item_response_failure_drains_reads(scylla_only, rest_api, test_table_sn, metrics):
     prefix = random_string()
     items = [{'p': prefix + str(i), 'c': i} for i in range(2)]
     with test_table_sn.batch_writer() as batch:
@@ -692,7 +693,9 @@ def test_batch_get_item_response_failure_drains_reads(scylla_only, rest_api, tes
     response_failure_injection = "alternator_batch_get_item_response_failure"
     table_parameters = {'table_name': test_table_sn.name}
     pause_parameters = {**table_parameters, 'position': 'later'}
-    with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
+    expected_rcu = [[2, {'cf': test_table_sn.name}]]
+    with check_increases_metric_exact(metrics, 'scylla_alternator_table_rcu_total', expected_rcu), \
+            concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
         with scylla_inject_error(rest_api, response_failure_injection, parameters=table_parameters):
             with scylla_inject_error(rest_api, pause_injection, parameters=pause_parameters):
                 request_future = executor.submit(

--- a/test/alternator/test_batch.py
+++ b/test/alternator/test_batch.py
@@ -6,16 +6,39 @@
 # Note that various other tests in other files also use these operations,
 # so they are actually tested by other tests as well.
 
+import concurrent.futures
 import random
 import sys
 import traceback
 import time
 
 import pytest
+import requests
 import urllib3
 from botocore.exceptions import ClientError, HTTPClientError
 
 from test.alternator.util import random_string, full_query, multiset, scylla_inject_error, client_no_transform
+
+
+def error_injection_enter_count(rest_api, injection):
+    response = requests.get(f'{rest_api}/v2/error_injection/injection/{injection}/enters', timeout=5)
+    response.raise_for_status()
+    return response.json()
+
+
+def wait_for_error_injection(rest_api, injection, threshold=1):
+    deadline = time.monotonic() + 60
+    while time.monotonic() < deadline:
+        count = error_injection_enter_count(rest_api, injection)
+        if count >= threshold:
+            return count
+        time.sleep(0.1)
+    pytest.fail(f'Timed out waiting for error injection {injection}')
+
+
+def message_error_injection(rest_api, injection):
+    response = requests.post(f'{rest_api}/v2/error_injection/injection/{injection}/message', timeout=5)
+    response.raise_for_status()
 
 
 # Test ensuring that items inserted by a batched statement can be properly extracted
@@ -613,6 +636,77 @@ def test_batch_get_item_partial(scylla_only, dynamodb, rest_api, test_table_sn):
         assert multiset(responses) == multiset(
             [{'p': p + str(i % partitions), 'c': i, 'content': content} for i in range(count)])
         assert some_keys_were_unprocessed
+
+# Regression test for #31295: a synchronous failure while launching one read
+# must not abandon an earlier read or misassociate later results with keys.
+def test_batch_get_item_launch_failure(scylla_only, rest_api, test_table_sn):
+    count = 2
+    prefix = random_string()
+    content = random_string()
+    items = [{'p': prefix + str(i), 'c': i, 'content': content} for i in range(count)]
+    with test_table_sn.batch_writer() as batch:
+        for item in items:
+            batch.put_item(Item=item)
+
+    request_items = {
+        test_table_sn.name: {
+            'Keys': [{'p': item['p'], 'c': item['c']} for item in items],
+            'ConsistentRead': True,
+        }
+    }
+    pause_injection = "alternator_batch_get_item_pause_read"
+    launch_failure_injection = "alternator_batch_get_item_launch_failure"
+    table_parameters = {'table_name': test_table_sn.name}
+    pause_parameters = {**table_parameters, 'position': 'first'}
+    with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
+        with scylla_inject_error(rest_api, pause_injection, parameters=pause_parameters):
+            with scylla_inject_error(rest_api, launch_failure_injection, one_shot=True, parameters=table_parameters):
+                request_future = executor.submit(
+                    test_table_sn.meta.client.batch_get_item, RequestItems=request_items)
+                try:
+                    wait_for_error_injection(rest_api, pause_injection)
+                    assert not request_future.done()
+                finally:
+                    message_error_injection(rest_api, pause_injection)
+                reply = request_future.result(timeout=60)
+
+    assert len(reply['UnprocessedKeys'][test_table_sn.name]['Keys']) == 1
+    responses = reply['Responses'][test_table_sn.name]
+    retry = test_table_sn.meta.client.batch_get_item(RequestItems=reply['UnprocessedKeys'])
+    responses.extend(retry['Responses'][test_table_sn.name])
+    assert multiset(responses) == multiset(items)
+
+
+# Response processing must wait for every read, because it can throw while a
+# later read still references request-owned state. Reproduces #31295.
+def test_batch_get_item_response_failure_drains_reads(scylla_only, rest_api, test_table_sn):
+    prefix = random_string()
+    items = [{'p': prefix + str(i), 'c': i} for i in range(2)]
+    with test_table_sn.batch_writer() as batch:
+        for item in items:
+            batch.put_item(Item=item)
+
+    keys = [{'p': item['p'], 'c': item['c']} for item in items]
+    request_items = {test_table_sn.name: {'Keys': keys, 'ConsistentRead': True}}
+    pause_injection = "alternator_batch_get_item_pause_read"
+    response_failure_injection = "alternator_batch_get_item_response_failure"
+    table_parameters = {'table_name': test_table_sn.name}
+    pause_parameters = {**table_parameters, 'position': 'later'}
+    with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
+        with scylla_inject_error(rest_api, response_failure_injection, parameters=table_parameters):
+            with scylla_inject_error(rest_api, pause_injection, parameters=pause_parameters):
+                request_future = executor.submit(
+                    test_table_sn.meta.client.batch_get_item, RequestItems=request_items)
+                try:
+                    wait_for_error_injection(rest_api, pause_injection)
+                    assert error_injection_enter_count(rest_api, response_failure_injection) == 0
+                    assert not request_future.done()
+                finally:
+                    message_error_injection(rest_api, pause_injection)
+                with pytest.raises(ClientError, match="InternalServerError"):
+                    request_future.result(timeout=60)
+                assert error_injection_enter_count(rest_api, response_failure_injection) == 1
+
 
 # Test that if the batch read failure is total, i.e. all read requests
 # failed, it's reported as an error and not as a regular response with


### PR DESCRIPTION
## Problem

`BatchGetItem` accumulates consumed RCUs as reads complete but charges the metrics while constructing the response. If response construction fails, completed reads are not charged. Re-resolving table stats at that point can also select a temporary stats object after concurrent table deletion.

## Fix

Keep each table stats object and its RCU count in request state, then charge global and per-table metrics immediately after all reads drain and before response construction.

This draft depends on #31375, which provides the safe post-drain accounting point. The accounting change is the final commit in this stacked PR.