### PR TITLE
test/cluster: skip tests that need error injections in release mode

### DIFF
--- a/test/cluster/mv/test_mv_topology_change.py
+++ b/test/cluster/mv/test_mv_topology_change.py
@@ -480,6 +480,7 @@ async def test_mv_write_during_migration(manager: ScyllaClusterManager, migratio
 # on the topology coordinator, but the joining node is delayed in applying the group0 state.
 # The joining node receives base mutations from the other nodes to apply as the new replica,
 # and it also should generate view updates for them while in a joining state.
+@pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_mv_write_during_node_join(manager: ScyllaClusterManager):
     cmdline = ['--logger-log-level', 'storage_service=debug', '--logger-log-level', 'raft_topology=debug']
     servers = await manager.servers_add(1, cmdline=cmdline)

--- a/test/cluster/object_store/test_backup.py
+++ b/test/cluster/object_store/test_backup.py
@@ -1800,6 +1800,7 @@ async def test_decommision_waits_for_backup(manager: ScyllaClusterManager, objec
 
     await do_test_backup_helper(manager, object_storage, "backup_task_pre_upload", decommission_and_check, 2)
 
+@pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_aborted_decommision_reenables_snapshot(manager: ScyllaClusterManager, object_storage):
     """
     Tests that an aborted decommission will still allow snapshots

--- a/test/cluster/object_store/test_basic.py
+++ b/test/cluster/object_store/test_basic.py
@@ -748,6 +748,7 @@ async def test_registry_cleanup_on_all_nodes(manager: ScyllaClusterManager, obje
 
 
 @pytest.mark.asyncio
+@pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_stream_sink_abort_on_object_storage(manager: ScyllaClusterManager, object_storage):
     """Verify that aborting a blob stream on object storage cleans up
     partial SSTable components instead of leaving orphaned S3 objects.

--- a/test/cluster/tasks/test_node_ops_tasks.py
+++ b/test/cluster/tasks/test_node_ops_tasks.py
@@ -194,6 +194,7 @@ async def check_decommission_tasks_tree(manager: ScyllaClusterManager, tm: TaskM
     vts_list = await get_new_virtual_tasks_list(tm, module_name, servers[0], previous_vts)
     return servers, previous_vts + [vts_list[0].task_id]
 
+@pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_node_ops_tasks_tree(manager: ScyllaClusterManager):
     """Test node ops task manager tasks."""
     module_name = "node_ops"
@@ -228,6 +229,7 @@ async def test_node_ops_tasks_ttl(manager: ScyllaClusterManager):
     time.sleep(3)
     await get_new_virtual_tasks_statuses(tm, module_name, servers, [], expected_task_num=0)
 
+@pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_node_ops_task_wait(manager: ScyllaClusterManager):
     """Test node ops virtual task's wait."""
     async def _decommission(manager: ScyllaClusterManager, server: ServerInfo):

--- a/test/cluster/test_cdc_generation_clearing.py
+++ b/test/cluster/test_cdc_generation_clearing.py
@@ -90,6 +90,7 @@ async def test_cdc_generation_clearing(manager: ScyllaClusterManager):
         await check_system_topology_and_cdc_generations_v3_consistency(manager, hosts)
 
 
+@pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_unpublished_cdc_generations_arent_cleared(manager: ScyllaClusterManager):
     """Test that unpublished CDC generations aren't removed from CDC_GENERATIONS_V3 and
        TOPOLOGY.committed_cdc_generations regardless of their timestamps."""

--- a/test/cluster/test_cdc_generation_data.py
+++ b/test/cluster/test_cdc_generation_data.py
@@ -12,6 +12,7 @@ logger = logging.getLogger(__name__)
 The injection forces the topology coordinator to send CDC generation data in multiple parts,
 if it didn't the command size would go over commitlog segment size limit making it impossible to commit and apply the command.
 """
+@pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_send_data_in_parts(manager: ScyllaClusterManager):
     config = {
         'schema_commitlog_segment_size_in_mb': 2

--- a/test/cluster/test_cdc_generation_publishing.py
+++ b/test/cluster/test_cdc_generation_publishing.py
@@ -76,6 +76,7 @@ async def test_cdc_generations_are_published(request, manager: ScyllaClusterMana
     logger.info(f"Timestamps after check_and_repair: {gen_timestamps}")
 
 
+@pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_multiple_unpublished_cdc_generations(request, manager: ScyllaClusterManager):
     """Test that the CDC generation publisher works correctly when there is more than one unpublished CDC generation."""
     query_gen_timestamps = SimpleStatement(

--- a/test/cluster/test_cdc_with_alter.py
+++ b/test/cluster/test_cdc_with_alter.py
@@ -16,6 +16,7 @@ import pytest
 
 logger = logging.getLogger(__name__)
 
+@pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_add_and_drop_column_with_cdc(manager: ScyllaClusterManager):
     """ Test writing to a table with CDC enabled while adding and dropping a column.
         In particular we are interested at the behavior when the schemas of the base table

--- a/test/cluster/test_deprecating_cluster_features.py
+++ b/test/cluster/test_deprecating_cluster_features.py
@@ -17,6 +17,7 @@ SUPPRESS_FEATURES = "suppress_features"
 ERROR_INJECTIONS_AT_STARTUP_CONFIG_KEY = "error_injections_at_startup"
 
 
+@pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_feature_deprecation_works(manager: ScyllaClusterManager) -> None:
     """Simulate a very old node which, long ago, has enabled some features,
        persisted them in system.scylla_local, and now some of them became

--- a/test/cluster/test_error_becoming_voter.py
+++ b/test/cluster/test_error_becoming_voter.py
@@ -17,6 +17,7 @@ from test.pylib.util import wait_for_cql_and_get_hosts
 logger = logging.getLogger(__name__)
 
 
+@pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_error_while_becoming_voter(request: pytest.FixtureRequest, manager: ScyllaClusterManager) -> None:
     """
     Test that a node is starting successfully if while joining a cluster and becoming a voter, it

--- a/test/cluster/test_hints.py
+++ b/test/cluster/test_hints.py
@@ -88,6 +88,7 @@ async def test_write_cl_any_to_dead_node_generates_hints(manager: ScyllaClusterM
             # For dropping the keyspace
             await manager.server_start(servers[1].server_id)
 
+@pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_limited_concurrency_of_writes(manager: ScyllaClusterManager):
     """
     We want to verify that Scylla correctly limits the concurrency of writing hints to disk.
@@ -256,6 +257,7 @@ async def test_hints_consistency_during_decommission(manager: ScyllaClusterManag
         for i in range(100):
             assert list(await cql.run_async(f"SELECT v FROM {table} WHERE pk = {i}")) == [(i + 1,)]
 
+@pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_hints_consistency_during_replace(manager: ScyllaClusterManager):
     """
     Reproducer for https://github.com/scylladb/scylladb/issues/24980

--- a/test/cluster/test_ip_mappings.py
+++ b/test/cluster/test_ip_mappings.py
@@ -18,6 +18,7 @@ from cassandra.cluster import ConsistencyLevel, SimpleStatement
 
 logger = logging.getLogger(__name__)
 
+@pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_broken_bootstrap(manager: ScyllaClusterManager):
     server_a = await manager.server_add()
     server_b = await manager.server_add(start=False)

--- a/test/cluster/test_long_join.py
+++ b/test/cluster/test_long_join.py
@@ -15,6 +15,7 @@ from test.pylib.util import wait_for
 
 logger = logging.getLogger(__name__)
 
+@pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_long_join(manager: ScyllaClusterManager) -> None:
     """The test checks that join works even if expiring entries are dropped
        between placement of the join request and its processing"""
@@ -28,6 +29,7 @@ async def test_long_join(manager: ScyllaClusterManager) -> None:
     await manager.api.message_injection(s1.ip_addr, inj)
     await asyncio.gather(task)
 
+@pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_long_join_drop_entries_on_bootstrapping(manager: ScyllaClusterManager) -> None:
     """The test checks that join works even if expiring entries are dropped
        on the joining node between placement of the join request and its processing"""

--- a/test/cluster/test_lwt_semaphore.py
+++ b/test/cluster/test_lwt_semaphore.py
@@ -14,6 +14,7 @@ from test.cluster.util import new_test_keyspace
 
 
 @pytest.mark.skip_mode(mode='debug', reason='aarch64/debug is unpredictably slow', platform_key='aarch64')
+@pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_cas_semaphore(manager):
     """ This is a regression test for scylladb/scylladb#19698 """
     servers = await manager.servers_add(1, cmdline=['--smp', '1'])

--- a/test/cluster/test_mutation_schema_change.py
+++ b/test/cluster/test_mutation_schema_change.py
@@ -20,6 +20,7 @@ logger = logging.getLogger(__name__)
 pytestmark = pytest.mark.prepare_3_racks_cluster
 
 
+@pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_mutation_schema_change(manager, random_tables):
     """
         Cluster A, B, C
@@ -81,6 +82,7 @@ async def test_mutation_schema_change(manager, random_tables):
                                     execution_profile='whitelist')
 
 
+@pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_mutation_schema_change_restart(manager, random_tables):
     """
         Cluster A, B, C

--- a/test/cluster/test_query_rebounce.py
+++ b/test/cluster/test_query_rebounce.py
@@ -18,6 +18,7 @@ from test.cluster.util import new_test_keyspace
 logger = logging.getLogger(__name__)
 
 
+@pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_query_rebounce(manager: ScyllaClusterManager):
     """
     Issue https://github.com/scylladb/scylladb/issues/15465.

--- a/test/cluster/test_raft_snapshot_truncation.py
+++ b/test/cluster/test_raft_snapshot_truncation.py
@@ -16,6 +16,7 @@ from test.pylib.rest_client import inject_error_one_shot
 
 logger = logging.getLogger(__name__)
 
+@pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_raft_snapshot_truncation(manager: ScyllaClusterManager):
     """
     Check that after snapshot creation, snapshot_trailing_size is taken into consideration,

--- a/test/cluster/test_repair.py
+++ b/test/cluster/test_repair.py
@@ -277,6 +277,7 @@ async def test_vnode_keyspace_describe_ring(manager: ScyllaClusterManager):
             assert natural_endpoints == ring_endpoints, f"natural_endpoint mismatch describe_ring for {key=} {token=} {natural_endpoints=} {ring_endpoints=}"
 
 
+@pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_repair_timtestamp_difference(manager):
     cmdline = [ "--smp", "1", "--logger-log-level", "api=trace", "--hinted-handoff-enabled", "0" ]
     node1, node2 = await manager.servers_add(2, cmdline=cmdline, auto_rack_dc="dc1")

--- a/test/cluster/test_snapshot.py
+++ b/test/cluster/test_snapshot.py
@@ -17,6 +17,7 @@ logger = logging.getLogger(__name__)
 pytestmark = pytest.mark.prepare_3_racks_cluster
 
 
+@pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_snapshot(manager, random_tables):
     """
         Cluster A, B, C

--- a/test/cluster/test_table_drop.py
+++ b/test/cluster/test_table_drop.py
@@ -9,6 +9,7 @@ import pytest
 
 logger = logging.getLogger(__name__)
 
+@pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_drop_table_during_streaming_receiver_side(manager: ScyllaClusterManager):
     servers = [await manager.server_add(config={
         'error_injections_at_startup': ['stream_mutation_fragments_table_dropped'],
@@ -21,6 +22,7 @@ async def test_drop_table_during_streaming_receiver_side(manager: ScyllaClusterM
 @pytest.mark.parametrize("feature_config", feature_configs(FeatureConfigurations.EVENTUAL_CONSISTENCY,
     FeatureConfigurations.STRONG_CONSISTENCY, FeatureConfigurations.LOGSTOR_EVENTUAL_CONSISTENCY,
     FeatureConfigurations.LOGSTOR_STRONG_CONSISTENCY))
+@pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_drop_table_during_flush(manager: ScyllaClusterManager, feature_config: FeatureConfig):
     servers = [await manager.server_add(config=feature_config.get_cluster_cfg({})) for _ in range(2)]
 

--- a/test/cluster/test_tablets2.py
+++ b/test/cluster/test_tablets2.py
@@ -79,6 +79,7 @@ async def wait_for_valid_load_stats(cql, table_id, timeout=120):
 
         await asyncio.sleep(0.2)
 
+@pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_tablet_metadata_propagates_with_schema_changes_in_snapshot_mode(manager: ScyllaClusterManager):
     """Test that you can create a table and insert and query data"""
 
@@ -171,6 +172,7 @@ async def test_scans(manager: ScyllaClusterManager):
             assert r.c == r.pk
 
 
+@pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_table_drop_with_auto_snapshot(manager: ScyllaClusterManager):
     logger.info("Bootstrapping cluster")
     cfg = { 'auto_snapshot': True }
@@ -190,6 +192,7 @@ async def test_table_drop_with_auto_snapshot(manager: ScyllaClusterManager):
     await cql.run_async("DROP KEYSPACE test;")
 
 
+@pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_topology_changes(manager: ScyllaClusterManager):
     logger.info("Bootstrapping cluster")
     servers = await manager.servers_add(3)

--- a/test/cluster/test_topology_remove_decom.py
+++ b/test/cluster/test_topology_remove_decom.py
@@ -35,6 +35,7 @@ async def test_remove_node_add_column(manager: ScyllaClusterManager, random_tabl
     await random_tables.verify_schema()
 
 
+@pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_decommission_node_add_column(manager: ScyllaClusterManager, random_tables: RandomTables):
     """Add a node, remove an original node, add a column"""
     table = await random_tables.add_table(ncolumns=5)

--- a/test/cluster/test_view_building_coordinator.py
+++ b/test/cluster/test_view_building_coordinator.py
@@ -585,6 +585,7 @@ async def test_view_building_failure(manager: ScyllaClusterManager):
         await check_view_contents(cql, ks, "tab", "mv_cf_view")
 
 # Reproduces scylladb/scylladb#25912
+@pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_concurrent_tablet_migrations(manager: ScyllaClusterManager):
     """
     The test creates a situation where a single tablet is replicated across
@@ -1039,6 +1040,7 @@ async def test_all_good_on_node_restart(manager: ScyllaClusterManager):
 # Test that view building does not trigger tombstone_warn_threshold warnings.
 # Uses a high tablet count (2048) to create many tasks, which produces many
 # tombstones when tasks are cleaned up. Verifies no warnings appear in logs.
+@pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_tombstone_warn_threshold(manager: ScyllaClusterManager):
     node_count = 1
     servers = await manager.servers_add(node_count, cmdline=cmdline_loggers, property_file=[

--- a/test/pylib/rest_client.py
+++ b/test/pylib/rest_client.py
@@ -807,7 +807,7 @@ async def inject_error(api: ScyllaRESTAPIClient, node_ip: IPAddress, injection: 
     await api.enable_injection(node_ip, injection, False, parameters)
     enabled = await api.get_enabled_injections(node_ip)
     logging.info(f"Error injections enabled on {node_ip}: {enabled}")
-    if not enabled:
+    if injection not in enabled:
         skip_env("Error injection not enabled in Scylla - try compiling in dev/debug/sanitize mode")
     try:
         yield InjectionHandler(api, injection, node_ip)
@@ -824,7 +824,7 @@ async def inject_error_one_shot(api: ScyllaRESTAPIClient, node_ip: IPAddress, in
     await api.enable_injection(node_ip, injection, True, parameters)
     enabled = await api.get_enabled_injections(node_ip)
     logging.info(f"Error injections enabled on {node_ip}: {enabled}")
-    if not enabled:
+    if injection not in enabled:
         skip_env("Error injection not enabled in Scylla - try compiling in dev/debug/sanitize mode")
     return InjectionHandler(api, injection, node_ip)
 

--- a/test/pylib/rest_client.py
+++ b/test/pylib/rest_client.py
@@ -15,11 +15,10 @@ from collections.abc import Mapping
 from contextlib import asynccontextmanager
 from typing import Any, Optional, AsyncIterator
 
+import pytest
 import universalasync
 from aiohttp import request, BaseConnector, ClientTimeout
 from cassandra.pool import Host                          # type: ignore # pylint: disable=no-name-in-module
-
-from test.pylib.skip_types import skip_env
 
 from test.pylib.internal_types import IPAddress, HostID
 from test.pylib.util import universalasync_typed_wrap
@@ -800,7 +799,10 @@ class InjectionHandler():
 async def inject_error(api: ScyllaRESTAPIClient, node_ip: IPAddress, injection: str,
                        parameters: dict[str, Any] = {}) -> AsyncIterator[InjectionHandler]:
     """Attempts to inject an error. Works only in specific build modes: debug,dev,sanitize.
-       It will trigger a test to be skipped if attempting to enable an injection has no effect.
+       It will fail a test if attempting to enable an injection has no effect.
+       Intended for suites that start their own Scylla (e.g. cluster), so the build mode
+       is known. Suites that can run against a foreign server (e.g. cqlpy) should keep
+       their own skipping helper.
        This is a context manager for enabling and disabling when done, therefore it can't be
        used for one shot.
     """
@@ -808,7 +810,9 @@ async def inject_error(api: ScyllaRESTAPIClient, node_ip: IPAddress, injection: 
     enabled = await api.get_enabled_injections(node_ip)
     logging.info(f"Error injections enabled on {node_ip}: {enabled}")
     if injection not in enabled:
-        skip_env("Error injection not enabled in Scylla - try compiling in dev/debug/sanitize mode")
+        pytest.fail(f"Failed to enable the error injection {injection}. Error injections are "
+                    "disabled in release mode, so the test must be marked with "
+                    "skip_mode(mode='release')")
     try:
         yield InjectionHandler(api, injection, node_ip)
     finally:
@@ -818,14 +822,19 @@ async def inject_error(api: ScyllaRESTAPIClient, node_ip: IPAddress, injection: 
 
 async def inject_error_one_shot(api: ScyllaRESTAPIClient, node_ip: IPAddress, injection: str, parameters: dict[str, Any] = {}) -> InjectionHandler:
     """Attempts to inject an error. Works only in specific build modes: debug,dev,sanitize.
-       It will trigger a test to be skipped if attempting to enable an injection has no effect.
+       It will fail a test if attempting to enable an injection has no effect.
+       Intended for suites that start their own Scylla (e.g. cluster), so the build mode
+       is known. Suites that can run against a foreign server (e.g. cqlpy) should keep
+       their own skipping helper.
        This is a one-shot injection enable.
     """
     await api.enable_injection(node_ip, injection, True, parameters)
     enabled = await api.get_enabled_injections(node_ip)
     logging.info(f"Error injections enabled on {node_ip}: {enabled}")
     if injection not in enabled:
-        skip_env("Error injection not enabled in Scylla - try compiling in dev/debug/sanitize mode")
+        pytest.fail(f"Failed to enable the error injection {injection}. Error injections are "
+                    "disabled in release mode, so the test must be marked with "
+                    "skip_mode(mode='release')")
     return InjectionHandler(api, injection, node_ip)
 
 


### PR DESCRIPTION
Error injections are disabled in release mode, so these tests only waste
resources while testing nothing useful. Some of them already skip at
runtime in inject_error, but that is still wasteful: the skip happens
inside the test body, once the cluster is up.

This PR also fails the test in inject_error and inject_error_one_shot
instead of skipping it to prevent writing tests that run for no reason in
release mode.

Fixes: SCYLLADB-4149

This PR only saves some resources in testing, so no backport.