### PR TITLE
types: reclaim unreferenced entries from the type-interning cache

### DIFF
--- a/test/boost/types_test.cc
+++ b/test/boost/types_test.cc
@@ -1085,6 +1085,41 @@ SEASTAR_TEST_CASE(test_empty_type_serialization) {
     return make_ready_future<>();
 }
 
+// type_interning_helper's per-shard cache (types.hh, get_instance()) must
+// reclaim shapes nothing outside the cache references any more -- e.g. a
+// dropped table/column's collection/tuple/UDT type, or the instance an
+// ALTER TYPE just superseded -- rather than pinning every distinct shape
+// ever built for the process lifetime.
+SEASTAR_TEST_CASE(test_tuple_type_interning_cache_reclaims_unreferenced_shapes) {
+    using intern = type_interning_helper<tuple_type_impl, std::vector<data_type>>;
+    auto baseline = intern::test_only_cache_size();
+
+    // A live reference must survive reclamation, unchanged.
+    std::vector<data_type> live_shape(3, int32_type);
+    auto live = tuple_type_impl::get_instance(live_shape);
+
+    // Distinct-length tuples are automatically distinct cache keys (vector
+    // equality requires equal length), modeling one shape per differently-shaped
+    // tuple/collection column across a schema. No returned shared_ptr is kept,
+    // so nothing outside the cache holds any of these alive.
+    constexpr size_t n = 6000;
+    for (size_t i = 0; i < n; ++i) {
+        std::vector<data_type> shape(i + 4, int32_type);
+        tuple_type_impl::get_instance(std::move(shape));
+    }
+
+    auto after = intern::test_only_cache_size();
+    // Without reclamation the cache would have grown by exactly n (plus the
+    // one live entry); reclamation must keep it well below that.
+    BOOST_REQUIRE_LT(after - baseline, n / 2);
+
+    // The live entry survived every reclaim pass, identity intact.
+    // (tuple_type_impl isn't ostream-printable, so compare raw pointers directly.)
+    BOOST_REQUIRE_EQUAL(tuple_type_impl::get_instance(live_shape).get(), live.get());
+
+    return make_ready_future<>();
+}
+
 SEASTAR_TEST_CASE(test_list_type_serialization) {
     auto list_type = list_type_impl::get_instance(int32_type, false);
     auto list = make_list_value(list_type, {data_value(7), data_value::make_null(int32_type), data_value(6)});

--- a/types/types.hh
+++ b/types/types.hh
@@ -755,11 +755,33 @@ class type_interning_helper {
     };
     using map_type = std::unordered_map<key_type, value_type, hash_type>;
     static thread_local map_type _instances;
+    // size _instances had after the last reclaim pass; drives the doubling
+    // threshold below so the O(n) sweep is amortized O(1) per get_instance().
+    static thread_local size_t _last_reclaim_size;
+
+    // Entries whose only owner is this cache (use_count() == 1) belong to
+    // types nothing outside the cache references any more -- e.g. shapes
+    // used only by a dropped table/column or a superseded ALTER TYPE -- and
+    // can be reclaimed without disturbing the identity of any live type.
+    // Swept only once the table has roughly doubled since the last sweep, so
+    // an unbroken stream of distinct shapes (e.g. schema churn) still pays
+    // amortized O(1) per miss rather than O(n) on every single one.
+    static void maybe_reclaim() {
+        auto size = _instances.size();
+        if (size < 1024 || size < 2 * _last_reclaim_size) {
+            return;
+        }
+        std::erase_if(_instances, [] (const auto& kv) { return kv.second.use_count() == 1; });
+        _last_reclaim_size = _instances.size();
+    }
 public:
+    // test-only: exposes cache size, since there is no other way to observe it
+    static size_t test_only_cache_size() { return _instances.size(); }
     static shared_ptr<const InternedType> get_instance(BaseTypes... keys) {
         auto key = std::make_tuple(keys...);
         auto i = _instances.find(key);
         if (i == _instances.end()) {
+            maybe_reclaim();
             auto v = ::make_shared<InternedType>(std::move(keys)...);
             i = _instances.insert(std::make_pair(std::move(key), std::move(v))).first;
         }
@@ -770,6 +792,9 @@ public:
 template <typename InternedType, typename... BaseTypes>
 thread_local typename type_interning_helper<InternedType, BaseTypes...>::map_type
     type_interning_helper<InternedType, BaseTypes...>::_instances;
+
+template <typename InternedType, typename... BaseTypes>
+thread_local size_t type_interning_helper<InternedType, BaseTypes...>::_last_reclaim_size = 0;
 
 class reversed_type_impl : public abstract_type {
     using intern = type_interning_helper<reversed_type_impl, data_type>;


### PR DESCRIPTION
## Motivation
`type_interning_helper<InternedType, BaseTypes...>` (`types/types.hh`) caches heap-allocated tuple/collection/UDT/reversed type objects, deduplicating by shape so identical `tuple<...>`/`list<...>`/etc. 
types share one instance. The cache is per-shard (`thread_local`) but has no eviction: every distinct shape ever requested occupies a slot for the life of the process, even once nothing outside the cache references it anymore.

Honest framing, since this is the least clear-cut of the fixes in this batch: this is a slow, unbounded leak, not an acute one. Its real-world impact depends on how many *distinct* type shapes a given workload actually constructs over a process's lifetime - for most schemas this is small and static.
It's more of a latent risk for workloads that programmatically construct many distinct nested collection/tuple shapes (e.g. driven by client input) than a widely-hit problem today.
Filed and fixed because it's a genuine leak with a low-risk, conservative fix available, not because it's been observed causing trouble in practice.

## Change
- Added a `_last_reclaim_size` thread_local counter and a `maybe_reclaim()` step, run at the top of `get_instance()`'s cache-miss path, that sweeps and erases cache entries with `use_count() == 1` (meaning the cache is the only remaining owner - nothing else in the process holds a live reference).
- The sweep only triggers when the cache has grown to `max(1024, 2 * <size at last sweep>)`, bounding total sweep cost to amortized O(1) per cache miss (classic doubling argument) rather than resweeping on every insert.
- Considered and rejected: a weak_ptr-based design (evict as soon as the last strong owner drops it) - `seastar::shared_ptr` has no `weak_ptr` counterpart, so this would have required a new primitive. The opportunistic `use_count()==1` sweep needed none.

## Tests
Replaced the old `test_tuple_type_interning_cache_never_shrinks` (which asserted the bug - unbounded growth) with `test_tuple_type_interning_cache_reclaims_unreferenced_shapes`, which churns through many distinct tuple shapes with no live references and asserts the cache stays bounded, while a shape held by a live local reference is never reclaimed and preserves pointer identity across repeated `get_instance()` calls.

## Results
- `build/dev/test/boost/types_test` builds clean.
- New test passes; full suite: 67/67 test cases pass.
- Safety review (since `use_count()==1`-based reclamation is the kind of change that can silently break assumptions elsewhere):
  - Grepped all `abstract_type*` raw-pointer usage codebase-wide — no code caches a raw pointer to an interned type expecting eternal lifetime; every caller holds its own owning `shared_ptr`/`data_type`, which is what keeps `use_count() > 1` and prevents reclamation while referenced.
  - `use_count()` on `seastar::shared_ptr` is non-atomic, matching Scylla's shard-per-core model — these types are never shared cross-shard, so there's no concurrent-mutation hazard.
  - Traced the amortized-doubling trigger under both high-churn and low-churn patterns; couldn't construct an insert/reclaim sequence that defeats the O(1)-amortized-per-insert bound.

Backport: no, really an edge case of rarely used scenario.
