### PR TITLE
raft: allow transferring leadership to a specific target

### DIFF
--- a/raft/fsm.cc
+++ b/raft/fsm.cc
@@ -810,6 +810,7 @@ void fsm::tick_leader() {
             leader_state().log_limiter_semaphore->signal(_config.max_log_size);
             state.stepdown.reset();
             state.timeout_now_sent.reset();
+            state.leadership_transfer_target.reset();
             _abort_leadership_transfer = true;
             _sm_events.signal(); // signal to handle aborting of leadership transfer
         } else if (state.timeout_now_sent) {
@@ -1037,9 +1038,11 @@ void fsm::append_entries_reply(server_id from, append_reply&& reply) {
         progress.become_pipeline();
 
         // If a leader is stepping down, transfer the leadership
-        // to a first voting node that has fully replicated log.
+        // to a first voting node that has fully replicated log,
+        // If a transfer target was selected, only accept that node.
         if (leader_state().stepdown && !leader_state().timeout_now_sent &&
-                         progress.can_vote && progress.match_idx == _log.last_idx()) {
+                progress.can_vote && progress.match_idx == _log.last_idx() &&
+                (!leader_state().leadership_transfer_target || *leader_state().leadership_transfer_target == progress.id)) {
             send_timeout_now(progress.id);
             // We may have resigned leadership if a stepdown process completed
             // while the leader is no longer part of the configuration.
@@ -1357,7 +1360,7 @@ bool fsm::apply_snapshot(snapshot_descriptor snp, size_t max_trailing_entries, s
     return true;
 }
 
-void fsm::transfer_leadership(logical_clock::duration timeout) {
+void fsm::transfer_leadership(logical_clock::duration timeout, server_id target) {
     check_is_leader();
     auto leader = leader_state().tracker.find(_my_id);
     if (configuration::voter_count(get_configuration().current) == 1 && leader && leader->can_vote) {
@@ -1366,10 +1369,16 @@ void fsm::transfer_leadership(logical_clock::duration timeout) {
         throw raft::no_other_voting_member();
     }
 
+    if (target) {
+        leader_state().leadership_transfer_target = target;
+    } else {
+        leader_state().leadership_transfer_target.reset();
+    }
+
     leader_state().stepdown = _clock.now() + timeout;
     // Stop new requests from coming in
     leader_state().log_limiter_semaphore->consume(_config.max_log_size);
-    // If there is a fully up-to-date voting replica make it start an election.
+    // If there is a fully up-to-date eligible replica make it start an election.
     //
     // Prefer one whose clock still works: the reason we transfer automatically
     // is that ours does not, and moving to another clockless node would not
@@ -1379,7 +1388,8 @@ void fsm::transfer_leadership(logical_clock::duration timeout) {
     for (const bool require_clock_ok : {true, false}) {
         for (auto&& [_, p] : leader_state().tracker) {
             if (p.id != _my_id && p.can_vote && p.match_idx == _log.last_idx()
-                    && (!require_clock_ok || p.clock_ok)) {
+                    && (!require_clock_ok || p.clock_ok)
+                    && (!leader_state().leadership_transfer_target || *leader_state().leadership_transfer_target == p.id)) {
                 send_timeout_now(p.id);
                 return;
             }

--- a/raft/fsm.hh
+++ b/raft/fsm.hh
@@ -123,6 +123,9 @@ struct leader {
     // If timeout_now was already sent to one of the followers contains the id of the follower
     // it was sent to
     std::optional<server_id> timeout_now_sent;
+    // If set, leadership transfer must select this voting follower once it has
+    // caught up with the leader's log.
+    std::optional<server_id> leadership_transfer_target;
     // A source of read ids - a monotonically growing (in single term) identifiers of
     // reads issued by the state machine. Using monotonic ids allows the leader to
     // resolve all preceding read requests when a quorum of acks from followers arrive
@@ -584,7 +587,12 @@ public:
     // sends timeout_now rpc to it and makes it initiate new election.
     // Can be used for leader stepdown if new configuration does not contain
     // current leader.
-    void transfer_leadership(logical_clock::duration timeout = logical_clock::duration(0));
+    // If a target is selected, the leadership transfer will be attempted to that target only.
+    // The target must be a voting member of the current configuration other than the leader
+    // itself. Nobody but the target is ever sent timeout_now, so any other target leaves the
+    // transfer with no one to hand leadership to. It then waits out `timeout` with the log limiter
+    // consumed - the group takes no writes for that whole time - before tick_leader() cancels it.
+    void transfer_leadership(logical_clock::duration timeout = logical_clock::duration(0), server_id target = {});
 
     void stop();
 

--- a/raft/server.cc
+++ b/raft/server.cc
@@ -119,7 +119,7 @@ public:
     void tick() override;
     raft::server_id id() const override;
     void set_applier_queue_max_size(size_t queue_max_size) override;
-    future<> stepdown(logical_clock::duration timeout) override;
+    future<> stepdown(logical_clock::duration timeout, server_id target) override;
     future<> modify_config(std::vector<config_member> add, std::vector<server_id> del, seastar::abort_source* as) override;
     future<entry_id> add_entry_on_leader(command command, seastar::abort_source* as);
     void register_metrics() override;
@@ -1994,12 +1994,12 @@ void server_impl::remove_from_rpc_config(const server_address& srv) {
     _current_rpc_config.erase(srv);
 }
 
-future<> server_impl::stepdown(logical_clock::duration timeout) {
+future<> server_impl::stepdown(logical_clock::duration timeout, server_id target) {
     if (_stepdown_promise) {
         return make_exception_future<>(std::logic_error("Stepdown is already in progress"));
     }
     try {
-        _fsm->transfer_leadership(timeout);
+        _fsm->transfer_leadership(timeout, target);
     } catch (...) {
         return make_exception_future<>(std::current_exception());
     }

--- a/raft/server.hh
+++ b/raft/server.hh
@@ -247,6 +247,10 @@ public:
     virtual future<> read_barrier(seastar::abort_source* as) = 0;
 
     // Initiate leader stepdown process.
+    // If target is specified, the leadership transfer will be attempted to that target only.
+    // The target must be a voting member of the current configuration other than the leader
+    // itself. With any other target the transfer has no one to hand leadership to: it blocks the
+    // group's writes until the timeout expires, then throws raft::timeout_error.
     //
     // Exceptions:
     // raft::timeout_error
@@ -257,7 +261,7 @@ public:
     //     Thrown if there is no other voting member.
     // std::logic_error
     //     Thrown if the stepdown process is already in progress.
-    virtual future<> stepdown(logical_clock::duration timeout) = 0;
+    virtual future<> stepdown(logical_clock::duration timeout, server_id target = {}) = 0;
 
     // Register metrics for this server. Metric are global but their names
     // depend on the server's ID, so it is possible to register metrics

--- a/test/raft/fsm_test.cc
+++ b/test/raft/fsm_test.cc
@@ -1181,6 +1181,110 @@ BOOST_AUTO_TEST_CASE(test_truncate_rederives_config_indices) {
     BOOST_CHECK(log.last_conf_for(index_t{1}).current == config_from_ids({A, B, C}).current);
 }
 
+// transfer_leadership() with a target picks that target, and does so when every voter is equally
+// up to date and any of them could be picked instead.
+//
+// Which one an untargeted transfer would have picked is not fixed: raft::tracker is a hash map
+// keyed by server ids. That is why test_leader_transfer_to_target_waits_for_target, where only the
+// target may be chosen, is the one which fails if the target stops being honoured.
+BOOST_AUTO_TEST_CASE(test_leader_transfer_to_target) {
+    raft::server_id A_id = id(), B_id = id(), C_id = id();
+    raft::log log(raft::snapshot_descriptor{.idx = raft::index_t{0},
+        .config = config_from_ids({A_id, B_id, C_id})});
+    auto A = create_follower(A_id, log);
+    auto B = create_follower(B_id, log);
+    auto C = create_follower(C_id, log);
+
+    election_timeout(A);
+    communicate(A, B, C);
+    BOOST_REQUIRE(A.is_leader());
+
+    A.transfer_leadership(raft::logical_clock::duration(5), C_id);
+
+    auto output = A.get_output();
+    BOOST_REQUIRE_EQUAL(output.messages.size(), 1);
+    BOOST_CHECK_EQUAL(output.messages.front().first, C_id);
+    BOOST_CHECK(std::holds_alternative<raft::timeout_now>(output.messages.front().second));
+}
+
+BOOST_AUTO_TEST_CASE(test_leader_transfer_to_target_waits_for_target) {
+    raft::server_id A_id = id(), B_id = id(), C_id = id();
+    raft::log log(raft::snapshot_descriptor{.idx = raft::index_t{0},
+        .config = config_from_ids({A_id, B_id, C_id})});
+    auto A = create_follower(A_id, log);
+    auto B = create_follower(B_id, log);
+    auto C = create_follower(C_id, log);
+
+    election_timeout(A);
+    communicate(A, B);
+    BOOST_REQUIRE(A.is_leader());
+
+    auto output = A.get_output();
+    BOOST_CHECK(output.messages.empty());
+
+    A.add_entry(raft::log_entry::dummy());
+    const auto idx = A.get_log().last_idx();
+    (void) A.get_output();
+
+    A.transfer_leadership(raft::logical_clock::duration(5), C_id);
+    output = A.get_output();
+    BOOST_CHECK(output.messages.empty());
+
+    // B catches up first. Without the target being honoured, this is where the leadership would
+    // be handed over: B is now a voter with a fully replicated log. The check that nothing is sent
+    // here is what this test is for.
+    A.step(B_id, raft::append_reply{A.get_current_term(), idx, raft::append_reply::accepted{idx}});
+    output = A.get_output();
+    BOOST_CHECK(std::ranges::none_of(output.messages, [] (const auto& m) {
+        return std::holds_alternative<raft::timeout_now>(m.second);
+    }));
+
+    A.step(C_id, raft::append_reply{A.get_current_term(), idx, raft::append_reply::accepted{idx}});
+    output = A.get_output();
+    BOOST_REQUIRE_EQUAL(output.messages.size(), 1);
+    BOOST_CHECK_EQUAL(output.messages.front().first, C_id);
+    BOOST_CHECK(std::holds_alternative<raft::timeout_now>(output.messages.front().second));
+}
+
+// A targeted transfer_leadership() whose target never catches up times out and gives the
+// leadership back to the leader, which can then transfer it to somebody else.
+//
+// The target is forgotten on the way, but that is not what this checks: it cannot be observed from
+// the outside, the target being consulted only while a stepdown is in progress.
+BOOST_AUTO_TEST_CASE(test_leader_transfer_timeout_forgets_target) {
+    raft::server_id A_id = id(), B_id = id(), C_id = id();
+    raft::log log(raft::snapshot_descriptor{.idx = raft::index_t{0},
+        .config = config_from_ids({A_id, B_id, C_id})});
+    auto A = create_follower(A_id, log);
+    auto B = create_follower(B_id, log);
+    auto C = create_follower(C_id, log);
+
+    election_timeout(A);
+    // C is left out, so it never catches up with A's log and cannot be transferred to.
+    communicate(A, B);
+    BOOST_REQUIRE(A.is_leader());
+    (void) A.get_output();
+
+    constexpr auto transfer_timeout = raft::logical_clock::duration(5);
+    A.transfer_leadership(transfer_timeout, C_id);
+    auto output = A.get_output();
+    BOOST_CHECK(output.messages.empty());
+
+    for (int i = 0; i <= transfer_timeout.count(); i++) {
+        A.tick();
+    }
+    output = A.get_output();
+    BOOST_CHECK(output.abort_leadership_transfer);
+    BOOST_REQUIRE(A.is_leader());
+
+    // The leadership is transferable again, and to B rather than to the target which timed out.
+    A.transfer_leadership(transfer_timeout);
+    output = A.get_output();
+    BOOST_REQUIRE_EQUAL(output.messages.size(), 1);
+    BOOST_CHECK_EQUAL(output.messages.front().first, B_id);
+    BOOST_CHECK(std::holds_alternative<raft::timeout_now>(output.messages.front().second));
+}
+
 BOOST_AUTO_TEST_CASE(test_empty_configuration) {
     // When a server is joining an existing cluster, its configuration is empty.
     // The leader sends its configuration over in AppendEntries or


### PR DESCRIPTION
transfer_leadership() picks the first voting follower which has fully replicated the leader's log. Add an optional target so that a caller can name the follower the leadership has to go to, and wait for that one to catch up instead of handing it over to whoever is up to date first.

The target has to be a voting member of the current configuration other than the leader itself, and stay one until the transfer completes. With an invalid target the group cannot accept writes until the stepdown deadline expires.

This will be used by strongly consistent tablet split, which needs the leader of a group replacing a tablet's group to sit on the same node as the leader of the group being replaced.

Refs #30888
