### PR TITLE
cql3: reject creating a mixed-storage cluster

### DIFF
--- a/alternator/executor.cc
+++ b/alternator/executor.cc
@@ -1883,6 +1883,26 @@ future<executor::request_return_type> executor::create_table_on_shard0(service::
                 }
             }
         }
+        // Alternator asks for no storage options, so this keyspace keeps its
+        // data locally. A cluster which is already mixed only gets a warning:
+        // refusing the table would not bring it back to either kind.
+        if (!_proxy.local_db().has_keyspace(keyspace_name)) {
+            switch (_proxy.local_db().get_user_storage_kind()) {
+                using enum replica::database::user_storage_kind;
+            case object_storage:
+                co_return api_error::validation(fmt::format("Cannot create table {}: this cluster keeps its user data in object storage, and an Alternator "
+                                                            "table keeps its data in local storage.",
+                                                            table_name));
+            case mixed:
+                elogger.warn("Creating table {}: this cluster keeps some of its user data locally and some in object "
+                             "storage. Such a cluster is not supported.",
+                             table_name);
+                break;
+            case none:
+            case local:
+                break;
+            }
+        }
         bool table_already_exists = false;
         try {
             schema_mutations = service::prepare_new_keyspace_announcement(_proxy.local_db(), ksm, ts);

--- a/cql3/statements/create_keyspace_statement.cc
+++ b/cql3/statements/create_keyspace_statement.cc
@@ -134,6 +134,18 @@ future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, utils::chun
             break;
         }
 
+        // Per node, and an operator can change it between restarts, so the check
+        // above against the cluster's own keyspaces stays the first word.
+        const auto configured_mode = cfg.storage_mode_for_new_keyspaces();
+        const bool configured_is_object_storage = configured_mode == db::keyspace_storage_mode_t::mode::object_storage;
+        if (configured_mode != db::keyspace_storage_mode_t::mode::unset && wants_object_storage != configured_is_object_storage) {
+            throw exceptions::invalid_request_exception(
+                seastar::format("Cannot create keyspace '{}' in {} storage: storage_mode_for_new_keyspaces is set to {}",
+                                _name,
+                                wants_object_storage ? "object" : "local",
+                                configured_mode));
+        }
+
         // If the new keyspace uses tablets, as long as there are features
         // which aren't supported by tablets we want to warn the user that
         // they will not be usable on the new keyspace - and suggest how a

--- a/cql3/statements/create_keyspace_statement.cc
+++ b/cql3/statements/create_keyspace_statement.cc
@@ -103,6 +103,37 @@ future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, utils::chun
     try {
         auto ksm = _attrs->as_ks_metadata(_name, *tmptr, feat, cfg);
         m = service::prepare_new_keyspace_announcement(qp.db().real_database(), ksm, ts);
+
+        // We hold a group0_guard, so no other coordinator can create a keyspace
+        // behind our back. A cluster which is already mixed cannot be brought
+        // back by refusing more keyspaces, so it only gets a warning.
+        const bool wants_object_storage = ksm->get_storage_options().is_object_storage_type();
+        switch (qp.db().real_database().get_user_storage_kind()) {
+            using enum replica::database::user_storage_kind;
+        case none:
+            break;
+        case local:
+            if (wants_object_storage) {
+                throw exceptions::invalid_request_exception(
+                    seastar::format("Cannot create keyspace '{}' in object storage: this cluster keeps its user data in local "
+                                    "storage. A cluster keeps all of its user data either locally or in object storage.",
+                                    _name));
+            }
+            break;
+        case object_storage:
+            if (!wants_object_storage) {
+                throw exceptions::invalid_request_exception(
+                    seastar::format("Cannot create keyspace '{}' in local storage: this cluster keeps its user data in object "
+                                    "storage. A cluster keeps all of its user data either locally or in object storage.",
+                                    _name));
+            }
+            break;
+        case mixed:
+            warnings.push_back("This cluster keeps some of its user data locally and some in object storage. Such a cluster is not supported.");
+            mylogger.warn("Creating keyspace {}: {}", _name, warnings.back());
+            break;
+        }
+
         // If the new keyspace uses tablets, as long as there are features
         // which aren't supported by tablets we want to warn the user that
         // they will not be usable on the new keyspace - and suggest how a

--- a/db/config.cc
+++ b/db/config.cc
@@ -326,6 +326,13 @@ const config_type& config_type_for<enum_option<db::tablets_mode_t>>() {
 }
 
 template <>
+const config_type& config_type_for<enum_option<db::keyspace_storage_mode_t>>() {
+    static config_type ct(
+        "keyspace storage mode", printable_to_json<enum_option<db::keyspace_storage_mode_t>>);
+    return ct;
+}
+
+template <>
 const config_type& config_type_for<db::config::hinted_handoff_enabled_type>() {
     static config_type ct("hinted handoff enabled", hinted_handoff_enabled_to_json);
     return ct;
@@ -519,6 +526,23 @@ template <>
 class convert<enum_option<db::tablets_mode_t>> {
 public:
     static bool decode(const Node& node, enum_option<db::tablets_mode_t>& rhs) {
+        std::string name;
+        if (!convert<std::string>::decode(node, name)) {
+            return false;
+        }
+        try {
+            std::istringstream(name) >> rhs;
+        } catch (boost::program_options::invalid_option_value&) {
+            return false;
+        }
+        return true;
+    }
+};
+
+template <>
+class convert<enum_option<db::keyspace_storage_mode_t>> {
+public:
+    static bool decode(const Node& node, enum_option<db::keyspace_storage_mode_t>& rhs) {
         std::string name;
         if (!convert<std::string>::decode(node, name)) {
             return false;
@@ -1797,6 +1821,10 @@ db::config::config(std::shared_ptr<db::extensions> exts)
             "\tdisabled: New keyspaces use vnodes by default, unless enabled by the tablets={'enabled':true} option\n"
             "\tenabled:  New keyspaces use tablets by default, unless disabled by the tablets={'enabled':false} option\n"
             "\tenforced: New keyspaces must use tablets. Tablets cannot be disabled using the CREATE KEYSPACE option")
+    , storage_mode_for_new_keyspaces(this, "storage_mode_for_new_keyspaces", liveness::MustRestart, value_status::Used, keyspace_storage_mode_t::mode::unset, "Which storage new keyspaces may use.  Can be set to the following values:\n"
+            "\tunset:          the keyspaces the cluster already has decide, and the first one created decides for an empty cluster\n"
+            "\tlocal:          keyspaces keep their data on local disks, and CREATE KEYSPACE with an object-storage STORAGE option is refused\n"
+            "\tobject_storage: keyspaces keep their data in object storage, and CREATE KEYSPACE without one is refused.  Alternator is not supported in this mode")
     , auto_repair_enabled_default(this, "auto_repair_enabled_default", liveness::LiveUpdate, value_status::Used, false, "Set true to enable auto repair for tablet tables by default. The value will be overridden by the per keyspace or per table configuration which is not implemented yet.")
     , auto_repair_threshold_default_in_seconds(this, "auto_repair_threshold_default_in_seconds", liveness::LiveUpdate, value_status::Used, 24 * 3600 , "Set the default time in seconds for the auto repair threshold for tablet tables. If the time since last repair is bigger than the configured time, the tablet is eligible for auto repair. The value will be overridden by the per keyspace or per table configuration which is not implemented yet.")
     , view_flow_control_delay_limit_in_ms(this, "view_flow_control_delay_limit_in_ms", liveness::LiveUpdate, value_status::Used, 1000,
@@ -2166,6 +2194,13 @@ std::unordered_map<sstring, db::tri_mode_restriction_t::mode> db::tri_mode_restr
             {"warn", db::tri_mode_restriction_t::mode::WARN}};
 }
 
+std::unordered_map<sstring, db::keyspace_storage_mode_t::mode> db::keyspace_storage_mode_t::map() {
+    return {{"unset", db::keyspace_storage_mode_t::mode::unset},
+            {"local", db::keyspace_storage_mode_t::mode::local},
+            {"object_storage", db::keyspace_storage_mode_t::mode::object_storage}
+            };
+}
+
 std::unordered_map<sstring, db::tablets_mode_t::mode> db::tablets_mode_t::map() {
     return {{"disabled", db::tablets_mode_t::mode::disabled},
             {"0", db::tablets_mode_t::mode::disabled},
@@ -2209,6 +2244,7 @@ template struct utils::config_file::named_value<enum_option<db::experimental_fea
 template struct utils::config_file::named_value<enum_option<db::replication_strategy_restriction_t>>;
 template struct utils::config_file::named_value<enum_option<db::consistency_level_restriction_t>>;
 template struct utils::config_file::named_value<enum_option<db::tablets_mode_t>>;
+template struct utils::config_file::named_value<enum_option<db::keyspace_storage_mode_t>>;
 template struct utils::config_file::named_value<enum_option<netw::dict_training_loop::when>>;
 template struct utils::config_file::named_value<netw::advanced_rpc_compressor::tracker::algo_config>;
 template struct utils::config_file::named_value<std::vector<enum_option<db::experimental_features_t>>>;

--- a/db/config.hh
+++ b/db/config.hh
@@ -160,6 +160,17 @@ struct tablets_mode_t {
     static std::unordered_map<sstring, mode> map(); // for enum_option<>
 };
 
+struct keyspace_storage_mode_t {
+    // `unset` leaves the choice to whichever keyspaces the cluster already
+    // has, which is how a cluster behaves when the operator says nothing.
+    enum class mode : int8_t {
+        unset = -1,
+        local = 0,
+        object_storage = 1,
+    };
+    static std::unordered_map<sstring, mode> map(); // for enum_option<>
+};
+
 class config final : public utils::config_file {
 public:
     config();
@@ -635,6 +646,7 @@ public:
     named_value<double> topology_barrier_stall_detector_threshold_seconds;
     named_value<bool> enable_tablets;
     named_value<enum_option<tablets_mode_t>> tablets_mode_for_new_keyspaces;
+    named_value<enum_option<keyspace_storage_mode_t>> storage_mode_for_new_keyspaces;
     named_value<bool> auto_repair_enabled_default;
     named_value<int32_t> auto_repair_threshold_default_in_seconds;
 
@@ -778,6 +790,7 @@ extern template struct utils::config_file::named_value<enum_option<db::experimen
 extern template struct utils::config_file::named_value<enum_option<db::replication_strategy_restriction_t>>;
 extern template struct utils::config_file::named_value<enum_option<db::consistency_level_restriction_t>>;
 extern template struct utils::config_file::named_value<enum_option<db::tablets_mode_t>>;
+extern template struct utils::config_file::named_value<enum_option<db::keyspace_storage_mode_t>>;
 extern template struct utils::config_file::named_value<enum_option<netw::dict_training_loop::when>>;
 extern template struct utils::config_file::named_value<netw::advanced_rpc_compressor::tracker::algo_config>;
 extern template struct utils::config_file::named_value<std::vector<enum_option<db::experimental_features_t>>>;

--- a/main.cc
+++ b/main.cc
@@ -2545,6 +2545,9 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
             startlog.info("Verifying that all of the tablet keyspaces use rack list replication factors");
             db.local().check_rack_list_everywhere(cfg->enforce_rack_list());
 
+            startlog.info("Verifying that the keyspaces agree with storage_mode_for_new_keyspaces");
+            db.local().check_storage_mode_for_new_keyspaces();
+
             // The table-based audit backend needs Raft (via join_cluster)
             // to create its keyspace and table.
             checkpoint(stop_signal, "starting audit storage");

--- a/main.cc
+++ b/main.cc
@@ -2826,6 +2826,11 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
 #endif
 
             if (bool enabled = cfg->alternator_port() || cfg->alternator_https_port()) {
+                // Alternator on object storage is untested, so it is refused
+                // rather than left to fail somewhere further in.
+                if (cfg->storage_mode_for_new_keyspaces() == db::keyspace_storage_mode_t::mode::object_storage) {
+                    throw std::runtime_error("Alternator is not supported when storage_mode_for_new_keyspaces is object_storage");
+                }
                 ss.local().register_protocol_server(alternator_ctl, enabled).get();
             }
 

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -1491,6 +1491,57 @@ std::vector<sstring> database::get_user_keyspaces() const {
     return res;
 }
 
+// The "audit" keyspace belongs to Scylla only while the table sink is
+// configured; otherwise the name is free for a user to take. "audit" is a
+// comma-separated list of sinks.
+static bool audit_table_sink_configured(const db::config& cfg) {
+    for (const auto sink : std::views::split(std::string_view(cfg.audit()), std::string_view(","))) {
+        auto name = std::string_view(sink.begin(), sink.end());
+        while (!name.empty() && name.front() == ' ') {
+            name.remove_prefix(1);
+        }
+        while (!name.empty() && name.back() == ' ') {
+            name.remove_suffix(1);
+        }
+        if (name == "table") {
+            return true;
+        }
+    }
+    return false;
+}
+
+// is_internal_keyspace() misses two keyspaces Scylla also creates itself:
+// "audit", which the table-based audit backend creates on demand, and
+// "system_distributed_everywhere", present only on an upgraded cluster.
+static bool is_always_local_keyspace(std::string_view name, bool audit_table_configured) {
+    return is_internal_keyspace(name) || (audit_table_configured && name == "audit") || name == "system_distributed_everywhere";
+}
+
+database::user_storage_kind database::get_user_storage_kind() const {
+    bool local = false;
+    bool object_storage = false;
+    const bool audit_table_configured = audit_table_sink_configured(_cfg);
+    for (auto const& i : _keyspaces) {
+        if (i.second.metadata()->get_storage_options().is_object_storage_type()) {
+            // Nothing but a user request ever asks for object storage, so there
+            // is no internal keyspace to filter out here.
+            object_storage = true;
+        } else if (!is_always_local_keyspace(i.first, audit_table_configured)) {
+            local = true;
+        }
+    }
+    if (local && object_storage) {
+        return user_storage_kind::mixed;
+    }
+    if (object_storage) {
+        return user_storage_kind::object_storage;
+    }
+    if (local) {
+        return user_storage_kind::local;
+    }
+    return user_storage_kind::none;
+}
+
 std::vector<sstring> database::get_all_keyspaces() const {
     std::vector<sstring> res;
     res.reserve(_keyspaces.size());

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -3922,6 +3922,28 @@ bool database::enforce_rf_rack_validity_for_keyspace(const db::config& cfg, cons
     return cfg.rf_rack_valid_keyspaces() || ksm.views().size() > 0;
 }
 
+void database::check_storage_mode_for_new_keyspaces() const {
+    const auto configured = _cfg.storage_mode_for_new_keyspaces();
+    if (configured == db::keyspace_storage_mode_t::mode::unset) {
+        return;
+    }
+    const auto kind = get_user_storage_kind();
+    // A cluster with no user keyspaces has nothing to disagree with, and one
+    // which is already mixed predates the setting.
+    if (kind == user_storage_kind::none || kind == user_storage_kind::mixed) {
+        return;
+    }
+    // A node which disagrees with the keyspaces the cluster already has can
+    // create no keyspace at all: one check refuses the configured kind, the
+    // other refuses everything else.
+    const bool cluster_object_storage = kind == user_storage_kind::object_storage;
+    if (cluster_object_storage != (configured == db::keyspace_storage_mode_t::mode::object_storage)) {
+        throw std::runtime_error(seastar::format("storage_mode_for_new_keyspaces is {}, but this cluster keeps its user data in {} storage",
+                                                 configured,
+                                                 cluster_object_storage ? "object" : "local"));
+    }
+}
+
 void database::check_rf_rack_validity(const locator::token_metadata_ptr tmptr) const {
     const auto& keyspaces = get_keyspaces();
     std::vector<std::string_view> invalid_keyspaces{};

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -2304,6 +2304,7 @@ public:
     // * If not `enforce_rack_list`, a warning will be printed for all keyspaces
     //   that use numeric replication factors, but no exception should be thrown.
     void check_rack_list_everywhere(const bool enforce_rack_list) const;
+    void check_storage_mode_for_new_keyspaces() const;
 
 private:
     // SSTable sampling might require considerable amounts of memory,

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -1991,6 +1991,14 @@ public:
     std::vector<sstring> get_non_system_keyspaces() const;
     std::vector<sstring> get_user_keyspaces() const;
     std::vector<sstring> get_all_keyspaces() const;
+    // Keyspaces created by Scylla itself are always local and do not count.
+    enum class user_storage_kind {
+        none,
+        local,
+        object_storage,
+        mixed,
+    };
+    user_storage_kind get_user_storage_kind() const;
     std::vector<sstring> get_non_local_strategy_keyspaces() const;
     std::vector<sstring> get_non_local_vnode_based_strategy_keyspaces() const;
     // All static_effective_replication_map_ptr must hold a vnode_effective_replication_map

--- a/test/boost/file_stream_test.cc
+++ b/test/boost/file_stream_test.cc
@@ -84,6 +84,7 @@ static cql_test_config make_object_storage_test_config(const data_dictionary::st
     cql_test_config cfg;
     cfg.db_config = make_shared<db::config>();
     cfg.db_config->object_storage_endpoints(sstables::make_storage_options_config(so));
+    cfg.keyspace_storage_options = so;
     return cfg;
 }
 

--- a/test/cluster/object_store/test_basic.py
+++ b/test/cluster/object_store/test_basic.py
@@ -1042,3 +1042,35 @@ async def test_scylla_sstable_dump_scylla_metadata(manager: ScyllaClusterManager
         returncode, out, err = await run_scylla_sstable(bad_args)
         assert returncode != 0
         assert "is not one" in out + err, f"unexpected diagnosis: {out} {err}"
+
+
+async def test_storage_mode_local_refuses_object_storage_keyspace(manager: ScyllaClusterManager, object_storage):
+    '''storage_mode_for_new_keyspaces=local refuses an object-storage keyspace.
+    The cluster has no user keyspace yet, so the setting is the only thing that
+    can refuse it'''
+    cfg = {'enable_user_defined_functions': False,
+           'object_storage_endpoints': object_storage.create_endpoint_conf(),
+           'storage_mode_for_new_keyspaces': 'local'}
+    await manager.server_add(config=cfg)
+
+    cql = manager.get_cql()
+    with pytest.raises(InvalidRequest, match='storage_mode_for_new_keyspaces is set to local'):
+        cql.execute(f'CREATE KEYSPACE {unique_name()} {keyspace_options(object_storage)};')
+
+
+async def test_storage_mode_object_storage_refuses_local_keyspace(manager: ScyllaClusterManager, object_storage):
+    '''the other direction, again on a cluster with no user keyspace yet'''
+    cfg = {'enable_user_defined_functions': False,
+           'object_storage_endpoints': object_storage.create_endpoint_conf(),
+           'storage_mode_for_new_keyspaces': 'object_storage'}
+    await manager.server_add(config=cfg)
+
+    cql = manager.get_cql()
+    replication_opts = format_tuples({'class': 'NetworkTopologyStrategy',
+                                      'replication_factor': '1'})
+    with pytest.raises(InvalidRequest, match='storage_mode_for_new_keyspaces is set to object_storage'):
+        cql.execute(f'CREATE KEYSPACE {unique_name()} WITH REPLICATION = {replication_opts};')
+
+    # the configured kind is still accepted
+    cql.execute(f'CREATE KEYSPACE {unique_name()} {keyspace_options(object_storage)};')
+

--- a/test/cluster/object_store/test_basic.py
+++ b/test/cluster/object_store/test_basic.py
@@ -11,7 +11,7 @@ import time
 import uuid
 
 from test.pylib.minio_server import MinioServer
-from cassandra.protocol import ConfigurationException
+from cassandra.protocol import ConfigurationException, InvalidRequest
 from cassandra.query import SimpleStatement, ConsistencyLevel
 from test.pylib.scylla_cluster_manager import ScyllaClusterManager
 from test.pylib.util import wait_for, wait_for_cql_and_get_hosts
@@ -863,6 +863,79 @@ async def test_stream_sink_abort_on_object_storage(manager: ScyllaClusterManager
             components, refs = get_components_and_refs()
             logger.error(f"Orphaned components: {components=} {refs=}: {e}")
             raise
+
+
+async def test_reject_object_storage_keyspace_when_local_exists(manager: ScyllaClusterManager, object_storage):
+    '''a cluster keeps its user data either locally or in object storage, so an
+    object-storage keyspace must be refused once a local user keyspace exists'''
+    objconf = object_storage.create_endpoint_conf()
+    cfg = {'enable_user_defined_functions': False,
+           'object_storage_endpoints': objconf}
+    await manager.server_add(config=cfg)
+
+    cql = manager.get_cql()
+    replication_opts = format_tuples({'class': 'NetworkTopologyStrategy',
+                                      'replication_factor': '1'})
+    cql.execute(f'CREATE KEYSPACE local_ks WITH REPLICATION = {replication_opts};')
+
+    with pytest.raises(InvalidRequest, match='in object storage: this cluster keeps its user data in local'):
+        cql.execute(f'CREATE KEYSPACE object_storage_ks {keyspace_options(object_storage)};')
+
+
+async def test_reject_local_keyspace_when_object_storage_exists(manager: ScyllaClusterManager, object_storage):
+    '''the other direction: a local keyspace must be refused once an
+    object-storage keyspace exists'''
+    objconf = object_storage.create_endpoint_conf()
+    cfg = {'enable_user_defined_functions': False,
+           'object_storage_endpoints': objconf}
+    await manager.server_add(config=cfg)
+
+    cql = manager.get_cql()
+    replication_opts = format_tuples({'class': 'NetworkTopologyStrategy',
+                                      'replication_factor': '1'})
+    cql.execute(f'CREATE KEYSPACE object_storage_ks {keyspace_options(object_storage)};')
+
+    with pytest.raises(InvalidRequest, match='in local storage: this cluster keeps its user data in object'):
+        cql.execute(f'CREATE KEYSPACE local_ks WITH REPLICATION = {replication_opts};')
+
+
+async def test_audit_keyspace_does_not_count_as_local(manager: ScyllaClusterManager, object_storage):
+    '''the table-based audit backend creates the local "audit" keyspace on
+    startup. It belongs to Scylla, not to the user, so it must not make the
+    cluster look like a local one and block object-storage keyspaces'''
+    objconf = object_storage.create_endpoint_conf()
+    cfg = {'enable_user_defined_functions': False,
+           'object_storage_endpoints': objconf,
+           'audit': 'table'}
+    await manager.server_add(config=cfg)
+
+    cql = manager.get_cql()
+    assert list(cql.execute("SELECT keyspace_name FROM system_schema.keyspaces WHERE keyspace_name = 'audit';")), \
+        'the audit keyspace was not created, the test would pass for the wrong reason'
+
+    # Were the audit keyspace counted as a user keyspace, the cluster would look
+    # local and this would be refused.
+    cql.execute(f'CREATE KEYSPACE object_storage_ks {keyspace_options(object_storage)};')
+
+
+async def test_user_keyspace_named_audit_counts_as_local(manager: ScyllaClusterManager, object_storage):
+    '''the audit keyspace only belongs to Scylla while the table sink is
+    configured. Without it the name is free, and such a keyspace is a user
+    keyspace like any other'''
+    # "audit" defaults to "table", which would have Scylla create the keyspace
+    # first and take the name.
+    cfg = {'enable_user_defined_functions': False,
+           'object_storage_endpoints': object_storage.create_endpoint_conf(),
+           'audit': 'none'}
+    await manager.server_add(config=cfg)
+
+    cql = manager.get_cql()
+    replication_opts = format_tuples({'class': 'NetworkTopologyStrategy',
+                                      'replication_factor': '1'})
+    cql.execute(f'CREATE KEYSPACE audit WITH REPLICATION = {replication_opts};')
+
+    with pytest.raises(InvalidRequest, match='this cluster keeps its user data in local'):
+        cql.execute(f'CREATE KEYSPACE {unique_name()} {keyspace_options(object_storage)};')
 
 
 async def run_scylla_sstable(args, timeout=300):

--- a/test/cluster/object_store/test_basic.py
+++ b/test/cluster/object_store/test_basic.py
@@ -1074,3 +1074,20 @@ async def test_storage_mode_object_storage_refuses_local_keyspace(manager: Scyll
     # the configured kind is still accepted
     cql.execute(f'CREATE KEYSPACE {unique_name()} {keyspace_options(object_storage)};')
 
+
+async def test_storage_mode_contradicting_the_cluster_refuses_to_start(manager: ScyllaClusterManager, object_storage):
+    '''flipping the setting on a cluster which already holds data leaves a node
+    that can create no keyspace at all, so it must refuse to start'''
+    cfg = {'enable_user_defined_functions': False,
+           'object_storage_endpoints': object_storage.create_endpoint_conf(),
+           'storage_mode_for_new_keyspaces': 'object_storage'}
+    server = await manager.server_add(config=cfg)
+
+    cql = manager.get_cql()
+    cql.execute(f'CREATE KEYSPACE {unique_name()} {keyspace_options(object_storage)};')
+
+    await manager.server_stop_gracefully(server.server_id)
+    await manager.server_update_config(server.server_id, 'storage_mode_for_new_keyspaces', 'local')
+    await manager.server_start(server.server_id,
+                               expected_error='storage_mode_for_new_keyspaces is local, but this cluster keeps its user data in object storage')
+

--- a/test/cluster/object_store/test_basic.py
+++ b/test/cluster/object_store/test_basic.py
@@ -1091,3 +1091,13 @@ async def test_storage_mode_contradicting_the_cluster_refuses_to_start(manager: 
     await manager.server_start(server.server_id,
                                expected_error='storage_mode_for_new_keyspaces is local, but this cluster keeps its user data in object storage')
 
+
+async def test_alternator_refuses_to_start_on_object_storage(manager: ScyllaClusterManager, object_storage):
+    '''Alternator is untested on object storage, so a node configured for both
+    must refuse to start'''
+    cfg = {'enable_user_defined_functions': False,
+           'object_storage_endpoints': object_storage.create_endpoint_conf(),
+           'storage_mode_for_new_keyspaces': 'object_storage'}
+    cfg.update(alternator_config)
+    await manager.server_add(config=cfg,
+                             expected_error='Alternator is not supported when storage_mode_for_new_keyspaces is object_storage')

--- a/test/cluster/object_store/test_basic.py
+++ b/test/cluster/object_store/test_basic.py
@@ -11,12 +11,14 @@ import time
 import uuid
 
 from test.pylib.minio_server import MinioServer
+from botocore.exceptions import ClientError
 from cassandra.protocol import ConfigurationException, InvalidRequest
 from cassandra.query import SimpleStatement, ConsistencyLevel
 from test.pylib.scylla_cluster_manager import ScyllaClusterManager
 from test.pylib.util import wait_for, wait_for_cql_and_get_hosts
 from test.pylib.object_storage import format_tuples, keyspace_options
 from test.cqlpy.rest_api import scylla_inject_error
+from test.cluster.test_alternator import alternator_config, get_alternator, unique_table_name
 from test.cluster.test_config import wait_for_config
 from test.cluster.util import new_test_keyspace, wait_for_token_ring_and_group0_consistency
 from test.pylib.tablets import get_all_tablet_replicas
@@ -936,6 +938,36 @@ async def test_user_keyspace_named_audit_counts_as_local(manager: ScyllaClusterM
 
     with pytest.raises(InvalidRequest, match='this cluster keeps its user data in local'):
         cql.execute(f'CREATE KEYSPACE {unique_name()} {keyspace_options(object_storage)};')
+
+
+async def test_alternator_create_table_rejected_on_object_storage_cluster(manager: ScyllaClusterManager, object_storage):
+    '''Alternator creates its keyspace with the default local storage, so a
+    CreateTable must be refused on a cluster which keeps its user data in
+    object storage'''
+    objconf = object_storage.create_endpoint_conf()
+    cfg = {'enable_user_defined_functions': False,
+           'object_storage_endpoints': objconf}
+    cfg.update(alternator_config)
+    server = await manager.server_add(config=cfg)
+
+    cql = manager.get_cql()
+    cql.execute(f'CREATE KEYSPACE object_storage_ks {keyspace_options(object_storage)};')
+
+    alternator = get_alternator(server.ip_addr)
+    with pytest.raises(ClientError, match='keeps its user data in object storage') as excinfo:
+        alternator.create_table(TableName=unique_table_name(),
+                                BillingMode='PAY_PER_REQUEST',
+                                KeySchema=[{'AttributeName': 'p', 'KeyType': 'HASH'}],
+                                AttributeDefinitions=[{'AttributeName': 'p', 'AttributeType': 'N'}])
+    # An InternalServerError carries the same message but asks the SDK to retry
+    # a request which can never succeed.
+    assert excinfo.value.response['Error']['Code'] == 'ValidationException', \
+        f"expected a ValidationException, got {excinfo.value.response['Error']}"
+
+    # The refusal must come before the keyspace is created, not after.
+    keyspaces = [row.keyspace_name for row in cql.execute('SELECT keyspace_name FROM system_schema.keyspaces;')]
+    assert not [ks for ks in keyspaces if ks.startswith('alternator_')], \
+        f'a local Alternator keyspace was left behind: {keyspaces}'
 
 
 async def run_scylla_sstable(args, timeout=300):

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -473,6 +473,14 @@ public:
         if (cfg.strongly_consistent_tables) {
             options += " and consistency = 'global'";
         }
+        if (cfg.keyspace_storage_options) {
+            // storage_options::from_map() takes the type plus the entries to_map() emits.
+            sstring storage = format("'type': '{}'", cfg.keyspace_storage_options->type_string());
+            for (const auto& [key, value] : cfg.keyspace_storage_options->to_map()) {
+                storage += format(", '{}': '{}'", key, value);
+            }
+            options += format(" and storage = {{{}}}", storage);
+        }
         auto query = seastar::format("create keyspace {} with replication = {{ 'class' : 'org.apache.cassandra.locator.NetworkTopologyStrategy', 'replication_factor' : 1}}{};", name,
                             options);
         return execute_cql(query).discard_result();

--- a/test/lib/cql_test_env.hh
+++ b/test/lib/cql_test_env.hh
@@ -20,6 +20,7 @@
 #include "db/view/view_update_generator.hh"
 #include "service/qos/service_level_controller.hh"
 #include "replica/database.hh"
+#include "data_dictionary/storage_options.hh"
 #include "transport/messages/result_message_base.hh"
 #include "cql3/query_options_fwd.hh"
 #include "cql3/values.hh"
@@ -109,6 +110,7 @@ public:
     std::optional<cql3::query_processor::memory_config> qp_mcfg;
     bool need_remote_proxy = false;
     std::optional<uint64_t> initial_tablets; // When engaged, the default keyspace will use tablets.
+    std::optional<data_dictionary::storage_options> keyspace_storage_options;
     locator::host_id host_id;
     gms::inet_address broadcast_address = gms::inet_address("localhost");
     bool ms_listen = false;


### PR DESCRIPTION
A cluster is expected to keep all of its user data either locally or in object storage, but nothing enforces it. `CREATE KEYSPACE ... WITH STORAGE = {'type':'S3', ...}` succeeds on a cluster whose user keyspaces are all local, and a plain `CREATE KEYSPACE` succeeds on a cluster whose user keyspaces are all in object storage. There is no validation below the keyspace level either. Alternator makes the same hole from the other side: it creates its keyspace with the default local storage, so `CreateTable` quietly plants a local keyspace on an object-storage cluster.

### Where a cluster keeps its user data

`replica::database` answers that question: nowhere yet, locally, in object storage, or both. Keyspaces Scylla creates for itself are always local and must not answer it. `is_internal_keyspace()` names most of them; the query also skips `system_distributed_everywhere`, which only exists on an upgraded cluster, and `audit` — but only while the table sink is configured, since otherwise that name is free for a user to take. Note `audit` defaults to `table`, so on most clusters that keyspace exists and the exemption is load-bearing: without it the first object-storage `CREATE KEYSPACE` on any cluster would be refused. The object-storage side of the question needs no such filter, because nothing but a user request ever asks for object storage.

### Refusing the mix

`CREATE KEYSPACE` refuses an object-storage keyspace on a cluster which keeps its user data locally, and a local keyspace on a cluster which keeps its user data in object storage. The check runs in `prepare_schema_mutations()`, which the statement reaches while holding a `group0_guard`: the guard is taken after a raft read barrier, and the command it produces is a compare-and-swap on the observed group0 state id, so a concurrent `CREATE KEYSPACE` on another coordinator either is already visible to the check or loses the CAS and retries the whole statement. It sits after `prepare_new_keyspace_announcement()` so that `CREATE KEYSPACE IF NOT EXISTS` naming an existing keyspace stays the no-op it is today, matching the RF-rack check a few lines below, which is placed there for the same reason and says so.

Alternator's `CreateTable` refuses the same mix and answers `ValidationException` — what it already returns when the cluster cannot host the table being asked for, such as a vector index on vnodes. Letting the exception escape instead would reach `convert_exception_ptr_to_api_error()` and become an `InternalServerError`, which SDKs retry against a request that can never succeed.

Refusing further keyspaces does not bring a cluster which is already mixed back to either kind, and would leave it unable to create any user keyspace at all. Such a cluster gets a warning instead, on the CQL response and in the log.

Only the paths a user drives are affected. The internal keyspaces — `system_auth`, `system_distributed`, `audit`, `system_traces`, `system_replicated_keys` — call `prepare_new_keyspace_announcement()` directly and never pass through the CQL statement or Alternator, so no exemption list guards node startup. An earlier draft put the check in `replica::database::validate_new_keyspace()` instead; because `audit` is absent from `is_internal_keyspace()`, that version made any object-storage cluster with the audit table sink fail to start.

### Letting the operator say which kind

Leaving the decision to whichever keyspace is created first is not enough for an operator who wants to state it up front, so `storage_mode_for_new_keyspaces` takes `local` or `object_storage` and a keyspace of the other kind is refused. It defaults to `unset`, which leaves the decision exactly where it is today. Like the `unset` mode of `tablets_mode_for_new_keyspaces`, that exists so an existing cluster keeps behaving as it did.

The setting is `liveness::MustRestart`, and a node whose setting disagrees with the keyspaces already in its schema refuses to start: such a node can create no keyspace at all, since the setting refuses one kind and the keyspaces refuse the other. A cluster which is already mixed predates the setting and is left alone.

Alternator is refused at startup when the setting names object storage, for the same reason its `CreateTable` is refused on an object-storage cluster: the combination is untested, and 2026.3 lists it as unsupported. Saying so once at startup beats failing every `CreateTable`.

The setting only gates the CQL path. The internal keyspaces are created local regardless of it, which is verified in the tests: a node with the setting on `object_storage` still creates `audit`, `system_auth`, `system_distributed`, `system_traces` and `system_replicated_keys`, and then accepts an object-storage keyspace.

### Open question for review

The default is `unset`, which changes nothing for an existing deployment. `local` was the alternative — it would force every deployment to declare itself, but combined with the startup refusal it means an existing object-storage cluster **fails to start** after an upgrade until scylla.yaml is edited on every node. Object-storage keyspaces are GA (`keyspace-storage-options` is `feature::UNUSED`), so that is a real fleet. This is a product decision rather than an engineering one, and it is deliberately left for review.

### Backward incompatibility

Old behaviour: a cluster whose user keyspaces are all of one storage kind accepts a keyspace of the other kind. New behaviour: that request is refused with an `InvalidRequest`, and Alternator's `CreateTable` with a `ValidationException`. A cluster which is already mixed keeps working and is only warned about. There is no way to restore the old behaviour; `storage_mode_for_new_keyspaces` can only tighten it, never relax it.

### Tests

Both directions of the refusal, the exemption that keeps it from firing on a keyspace Scylla created itself, a user-owned keyspace named `audit`, the Alternator refusal, both directions of the setting, and both startup refusals — in `test/cluster/object_store/test_basic.py` across the s3 and gs flavours. Every one was checked to fail with the corresponding change reverted and the binary rebuilt.

One existing test needed adapting. `cql_test_env` creates its default keyspace through CQL with no storage options, so every boost test starts from a cluster holding a local user keyspace, and `file_stream_test`'s object-storage cases were refused because of it. `cql_test_config` now carries optional storage options for that keyspace, set once in the helper every object-storage case in that file builds its config with. That commit comes before the guardrail, so no commit in the series leaves a failing test behind.

Local runs: `test/cluster/` 1374 passed, `test/cqlpy` + `test/alternator` 3705 passed, `test/boost/file_stream_test.cc` 34 passed, `test/cluster/object_store/` 185 passed. The remaining failures are a dev build without KMIP support and without the WASM fixtures, plus one known flake in `test_tablet_snapshot` that passes 5/5 in isolation.

Fixes: https://scylladb.atlassian.net/browse/SCYLLADB-3961

No backport. This adds a restriction that clusters on a release branch do not have today, and it is not fixing a regression.
