### PR TITLE
raft: append entries in add_entry() submission order

### DIFF
--- a/raft/server.cc
+++ b/raft/server.cc
@@ -364,6 +364,10 @@ private:
     template <LeaderAction AsyncAction>
     future<> do_on_leader_with_retries(seastar::abort_source* as, AsyncAction&& action);
 
+    // Makes the order in which callers enter add_entry() the order in which their
+    // entries are appended to the log. Taken only on the non-forwarding path.
+    seastar::semaphore _add_entry_admission{1};
+
     future<> override_snapshot_thresholds();
 
     friend std::ostream& operator<<(std::ostream& os, const server_impl& s);
@@ -793,7 +797,15 @@ future<> server_impl::add_entry(command command, wait_type type, seastar::abort_
         if (const auto leader = _fsm->current_leader(); leader != _id) {
             throw not_a_leader{leader};
         }
-        auto eid = co_await add_entry_on_leader(std::move(command), as);
+        entry_id eid;
+        {
+            // Taken before the first await which can reorder callers, released before
+            // waiting for the entry. See _add_entry_admission.
+            auto admission = as
+                    ? co_await get_units(_add_entry_admission, 1, *as)
+                    : co_await get_units(_add_entry_admission, 1);
+            eid = co_await add_entry_on_leader(std::move(command), as);
+        }
         co_await utils::get_local_injector().inject("block_raft_add_entry_before_wait_for_entry",
                 utils::wait_for_message(std::chrono::minutes(5)));
         co_return co_await wait_for_entry(eid, type, as);
@@ -1704,6 +1716,8 @@ future<> server_impl::abort(sstring reason) {
     _fsm->stop();
     _events.broken();
     _snapshot_desc_idx_changed.broken();
+    // Fail the callers waiting for admission like every other waiter below.
+    _add_entry_admission.broken(stopped_error(*_aborted));
 
     // IO and applier fibers may update waiters and start new snapshot
     // transfers, so abort them first

--- a/test/raft/raft_server_test.cc
+++ b/test/raft/raft_server_test.cc
@@ -4,6 +4,7 @@
 #include "utils/error_injection.hh"
 #include "test/lib/error_injection.hh"
 #include <seastar/util/defer.hh>
+#include <seastar/core/when_all.hh>
 
 #ifdef SEASTAR_DEBUG
 // Increase tick time to allow debug to process messages
@@ -526,4 +527,66 @@ SEASTAR_THREAD_TEST_CASE(test_commit_waiter_dropped_before_notifying_above_snaps
     // included in the snapshot.
     BOOST_CHECK_NO_THROW(fut.get());
 #endif
+}
+
+// Concurrent add_entry() calls on a leader must be appended to the log - and
+// therefore applied - in the order in which the calls entered add_entry().
+//
+// This discriminates only where the reactor shuffles its task queue: Debug, Sanitize and Fuzz
+// builds. That shuffling is what lets the submissions below reach the memory permit out of order.
+// Elsewhere they reach it in order anyway, a seastar semaphore handing its units out strictly
+// first-come-first-served, so the test passes with or without the admission.
+SEASTAR_THREAD_TEST_CASE(test_add_entry_preserves_submission_order) {
+    constexpr int n = 100;
+    const size_t command_size = sizeof(size_t);
+    auto applied = make_lw_shared<std::vector<int>>();
+    test_case test_config {
+        .nodes = 1,
+        .config = std::vector<raft::server::configuration>({
+            raft::server::configuration {
+                // Room for a couple of entries at a time - the commands are serialized ints, so
+                // two of them fit in max_log_size - with a snapshot after every entry so that the
+                // room comes back. Without this the limiter has 4MB and every one of the hundred
+                // submissions gets its memory permit synchronously, which orders the appends by
+                // construction and leaves the admission below untested.
+                .snapshot_threshold = 1,
+                .snapshot_threshold_log_size = 1,
+                .snapshot_trailing = 0,
+                .snapshot_trailing_size = 0,
+                .max_log_size = command_size,
+                // The path strongly consistent tables take, and the only one the ordering is
+                // kept on.
+                .enable_forwarding = false,
+                .max_command_size = command_size
+            }
+        })
+    };
+    raft_cluster<std::chrono::steady_clock> cluster(
+            std::move(test_config),
+            [applied](raft::server_id id, const raft::log_entry_ptr_list& commands, lw_shared_ptr<hasher_int> hasher) {
+                for (auto&& entry : commands) {
+                    auto&& d = std::get<raft::command>(entry->data);
+                    auto is = ser::as_input_stream(d);
+                    applied->push_back(ser::deserialize(is, std::type_identity<int>()));
+                }
+                return commands.size();
+            },
+            n, 0, 0, false, tick_delay, rpc_config{});
+    cluster.start_all().get();
+    auto stop = defer([&cluster] noexcept { cluster.stop_all().get(); });
+
+    // Submitted without awaiting in between, so that the submission order is the order
+    // of the loop. Waited for as applied, since the check below reads what was applied.
+    auto& server = cluster.get_server(0);
+    std::vector<future<>> futures;
+    futures.reserve(n);
+    for (int v = 0; v < n; ++v) {
+        futures.push_back(server.add_entry(create_command(v), raft::wait_type::applied, nullptr));
+    }
+    seastar::when_all_succeed(futures.begin(), futures.end()).get();
+
+    BOOST_REQUIRE_EQUAL(applied->size(), size_t(n));
+    for (int v = 0; v < n; ++v) {
+        BOOST_REQUIRE_EQUAL((*applied)[v], v);
+    }
 }


### PR DESCRIPTION
Concurrent add_entry() calls on a leader may be reordered while they wait on the memory permit. That can break linearizability, if entries whose timestamps say one thing are applied in an order which says another. It is also needed for strongly consistent tablet split, where a write submitted before the "start_resize" marker was committed has to be appended ahead of the "end_resize" marker which follows it.

Admit callers on the non-forwarding path of add_entry(), which strongly consistent tables take, through a FIFO semaphore taken before the first await which can reorder them, so that submission order becomes append order. Nothing awaits between entering add_entry() and taking the admission, so a caller which does not yield after sampling the state keeps its position. The semaphore has count = 1, so each signal wakes only the first waiter and cannot reorder them either. It is released before waiting for the entry, which takes a round trip and would otherwise serialize the writes behind it.

The forwarding path does not take the admission: an entry forwarded over RPC has already been reordered on the way, so there is nothing left to preserve for it.

server::abort() breaks the semaphore with stopped_error, as it fails every other waiter, instead of leaving the queued callers to be released one at a time into the broken log limiter. A caller's abort source fails the wait with the exception it was aborted with, as it does everywhere else.

Refs https://github.com/scylladb/scylladb/pull/30888