### PR TITLE
idl-compiler: take rpc send function parameters by const reference

### DIFF
--- a/idl-compiler.py
+++ b/idl-compiler.py
@@ -403,7 +403,10 @@ class RpcVerbParam(ASTBase):
     argument as an `foreign_ptr<unique_ptr<>>`
     If the [[lw_shared_ptr]] attribute is specified then handler function signature for an RPC verb will contain this
     argument as an `foreign_ptr<lw_shared_ptr<>>`
-    If the [[ref]] attribute is specified the send function signature will contain this type as const reference"""
+    Send function signature parameters are always taken as const reference, to avoid an extra copy
+    into the by-value parameter before it is forwarded (unchanged) into the underlying RPC sink call,
+    which itself takes its arguments by const reference. [[ref]] is accepted for backward compatibility
+    but has no effect."""
     def __init__(self, type, name, attributes=Attributes()):
         super().__init__(name)
         self.type = type
@@ -424,10 +427,6 @@ class RpcVerbParam(ASTBase):
     def is_unique(self):
         return True in [a.startswith('unique_ptr') for a in self.attributes.attr_items]
 
-    def is_ref(self):
-        return True in [a.startswith('ref') for a in self.attributes.attr_items]
-
-
     def to_string(self):
         res = self.type.to_string()
         if self.is_optional():
@@ -438,9 +437,7 @@ class RpcVerbParam(ASTBase):
         return res
 
     def to_string_send_fn_signature(self):
-        res = self.type.to_string()
-        if self.is_ref():
-            res = 'const ' + res + '&'
+        res = 'const ' + self.type.to_string() + '&'
         if self.name:
             res += ' '
             res += self.name
@@ -588,7 +585,9 @@ class RpcVerb(ASTBase):
             res += ', as'
         if self.params:
             for idx, p in enumerate(self.params):
-                res += ', ' + f'std::move({p.name if p.name else f"_{idx + 1}"})'
+                # Params are const references; std::move on them would silently
+                # copy (or fail to compile for a move-only type).
+                res += ', ' + (p.name if p.name else f'_{idx + 1}')
         return res
 
     def send_function_invocation(self):


### PR DESCRIPTION
**Related to #31392** (also IDL-compiler work) but independent: no textual/code overlap, applies cleanly regardless of merge order.

## Motivation
Generated `send_<verb>()` functions took their payload parameters by value and passed them on with `std::move()`.
The underlying `send_message*()` templates forward the arguments into the rpc layer, which serializes them into the outgoing buffer without ever taking ownership - so the by-value parameter was a pure extra copy for every lvalue argument.

## Changes
- Take all rpc send-function payload parameters by `const&` and pass them through unchanged.
- The `[[ref]]` attribute, previously needed to opt a single parameter into this, is accepted for backward compatibility but has no effect now.

## Tests
`idl_test` passes; verified generated `send_*()` call sites still compile against their existing (unchanged) call signatures.

## Results
Not separately benchmarked: this removes a copy of the rpc-verb argument at the call site, which is too small and too call-site-dependent (payload type/size varies per verb) to isolate with a synthetic single-verb harness like `perf-simple-query`.
Correctness confirmed via `idl_test` and a successful full build (every generated `send_*()` signature type-checks).

Backport: no, benign improvement.