### PR TITLE
[Backport 2026.1] sstables/storage_manager: fix race between object storage config update and keyspace creation

### DIFF
--- a/api/config.cc
+++ b/api/config.cc
@@ -82,15 +82,16 @@ void set_config(std::shared_ptr < api_registry_builder20 > rb, http_context& ctx
         });
     });
 
-    cs::find_config_id.set(r, [&cfg] (const_req r) {
-        auto id = r.get_path_param("id");
-        for (auto&& cfg_ref : cfg.values()) {
-            auto&& cfg = cfg_ref.get();
-            if (id == cfg.name()) {
-                return cfg.value_as_json();
-            }
+    cs::find_config_id.set(r, [&cfg] (std::unique_ptr<http::request> req) -> future<json::json_return_type> {
+        auto id = req->get_path_param("id");
+        auto value = co_await cfg.value_as_json_string_for_name(id);
+        if (!value) {
+            throw bad_param_exception(sstring("No such config entry: ") + id);
         }
-        throw bad_param_exception(sstring("No such config entry: ") + id);
+        //value is already a json string 
+        json::json_return_type ret{json::json_void()};
+        ret._res = std::move(*value);
+        co_return ret;
     });
 
     sp::get_rpc_timeout.set(r, [&cfg](const_req req)  {

--- a/db/config.cc
+++ b/db/config.cc
@@ -7,6 +7,7 @@
  * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
  */
 
+#include <optional>
 #include <unordered_map>
 #include <sstream>
 
@@ -19,6 +20,7 @@
 
 #include <seastar/core/coroutine.hh>
 #include <seastar/core/format.hh>
+#include <seastar/core/smp.hh>
 #include <seastar/core/sstring.hh>
 #include <seastar/json/json_elements.hh>
 #include <seastar/util/log.hh>
@@ -1689,6 +1691,23 @@ void db::config::maybe_in_workdir(named_value<string_list>& tos, const char* sub
         n.push_back(work_directory() + "/" + sub);
         tos(n);
     }
+}
+
+future<std::optional<sstring>> db::config::value_as_json_string_for_name(sstring name) const {
+    // Config reloads triggered by SIGHUP are applied on shard 0 and then
+    // broadcast to all other shards.  We read the value on shard 0 under
+    // a read lock to guarantee a consistent snapshot — the SIGHUP handler
+    // holds the write lock across the entire reload-and-broadcast sequence.
+    co_return co_await smp::submit_to(0, [this, name = std::move(name)] () -> future<std::optional<sstring>> {
+        auto lock = co_await _config_update_lock.hold_read_lock();
+        for (auto&& cfg_ref : values()) {
+            auto&& c = cfg_ref.get();
+            if (name == c.name()) {
+                co_return c.value_as_json()._res;
+            }
+        }
+        co_return std::nullopt;
+    });
 }
 
 const sstring db::config::default_tls_priority("SECURE128:-VERS-TLS1.0");

--- a/db/config.hh
+++ b/db/config.hh
@@ -12,6 +12,7 @@
 #include <unordered_map>
 
 #include <seastar/core/sstring.hh>
+#include <seastar/core/rwlock.hh>
 #include <seastar/util/program-options.hh>
 #include <seastar/util/log.hh>
 
@@ -172,6 +173,16 @@ public:
      */
     static fs::path get_conf_dir();
     static fs::path get_conf_sub(fs::path);
+
+    future<rwlock::holder> lock_for_config_update() {
+        return _config_update_lock.hold_write_lock();
+    };
+
+    // Look up a config entry by name and return its JSON representation as a string.
+    // Runs on shard 0 under a read lock so the result is consistent with
+    // any in-progress SIGHUP reload + broadcast_to_all_shards() sequence.
+    // Returns std::nullopt if no config entry with the given name exists.
+    future<std::optional<sstring>> value_as_json_string_for_name(sstring name) const;
 
     using string_map = std::unordered_map<sstring, sstring>;
                     //program_options::string_map;
@@ -644,6 +655,13 @@ private:
     void maybe_in_workdir(named_value<string_list>&, const char*);
 
     std::shared_ptr<db::extensions> _extensions;
+
+    // Read-write lock used to synchronize config updates (SIGHUP reload +
+    // broadcast to all shards) with config value readers.
+    // The SIGHUP handler holds the write lock across read_config() +
+    // broadcast_to_all_shards().  Readers acquire the read lock on shard 0
+    // via value_as_json_string_for_name() so they always see a consistent snapshot.
+    mutable rwlock _config_update_lock;
 };
 
 }

--- a/main.cc
+++ b/main.cc
@@ -331,6 +331,7 @@ private:
                         _pending = false;
                         try {
                             startlog.info("re-reading configuration file");
+                            auto lock = _cfg.lock_for_config_update().get();
                             read_config(_opts, _cfg).get();
                             _cfg.broadcast_to_all_shards().get();
                             startlog.info("completed re-reading configuration file");

--- a/test/cluster/object_store/test_basic.py
+++ b/test/cluster/object_store/test_basic.py
@@ -283,11 +283,10 @@ async def test_get_object_store_endpoints(manager: ManagerClient, config_with_fu
 
 @pytest.mark.asyncio
 async def test_create_keyspace_after_config_update(manager: ManagerClient, object_storage):
+    print('Trying to create a keyspace with an endpoint not configured in object_storage_endpoints should trip storage_manager::is_known_endpoint()')
     server = await manager.server_add()
     cql = manager.get_cql()
-
-    print('Trying to create a keyspace with an endpoint not configured in object_storage_endpoints should trip storage_manager::is_known_endpoint()')
-    endpoint = 'http://a:456'
+    endpoint = object_storage.address  
     replication_opts = format_tuples({'class': 'NetworkTopologyStrategy',
                                       'replication_factor': '1'})
     storage_opts = format_tuples(type=f'{object_storage.type}',
@@ -299,12 +298,51 @@ async def test_create_keyspace_after_config_update(manager: ManagerClient, objec
                       f' REPLICATION = {replication_opts} AND STORAGE = {storage_opts};'))
 
     print('Update config with a new endpoint and SIGHUP Scylla to reload configuration')
-    new_endpoint = MinioServer.create_conf(endpoint, 'region')
-    await manager.server_update_config(server.server_id, 'object_storage_endpoints', new_endpoint)
-    await wait_for_config(manager, server, 'object_storage_endpoints', {endpoint: '{ "type": "s3", "aws_region": "region", "iam_role_arn": "" }'})
+    objconf = object_storage.create_endpoint_conf()
+    await manager.server_update_config(server.server_id, 'object_storage_endpoints', objconf)
+    ep = objconf[0]
+    if ep['type'] == 's3':
+        expected_conf = f'{{ "type": "s3", "aws_region": "{ep["aws_region"]}", "iam_role_arn": "{ep["iam_role_arn"]}" }}'
+    else:
+        expected_conf = f'{{ "type": "gs", "credentials_file": "{ep["credentials_file"]}" }}'
+    await wait_for_config(manager, server, 'object_storage_endpoints', {ep['name']: expected_conf})
 
     print('Passing a known endpoint will make the CREATE KEYSPACE stmt to succeed')
     cql.execute((f'CREATE KEYSPACE random_ks WITH'
                     f' REPLICATION = {replication_opts} AND STORAGE = {storage_opts};'))
     
+
+    print('Create a table, insert data and flush the keyspace to force object_storage_client creation')
+    cql.execute(f'CREATE TABLE random_ks.test (name text PRIMARY KEY, value int);')
+    await cql.run_async(f"INSERT INTO random_ks.test (name, value) VALUES ('test_key', 123);")
+    await manager.api.flush_keyspace(server.ip_addr, 'random_ks')
+    res = cql.execute(f"SELECT value FROM random_ks.test WHERE name = 'test_key';")
+    assert res.one().value == 123, f'Unexpected value after flush: {res.one().value}'
+
+    # Now that a live object_storage_client exists for this endpoint, push a
+    # config update that modifies the endpoint parameters.  This exercises the
+    # update_config_sync path on an already-instantiated client
+    print('Push a config update to reconfigure the live object_storage_client')
+    updated_objconf = object_storage.create_endpoint_conf()
+    updated_ep = updated_objconf[0]
+    if updated_ep['type'] == 's3':
+        updated_ep['aws_region'] = 'updated-region'
+        updated_expected_conf = f'{{ "type": "s3", "aws_region": "{updated_ep["aws_region"]}", "iam_role_arn": "{updated_ep["iam_role_arn"]}" }}'
+    else:
+        updated_ep['credentials_file'] = ''
+        updated_expected_conf = f'{{ "type": "gs", "credentials_file": "{updated_ep["credentials_file"]}" }}'
+        pytest.skip("https://scylladb.atlassian.net/browse/SCYLLADB-1559")
+
+    await manager.server_update_config(server.server_id, 'object_storage_endpoints', updated_objconf)
+    await wait_for_config(manager, server, 'object_storage_endpoints', {updated_ep['name']: updated_expected_conf})
+
+    print('Verify the reconfigured client still works: insert more data and flush')
+    await cql.run_async(f"INSERT INTO random_ks.test (name, value) VALUES ('after_reconfig', 456);")
+    await manager.api.flush_keyspace(server.ip_addr, 'random_ks')
+    res = cql.execute(f"SELECT value FROM random_ks.test WHERE name = 'after_reconfig';")
+    assert res.one().value == 456, f'Unexpected value after reconfiguration flush: {res.one().value}'
+
+    print('Verify all data is intact')
+    rows = {r.name: r.value for r in cql.execute(f'SELECT * FROM random_ks.test;')}
+    assert rows == {'test_key': 123, 'after_reconfig': 456}, f'Unexpected table content: {rows}'
 

--- a/test/cluster/test_config.py
+++ b/test/cluster/test_config.py
@@ -17,7 +17,7 @@ async def wait_for_config(manager, server, config_name, value):
     async def config_value_equal():
         await read_barrier(manager.api, server.ip_addr)
         resp = await manager.api.get_config(server.ip_addr, config_name)
-        logging.info(f"Obtained config via REST api - config_name={config_name} value={value}")
+        logging.info(f"Obtained config via REST api - config_name={config_name} response={resp}  expected value={value}")
         if resp == value:
             return True
         return None


### PR DESCRIPTION
Previously, config_updater used a serialized_action to trigger update_config() when object_storage_endpoints changed. Because serialized_action::trigger() always schedules the action as a new reactor task (via semaphore::wait().then()), there was a window between the config value becoming visible to the REST API and update_config() actually running. This allowed a concurrent CREATE KEYSPACE to see the new endpoint via is_known_endpoint() before storage_manager had registered it in _object_storage_endpoints. 

Now config observers run synchronously in a reactor turn and must not suspend. Split the previous monolithic async update_config() coroutine  into two phases:    

- Sync (in the observer, never suspends): storage_manager::_object_storage_endpoints is updated in place; for already-instantiated clients, update_config_sync swaps the new config atomically                                                                                                                                                                                                             
- Async (per-client gate): background fibers finish the work that can't run in the observer — S3 refreshes credentials under _creds_sem; GCS drains and closes the replaced client.  

Config reloads triggered by SIGHUP are applied on shard 0 and then broadcast to all other shards. An rwlock has been also introduced to make sure that the configuration has been propagated to all cores. This guarantees that a client requesting a config via the REST API will see a consistent snapshot

Fixes: https://scylladb.atlassian.net/browse/SCYLLADB-757
Fixes: [28141](https://github.com/scylladb/scylladb/issues/28141)

- (cherry picked from commit 71714fdc0ea01e861832ffa7ae3f5fc3a3da9f8b)
- (cherry picked from commit a958da0ab9051e7b2bd774007ab8ca899bb634b0)
- (cherry picked from commit ca003680a72e41cc0ace407e1ec154e83c0ed5bf)

Parent PR: #28950