### PR TITLE
test.py: update docs and guardrail for python version

### DIFF
--- a/docs/dev/testing.md
+++ b/docs/dev/testing.md
@@ -10,7 +10,7 @@ This is a manual for `test.py`.
 
 ## Installation
 
-To run `test.py`, Python 3.11 or higher is required.
+To run `test.py`, Python 3.14 or higher is required.
 `./install-dependencies.sh` should install all the required Python
 modules. If `install-dependencies.sh` does not support your distribution,
 please manually install all Python modules it lists with `pip`.

--- a/test.py
+++ b/test.py
@@ -687,7 +687,7 @@ if __name__ == "__main__":
     if "SCYLLA_HOME" in os.environ:
         del os.environ["SCYLLA_HOME"]
 
-    if sys.version_info < (3, 11):
-        print("Python 3.11 or newer is required to run this program")
+    if sys.version_info < (3, 14):
+        print("Python 3.14 or newer is required to run this program")
         sys.exit(-1)
     sys.exit(asyncio.run(main()))


### PR DESCRIPTION
Since frozen toolchain uses python 3.14 and there are some features that are used in the project requires 3.14, I'm just updating the version check.

Backporting to 2026.1, 2026.2, 2026.3 since all of them already using python 3.14

Fixes: SCYLLADB-4142