### PR TITLE
serializer: move deserialized key/value into std::map::emplace

### DIFF
--- a/serializer_impl.hh
+++ b/serializer_impl.hh
@@ -385,7 +385,7 @@ struct serializer<std::map<K, V>> {
         while (sz--) {
             K k = deserialize(in, std::type_identity<K>());
             V v = deserialize(in, std::type_identity<V>());
-            m.emplace(k, v);
+            m.emplace(std::move(k), std::move(v));
         }
         return m;
     }


### PR DESCRIPTION
**Related to #31392** (also IDL-compiler work) but independent: no textual/code overlap, applies cleanly regardless of merge order.

## Motivation
The generated `std::map` deserializer copied the freshly deserialized key and value into `emplace()`, then discarded the local copies right after. Pure extra copy on every map element.

## Changes
Move the key/value into `emplace()` instead of copying.

## Tests
`idl_test`, `serialization_test` (pass, unchanged behavior — this is a copy-elision-only change).

## Results
Not separately benchmarked: the change removes one copy per deserialized map element, too small a delta to isolate from noise at the map sizes `perf-simple-query` can exercise. Correctness confirmed via the existing serializer/IDL test suite.

Backport: no, benign improvement.
