### PR TITLE
alternator: vector search: document the client that can actually send these requests, fix false Select comment

### DIFF
--- a/alternator/executor_read.cc
+++ b/alternator/executor_read.cc
@@ -1703,13 +1703,15 @@ static future<executor::request_return_type> query_vector(
     std::unordered_set<std::string> used_attribute_names;
     std::unordered_set<std::string> used_attribute_values;
     // Parse the Select parameter and determine which attributes to return.
-    // For a vector index, the default Select is ALL_ATTRIBUTES (full items).
+    // For a vector index, as for any other index, the default Select is
+    // ALL_PROJECTED_ATTRIBUTES - i.e., key attributes only (see below) - and
+    // *not* ALL_ATTRIBUTES.
     // ALL_PROJECTED_ATTRIBUTES is significantly more efficient because it
     // returns what the vector store returned without looking up additional
     // base-table data. Currently only the primary key attributes are projected
     // but in the future we'll implement projecting additional attributes into
     // the vector index - these additional attributes will also be usable for
-    // filtering). COUNT returns only the count without items.
+    // filtering. COUNT returns only the count without items.
     select_type select = parse_select(request, table_or_view_type::vector_index);
     if (return_scores && select == select_type::count) {
         co_return api_error::validation(

--- a/docs/alternator/vector-search.md
+++ b/docs/alternator/vector-search.md
@@ -28,6 +28,33 @@ and
 [Vector Search Glossary](https://cloud.docs.scylladb.com/stable/vector-search/vector-search-glossary.html)
 sections of the ScyllaDB Cloud documentation.
 
+### Client library
+
+The Python examples on this page use
+[alternator-client](https://github.com/scylladb/alternator-client-python), the
+Python [Alternator client library](sdks.md). It injects the Alternator
+vector-search request shapes into botocore's DynamoDB model at run time, so
+the requests documented below can be sent as written.
+
+Plain boto3 **cannot** send these requests. Amazon DynamoDB has since grown a
+native vector-index API of its own with a different request shape, and recent
+boto3 releases validate against that model on the client side — so plain boto3
+rejects the shapes documented here with a `ParamValidationError`, before any
+network call is made. This is purely a client-side limitation: the Alternator
+server accepts the shapes documented on this page.
+
+Vector search support currently lives only on the `main` branch of
+alternator-client; the `1.0.0` PyPI release does not include it yet:
+
+```
+pip install 'alternator-client @ git+https://github.com/scylladb/alternator-client-python.git@main'
+```
+
+Runnable end-to-end examples are available in the
+[vector-store repository](https://github.com/scylladb/vector-store/tree/master/docs/examples/alternator):
+`list_of_numbers.py` stores vectors as a standard DynamoDB list of numbers,
+and `native_vector.py` uses the optimized ScyllaDB vector type.
+
 ## Overview
 
 The workflow has three steps:
@@ -88,7 +115,7 @@ returned when `Select=ALL_PROJECTED_ATTRIBUTES` is used in a vector search query
 > Since `KEYS_ONLY` is also the default, omitting `Projection` entirely is
 > equivalent to specifying `{'ProjectionType': 'KEYS_ONLY'}`.
 
-Example (using boto3):
+Example (using `alternator-client`, see [Client library](#client-library)):
 ```python
 table = dynamodb.create_table(
     TableName='my-table',


### PR DESCRIPTION
Two independent defects from SCYLLADB-4157, one per commit.

### 1. `docs/alternator/vector-search.md` — the example implies a client that cannot send it

The index-creation example was introduced as *"Example (using boto3)"*, but plain boto3 cannot send it. Amazon DynamoDB has since grown a native vector-index API of its own with a different request shape, and recent boto3 releases validate against that model client-side. boto3 1.43.69 requires `VectorIndexUpdates[].Create` to carry `Projection`, `Dimensions` and `DistanceFunction` at the `Create` level with `VectorAttribute` holding only `AttributeName`, so the documented shape is rejected before any network call:

```
botocore.exceptions.ParamValidationError: Parameter validation failed:
Missing required parameter in VectorIndexUpdates[0].Create: "Projection"
Missing required parameter in VectorIndexUpdates[0].Create: "Dimensions"
Missing required parameter in VectorIndexUpdates[0].Create: "DistanceFunction"
Unknown parameter in VectorIndexUpdates[0].Create.VectorAttribute: "Dimensions", must be one of: AttributeName
```

This is purely a client-side limitation — the server accepts the shapes on this page, verified on a live cluster where `DescribeTable` echoes the index back with its `Projection` and `SimilarityFunction`. The prose on the page is otherwise accurate; only the client it names is wrong.

We already ship a client that works. `alternator-client` injects the Alternator vector-search shapes into botocore's DynamoDB model at run time, matching the server. This adds a **Client library** section to the introduction saying so, with the install line (vector search is only on `main` so far; the `1.0.0` PyPI release does not include it) and a pointer to the runnable examples in the vector-store repository, and relabels the example accordingly.

### 2. `alternator/executor_read.cc` — false comment above `parse_select`

`query_vector` claimed *"For a vector index, the default Select is ALL_ATTRIBUTES (full items)"*. `parse_select` returns `select_type::regular` only for `table_or_view_type::base`; `query_vector` passes `table_or_view_type::vector_index`, so with no explicit `Select` and no `ProjectionExpression`/`AttributesToGet` the default is `ALL_PROJECTED_ATTRIBUTES` — today the key attributes only. Confirmed live: with a default `Select`, every returned match contained only the key attribute.

This matches DynamoDB, and it matches our own docs on the very page above, which already describe the default correctly. The comment sits directly above the `parse_select` call and is the most authoritative-looking statement at that call site; it has already misled a downstream review into asserting the opposite. Comment-only change, plus a stray closing paren dropped in the same block.

### Testing

No build: the C++ change is comment-only, and the rest is documentation. The `#client-library` anchor follows the implicit-heading-anchor convention already used at `docs/alternator/sdks.md:35`. The vector-store example link was verified to resolve — default branch `master`, and `docs/examples/alternator/` contains `list_of_numbers.py` and `native_vector.py`.

### Backports

Both defects are present identically on `branch-2026.2` and `branch-2026.3`. 

Fixes SCYLLADB-4157