### PR TITLE
encrypted_file_impl.cc: include seastar/core/align.hh

### DIFF
--- a/ent/encryption/encrypted_file_impl.cc
+++ b/ent/encryption/encrypted_file_impl.cc
@@ -9,6 +9,7 @@
 
 #include <fcntl.h>
 #include <fmt/format.h>
+#include <seastar/core/align.hh>
 #include <seastar/core/file.hh>
 #include <seastar/core/byteorder.hh>
 #include <seastar/core/iostream.hh>


### PR DESCRIPTION
The file encrypted_file_impl.cc uses seastar::{align_up,align_down}. It used to be transitively included from seastar/core/file.hh, but after scylladb/seastar@2d6223ac26525a10500cce35debf2a2de8eb5828 that is no longer the case. The file no longer compiles on its own, but the issue is masked by the precompiled header use and thus it was not blocked by CI.

Fix the issue for non-PCH users by explicitly including this file in encrypted_file_impl.cc.

No need to backport, the seastar version used on the 2026.3 branch still transitively includes align.hh from file.hh so the issue is not present on older branches.