### PR TITLE
idl-compiler: validate [[version]] field ordering within a class

### DIFF
--- a/idl-compiler.py
+++ b/idl-compiler.py
@@ -680,7 +680,9 @@ def class_def_parse_action(tokens):
     template_params = None
     if 'template' in tokens:
         template_params = [ClassTemplateParam(typename=tp[0], name=tp[1]) for tp in tokens['template']]
-    return ClassDef(name=tokens['name'], members=class_members, final=is_final, stub=is_stub, attribute=attribute, template_params=template_params)
+    cls = ClassDef(name=tokens['name'], members=class_members, final=is_final, stub=is_stub, attribute=attribute, template_params=template_params)
+    validate_member_versioning(cls)
+    return cls
 
 
 def rpc_verb_param_parse_action(tokens):
@@ -927,6 +929,62 @@ def get_member_name(name):
 
 def get_members(cls):
     return [p for p in cls.members if not isinstance(p, ClassDef) and not isinstance(p, EnumDef)]
+
+
+def has_version(member):
+    '''True if a member's [[version]] attribute makes it optional on the wire.'''
+    return member.attribute is not None and member.attribute.startswith('version')
+
+
+def parse_version(attribute):
+    '''Parse the "version X.Y[.Z]" attribute string into a tuple of ints.'''
+    version = tuple(int(p) for p in attribute[len('version'):].strip().split('.'))
+    if len(version) not in (2, 3):
+        raise ValueError(f"version attribute '{attribute}' must have 2 or 3 components")
+    return version
+
+
+def validate_member_versioning(cls):
+    '''Enforce the [[version]] wire-format invariant for a class' members:
+    once a member is versioned, every member after it (in declaration/wire
+    order) must be versioned too, and version numbers must not decrease.
+    This is required because a versioned field is deserialized as
+    `(in.size()>0) ? deserialize(...) : default`, which only works correctly
+    for a field appended at the end of the wire layout. Also rejects
+    [[version]] members in a `final` class, since final classes carry no
+    size frame for skip() to fall back on.'''
+    prev_version = None
+    prev_name = None
+    for member in get_members(cls):
+        if has_version(member):
+            if cls.final:
+                raise TypeError(
+                    f"field '{member.name}' in class '{cls.name}' is [[version]] but the class is 'final' — "
+                    f"final classes have no size frame, so skip() cannot leave a missing versioned tail "
+                    f"unread; drop 'final' or drop [[version]] from '{member.name}'")
+            try:
+                version = parse_version(member.attribute)
+            except ValueError:
+                raise ValueError(
+                    f"field '{member.name}' in class '{cls.name}' has a malformed version attribute "
+                    f"'[[{member.attribute}]]' — expected [[version X.Y[.Z]]]") from None
+            if prev_version is not None:
+                n = max(len(prev_version), len(version))
+                padded_prev = prev_version + (0,) * (n - len(prev_version))
+                padded_cur = version + (0,) * (n - len(version))
+                if padded_cur < padded_prev:
+                    raise ValueError(
+                        f"field '{member.name}' in class '{cls.name}' has [[version {'.'.join(map(str, version))}]] "
+                        f"which is lower than the version of the preceding versioned field '{prev_name}' "
+                        f"([[version {'.'.join(map(str, prev_version))}]]) — [[version]] numbers must be "
+                        f"non-decreasing within a class")
+            prev_version = version
+            prev_name = member.name
+        elif prev_version is not None:
+            raise TypeError(
+                f"field '{member.name}' in class '{cls.name}' is not versioned but follows versioned field "
+                f"'{prev_name}' — new mandatory fields must come before all [[version]] fields, or be "
+                f"versioned themselves")
 
 
 def get_variant_type(t):


### PR DESCRIPTION
**Related to #31392** (also IDL-compiler work) but independent: no textual/code overlap, applies cleanly regardless of merge order.

## Motivation
A versioned field is deserialized as `(in.size()>0) ? deserialize(...) : default`, which only works correctly for a field appended at the end of the wire layout. Nothing enforced that invariant: a mandatory field placed after a versioned one, or non-decreasing version numbers, would silently misalign the wire format between old and new nodes.

## Changes
- Add `validate_member_versioning()`, run once per parsed class: once a member is `[[version]]`, every later member must be `[[version]]` too, and version numbers must be non-decreasing.
- Reject `[[version]]` members on a `final` class: a final class carries no size frame for `skip()` to fall back on, so a missing versioned tail can't be safely skipped.

## Tests
The full idl-compiler.py run against every `.idl.hh` file in the tree (part of any build) is a clean pass — the positive path (valid existing versioned fields) is exercised by the normal build. No dedicated unit test yet asserts the compiler actually rejects a malformed ordering/version-number case; happy to add one if wanted before merge.

## Results
Not applicable — this is a compile-time-only validation added to `idl-compiler.py`, it emits no different runtime code and has no runtime performance impact.
