### PR TITLE
Restore optional manifests fields

### DIFF
--- a/docs/dev/object_storage.md
+++ b/docs/dev/object_storage.md
@@ -266,6 +266,8 @@ The json structure is as follows:
       "index_size": 8,
       "first_token": -8629266958227979430,
       "last_token": 9168982884335614769,
+      "tablet_id": 0,
+      "repaired_at": 0,
     },
     {
       "id": "67e35000-d8c6-11f0-85dc-0625e9f3bd1b",
@@ -309,6 +311,8 @@ The `sstables` member is a list containing metadata about the SSTables in the sn
 - `toc_name` - is the name of the SSTable Table Of Contents (TOC) component.
 - `data_size` and `index_size` - are the sizes of the SSTable's data and index components, respectively.  They can be used to estimate how much disk space is needed for restore.
 - `first_token` and `last_token` - are the first and last tokens in the SSTable, respectively.  They can be used to determine if a SSTable is fully contained in a (tablet) token range to enable efficient file-based streaming of the SSTable.
+- `tablet_id` - Optional. The id of the tablet that owned the SSTable when the snapshot was taken. Omitted for vnode-based tables.
+- `repaired_at` - Optional. When the SSTable was last repaired, or 0 if it was never repaired.
 
 The optional `files` member may contain a list of non-SSTable files included in the snapshot directory, not including the manifest.json file and schema.cql.
 ```

--- a/sstables_loader.cc
+++ b/sstables_loader.cc
@@ -1204,9 +1204,11 @@ static future<manifest_summary> process_manifest(input_stream<char>& is, sstring
         auto last_token = rjson::to_token(rjson::get(sstable_entry, "last_token"));
         auto toc_name = rjson::to_sstring(rjson::get(sstable_entry, "toc_name"));
         auto tablet_id = rjson::get<size_t>(sstable_entry, "tablet_id");
-        auto repaired_at = rjson::get<int64_t>(sstable_entry, "repaired_at");
-        auto data_size = rjson::get<int64_t>(sstable_entry, "data_size");
-        auto index_size = rjson::get<int64_t>(sstable_entry, "index_size");
+        // The fields below are not needed to restore the sstable, they are only recorded
+        // in system_distributed.snapshot_sstables for informational purposes.
+        auto repaired_at = rjson::get_opt<int64_t>(sstable_entry, "repaired_at").value_or(0);
+        auto data_size = rjson::get_opt<int64_t>(sstable_entry, "data_size").value_or(0);
+        auto index_size = rjson::get_opt<int64_t>(sstable_entry, "index_size").value_or(0);
         auto prefix = sstring(std::filesystem::path(manifest_prefix).parent_path().string());
         // Insert the snapshot sstable metadata into system_distributed.snapshot_sstables with a TTL of 3 days, that should be enough
         // for any snapshot restore operation to complete, and after that the metadata will be automatically cleaned up from the table

--- a/test/boost/tablet_aware_restore_test.cc
+++ b/test/boost/tablet_aware_restore_test.cc
@@ -17,12 +17,16 @@
 #include <seastar/core/future.hh>
 #include <seastar/testing/test_case.hh>
 #include <seastar/testing/test_fixture.hh>
+#include <seastar/util/closeable.hh>
+#include <seastar/util/short_streams.hh>
 
 #include "db/config.hh"
 #include "db/consistency_level_type.hh"
 #include "db/system_distributed_keyspace.hh"
 #include "sstables/object_storage_client.hh"
 #include "sstables/storage.hh"
+#include "utils/memory_data_sink.hh"
+#include "utils/rjson.hh"
 #include "sstables_loader.hh"
 #include "replica/database_fwd.hh"
 #include "replica/tablets.hh"
@@ -320,7 +324,7 @@ future<sstring> backup(cql_test_env& env, sstring endpoint, sstring bucket) {
     co_return prefix;
 }
 
-future<> check_snapshot_sstables(cql_test_env& env) {
+future<> check_snapshot_sstables(cql_test_env& env, std::function<void(const db::snapshot_sstable_entry&)> check_entry = {}) {
     auto& topology = env.get_storage_proxy().local().get_token_metadata_ptr()->get_topology();
     auto dc = topology.get_datacenter();
     auto rack = topology.get_rack();
@@ -345,6 +349,9 @@ future<> check_snapshot_sstables(cql_test_env& env) {
 
     for (const auto& sstable : sstables) {
         BOOST_CHECK(expected_sstables.contains(sstable.toc_name));
+        if (check_entry) {
+            check_entry(sstable);
+        }
     }
 }
 
@@ -373,6 +380,65 @@ SEASTAR_TEST_CASE(test_populate_snapshot_sstables_from_manifests, *boost::unit_t
             populate_snapshot_sstables_from_manifests(env.get_sstorage_manager().local(), env.get_system_distributed_keyspace().local(), "ks", "cf", ep, bucket, "", "snapshot", dc, {manifest_path}, db::consistency_level::ONE).get();
 
             check_snapshot_sstables(env).get();
+    }, false, db_cfg_ptr, 10);
+}
+
+future<sstring> download_object(cql_test_env& env, sstring endpoint, sstring bucket, sstring path) {
+    auto client = env.get_sstorage_manager().local().get_endpoint_client(endpoint);
+    auto source = client->make_download_source(object_name(bucket, path));
+    return seastar::with_closeable(input_stream<char>(std::move(source)), [] (input_stream<char>& is) {
+        return util::read_entire_stream_contiguous(is);
+    });
+}
+
+future<> upload_object(cql_test_env& env, sstring endpoint, sstring bucket, sstring path, sstring content) {
+    auto client = env.get_sstorage_manager().local().get_endpoint_client(endpoint);
+    memory_data_sink_buffers bufs;
+    bufs.push_back(temporary_buffer<char>(content.data(), content.size()));
+    return client->put_object(object_name(bucket, path), std::move(bufs), object_storage_attributes{});
+}
+
+// Manifests written by older Scylla versions lack the optional per-sstable metadata
+// fields. Restore must not fail on them.
+SEASTAR_TEST_CASE(test_restore_should_handle_missing_optional_fields, *boost::unit_test::precondition(tests::has_scylla_test_env)) {
+    using namespace sstables;
+
+    auto db_cfg_ptr = make_shared<db::config>();
+    db_cfg_ptr->tablets_mode_for_new_keyspaces(db::tablets_mode_t::mode::enabled);
+    auto storage_options = make_test_object_storage_options("S3");
+    db_cfg_ptr->object_storage_endpoints(make_storage_options_config(storage_options));
+
+    return do_with_some_data_in_thread({"cf"}, [storage_options = std::move(storage_options)] (cql_test_env& env) {
+            take_snapshot(env, "ks", "cf", "snapshot").get();
+
+            auto ep = storage_options.to_map()["endpoint"];
+            auto bucket = storage_options.to_map()["bucket"];
+            auto prefix = backup(env, ep, bucket).get();
+
+            auto dc = env.get_storage_proxy().local().get_token_metadata_ptr()->get_topology().get_datacenter();
+
+            // Download the manifest just written and strip the optional fields from every
+            // sstable entry, to emulate a manifest written before 2026.3, which had none.
+            auto manifest = rjson::parse(download_object(env, ep, bucket, prefix + "/manifest.json").get());
+            auto* sstables = rjson::find(manifest, "sstables");
+            BOOST_REQUIRE(sstables && sstables->IsArray() && sstables->Size() > 0);
+            for (auto& sstable_entry : sstables->GetArray()) {
+                for (auto field : {"repaired_at", "data_size", "index_size"}) {
+                    BOOST_REQUIRE(rjson::remove_member(sstable_entry, field));
+                }
+            }
+
+            auto manifest_path = prefix + "/manifest-without-optional-fields.json";
+            upload_object(env, ep, bucket, manifest_path, rjson::print(manifest)).get();
+
+            populate_snapshot_sstables_from_manifests(env.get_sstorage_manager().local(), env.get_system_distributed_keyspace().local(), "ks", "cf", ep, bucket, "", "snapshot", dc, {manifest_path}, db::consistency_level::ONE).get();
+
+            check_snapshot_sstables(env, [] (const db::snapshot_sstable_entry& e) {
+                // the fields dropped above default to 0
+                BOOST_CHECK_EQUAL(e.repaired_at, 0);
+                BOOST_CHECK_EQUAL(e.data_size, 0);
+                BOOST_CHECK_EQUAL(e.index_size, 0);
+            }).get();
     }, false, db_cfg_ptr, 10);
 }
 


### PR DESCRIPTION
Tablet-aware restore fails with HTTP 500 on `POST /storage_service/tablets/restore` whenever the snapshot manifest does not carry every per-sstable metadata field:

```json
{"message": "rjson::missing_value (JSON parameter repaired_at not found)", "code": 500}
```

`process_manifest()` reads `repaired_at`, `data_size` and `index_size` with `rjson::get()`, which throws `rjson::missing_value` when the member is absent.

None of the three fields is used to restore an sstable. They are only recorded in `system_distributed.snapshot_sstables`, and `snapshot_table_helper::get_snapshot_sstables()` already reads them back with `get_or<>(..., 0)` - the storage layer treats them as optional, the manifest reader was the only place that insisted on them.

Fixes: https://scylladb.atlassian.net/browse/SCYLLADB-3119

Backport to 2026.3 - the only release branch that has 4a504acc4d, i.e. the only one where restore requires the fields.