### PR TITLE
sstables: forgive ENOENT when removing leftover upload .tmp TOC files

### DIFF
--- a/sstables/sstable_directory.cc
+++ b/sstables/sstable_directory.cc
@@ -25,6 +25,7 @@
 #include "utils/lister.hh"
 #include "utils/overloaded_functor.hh"
 #include "utils/directories.hh"
+#include "utils/exceptions.hh"
 #include "utils/s3/client.hh"
 #include "replica/database.hh"
 #include "dht/auto_refreshing_sharder.hh"
@@ -470,9 +471,22 @@ future<> sstable_directory::commit_directory_changes() {
 
 future<> sstable_directory::filesystem_components_lister::commit() {
     // Remove all files scheduled for removal
-    return parallel_for_each(std::exchange(_state->files_for_removal, {}), [] (sstring path) {
+    return parallel_for_each(std::exchange(_state->files_for_removal, {}), [] (sstring path) -> future<> {
         dirlog.info("Removing file {}", path);
-        return remove_file(std::move(path));
+        try {
+            co_await remove_file(path);
+        } catch (...) {
+            // Two overlapping directory-processing passes (e.g. process_sstable_dir()
+            // and a subsequent reshard/reshape pass) can independently schedule the
+            // same leftover temporary file for removal. The file is already gone by
+            // the time the second pass gets to it, so ENOENT here is expected and
+            // not an error, consistent with how leftover-component removal is
+            // handled elsewhere (see filesystem_storage::wipe()).
+            if (!is_system_error_errno(ENOENT)) {
+                throw;
+            }
+            dirlog.debug("Forgiving ENOENT when removing file {}", path);
+        }
     });
 }
 


### PR DESCRIPTION
nodetool refresh (load-and-stream from the upload directory) can fail
with a 500 error when the sstable loader's cleanup pass tries to
remove a leftover *-TOC.txt.tmp file that has already been removed by
an earlier, overlapping directory-processing pass over the same
upload directory (e.g. the initial process_sstable_dir() scan and a
subsequent reshard/reshape pass triggered from process_upload_dir()).
The second remove() then fails with ENOENT, which propagates up and
surfaces as a filesystem_error on the refresh request.

Forgive ENOENT in filesystem_components_lister::commit(), matching
the existing convention for the same class of leftover-component
removal in filesystem_storage::wipe().

**backport/none: this is a bug fix for a race that is only exercised
by the recently added overlapping directory-processing pass; no
backport is required.**

Fixes: SCYLLADB-4080
Fixes: SCYLLADB-3966