### PR TITLE
commitlog: keep requesting flushes for still-dirty segments

### DIFF
--- a/db/commitlog/commitlog.cc
+++ b/db/commitlog/commitlog.cc
@@ -2234,27 +2234,39 @@ void db::commitlog::segment_manager::flush_segments(uint64_t size_to_remove) {
         }
 
         auto rp = replay_position(s->_desc.id, db::position_type(s->size_on_disk()));
-        if (rp <= _flush_position) {
-            // already requested.
-            continue;
-        }
 
-        auto size = s->size_on_disk();
-        auto waste = s->_waste;
-
-        flushing += size - waste;
-
-        for (auto& id : s->_cf_dirty |  std::views::keys) {
+        // Collect the dirty tables of every closed segment, including ones
+        // already named in a previous request round: a flush request only
+        // releases commitlog references whose data already sits in a memtable,
+        // and a reference obtained from add() can reach a memtable long after
+        // the segment's first request round (e.g. a raft log entry is applied
+        // to the memtable only once its raft group commits it; until then the
+        // reference is held by the raft layer). Repeating a request is cheap:
+        // the table skips it unless its memtable holds data at or below the
+        // requested position.
+        for (auto& id : s->_cf_dirty | std::views::keys) {
             auto& target_high = ids[id];
             target_high = std::max(target_high, rp);
         }
+
+        if (rp <= _flush_position) {
+            // Already counted toward a previous round's size_to_remove target,
+            // so it must not contribute to the byte accounting or the
+            // watermark again.
+            continue;
+        }
+
+        const auto size = s->size_on_disk();
+        const auto waste = s->_waste;
+
+        flushing += size - waste;
 
         if (size_to_remove != 0) {
             if (n <= size) {
                 high = rp;
                 break;
             }
-            n -= s->size_on_disk();
+            n -= size;
         }
     }
 
@@ -2288,10 +2300,12 @@ void db::commitlog::segment_manager::check_no_data_older_than_allowed() {
 
     for (auto& s : _segments) {
         auto rp = replay_position(s->_desc.id, db::position_type(s->size_on_disk()));
-        if (rp <= _flush_position) {
-            // already requested.
-            continue;
-        }
+        // Deliberately no _flush_position cut-off here: a segment named in an
+        // earlier request round can still be dirty, because commitlog references
+        // may reach the memtables only after that round has passed (see
+        // flush_segments above). Without a repeated request, such a segment
+        // would stay on disk until some later write of the same table lands
+        // above the watermark - for a quiescent table, indefinitely.
 
         bool any_found = false;
 
@@ -2342,7 +2356,11 @@ void db::commitlog::segment_manager::check_no_data_older_than_allowed() {
                 }
             }
         }
-        _flush_position = *high;
+        // high can now point below _flush_position, since old, still-dirty
+        // segments are re-examined. The watermark must never move backwards,
+        // or flush_segments would count those segments' sizes toward
+        // size_to_remove a second time.
+        _flush_position = std::max(_flush_position, *high);
     }
 }
 

--- a/test/boost/commitlog_test.cc
+++ b/test/boost/commitlog_test.cc
@@ -1969,6 +1969,139 @@ SEASTAR_TEST_CASE(test_commitlog_update_max_data_lifetime) {
     co_await log.clear();
 }
 
+// The commitlog only knows a segment is still needed via the per-table dirty
+// counts, but the data those counts protect can reach the memtables long after
+// the segment was first named in a flush request (e.g. a raft log entry is
+// applied to the memtables only once its raft group commits it; until then the
+// rp_handle is held by the raft layer). A request round that ran in that window
+// found nothing to flush, yet used to advance _flush_position past the segment,
+// so no request for it was repeated and the segment stayed on disk until some
+// later write of the same table landed above the watermark - for a quiescent
+// table, indefinitely. Verify that the max-data-lifetime sweep keeps
+// requesting a flush while the segment remains dirty.
+SEASTAR_TEST_CASE(test_commitlog_flush_requests_repeat_while_segment_dirty) {
+    commitlog::config cfg;
+
+    constexpr auto max_size_mb = 1;
+
+    cfg.commitlog_segment_size_in_mb = max_size_mb;
+    // Plenty of headroom: disk usage stays below the flush threshold (half the
+    // total space), so the max-data-lifetime sweep is the only source of flush
+    // requests in this test.
+    cfg.commitlog_total_space_in_mb = 8 * max_size_mb * this_smp_shard_count();
+    cfg.commitlog_sync_period_in_ms = 10;
+    cfg.commitlog_data_max_lifetime_in_seconds = 1;
+    cfg.allow_going_over_size_limit = false;
+    cfg.use_o_dsync = true; // make sure we pre-allocate.
+
+    tmpdir tmp;
+    cfg.commit_log_location = tmp.path().string();
+    auto log = co_await commitlog::create_commitlog(cfg);
+
+    rp_set rps;
+    auto tid = make_table_id();
+    promise<> released;
+    // Not captured by value: each request round invokes a fresh copy of the
+    // handler (flush_segments copies the handler map defensively), so state
+    // inside the lambda would reset on every round.
+    int requests = 0;
+
+    auto r = log.add_flush_handler([&](cf_id_type id, replay_position) {
+        BOOST_CHECK(id == tid);
+        // The first request finds the data still outside the memtables (the
+        // rp_handle is stashed in rps). By the second request the data has
+        // reached the memtables, so the flush releases the segment.
+        if (++requests == 2) {
+            log.discard_completed_segments(id, rps);
+            released.set_value();
+        }
+    });
+
+    rp_handle h = co_await log.add_mutation(tid, 1, db::commitlog::force_sync::no, [](db::commitlog::output& dst) {
+        dst.fill('1', 1);
+    });
+    rps.put(std::move(h));
+
+    co_await with_timeout(timeout_clock::now() + 60s, released.get_future());
+
+    BOOST_CHECK_EQUAL(log.get_num_dirty_segments(), 0);
+
+    co_await log.shutdown();
+    co_await log.clear();
+}
+
+// Same scenario, but exercising the disk-pressure request rounds
+// (segment_manager::flush_segments) instead of the max-data-lifetime sweep.
+// A table whose only dirty segment is behind _flush_position must still be
+// named in later rounds while the segment stays dirty. The timer runs a round
+// only when a new segment was activated since the previous round
+// (_new_counter), so the test writes one more entry after the first request
+// to arm the second round.
+SEASTAR_TEST_CASE(test_commitlog_flush_requests_repeat_under_pressure) {
+    commitlog::config cfg;
+
+    constexpr auto max_size_mb = 1;
+
+    cfg.commitlog_segment_size_in_mb = max_size_mb;
+    // Two segments of total space: the flush threshold is half of it, and a
+    // closed pre-allocated segment counts toward the footprint in full (the
+    // unwritten remainder as waste), so one closed segment keeps the footprint
+    // at the threshold and every armed round fires.
+    cfg.commitlog_total_space_in_mb = 2 * max_size_mb * this_smp_shard_count();
+    cfg.commitlog_sync_period_in_ms = 10;
+    cfg.allow_going_over_size_limit = false;
+    cfg.use_o_dsync = true; // make sure we pre-allocate.
+
+    tmpdir tmp;
+    cfg.commit_log_location = tmp.path().string();
+    auto log = co_await commitlog::create_commitlog(cfg);
+
+    rp_set rps;
+    auto tid = make_table_id();
+    promise<> first_request, released;
+    // Not captured by value: see the sibling test above.
+    int requests = 0;
+
+    auto r = log.add_flush_handler([&](cf_id_type id, replay_position) {
+        BOOST_CHECK(id == tid);
+        switch (++requests) {
+        case 1:
+            first_request.set_value();
+            break;
+        case 2:
+            // By now the data has reached the memtables; the flush releases
+            // the stashed segment.
+            log.discard_completed_segments(id, rps);
+            released.set_value();
+            break;
+        }
+    });
+
+    rp_handle h = co_await log.add_mutation(tid, 1, db::commitlog::force_sync::no, [](db::commitlog::output& dst) {
+        dst.fill('1', 1);
+    });
+    rps.put(std::move(h));
+
+    // Flush requests only ever name closed segments.
+    co_await log.force_new_active_segment();
+    co_await with_timeout(timeout_clock::now() + 60s, first_request.get_future());
+
+    // The first round named the stashed segment and moved _flush_position
+    // past it. Activate one more segment to arm the next round; only the
+    // re-request of the old, still-dirty segment can deliver the second call.
+    h = co_await log.add_mutation(tid, 1, db::commitlog::force_sync::no, [](db::commitlog::output& dst) {
+        dst.fill('1', 1);
+    });
+    rps.put(std::move(h));
+
+    co_await with_timeout(timeout_clock::now() + 60s, released.get_future());
+
+    BOOST_CHECK_EQUAL(log.get_num_dirty_segments(), 0);
+
+    co_await log.shutdown();
+    co_await log.clear();
+}
+
 /**
  * Test allocating oversized multi-entry
 */


### PR DESCRIPTION
flush_segments() and check_no_data_older_than_allowed() request a flush from each dirty table once per segment, tracked by the _flush_position watermark. This silently assumes that by the time a segment's round runs, everything pinning it from a memtable is already there. A dirty count whose rp_handle lives outside the
memtables at that moment breaks the assumption: the request finds nothing to flush (the _lowest_rp check skips it), the watermark moves past the segment, and the request is never repeated. A later write of the same table unblocks the segment - its rp_handle lands above the watermark and the next round's request flushes the whole memtable - so the segment is stranded for as long as the table sees no further writes, in the worst case until shutdown.

The main consumer of the fix is Strong Consistency: its raft persistence holds per-entry rp_handles between store_log_entries() and apply(), so entries reach the memtables only when their raft group commits them, routinely after the segment's only request round. But an EC workload can hit the same window whenever an rp_handle is kept outside a memtable for a while, e.g. a write stalled on memory pressure admission.

Fix: flush_segments() still counts each segment's size toward size_to_remove once, but collects the dirty tables of every closed segment, watermark notwithstanding; the max-data-lifetime sweep drops its watermark cut-off (the age gate stays); the watermark itself never moves backwards. Repeated requests are cheap: the table skips them unless its memtable actually holds data at or below the requested position, and they stop once the segment goes clean and leaves _segments.

Add boost tests covering both request paths; both fail without the change (the second flush request never arrives).

backport: no need, mostly relevant for Strong Consistency (currently experimental)