### PR TITLE
strong consistency: step down tablet leaders on graceful shutdown

### DIFF
--- a/raft/server.cc
+++ b/raft/server.cc
@@ -1777,6 +1777,10 @@ future<> server_impl::abort(sstring reason) {
         _state_change_promise->set_exception(stopped_error(*_aborted));
     }
 
+    if (_stepdown_promise) {
+        _stepdown_promise->set_exception(stopped_error(*_aborted));
+    }
+
     abort_snapshot_transfers();
 
     auto append_futures = _append_request_status | boost::adaptors::map_values |  boost::adaptors::transformed([] (append_request_queue& a) -> future<>& { return a.f; });

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -3005,6 +3005,21 @@ future<> storage_service::drain() {
 future<> storage_service::do_drain() {
     co_await utils::get_local_injector().inject("storage_service_drain_wait", utils::wait_for_message(60s));
 
+    // Hand the leadership of strongly consistent tablet groups led by this node
+    // over to other replicas. Otherwise the tablets we lead would stay unavailable for writes
+    // until the remaining replicas expired their election timeouts.
+    //
+    // This has to happen before stop_transport() below: the transfer is done with Raft RPCs,
+    // which need messaging_service to be up. That is also why it is not a part of
+    // groups_manager::stop(), which runs only after the transport is gone.
+    try {
+        co_await _groups_manager.container().invoke_on_all(
+                &strong_consistency::groups_manager::stepdown_leaders);
+    } catch (...) {
+        slogger.warn("Failed to transfer Raft leadership of strongly consistent tablets: {}. Ignored.",
+                std::current_exception());
+    }
+
     // Need to stop transport before group0, otherwise RPCs may fail with raft_group_not_found.
     co_await stop_transport();
 

--- a/service/strong_consistency/groups_manager.cc
+++ b/service/strong_consistency/groups_manager.cc
@@ -38,6 +38,15 @@ static raft::server_id to_server_id(host_id host_id) {
     return raft::server_id{host_id.uuid()};
 };
 
+// Tests may lengthen the tick interval via error injection so that any
+// unwanted waiting on a raft tick becomes visible as a large delay.
+static raft_ticker_type::duration get_tick_interval() {
+    return utils::get_local_injector()
+            .inject_parameter<int64_t>("strongly-consistent-raft-group-tick-interval-in-ms")
+            .transform([](int64_t ms) { return raft_ticker_type::duration{std::chrono::milliseconds{ms}}; })
+            .value_or(raft_tick_interval);
+}
+
 // Precondition: The passed group_leader must be a non-trivial raft::server_id.
 static std::optional<locator::tablet_replica_set> prepare_replicas_for_sc_tablet_version(locator::tablet_replica_set replicas, raft::server_id group_leader) {
     std::ranges::sort(replicas);
@@ -208,13 +217,6 @@ future<> groups_manager::start_raft_group(global_tablet_id tablet,
     // initialize the corresponding timer to tick the raft server instance
     auto ticker = std::make_unique<raft_ticker_type>([srv = server.get()] { srv->tick(); });
 
-    // Tests may lengthen the tick interval via error injection so that any
-    // unwanted waiting on a raft tick becomes visible as a large delay.
-    const auto tick_interval = utils::get_local_injector()
-            .inject_parameter<int64_t>("strongly-consistent-raft-group-tick-interval-in-ms")
-            .transform([](int64_t ms) { return raft_ticker_type::duration{std::chrono::milliseconds{ms}}; })
-            .value_or(raft_tick_interval);
-
     co_await _raft_gr.start_server_for_group(raft_server_for_group {
         .gid = group_id,
         .server = std::move(server),
@@ -222,7 +224,7 @@ future<> groups_manager::start_raft_group(global_tablet_id tablet,
         .rpc = rpc_ref,
         .persistence = persistence_ref,
         .state_machine = state_machine_ref
-    }, tick_interval);
+    }, get_tick_interval());
 }
 
 void groups_manager::schedule_raft_group_deletion(raft::group_id id, raft_group_state& state) {
@@ -544,6 +546,50 @@ void groups_manager::start() {
     if (_pending_tm) {
         update(std::move(_pending_tm));
     }
+}
+
+future<> groups_manager::stepdown_leaders() {
+    if (!_started || !_features.strongly_consistent_tables) {
+        co_return;
+    }
+    if (_raft_groups.size() == 0) {
+        logger.debug("stepdown_leaders(): no tablet raft groups on this node");
+        co_return;
+    }
+
+    const auto stepdown_timeout_ticks = std::max<int64_t>(std::chrono::seconds(5) / get_tick_interval(), 1);
+    size_t transferred = 0;
+
+    logger.info("stepdown_leaders(): transferring leadership away from this node, {} raft group(s) to consider",
+        _raft_groups.size());
+
+    co_await coroutine::parallel_for_each(_raft_groups, [&] (auto& entry) -> future<> {
+        const auto& [gid, state] = entry;
+
+        auto holder = state.gate->try_hold();
+        if (!holder) {
+            // A closed gate means the group is being deleted.
+            co_return;
+        }
+        // The holder also keeps state alive across the stepdown below: a reference
+        // into the map survives a rehash, and the erase cannot run before we let go.
+
+        if (!state.server || !state.server->is_leader()) {
+            co_return;
+        }
+
+        try {
+            co_await state.server->stepdown(raft::logical_clock::duration(stepdown_timeout_ticks));
+            ++transferred;
+            logger.debug("stepdown_leaders(): group id {}: leadership transferred", gid);
+        } catch (...) {
+            logger.info("stepdown_leaders(): group id {}: failed to transfer leadership: {}",
+                gid, std::current_exception());
+        }
+    });
+
+    logger.info("stepdown_leaders(): transferred leadership for {} raft group(s)",
+        transferred);
 }
 
 future<> groups_manager::stop() {

--- a/service/strong_consistency/groups_manager.hh
+++ b/service/strong_consistency/groups_manager.hh
@@ -183,6 +183,15 @@ public:
     // Called during node shutdown. Waits for all raft::server instances to stop.
     future<> stop();
 
+    // Hands Raft leadership over to another replica for every strongly consistent
+    // tablet group hosted on this shard which this node currently leads.
+    //
+    // Transferring leadership takes a round of Raft RPCs with the other replicas,
+    // so it must run while messaging_service is still up. stop() runs late in the
+    // shutdown sequence, after storage_service::do_drain() has already shut the
+    // transport down, so we need a separate entry point to trigger stepdown().
+    future<> stepdown_leaders();
+
     future<> wait_for_groups_to_start(lowres_clock::time_point timeout);
 
     // Sends an RPC to every host that holds a tablet replica of the given table, asking it to wait

--- a/test/cluster/test_strong_consistency.py
+++ b/test/cluster/test_strong_consistency.py
@@ -1585,3 +1585,71 @@ async def test_write_from_non_replica_after_leader_down(manager: ScyllaClusterMa
             rows = await cql.run_async(f"SELECT * FROM {table} WHERE pk = 2", host=non_replica_host)
             assert len(rows) == 1
             assert rows[0].c == 2
+
+@pytest.mark.asyncio
+@pytest.mark.skip_mode(mode="release", reason="error injections are not supported in release mode")
+async def test_stepdown_on_graceful_shutdown(manager: ScyllaClusterManager):
+    """
+    Verify that a node which is being shut down gracefully hands the leadership
+    of the strongly consistent tablets it leads over to another replica, instead
+    of leaving the group leaderless until the remaining replicas expire their
+    election timeouts.
+
+    All nodes run with a stretched raft tick interval, so expiring an election
+    timeout (at least 10 ticks) takes much longer than the leader's shutdown plus
+    the time this test gives the group to show its new leader.
+    """
+    tick_interval = 4
+    config = DEFAULT_CONFIG | {'error_injections_at_startup': [{
+        'name': 'strongly-consistent-raft-group-tick-interval-in-ms',
+        'value': str(tick_interval * 1000)
+    }]}
+    cmdline = DEFAULT_CMDLINE + ['--smp=1']
+    servers = await manager.servers_add(3, config=config, cmdline=cmdline, auto_rack_dc='my_dc')
+    cql, _ = await manager.get_ready_cql(servers)
+    host_ids = await gather_safely(*[manager.get_host_id(s.server_id) for s in servers])
+
+    async with new_test_keyspace(manager,
+            "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 3}"
+            " AND tablets = {'initial': 1} AND consistency = 'global'") as ks:
+        async with new_test_table(manager, ks, "pk int PRIMARY KEY, c int") as table:
+            table_name = table.split('.')[-1]
+            group_id = await get_table_raft_group_id(manager, ks, table_name)
+
+            # Every node is a replica, so any of them can be asked for the leader.
+            leader_host_id = await wait_for_leader(manager, servers[0], group_id)
+            leader_server = next(s for s, host_id in zip(servers, host_ids) if host_id == leader_host_id)
+            others = [s for s, host_id in zip(servers, host_ids) if host_id != leader_host_id]
+            logger.info(f"Group {group_id} is led by {leader_host_id}")
+
+            # Replicate something, so that the followers' match index reaches the
+            # leader's last log index and the stepdown below has a successor to
+            # pick immediately.
+            await cql.run_async(f"INSERT INTO {table} (pk, c) VALUES (1, 1)")
+
+            log = await manager.server_open_log(leader_server.server_id)
+            mark = await log.mark()
+
+            logger.info(f"Stopping the leader {leader_host_id} gracefully")
+            await manager.server_stop_gracefully(leader_server.server_id)
+
+            matches = await log.grep(r"stepdown_leaders\(\): transferred leadership for 1 raft group",
+                                     from_mark=mark)
+            assert matches, "The node being shut down did not transfer the leadership of its raft group"
+
+            # stepdown() only completes once the successor has started its election, which
+            # it wins long before the old leader's process exits, so a new leader should be
+            # there already. The other replicas cannot elect one on their own sooner than
+            # ELECTION_TIMEOUT (10 raft ticks) after losing the leader, so one that shows up
+            # this early can only be the stepdown's successor.
+            async def get_new_leader():
+                new_leader_host_id = await manager.api.get_raft_leader(others[0].ip_addr, group_id)
+                if uuid.UUID(new_leader_host_id).int == 0 or new_leader_host_id == leader_host_id:
+                    return None
+                return new_leader_host_id
+            new_leader_host_id = await wait_for(get_new_leader, time.time() + 2 * tick_interval)
+            logger.info(f"Group {group_id} is now led by {new_leader_host_id}")
+
+            # The new leader can serve writes right away.
+            cql, _ = await manager.get_ready_cql(others)
+            await cql.run_async(f"INSERT INTO {table} (pk, c) VALUES (2, 2)")


### PR DESCRIPTION
Every strongly consistent tablet whose Raft group is led by a node that
goes down is unavailable for writes until the remaining replicas expire
their election timeouts and elect a new leader. For a node that is
stopped on purpose, there is no reason to pay for that. It can hand
the leadership over itself, before it goes away.

Add `groups_manager::stepdown_leaders()`, which calls `stepdown()` on every
strongly consistent tablet group hosted on the shard that this node
currently leads, and call it from `storage_service::do_drain()`.

Fixes SCYLLADB-3994

Strong consistency is in development, no need to backport.