### PR TITLE
cql3: strong consistency: reject unsupported CQL with clear errors

### DIFF
--- a/cdc/log.cc
+++ b/cdc/log.cc
@@ -204,6 +204,7 @@ public:
             auto logname = log_name(schema.cf_name());
             check_that_cdc_log_table_does_not_exist(db, schema, logname);
             ensure_that_table_has_no_counter_columns(schema);
+            ensure_that_keyspace_is_not_strongly_consistent(ksm, schema);
             if (!db.features().cdc_with_tablets) {
                 ensure_that_table_uses_vnodes(ksm, schema, db.get_token_metadata().get_topology());
             }
@@ -248,6 +249,7 @@ public:
 
             check_for_attempt_to_create_nested_cdc_log(db, new_schema);
             ensure_that_table_has_no_counter_columns(new_schema);
+            ensure_that_keyspace_is_not_strongly_consistent(*keyspace.metadata(), new_schema);
             if (!db.features().cdc_with_tablets) {
                 ensure_that_table_uses_vnodes(*keyspace.metadata(), new_schema, db.get_token_metadata().get_topology());
             }
@@ -344,6 +346,14 @@ private:
     static void ensure_that_table_has_no_counter_columns(const schema& schema) {
         if (schema.is_counter()) {
             throw exceptions::invalid_request_exception(format("Cannot create CDC log for table {}.{}. Counter support not implemented",
+                    schema.ks_name(), schema.cf_name()));
+        }
+    }
+
+    static void ensure_that_keyspace_is_not_strongly_consistent(const keyspace_metadata& ksm, const schema& schema) {
+        using data_dictionary::consistency_config_option;
+        if (ksm.consistency_option().value_or(consistency_config_option::eventual) != consistency_config_option::eventual) {
+            throw exceptions::invalid_request_exception(format("Cannot create CDC log for table {}.{}: CDC is not supported in strongly consistent keyspaces",
                     schema.ks_name(), schema.cf_name()));
         }
     }

--- a/cql3/statements/batch_statement.cc
+++ b/cql3/statements/batch_statement.cc
@@ -471,6 +471,8 @@ batch_statement::prepare(data_dictionary::database db, cql_stats& stats, const c
     std::vector<std::reference_wrapper<const audit::audit_info>> batch_audit_infos;
     batch_audit_infos.reserve(_parsed_statements.size());
 
+    bool has_sc_statements = false;
+    bool has_non_sc_statements = false;
     for (auto&& parsed : _parsed_statements) {
         if (!first_ks) {
             first_ks = parsed->keyspace();
@@ -480,11 +482,19 @@ batch_statement::prepare(data_dictionary::database db, cql_stats& stats, const c
             have_multiple_cfs |= first_cf.value() != parsed->column_family();
         }
         auto statement = parsed->prepare(db, meta, stats);
+        if (strong_consistency::is_strongly_consistent(db, parsed->keyspace())) {
+            has_sc_statements = true;
+        } else {
+            has_non_sc_statements = true;
+        }
         if (auto* audit_info = statement->get_audit_info()) {
             audit_info->set_query_string(parsed->get_raw_cql());
             batch_audit_infos.emplace_back(*audit_info);
         }
         statements.emplace_back(std::move(statement));
+    }
+    if (has_sc_statements && has_non_sc_statements) {
+        throw exceptions::invalid_request_exception("Cannot mix strongly consistent and eventually consistent statements in a batch");
     }
 
     auto&& prep_attrs = _attrs->prepare(db, "[batch]", "[batch]");
@@ -496,7 +506,7 @@ batch_statement::prepare(data_dictionary::database db, cql_stats& stats, const c
     }
 
     shared_ptr<cql_statement> statement;
-    if (first_ks && strong_consistency::is_strongly_consistent(db, *first_ks)) {
+    if (has_sc_statements) {
         auto sc_statements = statements | std::views::as_rvalue | std::views::transform([] (auto&& s) {
             return strong_consistency::batch_statement::single_statement{::make_shared<strong_consistency::modification_statement>(std::move(s.statement))};
         }) | std::ranges::to<std::vector>();

--- a/cql3/statements/cf_prop_defs.cc
+++ b/cql3/statements/cf_prop_defs.cc
@@ -11,6 +11,7 @@
 #include "cql3/statements/cf_prop_defs.hh"
 #include "cql3/statements/property_definitions.hh"
 #include "cql3/statements/request_validations.hh"
+#include "cql3/statements/strong_consistency/statement_helpers.hh"
 #include "data_dictionary/data_dictionary.hh"
 #include "db/extensions.hh"
 #include "db/tags/extension.hh"
@@ -150,6 +151,9 @@ void cf_prop_defs::validate(const data_dictionary::database db, sstring ks_name,
     auto per_partition_rate_limit_options = get_per_partition_rate_limit_options(schema_extensions);
     if (per_partition_rate_limit_options && !db.features().typed_errors_in_read_rpc) {
         throw exceptions::configuration_exception("Per-partition rate limit is not supported yet by the whole cluster");
+    }
+    if (per_partition_rate_limit_options && strong_consistency::is_strongly_consistent(db, ks_name)) {
+        throw exceptions::configuration_exception("Per-partition rate limit is not supported in strongly consistent keyspaces");
     }
 
     auto tombstone_gc_options = get_tombstone_gc_options(schema_extensions);

--- a/cql3/statements/create_table_statement.cc
+++ b/cql3/statements/create_table_statement.cc
@@ -221,6 +221,7 @@ std::unique_ptr<prepared_statement> create_table_statement::raw_statement::prepa
     } catch (const data_dictionary::no_such_keyspace& e) {
         throw exceptions::invalid_request_exception("Cannot create a table in a non-existent keyspace: " + keyspace());
     }
+    const bool ks_strongly_consistent = strong_consistency::is_strongly_consistent(db, keyspace());
 
     std::optional<std::map<bytes, data_type>> defined_multi_cell_columns;
     for (auto&& entry : _definitions) {
@@ -229,6 +230,10 @@ std::unique_ptr<prepared_statement> create_table_statement::raw_statement::prepa
 
         if (has_default_ttl && pt.is_counter()) {
             throw exceptions::invalid_request_exception("Cannot set default_time_to_live on a table with counters");
+        }
+
+        if (ks_strongly_consistent && pt.is_counter()) {
+            throw exceptions::invalid_request_exception(format("Cannot use the 'counter' type for table {}.{}: counters are not supported in strongly consistent keyspaces", keyspace(), cf_name));
         }
 
         if (ks_uses_tablets && pt.is_counter() && !db.features().counters_with_tablets) {

--- a/cql3/statements/modification_statement.cc
+++ b/cql3/statements/modification_statement.cc
@@ -647,6 +647,13 @@ modification_statement::prepare(data_dictionary::database db, prepare_context& c
         if (_if_not_exists || _if_exists || _conditions) {
             throw exceptions::invalid_request_exception("Strongly consistent updates don't support conditions");
         }
+        // logstor needs a row marker or partition tombstone on every mutation.
+        // Cell-only changes have neither and fail inside raft apply, which aborts the node.
+        if (schema->logstor_enabled() && !prepared_stmt->type.is_insert() && prepared_stmt->has_column_operations()) {
+            throw exceptions::invalid_request_exception(prepared_stmt->type.is_update()
+                    ? "UPDATE is not supported on logstor tables in strongly consistent keyspaces"
+                    : "Deleting individual columns is not supported on logstor tables in strongly consistent keyspaces");
+        }
     }
 
     // At this point the prepare context instance should have a list of

--- a/cql3/statements/modification_statement.cc
+++ b/cql3/statements/modification_statement.cc
@@ -642,6 +642,11 @@ modification_statement::prepare(data_dictionary::database db, prepare_context& c
         if (prepared_stmt->is_timestamp_set()) {
             throw exceptions::invalid_request_exception("Strongly consistent queries don't support user-provided timestamps");
         }
+        // The raw IF clauses, not has_conditions(): INSERT JSON ... IF NOT
+        // EXISTS never sets the flags behind has_conditions() (issue #8682).
+        if (_if_not_exists || _if_exists || _conditions) {
+            throw exceptions::invalid_request_exception("Strongly consistent updates don't support conditions");
+        }
     }
 
     // At this point the prepare context instance should have a list of

--- a/cql3/statements/modification_statement.hh
+++ b/cql3/statements/modification_statement.hh
@@ -190,6 +190,7 @@ public:
     // True if any of update operations of this statement requires
     // a prefetch of the old cell.
     bool requires_read() const { return _requires_read; }
+    bool has_column_operations() const { return !_column_operations.empty(); }
 
     // True if any of the update operations requires LWT for atomicity.
     bool requires_lwt() const { return _requires_lwt; }

--- a/cql3/statements/select_statement.cc
+++ b/cql3/statements/select_statement.cc
@@ -2313,6 +2313,9 @@ std::unique_ptr<prepared_statement> select_statement::prepare(data_dictionary::d
     };
 
     if (strong_consistency::is_strongly_consistent(db, schema->ks_name())) {
+        if (!group_by_cell_indices->empty()) {
+            throw exceptions::invalid_request_exception("Strongly consistent queries don't support GROUP BY");
+        }
         stmt = ::make_shared<strong_consistency::select_statement>(
                 schema,
                 ctx.bound_variables_size(),

--- a/cql3/statements/select_statement.cc
+++ b/cql3/statements/select_statement.cc
@@ -2313,6 +2313,12 @@ std::unique_ptr<prepared_statement> select_statement::prepare(data_dictionary::d
     };
 
     if (strong_consistency::is_strongly_consistent(db, schema->ks_name())) {
+        if (_parameters->is_mutation_fragments()) {
+            throw exceptions::invalid_request_exception("SELECT FROM MUTATION_FRAGMENTS() is not supported on strongly consistent tables");
+        }
+        if (_parameters->is_prune_materialized_view()) {
+            throw exceptions::invalid_request_exception("PRUNE MATERIALIZED VIEW is not supported on strongly consistent tables");
+        }
         if (!group_by_cell_indices->empty()) {
             throw exceptions::invalid_request_exception("Strongly consistent queries don't support GROUP BY");
         }

--- a/cql3/statements/strong_consistency/batch_statement.cc
+++ b/cql3/statements/strong_consistency/batch_statement.cc
@@ -139,6 +139,13 @@ void batch_statement::validate() const {
         throw exceptions::invalid_request_exception("Counter batches are not supported with strongly consistent tables");
     }
 
+    if (_attrs->is_time_to_live_set()) {
+        throw exceptions::invalid_request_exception("Global TTL on the BATCH statement is not supported.");
+    }
+    if (_attrs->is_timestamp_set()) {
+        throw exceptions::invalid_request_exception("Strongly consistent queries don't support user-provided timestamps");
+    }
+
     schema_ptr batch_schema;
     for (const auto& s: _statements) {
         const auto& stmt = s.statement->inner_statement();

--- a/cql3/statements/strong_consistency/batch_statement.cc
+++ b/cql3/statements/strong_consistency/batch_statement.cc
@@ -52,6 +52,8 @@ future<shared_ptr<result_message>> batch_statement::execute_without_checking_exc
         co_return seastar::make_shared<result_message::void_message>();
     }
 
+    validate_write_consistency_level(options.get_consistency());
+
     auto timeout = db::timeout_clock::now() + (_attrs->is_timeout_set() ? _attrs->get_timeout(options) : qs.get_client_state().get_timeout_config().write_timeout);
 
     // Build partition keys for all statements and validate they all target the same partition

--- a/cql3/statements/strong_consistency/batch_statement.cc
+++ b/cql3/statements/strong_consistency/batch_statement.cc
@@ -70,6 +70,7 @@ future<shared_ptr<result_message>> batch_statement::execute_without_checking_exc
     for (size_t i = 0; i < _statements.size(); ++i) {
         const auto& stmt = _statements[i].statement->inner_statement();
         const auto& statement_options = options.for_statement(i);
+        stmt.restrictions().validate_primary_key(statement_options);
         auto json_cache = stmt.maybe_prepare_json_cache(statement_options);
         auto keys = stmt.build_partition_keys(statement_options, json_cache);
 

--- a/cql3/statements/strong_consistency/modification_statement.cc
+++ b/cql3/statements/strong_consistency/modification_statement.cc
@@ -55,6 +55,7 @@ future<shared_ptr<result_message>> modification_statement::execute_without_check
         std::optional<service::group0_guard> guard) const
 {
     validate_write_consistency_level(options.get_consistency());
+    _statement->restrictions().validate_primary_key(options);
 
     auto timeout = db::timeout_clock::now() + _statement->get_timeout(qs.get_client_state(), options);
     auto json_cache = _statement->maybe_prepare_json_cache(options);

--- a/cql3/statements/strong_consistency/modification_statement.cc
+++ b/cql3/statements/strong_consistency/modification_statement.cc
@@ -36,12 +36,6 @@ future<shared_ptr<result_message>> modification_statement::execute(query_process
             .then(cql_transport::messages::propagate_exception_as_future<shared_ptr<result_message>>);
 }
 
-static void validate_consistency_level(const db::consistency_level& cl) {
-    if (cl != db::consistency_level::QUORUM && cl != db::consistency_level::LOCAL_QUORUM) {
-        throw exceptions::invalid_request_exception("Strongly consistent writes must use QUORUM/LOCAL_QUORUM consistency level");
-    }
-}
-
 mutation modification_statement::get_mutation(const query_options& options, api::timestamp_type ts,
         base_statement::json_cache_opt& json_cache, const std::vector<dht::partition_range>& keys) const {
     const auto prefetch_data = update_parameters::prefetch_data(_statement->s);
@@ -60,7 +54,7 @@ future<shared_ptr<result_message>> modification_statement::execute_without_check
         query_processor& qp, service::query_state& qs, const query_options& options,
         std::optional<service::group0_guard> guard) const
 {
-    validate_consistency_level(options.get_consistency());
+    validate_write_consistency_level(options.get_consistency());
 
     auto timeout = db::timeout_clock::now() + _statement->get_timeout(qs.get_client_state(), options);
     auto json_cache = _statement->maybe_prepare_json_cache(options);

--- a/cql3/statements/strong_consistency/statement_helpers.cc
+++ b/cql3/statements/strong_consistency/statement_helpers.cc
@@ -8,6 +8,7 @@
 
 #include "statement_helpers.hh"
 
+#include "exceptions/exceptions.hh"
 #include "transport/messages/result_message_base.hh"
 #include "cql3/query_processor.hh"
 #include "replica/database.hh"
@@ -36,6 +37,12 @@ future<::shared_ptr<cql_transport::messages::result_message>> redirect_statement
 bool is_strongly_consistent(data_dictionary::database db, std::string_view ks_name) {
     const auto* tablet_aware_rs = db.find_keyspace(ks_name).get_replication_strategy().maybe_as_tablet_aware();
     return tablet_aware_rs && tablet_aware_rs->get_consistency() != data_dictionary::consistency_config_option::eventual;
+}
+
+void validate_write_consistency_level(const db::consistency_level& cl) {
+    if (cl != db::consistency_level::QUORUM && cl != db::consistency_level::LOCAL_QUORUM) {
+        throw exceptions::invalid_request_exception("Strongly consistent writes must use QUORUM/LOCAL_QUORUM consistency level");
+    }
 }
 
 }

--- a/cql3/statements/strong_consistency/statement_helpers.hh
+++ b/cql3/statements/strong_consistency/statement_helpers.hh
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "cql3/cql_statement.hh"
+#include "db/consistency_level_type.hh"
 #include "locator/tablets.hh"
 
 namespace service::strong_consistency { struct stats; }
@@ -25,5 +26,7 @@ future<::shared_ptr<cql_transport::messages::result_message>> redirect_statement
     locator::host_id_or_exception_callback on_forwarding_finished = {});
 
 bool is_strongly_consistent(data_dictionary::database db, std::string_view ks_name);
+
+void validate_write_consistency_level(const db::consistency_level& cl);
 
 }

--- a/db/view/view.cc
+++ b/db/view/view.cc
@@ -59,6 +59,7 @@
 #include "keys/keys.hh"
 #include "locator/abstract_replication_strategy.hh"
 #include "locator/network_topology_strategy.hh"
+#include "locator/tablet_replication_strategy.hh"
 #include "mutation/mutation.hh"
 #include "mutation/mutation_partition.hh"
 #include <seastar/core/on_internal_error.hh>
@@ -3557,14 +3558,20 @@ void validate_view_keyspace(const data_dictionary::database& db, std::string_vie
     const auto& rs = db.find_keyspace(keyspace_name).get_replication_strategy();
 
     if (rs.uses_tablets() && !db.features().views_with_tablets) {
-        throw std::logic_error("Materialized views and secondary indexes are not supported on base tables with tablets. "
+        throw exceptions::invalid_request_exception("Materialized views and secondary indexes are not supported on base tables with tablets. "
                 "To be able to use them, make sure all nodes in the cluster are upgraded.");
+    }
+
+    const auto* tablet_rs = rs.maybe_as_tablet_aware();
+    if (tablet_rs && tablet_rs->get_consistency() != data_dictionary::consistency_config_option::eventual) {
+        throw exceptions::invalid_request_exception(
+                "Materialized views and secondary indexes are not supported on tables in strongly consistent keyspaces");
     }
 
     try {
         locator::assert_rf_rack_valid_keyspace(keyspace_name, tmptr, rs);
     } catch (const std::invalid_argument& e) {
-        throw std::logic_error(fmt::format(
+        throw exceptions::invalid_request_exception(fmt::format(
             "Materialized views and secondary indexes are not supported on the keyspace '{}': {}",
             keyspace_name, e.what()));
     }

--- a/service/strong_consistency/coordinator.cc
+++ b/service/strong_consistency/coordinator.cc
@@ -320,6 +320,12 @@ future<value_or_redirect<>> coordinator::mutate(schema_ptr schema,
             return std::make_exception_ptr(exceptions::server_exception(
                 "The outcome of this statement is unknown. It may or may not have been applied. "
                 "Retrying the statement may be necessary."));
+        } else if (auto* too_big = try_catch<raft::command_is_too_big_error>(ex)) {
+            logger.trace("mutate(): command of {} bytes exceeds the limit of {}, table {}.{}, token {}",
+                too_big->command_size, too_big->limit, schema->ks_name(), schema->cf_name(), token);
+            ++_stats.write_errors_other;
+            return std::make_exception_ptr(exceptions::invalid_request_exception(fmt::format(
+                "Strongly consistent write of {} bytes exceeds the limit of {} bytes", too_big->command_size, too_big->limit)));
         } else {
             ++_stats.write_errors_other;
             logger.trace("mutate(): unknown exception {}, table {}.{}, token {}, {}",

--- a/test/cluster/test_strong_consistency_validation.py
+++ b/test/cluster/test_strong_consistency_validation.py
@@ -1,0 +1,38 @@
+#
+# Copyright (C) 2026-present ScyllaDB
+#
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
+#
+
+# Tests for strongly consistent keyspaces that need a server started with
+# a specific configuration or an error injection.
+
+import pytest
+
+from test.pylib.scylla_cluster_manager import ScyllaClusterManager
+from test.cluster.util import new_test_keyspace
+from cassandra.protocol import InvalidRequest
+
+DEFAULT_CONFIG = {'experimental_features': ['strongly-consistent-tables']}
+
+SC_KS_OPTS = ("WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} "
+              "AND tablets = {'initial': 1} AND consistency = 'global'")
+
+
+@pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
+async def test_counter_table_creation_during_upgrade(manager: ScyllaClusterManager):
+    """
+    The strongly consistent check runs before the counters-with-tablets
+    feature check. With the feature suppressed the cluster looks
+    mid-upgrade and both conditions hold. The permanent strongly
+    consistent error must be the one thrown, not the transient upgrade
+    hint.
+    """
+    config = DEFAULT_CONFIG | {'error_injections_at_startup': [
+        {'name': 'suppress_features', 'value': 'COUNTERS_WITH_TABLETS'}]}
+    server = await manager.server_add(config=config)
+    cql, _ = await manager.get_ready_cql([server])
+
+    async with new_test_keyspace(manager, SC_KS_OPTS) as ks:
+        with pytest.raises(InvalidRequest, match="counters are not supported in strongly consistent keyspaces"):
+            await cql.run_async(f"CREATE TABLE {ks}.counters (pk int PRIMARY KEY, c counter)")

--- a/test/cluster/test_strong_consistency_validation.py
+++ b/test/cluster/test_strong_consistency_validation.py
@@ -10,7 +10,7 @@
 import pytest
 
 from test.pylib.scylla_cluster_manager import ScyllaClusterManager
-from test.cluster.util import new_test_keyspace
+from test.cluster.util import new_test_keyspace, new_test_table
 from cassandra.protocol import InvalidRequest
 
 DEFAULT_CONFIG = {'experimental_features': ['strongly-consistent-tables']}
@@ -36,3 +36,32 @@ async def test_counter_table_creation_during_upgrade(manager: ScyllaClusterManag
     async with new_test_keyspace(manager, SC_KS_OPTS) as ks:
         with pytest.raises(InvalidRequest, match="counters are not supported in strongly consistent keyspaces"):
             await cql.run_async(f"CREATE TABLE {ks}.counters (pk int PRIMARY KEY, c counter)")
+
+
+async def test_cell_only_writes_on_sc_logstor_table(manager: ScyllaClusterManager):
+    """
+    UPDATE and column deletes on a logstor table in a strongly consistent
+    keyspace are rejected. logstor needs a row marker or a partition
+    tombstone on every mutation. A write without one fails inside raft
+    apply and aborts the node.
+    """
+    config = {'experimental_features': ['strongly-consistent-tables', 'logstor']}
+    server = await manager.server_add(config=config)
+    cql, _ = await manager.get_ready_cql([server])
+
+    async with new_test_keyspace(manager, SC_KS_OPTS) as ks:
+        async with new_test_table(manager, ks, "pk int PRIMARY KEY, v int", " WITH storage_engine = 'logstor'") as table:
+            await cql.run_async(f"INSERT INTO {table} (pk, v) VALUES (1, 1)")
+
+            update_msg = "UPDATE is not supported on logstor tables in strongly consistent keyspaces"
+            with pytest.raises(InvalidRequest, match=update_msg):
+                await cql.run_async(f"UPDATE {table} SET v = 2 WHERE pk = 1")
+            with pytest.raises(InvalidRequest, match=update_msg):
+                await cql.run_async(f"BEGIN BATCH UPDATE {table} SET v = 2 WHERE pk = 1; APPLY BATCH")
+            with pytest.raises(InvalidRequest, match="Deleting individual columns is not supported on logstor tables in strongly consistent keyspaces"):
+                await cql.run_async(f"DELETE v FROM {table} WHERE pk = 1")
+
+            await cql.run_async(f"DELETE FROM {table} WHERE pk = 1")
+            await cql.run_async(f"INSERT INTO {table} (pk, v) VALUES (1, 3)")
+            rows = await cql.run_async(f"SELECT v FROM {table} WHERE pk = 1")
+            assert [r.v for r in rows] == [3]

--- a/test/cqlpy/strong_consistency/test_strong_consistency.py
+++ b/test/cqlpy/strong_consistency/test_strong_consistency.py
@@ -290,3 +290,20 @@ def test_per_partition_rate_limit_on_sc_table(cql, sc_keyspace):
     with new_test_table(cql, sc_keyspace, "pk int PRIMARY KEY, v int") as table:
         with pytest.raises(ConfigurationException, match=rate_limit_msg):
             cql.execute(f"ALTER TABLE {table} WITH per_partition_rate_limit = {{'max_reads_per_second': 100}}")
+
+
+def test_views_and_indexes_on_sc_table(cql, sc_keyspace):
+    """
+    Materialized views and secondary indexes are rejected on tables in
+    strongly consistent keyspaces. They would never be updated: view
+    updates are generated on the coordinator write path, which strongly
+    consistent writes bypass.
+    """
+    with new_test_table(cql, sc_keyspace, "pk int PRIMARY KEY, v int") as table:
+        error_msg = "not supported on tables in strongly consistent keyspaces"
+        with pytest.raises(InvalidRequest, match=error_msg):
+            cql.execute(f"CREATE MATERIALIZED VIEW {table}_mv AS"
+                        f" SELECT * FROM {table} WHERE v IS NOT NULL AND pk IS NOT NULL"
+                        f" PRIMARY KEY (v, pk)")
+        with pytest.raises(InvalidRequest, match=error_msg):
+            cql.execute(f"CREATE INDEX ON {table} (v)")

--- a/test/cqlpy/strong_consistency/test_strong_consistency.py
+++ b/test/cqlpy/strong_consistency/test_strong_consistency.py
@@ -274,3 +274,19 @@ def test_cdc_on_sc_table(cql, sc_keyspace):
     with new_test_table(cql, sc_keyspace, "pk int PRIMARY KEY, v int") as table:
         with pytest.raises(InvalidRequest, match=error_msg):
             cql.execute(f"ALTER TABLE {table} WITH cdc = {{'enabled': true}}")
+
+
+def test_per_partition_rate_limit_on_sc_table(cql, sc_keyspace):
+    """
+    per_partition_rate_limit is rejected for tables in strongly
+    consistent keyspaces. Rate limits are enforced on the coordinator
+    read and write paths, which strongly consistent queries bypass.
+    """
+    rate_limit_msg = "Per-partition rate limit is not supported in strongly consistent keyspaces"
+    with pytest.raises(ConfigurationException, match=rate_limit_msg):
+        cql.execute(f"CREATE TABLE {sc_keyspace}.{unique_name()} (pk int PRIMARY KEY, v int)"
+                    " WITH per_partition_rate_limit = {'max_writes_per_second': 100}")
+
+    with new_test_table(cql, sc_keyspace, "pk int PRIMARY KEY, v int") as table:
+        with pytest.raises(ConfigurationException, match=rate_limit_msg):
+            cql.execute(f"ALTER TABLE {table} WITH per_partition_rate_limit = {{'max_reads_per_second': 100}}")

--- a/test/cqlpy/strong_consistency/test_strong_consistency.py
+++ b/test/cqlpy/strong_consistency/test_strong_consistency.py
@@ -11,6 +11,8 @@
 # these tests run against gets the strongly-consistent-tables feature.
 #############################################################################
 
+import re
+
 import pytest
 from cassandra.cluster import ConsistencyLevel
 from cassandra.protocol import ConfigurationException, InvalidRequest
@@ -483,3 +485,19 @@ def test_null_primary_key_on_sc_table(cql, sc_keyspace):
             cql.execute(batch)
 
         assert list(cql.execute(f"SELECT * FROM {table} WHERE pk = 1")) == []
+
+
+def test_oversized_write_on_sc_table(cql, sc_keyspace):
+    """
+    A write whose raft command exceeds the command size limit of the
+    group is rejected with a clear error, not the raft error surfacing as
+    a server error.
+    """
+    with new_test_table(cql, sc_keyspace, "pk int PRIMARY KEY, v blob") as table:
+        insert = cql.prepare(f"INSERT INTO {table} (pk, v) VALUES (?, ?)")
+        cql.execute(insert, [1, b'x' * 1024])
+        with pytest.raises(InvalidRequest, match="Strongly consistent write of .* bytes exceeds the limit of .* bytes") as e:
+            cql.execute(insert, [2, b'x' * (200 * 1024)])
+        m = re.search(r"write of (\d+) bytes exceeds the limit of (\d+) bytes", str(e.value))
+        size, limit = int(m.group(1)), int(m.group(2))
+        assert size >= 200 * 1024 > limit

--- a/test/cqlpy/strong_consistency/test_strong_consistency.py
+++ b/test/cqlpy/strong_consistency/test_strong_consistency.py
@@ -416,3 +416,18 @@ def test_mixed_keyspace_batch_on_sc_table(cql, sc_keyspace, test_keyspace):
                     INSERT INTO {ec_table} (pk, v) VALUES (1, 1);
                     APPLY BATCH
                 """)
+
+
+def test_group_by_on_sc_table(cql, sc_keyspace):
+    """
+    GROUP BY is rejected on strongly consistent SELECTs. The strongly
+    consistent read path builds its result set without the grouping
+    indices, so an aggregate over GROUP BY would return one global row
+    instead of one row per group.
+    """
+    with new_test_table(cql, sc_keyspace, "pk int, ck int, v int, PRIMARY KEY (pk, ck)") as table:
+        for ck in (1, 2, 3):
+            cql.execute(f"INSERT INTO {table} (pk, ck, v) VALUES (1, {ck}, {ck})")
+
+        with pytest.raises(InvalidRequest, match="Strongly consistent queries don't support GROUP BY"):
+            cql.execute(f"SELECT ck, count(v) FROM {table} WHERE pk = 1 GROUP BY pk, ck")

--- a/test/cqlpy/strong_consistency/test_strong_consistency.py
+++ b/test/cqlpy/strong_consistency/test_strong_consistency.py
@@ -462,3 +462,24 @@ def test_debug_selects_on_sc_table(cql, sc_keyspace, test_keyspace):
 
         with new_materialized_view(cql, ec_table, '*', 'v, pk', 'v is not null and pk is not null') as mv:
             assert list(cql.execute(f"PRUNE MATERIALIZED VIEW {mv} WHERE v = 2")) == []
+
+
+def test_null_primary_key_on_sc_table(cql, sc_keyspace):
+    """
+    Null primary key values are rejected on strongly consistent writes,
+    as on eventually consistent ones. Without the check a null clustering
+    key value was accepted and the write changed nothing.
+    """
+    with new_test_table(cql, sc_keyspace, "pk int, ck int, v int, PRIMARY KEY (pk, ck)") as table:
+        insert = cql.prepare(f"INSERT INTO {table} (pk, ck, v) VALUES (?, ?, ?)")
+        with pytest.raises(InvalidRequest, match="Invalid null value in condition for column ck"):
+            cql.execute(insert, [1, None, 1])
+        with pytest.raises(InvalidRequest, match="Invalid null value in condition for column pk"):
+            cql.execute(insert, [None, 1, 1])
+
+        batch = BatchStatement(batch_type=BatchType.UNLOGGED)
+        batch.add(insert, [1, None, 1])
+        with pytest.raises(InvalidRequest, match="Invalid null value in condition for column ck"):
+            cql.execute(batch)
+
+        assert list(cql.execute(f"SELECT * FROM {table} WHERE pk = 1")) == []

--- a/test/cqlpy/strong_consistency/test_strong_consistency.py
+++ b/test/cqlpy/strong_consistency/test_strong_consistency.py
@@ -258,3 +258,19 @@ def test_counter_batch_on_sc_table(cql, sc_keyspace):
         batch.add(cql.prepare(f"INSERT INTO {table} (pk, v) VALUES (?, ?)"), (1, 2))
         with pytest.raises(InvalidRequest, match=error_msg):
             cql.execute(batch)
+
+
+def test_cdc_on_sc_table(cql, sc_keyspace):
+    """
+    CDC is rejected on tables in strongly consistent keyspaces, at
+    CREATE TABLE and with ALTER TABLE. The CDC log would never be
+    populated: log rows are generated on the coordinator write path,
+    which strongly consistent writes bypass.
+    """
+    error_msg = "CDC is not supported in strongly consistent keyspaces"
+    with pytest.raises(InvalidRequest, match=error_msg):
+        cql.execute(f"CREATE TABLE {sc_keyspace}.{unique_name()} (pk int PRIMARY KEY, v int) WITH cdc = {{'enabled': true}}")
+
+    with new_test_table(cql, sc_keyspace, "pk int PRIMARY KEY, v int") as table:
+        with pytest.raises(InvalidRequest, match=error_msg):
+            cql.execute(f"ALTER TABLE {table} WITH cdc = {{'enabled': true}}")

--- a/test/cqlpy/strong_consistency/test_strong_consistency.py
+++ b/test/cqlpy/strong_consistency/test_strong_consistency.py
@@ -307,3 +307,36 @@ def test_views_and_indexes_on_sc_table(cql, sc_keyspace):
                         f" PRIMARY KEY (v, pk)")
         with pytest.raises(InvalidRequest, match=error_msg):
             cql.execute(f"CREATE INDEX ON {table} (v)")
+
+
+def test_lwt_on_sc_table(cql, sc_keyspace):
+    """
+    Conditional statements (LWT) are rejected on strongly consistent
+    tables, standalone and inside a batch. The strongly consistent
+    execution path never evaluates conditions, so accepting them would
+    silently execute the write unconditionally. INSERT JSON is covered
+    separately: its IF NOT EXISTS is not tracked as a condition in the
+    prepared statement.
+    """
+    with new_test_table(cql, sc_keyspace, "pk int PRIMARY KEY, v int") as table:
+        cql.execute(f"INSERT INTO {table} (pk, v) VALUES (1, 1)")
+
+        error_msg = "Strongly consistent updates don't support conditions"
+        with pytest.raises(InvalidRequest, match=error_msg):
+            cql.execute(f"INSERT INTO {table} (pk, v) VALUES (1, 999) IF NOT EXISTS")
+        with pytest.raises(InvalidRequest, match=error_msg):
+            cql.execute(f"UPDATE {table} SET v = 7 WHERE pk = 1 IF v = 12345")
+        with pytest.raises(InvalidRequest, match=error_msg):
+            cql.execute(f"UPDATE {table} SET v = 7 WHERE pk = 1 IF EXISTS")
+        with pytest.raises(InvalidRequest, match=error_msg):
+            cql.execute(f"DELETE FROM {table} WHERE pk = 1 IF EXISTS")
+        with pytest.raises(InvalidRequest, match=error_msg):
+            cql.execute(f"""INSERT INTO {table} JSON '{{"pk": 1, "v": 999}}' IF NOT EXISTS""")
+        with pytest.raises(InvalidRequest, match=error_msg):
+            cql.execute(f"""
+                BEGIN BATCH
+                UPDATE {table} SET v = 8 WHERE pk = 1 IF v = 12345;
+                APPLY BATCH
+            """)
+
+        assert cql.execute(f"SELECT v FROM {table} WHERE pk = 1").one().v == 1

--- a/test/cqlpy/strong_consistency/test_strong_consistency.py
+++ b/test/cqlpy/strong_consistency/test_strong_consistency.py
@@ -55,17 +55,16 @@ def test_reject_user_provided_timestamps(cql, sc_keyspace):
             cql.execute(f"UPDATE {table} USING TIMESTAMP 23 SET v = 13 WHERE pk = 0")
         with pytest.raises(InvalidRequest, match=error_msg):
             cql.execute(f"DELETE FROM {table} USING TIMESTAMP 23 WHERE pk = 0")
-        # FIXME(SCYLLADB-977):
-        # Add test cases for batches with timestamps. Remember to
-        # handle both whole-batch timestamps, e.g.
-        #   BEGIN BATCH USING TIMESTAMP ts
-        #     ...
-        #   APPLY BATCH
-        # as well as timestamps for individual items, e.g.
-        #   BEGIN BATCH
-        #     INSERT INTO ... USING TIMESTAMP st;
-        #     ...
-        #   APPLY BATCH
+        # A timestamp on an individual batch item, rejected when the
+        # inner statements are prepared. Whole-batch timestamps are
+        # covered by test_batch_attributes_on_sc_table.
+        with pytest.raises(InvalidRequest, match=error_msg):
+            cql.execute(f"""
+                BEGIN BATCH
+                INSERT INTO {table} (pk, v) VALUES (0, 13) USING TIMESTAMP 23;
+                INSERT INTO {table} (pk, v) VALUES (0, 14);
+                APPLY BATCH
+            """)
 
 
 @pytest.mark.parametrize("batch_mode", ["text", "prepared"], ids=["text", "prepared"])
@@ -340,3 +339,28 @@ def test_lwt_on_sc_table(cql, sc_keyspace):
             """)
 
         assert cql.execute(f"SELECT v FROM {table} WHERE pk = 1").one().v == 1
+
+
+def test_batch_attributes_on_sc_table(cql, sc_keyspace):
+    """
+    Batch-level USING TTL and USING TIMESTAMP are rejected on strongly
+    consistent batches. The strongly consistent batch reads its USING
+    attributes only to compute the timeout, so both would be parsed
+    and then silently ignored.
+    """
+    with new_test_table(cql, sc_keyspace, "pk int PRIMARY KEY, v int") as table:
+        with pytest.raises(InvalidRequest, match="Global TTL on the BATCH statement is not supported"):
+            cql.execute(f"""
+                BEGIN BATCH USING TTL 100
+                INSERT INTO {table} (pk, v) VALUES (1, 2);
+                INSERT INTO {table} (pk, v) VALUES (1, 3);
+                APPLY BATCH
+            """)
+
+        with pytest.raises(InvalidRequest, match="Strongly consistent queries don't support user-provided timestamps"):
+            cql.execute(f"""
+                BEGIN BATCH USING TIMESTAMP 42
+                INSERT INTO {table} (pk, v) VALUES (2, 2);
+                INSERT INTO {table} (pk, v) VALUES (2, 3);
+                APPLY BATCH
+            """)

--- a/test/cqlpy/strong_consistency/test_strong_consistency.py
+++ b/test/cqlpy/strong_consistency/test_strong_consistency.py
@@ -18,7 +18,7 @@ from cassandra.query import BatchStatement, BatchType, SimpleStatement
 
 from test.pylib.skip_types import skip_env
 
-from ..util import new_test_table, unique_name
+from ..util import new_materialized_view, new_test_table, unique_name
 
 
 # A keyspace whose tables are strongly consistent. Cassandra and the --vnodes
@@ -431,3 +431,34 @@ def test_group_by_on_sc_table(cql, sc_keyspace):
 
         with pytest.raises(InvalidRequest, match="Strongly consistent queries don't support GROUP BY"):
             cql.execute(f"SELECT ck, count(v) FROM {table} WHERE pk = 1 GROUP BY pk, ck")
+
+
+def test_debug_selects_on_sc_table(cql, sc_keyspace, test_keyspace):
+    """
+    SELECT FROM MUTATION_FRAGMENTS() and PRUNE MATERIALIZED VIEW are
+    rejected on strongly consistent tables. Both would otherwise be
+    dispatched as plain strongly consistent reads: an internal server
+    error for MUTATION_FRAGMENTS(), a silent no-op for PRUNE
+    MATERIALIZED VIEW. The eventually consistent behavior of both
+    statements serves as contrast: MUTATION_FRAGMENTS() returns the
+    partition's fragments, and PRUNE is rejected on a plain table and
+    returns no rows from a view.
+    """
+    with new_test_table(cql, sc_keyspace, "pk int PRIMARY KEY, v int") as table:
+        cql.execute(f"INSERT INTO {table} (pk, v) VALUES (1, 2)")
+
+        with pytest.raises(InvalidRequest, match="MUTATION_FRAGMENTS.. is not supported on strongly consistent tables"):
+            cql.execute(f"SELECT * FROM MUTATION_FRAGMENTS({table}) WHERE pk = 1")
+
+        with pytest.raises(InvalidRequest, match="PRUNE MATERIALIZED VIEW is not supported on strongly consistent tables"):
+            cql.execute(f"PRUNE MATERIALIZED VIEW {table} WHERE pk = 1")
+
+    with new_test_table(cql, test_keyspace, "pk int PRIMARY KEY, v int") as ec_table:
+        cql.execute(f"INSERT INTO {ec_table} (pk, v) VALUES (1, 2)")
+        assert len(list(cql.execute(f"SELECT * FROM MUTATION_FRAGMENTS({ec_table}) WHERE pk = 1"))) > 0
+
+        with pytest.raises(InvalidRequest, match="Ghost rows can only be deleted from materialized views"):
+            cql.execute(f"PRUNE MATERIALIZED VIEW {ec_table} WHERE pk = 1")
+
+        with new_materialized_view(cql, ec_table, '*', 'v, pk', 'v is not null and pk is not null') as mv:
+            assert list(cql.execute(f"PRUNE MATERIALIZED VIEW {mv} WHERE v = 2")) == []

--- a/test/cqlpy/strong_consistency/test_strong_consistency.py
+++ b/test/cqlpy/strong_consistency/test_strong_consistency.py
@@ -388,3 +388,31 @@ def test_batch_consistency_level_on_sc_table(cql, sc_keyspace):
             f"BEGIN BATCH INSERT INTO {table} (pk, v) VALUES (1, 2); APPLY BATCH",
             consistency_level=ConsistencyLevel.QUORUM))
         assert cql.execute(f"SELECT v FROM {table} WHERE pk = 1").one().v == 2
+
+
+def test_mixed_keyspace_batch_on_sc_table(cql, sc_keyspace, test_keyspace):
+    """
+    A CQL text batch that mixes statements on strongly consistent and
+    eventually consistent keyspaces is rejected, in both statement
+    orders, like on the native protocol batch path. Such a batch
+    cannot be executed: strongly consistent writes go through the
+    tablet raft groups and eventually consistent writes do not.
+    """
+    with new_test_table(cql, sc_keyspace, "pk int PRIMARY KEY, v int") as sc_table:
+        with new_test_table(cql, test_keyspace, "pk int PRIMARY KEY, v int") as ec_table:
+            error_msg = "Cannot mix strongly consistent and eventually consistent statements in a batch"
+            with pytest.raises(InvalidRequest, match=error_msg):
+                cql.execute(f"""
+                    BEGIN BATCH
+                    INSERT INTO {ec_table} (pk, v) VALUES (1, 1);
+                    INSERT INTO {sc_table} (pk, v) VALUES (1, 2);
+                    APPLY BATCH
+                """)
+
+            with pytest.raises(InvalidRequest, match=error_msg):
+                cql.execute(f"""
+                    BEGIN BATCH
+                    INSERT INTO {sc_table} (pk, v) VALUES (1, 2);
+                    INSERT INTO {ec_table} (pk, v) VALUES (1, 1);
+                    APPLY BATCH
+                """)

--- a/test/cqlpy/strong_consistency/test_strong_consistency.py
+++ b/test/cqlpy/strong_consistency/test_strong_consistency.py
@@ -12,8 +12,9 @@
 #############################################################################
 
 import pytest
+from cassandra.cluster import ConsistencyLevel
 from cassandra.protocol import ConfigurationException, InvalidRequest
-from cassandra.query import BatchStatement, BatchType
+from cassandra.query import BatchStatement, BatchType, SimpleStatement
 
 from test.pylib.skip_types import skip_env
 
@@ -364,3 +365,26 @@ def test_batch_attributes_on_sc_table(cql, sc_keyspace):
                 INSERT INTO {table} (pk, v) VALUES (2, 3);
                 APPLY BATCH
             """)
+
+
+def test_batch_consistency_level_on_sc_table(cql, sc_keyspace):
+    """
+    A strongly consistent batch requires QUORUM or LOCAL_QUORUM, like
+    a standalone strongly consistent write.
+    """
+    with new_test_table(cql, sc_keyspace, "pk int PRIMARY KEY, v int") as table:
+        cl_error = "Strongly consistent writes must use QUORUM/LOCAL_QUORUM"
+        with pytest.raises(InvalidRequest, match=cl_error):
+            cql.execute(SimpleStatement(
+                f"INSERT INTO {table} (pk, v) VALUES (1, 2)",
+                consistency_level=ConsistencyLevel.ONE))
+
+        with pytest.raises(InvalidRequest, match=cl_error):
+            cql.execute(SimpleStatement(
+                f"BEGIN BATCH INSERT INTO {table} (pk, v) VALUES (1, 2); APPLY BATCH",
+                consistency_level=ConsistencyLevel.ONE))
+
+        cql.execute(SimpleStatement(
+            f"BEGIN BATCH INSERT INTO {table} (pk, v) VALUES (1, 2); APPLY BATCH",
+            consistency_level=ConsistencyLevel.QUORUM))
+        assert cql.execute(f"SELECT v FROM {table} WHERE pk = 1").one().v == 2

--- a/test/cqlpy/strong_consistency/test_strong_consistency.py
+++ b/test/cqlpy/strong_consistency/test_strong_consistency.py
@@ -82,8 +82,7 @@ def test_batch(cql, sc_keyspace, batch_mode):
     Rejection cases:
     - batch touching multiple tables,
     - batch touching multiple partitions,
-    - statement touching multiple partition keys,
-    - counter batch.
+    - statement touching multiple partition keys.
     """
 
     def _prepared_batch_type(kind):
@@ -91,8 +90,6 @@ def test_batch(cql, sc_keyspace, batch_mode):
             return BatchType.LOGGED
         if kind == "unlogged":
             return BatchType.UNLOGGED
-        if kind == "counter":
-            return BatchType.COUNTER
         raise ValueError(f"Unexpected batch kind: {kind}")
 
     def _render_text_statement(table_name, op, args):
@@ -108,25 +105,17 @@ def test_batch(cql, sc_keyspace, batch_mode):
         if op == "delete_in":
             pk1, pk2, ck = args
             return f"DELETE FROM {table_name} WHERE pk IN ({pk1}, {pk2}) AND ck = {ck}"
-        if op == "counter_add":
-            delta, pk = args
-            return f"UPDATE {table_name} SET c = c + {delta} WHERE pk = {pk}"
         raise ValueError(f"Unexpected operation: {op}")
 
-    def _make_batch_runner(table_name, *, counter_table=False):
+    def _make_batch_runner(table_name):
         prepared_statements = {}
         if batch_mode == "prepared":
-            if counter_table:
-                prepared_statements = {
-                    "counter_add": cql.prepare(f"UPDATE {table_name} SET c = c + ? WHERE pk = ?"),
-                }
-            else:
-                prepared_statements = {
-                    "insert": cql.prepare(f"INSERT INTO {table_name} (pk, ck, v) VALUES (?, ?, ?)"),
-                    "update": cql.prepare(f"UPDATE {table_name} SET v = ? WHERE pk = ? AND ck = ?"),
-                    "delete": cql.prepare(f"DELETE FROM {table_name} WHERE pk = ? AND ck = ?"),
-                    "delete_in": cql.prepare(f"DELETE FROM {table_name} WHERE pk IN (?, ?) AND ck = ?"),
-                }
+            prepared_statements = {
+                "insert": cql.prepare(f"INSERT INTO {table_name} (pk, ck, v) VALUES (?, ?, ?)"),
+                "update": cql.prepare(f"UPDATE {table_name} SET v = ? WHERE pk = ? AND ck = ?"),
+                "delete": cql.prepare(f"DELETE FROM {table_name} WHERE pk = ? AND ck = ?"),
+                "delete_in": cql.prepare(f"DELETE FROM {table_name} WHERE pk IN (?, ?) AND ck = ?"),
+            }
 
         def _run(ops, *, kind):
             if batch_mode == "prepared":
@@ -135,9 +124,7 @@ def test_batch(cql, sc_keyspace, batch_mode):
                     batch.add(prepared_statements[op], args)
                 return cql.execute(batch)
 
-            if kind == "counter":
-                begin = "BEGIN COUNTER BATCH"
-            elif kind == "unlogged":
+            if kind == "unlogged":
                 begin = "BEGIN UNLOGGED BATCH"
             elif kind == "logged":
                 begin = "BEGIN BATCH"
@@ -200,14 +187,6 @@ def test_batch(cql, sc_keyspace, batch_mode):
                         APPLY BATCH
                     """)
 
-    with new_test_table(cql, sc_keyspace, "pk int PRIMARY KEY, c counter") as table:
-        run_counter_batch = _make_batch_runner(table, counter_table=True)
-
-        with pytest.raises(InvalidRequest, match="Counter batches are not supported"):
-            run_counter_batch([
-                ("counter_add", (1, 1)),
-            ], kind="counter")
-
 
 # The single statement write path used to hand an empty JSON cache to the code
 # building the keys, so an INSERT ... JSON killed the coordinator on the
@@ -244,3 +223,38 @@ def test_insert_json_in_batch(cql, sc_keyspace):
             APPLY BATCH
         """)
         assert list(cql.execute(f"SELECT pk, v FROM {table} WHERE pk = 1")) == [(1, 2)]
+
+
+def test_counter_table_creation(cql, sc_keyspace):
+    """
+    Counter tables are rejected in strongly consistent keyspaces: a
+    counter update is a delta, and the write path would store it raw
+    instead of folding it into the counter value, aborting the node
+    when the counter is read back.
+    """
+    with pytest.raises(InvalidRequest, match="counters are not supported in strongly consistent keyspaces"):
+        cql.execute(f"CREATE TABLE {sc_keyspace}.{unique_name()} (pk int PRIMARY KEY, c counter)")
+
+
+def test_counter_batch_on_sc_table(cql, sc_keyspace):
+    """
+    Counter batches are rejected on strongly consistent keyspaces.
+    The batch type is checked before the statements in it, so the
+    batch here carries a regular INSERT. It could not carry a counter
+    update anyway: that needs a counter table, and counter tables
+    cannot be created in strongly consistent keyspaces (see
+    test_counter_table_creation).
+    """
+    with new_test_table(cql, sc_keyspace, "pk int PRIMARY KEY, v int") as table:
+        error_msg = "Counter batches are not supported with strongly consistent tables"
+        with pytest.raises(InvalidRequest, match=error_msg):
+            cql.execute(f"""
+                BEGIN COUNTER BATCH
+                INSERT INTO {table} (pk, v) VALUES (1, 2);
+                APPLY BATCH
+            """)
+
+        batch = BatchStatement(batch_type=BatchType.COUNTER)
+        batch.add(cql.prepare(f"INSERT INTO {table} (pk, v) VALUES (?, ?)"), (1, 2))
+        with pytest.raises(InvalidRequest, match=error_msg):
+            cql.execute(batch)


### PR DESCRIPTION
Strongly consistent keyspaces accept CQL that they cannot execute correctly. The user gets no signal that anything is wrong:

- Silently ignored: LWT conditions, batch-level `USING TIMESTAMP` and `USING TTL`, `GROUP BY`, batch consistency level, a null primary key value (the write succeeds and changes nothing).
- Data corrupted or diverged: a counter write aborts the node on the next read, a mixed batch writes into a strongly consistent table past its raft group, materialized views, indexes and CDC logs are created but never updated, an `UPDATE` on a logstor table aborts the node.
- Internal errors: `SELECT FROM MUTATION_FRAGMENTS()`, `PRUNE MATERIALIZED VIEW` runs as a plain `SELECT`, a write over the raft command size limit shows the raft error as `SERVER_ERROR`.

This series rejects each such statement with a clear error saying what is not supported. Each guard sits at the earliest point that has the needed context. Statements that work are left alone.

For reviewers, the series is 13 independent commits, one per case. Each commit adds the guard and the test that expects the error. Any commit can be dropped on its own. Every commit builds and passes its tests, for bisect.

Tests live in a new file, `test/cluster/test_strong_consistency_validation.py`. They run in `test/cluster` because the `strongly-consistent-tables` feature is experimental. They can move to the `cqlpy` strong consistency suite once it exists. This PR goes in that direction: https://github.com/scylladb/scylladb/pull/31350.

Fixes SCYLLADB-2580

This is an enhancement. No backport needed.