### PR TITLE
service: let alter_table_with_tablet_hints remove unset tablet hints

### DIFF
--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -3172,19 +3172,20 @@ future<> storage_service::wait_for_topology_not_busy() {
 future<> storage_service::alter_table_with_tablet_hints(table_id tid,
                                                         std::optional<size_t> min_tablet_count,
                                                         std::optional<size_t> max_tablet_count,
-                                                        bool wait_balancer) {
+                                                        bool wait_balancer,
+                                                        bool remove_unset) {
     if (this_shard_id() != 0) {
         co_return co_await container().invoke_on(0, [&] (auto& ss) {
-            return ss.alter_table_with_tablet_hints(tid, min_tablet_count, max_tablet_count, wait_balancer);
+            return ss.alter_table_with_tablet_hints(tid, min_tablet_count, max_tablet_count, wait_balancer, remove_unset);
         });
     }
 
-    if (!min_tablet_count && !max_tablet_count) {
+    if (!min_tablet_count && !max_tablet_count && !remove_unset) {
         slogger.info("alter_table_with_tablet_hints: the tablet hints passed are both nullopt, nothing to update");
         co_return;
     }
 
-    if (wait_balancer && min_tablet_count != max_tablet_count) {
+    if (wait_balancer && (!min_tablet_count || !max_tablet_count || *min_tablet_count != *max_tablet_count)) {
         throw std::invalid_argument(format(
             "wait_balancer requires both min_tablet_count and max_tablet_count to be provided and equal, got min={} max={}",
             min_tablet_count ? to_sstring(*min_tablet_count) : "nullopt",
@@ -3204,9 +3205,13 @@ future<> storage_service::alter_table_with_tablet_hints(table_id tid,
         auto tablet_options = schema->raw_tablet_options();
         if (min_tablet_count) {
             tablet_options["min_tablet_count"] = to_sstring(*min_tablet_count);
+        } else if (remove_unset) {
+            tablet_options.erase("min_tablet_count");
         }
         if (max_tablet_count) {
             tablet_options["max_tablet_count"] = to_sstring(*max_tablet_count);
+        } else if (remove_unset) {
+            tablet_options.erase("max_tablet_count");
         }
 
         schema_builder builder(schema);
@@ -3216,8 +3221,8 @@ future<> storage_service::alter_table_with_tablet_hints(table_id tid,
         auto ts = group0_guard.write_timestamp();
         sstring description = format("Altering table {}.{} with tablet count hints min_tablet_count={} max_tablet_count={}",
             schema->ks_name(), schema->cf_name(),
-            min_tablet_count ? to_sstring(*min_tablet_count) : "unchanged",
-            max_tablet_count ? to_sstring(*max_tablet_count) : "unchanged");
+            min_tablet_count ? to_sstring(*min_tablet_count) : (remove_unset ? "removed" : "unchanged"),
+            max_tablet_count ? to_sstring(*max_tablet_count) : (remove_unset ? "removed" : "unchanged"));
 
         auto mutations = co_await prepare_column_family_update_announcement(sp, modified_schema, /*view_updates=*/{}, ts);
 

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -1109,10 +1109,14 @@ public:
     // hints are applied; if both are disengaged the call is a no-op. When
     // wait_balancer is set, waits for the load balancer to reach the requested
     // tablet count (which requires both hints to be engaged and equal).
+    // When remove_unset is set, a disengaged hint removes that key from the table's
+    // tablet options instead of leaving it unchanged - needed to put back the schema
+    // of a table which had no hint of its own.
     future<> alter_table_with_tablet_hints(table_id tid,
                                            std::optional<size_t> min_tablet_count,
                                            std::optional<size_t> max_tablet_count,
-                                           bool wait_balancer = true);
+                                           bool wait_balancer = true,
+                                           bool remove_unset = false);
 
     friend class join_node_rpc_handshaker;
     friend class node_ops::node_ops_virtual_task;

--- a/sstables_loader.cc
+++ b/sstables_loader.cc
@@ -1357,7 +1357,9 @@ protected:
 
         try {
             llog.info("Restoring table with tid {} to the original schema", _tid);
-            co_await loader._ss.local().alter_table_with_tablet_hints(_tid, min_tablet_count, max_tablet_count, false);
+            // remove_unset: the table saved nullopt because it had no hint of its own, and
+            // passing nullopt back would leave it pinned at min == max forever.
+            co_await loader._ss.local().alter_table_with_tablet_hints(_tid, min_tablet_count, max_tablet_count, false, true);
         } catch (...) {
             llog.error("Failed to restore original schema for table_id {}. Error: {}", _tid, std::current_exception());
         }

--- a/test/boost/tablet_aware_restore_test.cc
+++ b/test/boost/tablet_aware_restore_test.cc
@@ -405,3 +405,60 @@ SEASTAR_TEST_CASE(test_restore_alter_table_with_tablet_hints, *boost::unit_test:
         verify_tablet_options(env, tid, desired_count, true);
     }, false, db_cfg_ptr, 10);
 }
+
+// The tablet restore task pins a table's tablet count with min_tablet_count == max_tablet_count
+// and puts the table's own hints back when it is done. A table which had no hint of its own
+// saves nullopt for both, and nullopt means "leave this hint alone" - so the pin used to stay,
+// leaving the table with min == max and unable to ever split or merge again. Passing
+// remove_unset makes a disengaged hint remove the key instead.
+SEASTAR_TEST_CASE(test_restore_alter_table_with_tablet_hints_removes_unset, *boost::unit_test::precondition(tests::has_scylla_test_env)) {
+    auto db_cfg_ptr = make_shared<db::config>();
+    db_cfg_ptr->tablets_mode_for_new_keyspaces(db::tablets_mode_t::mode::enabled);
+
+    return do_with_some_data_in_thread({"cf"}, [] (cql_test_env& env) {
+        table_id tid = env.local_db().find_uuid("ks", "cf");
+
+        auto token_metadata = env.local_db().get_token_metadata_ptr();
+        auto& tmap = token_metadata->tablets().get_tablet_map(tid);
+        auto desired_count = tmap.tablet_count();
+
+        auto& ss = env.get_storage_service().local();
+
+        // The table is created without tablet hints of its own.
+        verify_tablet_options(env, tid, desired_count, false);
+
+        // Pin the tablet count, the way the restore task does before it starts restoring.
+        ss.alter_table_with_tablet_hints(tid, desired_count, desired_count).get();
+        verify_tablet_options(env, tid, desired_count, true);
+
+        // Put the saved hints back - both disengaged, because the table had none. The pin has
+        // to go away, otherwise the table is left permanently pinned at min == max.
+        ss.alter_table_with_tablet_hints(tid, std::nullopt, std::nullopt, /*wait_balancer=*/false,
+                                         /*remove_unset=*/true).get();
+        verify_tablet_options(env, tid, desired_count, false);
+    }, false, db_cfg_ptr, 10);
+}
+
+// wait_balancer needs a count to wait for. Two disengaged hints compare equal to each other, so
+// testing the two against each other is not enough - with remove_unset they also get past the
+// no-op return, and the wait would then dereference a disengaged max_tablet_count.
+SEASTAR_TEST_CASE(test_restore_alter_table_with_tablet_hints_rejects_waiting_without_hints, *boost::unit_test::precondition(tests::has_scylla_test_env)) {
+    auto db_cfg_ptr = make_shared<db::config>();
+    db_cfg_ptr->tablets_mode_for_new_keyspaces(db::tablets_mode_t::mode::enabled);
+
+    return do_with_some_data_in_thread({"cf"}, [] (cql_test_env& env) {
+        table_id tid = env.local_db().find_uuid("ks", "cf");
+        auto desired_count = env.local_db().get_token_metadata_ptr()->tablets().get_tablet_map(tid).tablet_count();
+        auto& ss = env.get_storage_service().local();
+
+        BOOST_REQUIRE_THROW(ss.alter_table_with_tablet_hints(tid, std::nullopt, std::nullopt,
+                                                             /*wait_balancer=*/true, /*remove_unset=*/true).get(),
+                            std::invalid_argument);
+        BOOST_REQUIRE_THROW(ss.alter_table_with_tablet_hints(tid, std::nullopt, desired_count,
+                                                             /*wait_balancer=*/true, /*remove_unset=*/true).get(),
+                            std::invalid_argument);
+
+        // Rejected before anything was announced.
+        verify_tablet_options(env, tid, desired_count, false);
+    }, false, db_cfg_ptr, 10);
+}

--- a/test/cluster/object_store/test_backup.py
+++ b/test/cluster/object_store/test_backup.py
@@ -22,7 +22,7 @@ from test.pylib.internal_types import ServerInfo
 from test.cluster.util import wait_for_cql_and_get_hosts, get_replication, new_test_keyspace, new_test_table
 from test.pylib.rest_client import read_barrier, HTTPError
 from test.pylib.util import unique_name, wait_all, wait_for_view
-from test.pylib.tablets import get_tablet_replica, get_all_tablet_replicas
+from test.pylib.tablets import get_tablet_replica, get_all_tablet_replicas, get_tablet_count
 from cassandra import ReadFailure
 from cassandra.cluster import ConsistencyLevel
 from collections import defaultdict
@@ -1312,6 +1312,56 @@ async def test_restore_tablets_with_different_tablet_hints(build_mode: str, mana
         desc = (await cql.run_async(f"DESC TABLE {ks}.test"))[0].create_statement
         assert f"'min_tablet_count': '{min_tablet_count_before_restore}'" in desc, f"Expected min_tablet_count={min_tablet_count_before_restore} in: {desc}"
         assert f"'max_tablet_count': '{max_tablet_count_before_restore}'" in desc, f"Expected max_tablet_count={max_tablet_count_before_restore} in: {desc}"
+
+
+async def test_restore_tablets_leaves_a_hintless_table_resizable(build_mode: str, manager: ScyllaClusterManager,
+                                                                 object_storage):
+    # Three nodes because a tablet-aware restore writes system_distributed.snapshot_sstables at
+    # EACH_QUORUM, which a single node cannot satisfy.
+    topology = topo(rf = 1, nodes = 3, racks = 1, dcs = 1)
+
+    # A small target tablet size, so the restored rows in one tablet are well past the
+    # 2 * target the balancer splits at.
+    servers, _ = await create_cluster(topology, manager, logger, object_storage,
+                                     extra_config={'tablet_load_stats_refresh_interval_in_seconds': 1},
+                                     extra_cmdline=['--target-tablet-size-in-bytes', '1024',
+                                                    '--logger-log-level', 'load_balancer=debug'])
+    cql = manager.get_cql()
+    replication = f"WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor': {topology.rf}}}"
+    num_keys = 1000
+
+    async with new_test_keyspace(manager, replication) as src_ks:
+        # Back the table up at one tablet, which is what the restore pins the destination to.
+        snap_name, manifests = await populate_and_backup(manager, cql, servers, object_storage, src_ks, 'test',
+                                                         "WITH tablets = {'min_tablet_count': 1, 'max_tablet_count': 1}",
+                                                         num_keys)
+
+    async with new_test_keyspace(manager, replication) as ks:
+        # The destination declares no tablet hints of its own - the ordinary case for a user table.
+        await cql.run_async(f"CREATE TABLE {ks}.test ( pk text primary key, value int );")
+
+        logger.info(f'Restore cluster via {servers[0].ip_addr}')
+        tid = await manager.api.restore_tablets(servers[0].ip_addr, ks, 'test', snap_name, servers[0].datacenter,
+                                                object_storage.address, object_storage.bucket_name, manifests)
+        status = await manager.api.wait_task(servers[0].ip_addr, tid)
+        assert (status is not None) and (status['state'] == 'done')
+
+        restored_count = await get_tablet_count(manager, servers[0], ks, 'test')
+        assert restored_count == 1, f"Expected the restore to leave 1 tablet, got {restored_count}"
+
+        # Give the balancer the on-disk sizes it decides resizes on.
+        await asyncio.gather(*(manager.api.flush_keyspace(s.ip_addr, ks) for s in servers))
+        await asyncio.gather(*(manager.api.keyspace_compaction(s.ip_addr, ks, 'test') for s in servers))
+
+        async def split():
+            return True if await get_tablet_count(manager, servers[0], ks, 'test') > restored_count else None
+        await wait_for(split, time.time() + 120,
+                       label=f"the balancer to split the restored table away from {restored_count} tablet")
+
+        # ... and the hints the restore put back must be the ones the table declared, i.e. none.
+        desc = (await cql.run_async(f"DESC TABLE {ks}.test"))[0].create_statement
+        assert 'min_tablet_count' not in desc, f"Expected no min_tablet_count in: {desc}"
+        assert 'max_tablet_count' not in desc, f"Expected no max_tablet_count in: {desc}"
 
 # The keyspace and table parameters of both restore APIs name the destination, while the source is
 # addressed by the bucket prefix together with the sstable list (plain restore) or by the manifests


### PR DESCRIPTION
A caller that pins a table's tablet count has to put the old hints back when
it is done. If the table had no hint of its own, the saved value is nullopt,
and passing nullopt leaves the pin in place - min == max == the pinned count,
which forbids the table from ever splitting or merging until the hints are removed or changed by hand. 

Add a remove_unset flag which erases the key for a disengaged hint instead of
leaving it alone, and use it where the tablet restore task restores a table's
hints.

Fixes https://scylladb.atlassian.net/browse/SCYLLADB-4062.
Backport is required