### PR TITLE
repair: validate the ranges_parallelism option

### DIFF
--- a/repair/repair.cc
+++ b/repair/repair.cc
@@ -25,6 +25,7 @@
 #include "partition_range_compat.hh"
 #include "utils/assert.hh"
 #include "utils/error_injection.hh"
+#include "utils/from_chars_exactly.hh"
 
 #include <boost/algorithm/string/predicate.hpp>
 #include <boost/algorithm/string/split.hpp>
@@ -1027,14 +1028,10 @@ struct repair_options {
         if (incremental) {
             throw std::runtime_error("unsupported incremental repair");
         }
-        // We do not currently support the distinction between "parallel" and
-        // "sequential" repair, and operate the same for both.
-        // We don't currently support "dc parallel" parallelism.
-        int parallelism = PARALLEL;
-        int_opt(parallelism, options, PARALLELISM_KEY);
-        if (parallelism != PARALLEL && parallelism != SEQUENTIAL) {
-            throw std::runtime_error(format("unsupported repair parallelism: {}", parallelism));
-        }
+        // We do not currently support the distinction between "parallel",
+        // "sequential" and "dc parallel" repair, and operate the same for all
+        // of them. Still, reject a value we do not recognize at all.
+        parallelism_opt(options, PARALLELISM_KEY);
         string_opt(start_token, options, START_TOKEN);
         string_opt(end_token, options, END_TOKEN);
 
@@ -1108,6 +1105,34 @@ private:
             }
             options.erase(it);
         }
+    }
+
+    // Nodetool sends the "parallelism" option as the name of Cassandra's
+    // RepairParallelism enum, e.g. "parallel", while other callers send the
+    // ordinal of that enum, e.g. "1". Accept both spellings. The value itself
+    // is unused, all we do is reject a value we do not recognize.
+    static void parallelism_opt(std::unordered_map<sstring, sstring>& options,
+            const sstring& key) {
+        auto it = options.find(key);
+        if (it == options.end()) {
+            return;
+        }
+        static const std::unordered_map<sstring, repair_parallelism> names = {
+            {"sequential", SEQUENTIAL},
+            {"parallel", PARALLEL},
+            {"dc_parallel", DATACENTER_AWARE},
+        };
+        const auto& value = it->second;
+        auto unsupported = [] (std::string_view value) {
+            return std::invalid_argument(format("unsupported repair parallelism: '{}'", value));
+        };
+        if (!names.contains(value)) {
+            auto parallelism = utils::from_chars_exactly<int>(std::string_view(value), unsupported);
+            if (parallelism != SEQUENTIAL && parallelism != PARALLEL && parallelism != DATACENTER_AWARE) {
+                throw unsupported(std::string_view(value));
+            }
+        }
+        options.erase(it);
     }
 
     static void string_opt(sstring& var,

--- a/repair/repair.cc
+++ b/repair/repair.cc
@@ -1044,7 +1044,17 @@ struct repair_options {
         int job_threads;
         int_opt(job_threads, options, JOB_THREADS_KEY);
 
-        int_opt(ranges_parallelism, options, RANGES_PARALLELISM_KEY);
+        // The default, -1, means no user-specified ranges_parallelism is
+        // applied, i.e. the per-task semaphore is not created at all. It is
+        // an internal sentinel, the user is not allowed to ask for it. Any
+        // non-positive value would create the semaphore with no units and
+        // hang the repair forever, so only accept positive values.
+        if (options.contains(RANGES_PARALLELISM_KEY)) {
+            int_opt(ranges_parallelism, options, RANGES_PARALLELISM_KEY);
+            if (ranges_parallelism < 1) {
+                throw std::invalid_argument(format("invalid ranges_parallelism: {}. It must be a positive integer", ranges_parallelism));
+            }
+        }
 
         bool_opt(small_table_optimization, options, SMALL_TABLE_OPTIMIZATION_KEY);
 
@@ -1098,11 +1108,11 @@ private:
             const sstring& key) {
         auto it = options.find(key);
         if (it != options.end()) {
-            errno = 0;
-            var = strtol(it->second.c_str(), nullptr, 10);
-            if (errno) {
-                throw(std::runtime_error(format("cannot parse integer: '{}'", it->second)));
-            }
+            // Throw std::invalid_argument so that the REST API reports a bad
+            // parameter (400) rather than an internal server error (500).
+            var = utils::from_chars_exactly<int>(std::string_view(it->second), [] (std::string_view value) {
+                return std::invalid_argument(format("cannot parse integer: '{}'", value));
+            });
             options.erase(it);
         }
     }

--- a/test/cluster/test_repair.py
+++ b/test/cluster/test_repair.py
@@ -855,3 +855,41 @@ async def test_tablet_migration_barrier_does_not_abort_vnode_repair(manager: Man
                                                host=servers[0].ip_addr,
                                                params={"id": str(sequence_number)})
     assert status == "SUCCESSFUL"
+
+
+async def test_repair_rejects_invalid_ranges_parallelism(manager):
+    """Verify that repair rejects invalid ranges_parallelism values.
+
+    ranges_parallelism was parsed with strtol without checking that anything
+    was parsed, so a non-numeric value silently became 0, and any value below
+    1 initialized the per-task semaphore with no units, hanging the repair
+    forever.
+    """
+    servers = await manager.servers_add(2, auto_rack_dc="dc1")
+
+    cql = manager.get_cql()
+
+    cql.execute("CREATE KEYSPACE ks WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 2} AND TABLETS = {'enabled': false}")
+    cql.execute("CREATE TABLE ks.tbl (pk int PRIMARY KEY)")
+
+    for value, error in [("0", "invalid ranges_parallelism"),
+                         ("-1", "invalid ranges_parallelism"),
+                         ("-2", "invalid ranges_parallelism"),
+                         ("abc", "cannot parse integer"),
+                         ("1x", "cannot parse integer")]:
+        params = {"columnFamilies": "tbl", "ranges_parallelism": value}
+        with pytest.raises(HTTPError, match=error):
+            await manager.api.client.post_json("/storage_service/repair_async/ks",
+                                               host=servers[0].ip_addr, params=params)
+
+    # A positive value, and omitting the option altogether, must keep working.
+    # repair_status without a timeout blocks until the repair reaches a
+    # terminal state, so the status read below is not racy.
+    for params in [{"columnFamilies": "tbl", "ranges_parallelism": "1"},
+                   {"columnFamilies": "tbl"}]:
+        sequence_number = await manager.api.client.post_json("/storage_service/repair_async/ks",
+                                                             host=servers[0].ip_addr, params=params)
+        status = await manager.api.client.get_json("/storage_service/repair_status",
+                                                   host=servers[0].ip_addr,
+                                                   params={"id": str(sequence_number)})
+        assert status == "SUCCESSFUL"

--- a/test/rest_api/test_storage_service.py
+++ b/test/rest_api/test_storage_service.py
@@ -787,6 +787,20 @@ def test_storage_service_system_keyspace_repair(rest_api):
     resp.raise_for_status()
     assert not [stats for stats in resp.json() if stats["sequence_number"] == sequence_number], "Repair task for keyspace with local replication strategy was created"
 
+# Nodetool sends the parallelism option as the name of Cassandra's
+# RepairParallelism enum, while other callers send the enum's ordinal. Both
+# have to be accepted, and anything else has to be rejected.
+@pytest.mark.parametrize("parallelism", ["sequential", "parallel", "dc_parallel", "0", "1", "2"])
+def test_storage_service_repair_parallelism(rest_api, parallelism):
+    resp = rest_api.send("POST", "storage_service/repair_async/system", {"parallelism": parallelism})
+    resp.raise_for_status()
+    assert resp.json() > 0, "Repair got invalid sequence number"
+
+@pytest.mark.parametrize("parallelism", ["3", "-1", "par", "1x"])
+def test_storage_service_repair_parallelism_invalid(rest_api, parallelism):
+    resp = rest_api.send("POST", "storage_service/repair_async/system", {"parallelism": parallelism})
+    assert resp.status_code == requests.codes.bad_request
+
 @pytest.mark.parametrize("tablets_enabled", ["true", "false"])
 def test_storage_service_get_natural_endpoints(cql, rest_api, tablets_enabled, skip_without_tablets):
     with new_test_keyspace(cql, f"WITH REPLICATION = {{ 'class' : 'NetworkTopologyStrategy', 'replication_factor' : 1 }} AND TABLETS = {{ 'enabled': {tablets_enabled} }}") as keyspace:

--- a/test/rest_api/test_storage_service.py
+++ b/test/rest_api/test_storage_service.py
@@ -801,6 +801,19 @@ def test_storage_service_repair_parallelism_invalid(rest_api, parallelism):
     resp = rest_api.send("POST", "storage_service/repair_async/system", {"parallelism": parallelism})
     assert resp.status_code == requests.codes.bad_request
 
+# The integer repair options are parsed strictly, and ranges_parallelism has to
+# be positive. An unusable value is a bad parameter, not a server error.
+@pytest.mark.parametrize("option,value", [("ranges_parallelism", "0"),
+                                          ("ranges_parallelism", "-1"),
+                                          ("ranges_parallelism", "abc"),
+                                          ("ranges_parallelism", "1x"),
+                                          ("ranges_parallelism", "9999999999"),
+                                          ("jobThreads", "abc"),
+                                          ("jobThreads", "1x")])
+def test_storage_service_repair_int_option_invalid(rest_api, option, value):
+    resp = rest_api.send("POST", "storage_service/repair_async/system", {option: value})
+    assert resp.status_code == requests.codes.bad_request
+
 @pytest.mark.parametrize("tablets_enabled", ["true", "false"])
 def test_storage_service_get_natural_endpoints(cql, rest_api, tablets_enabled, skip_without_tablets):
     with new_test_keyspace(cql, f"WITH REPLICATION = {{ 'class' : 'NetworkTopologyStrategy', 'replication_factor' : 1 }} AND TABLETS = {{ 'enabled': {tablets_enabled} }}") as keyspace:


### PR DESCRIPTION
The ranges_parallelism repair option was parsed with strtol without checking that anything was parsed, so a non-numeric value silently became 0. Internally, -1 means no user-specified ranges_parallelism is applied (the per-task semaphore is not created at all); any other value is used verbatim as the initial count of that semaphore, so 0, and therefore also any non-numeric value, as well as any negative value, make the first repair_range() wait on the semaphore forever and the repair task hangs until aborted.

Parse integer repair options strictly, rejecting trailing garbage, empty values and values that do not fit in an int. This also makes non-numeric parallelism and jobThreads values an error instead of silently parsing as 0.

Reject ranges_parallelism values below 1 whenever the option is given. The -1 sentinel is internal only, it is not a value the user is allowed to ask for over the REST API, so it is rejected as well and the option keeps its default only when it is not passed at all. The check throws std::invalid_argument, so the REST API reports it as a bad parameter (400) instead of an internal server error (500), like the neighbouring start/end token validation does.

Add a regression test checking that the invalid values are rejected and that a positive value, as well as omitting the option, still repairs successfully.

Fixes SCYLLADB-4112

Backport to all active branches. 