### PR TITLE
auth: avoid pre-auth deref on rejected transitional login

### DIFF
--- a/audit/audit.cc
+++ b/audit/audit.cc
@@ -11,6 +11,7 @@
 #include "audit/audit.hh"
 #include "audit/audit_rule.hh"
 #include "audit/preprocessed_audit_rules.hh"
+#include "auth/authenticated_user.hh"
 #include "utils/rjson.hh"
 #include "db/config.hh"
 #include "cql3/cql_statement.hh"
@@ -336,8 +337,7 @@ future<> audit::log(const audit_info& audit_info, const service::client_state& c
         role = *client_state.user()->name;
     }
     thread_local static sstring no_username("undefined");
-    static const sstring anonymous_username("anonymous");
-    const sstring& username = client_state.user() ? client_state.user()->name.value_or(anonymous_username) : no_username;
+    const sstring& username = client_state.user() ? client_state.user()->name.value_or(auth::anonymous_username) : no_username;
     socket_address client_ip = client_state.get_client_address().addr();
     socket_address node_ip = _token_metadata.get()->get_topology().my_address().addr();
     if (audit_info.alternator_batch_tables()) {

--- a/auth/authenticated_user.hh
+++ b/auth/authenticated_user.hh
@@ -40,6 +40,11 @@ public:
 
 const authenticated_user& anonymous_user() noexcept;
 
+///
+/// The name reported for the anonymous user, which has none of its own.
+///
+inline const sstring anonymous_username = "anonymous";
+
 inline bool is_anonymous(const authenticated_user& u) noexcept {
     return u == anonymous_user();
 }
@@ -56,7 +61,7 @@ struct fmt::formatter<auth::authenticated_user> : fmt::formatter<string_view> {
         if (u.name) {
             return fmt::format_to(ctx.out(), "{}", *u.name);
         } else {
-            return fmt::format_to(ctx.out(), "{}", "anonymous");
+            return fmt::format_to(ctx.out(), "{}", auth::anonymous_username);
         }
     }
 };

--- a/auth/sasl_challenge.cc
+++ b/auth/sasl_challenge.cc
@@ -65,6 +65,9 @@ bool plain_sasl_challenge::is_complete() const {
 }
 
 future<authenticated_user> plain_sasl_challenge::get_authenticated_user() const {
+    if (!_username || !_password) {
+        throw std::logic_error("plain_sasl_challenge::get_authenticated_user() called without credentials");
+    }
     return _when_complete(*_username, *_password);
 }
 

--- a/auth/transitional.cc
+++ b/auth/transitional.cc
@@ -108,6 +108,8 @@ const resource_set& transitional_authenticator::protected_resources() const {
             try {
                 return _sasl->evaluate_response(client_response);
             } catch (const exceptions::authentication_exception&) {
+                // Transitional mode: a login that cannot be authenticated
+                // degrades to the anonymous user.
                 _rejected = true;
                 return {};
             }
@@ -118,6 +120,9 @@ const resource_set& transitional_authenticator::protected_resources() const {
         }
 
         virtual future<authenticated_user> get_authenticated_user() const override {
+            if (_rejected) {
+                return make_ready_future<authenticated_user>(anonymous_user());
+            }
             return futurize_invoke([this] {
                 return _sasl->get_authenticated_user().handle_exception([](auto ep) {
                     try {
@@ -131,6 +136,9 @@ const resource_set& transitional_authenticator::protected_resources() const {
         }
 
         const sstring& get_username() const override {
+            if (_rejected) {
+                return anonymous_username;
+            }
             return _sasl->get_username();
         }
 

--- a/auth/transitional.cc
+++ b/auth/transitional.cc
@@ -108,13 +108,13 @@ const resource_set& transitional_authenticator::protected_resources() const {
             try {
                 return _sasl->evaluate_response(client_response);
             } catch (const exceptions::authentication_exception&) {
-                _complete = true;
+                _rejected = true;
                 return {};
             }
         }
 
         virtual bool is_complete() const override {
-            return _complete || _sasl->is_complete();
+            return _rejected || _sasl->is_complete();
         }
 
         virtual future<authenticated_user> get_authenticated_user() const override {
@@ -137,7 +137,7 @@ const resource_set& transitional_authenticator::protected_resources() const {
     private:
         ::shared_ptr<sasl_challenge> _sasl;
 
-        bool _complete = false;
+        bool _rejected = false;
     };
     return ::make_shared<sasl_wrapper>(_authenticator->new_sasl_challenge());
 }

--- a/cql3/query_processor.cc
+++ b/cql3/query_processor.cc
@@ -17,6 +17,7 @@
 #include <seastar/coroutine/as_future.hh>
 #include <seastar/coroutine/try_future.hh>
 
+#include "auth/authenticated_user.hh"
 #include "service/storage_proxy.hh"
 #include "service/migration_manager.hh"
 #include "service/mapreduce_service.hh"
@@ -668,7 +669,7 @@ query_processor::execute_direct_statement_without_checking_exception_message(std
             metrics.regularStatementsExecuted.inc();
 #endif
     auto user = query_state.get_client_state().user();
-    tracing::trace(query_state.get_trace_state(), "Processing a statement for authenticated user: {}", user ? (user->name ? *user->name : "anonymous") : "no user authenticated");
+    tracing::trace(query_state.get_trace_state(), "Processing a statement for authenticated user: {}", user ? (user->name ? *user->name : auth::anonymous_username) : "no user authenticated");
     return execute_maybe_with_guard(query_state, std::move(statement), options, &query_processor::do_execute_direct, std::move(p->warnings));
 }
 

--- a/db/virtual_tables.cc
+++ b/db/virtual_tables.cc
@@ -15,6 +15,7 @@
 #include <seastar/json/json_elements.hh>
 #include <seastar/core/reactor.hh>
 
+#include "auth/authenticated_user.hh"
 #include "cdc/generation_service.hh"
 #include "cdc/log.hh"
 #include "cdc/metadata.hh"
@@ -893,7 +894,7 @@ class clients_table : public streaming_virtual_table {
                 if (cd->ssl_protocol) {
                     set_cell(cr.cells(), "ssl_protocol", *cd->ssl_protocol);
                 }
-                set_cell(cr.cells(), "username", cd->username ? *cd->username : sstring("anonymous"));
+                set_cell(cr.cells(), "username", cd->username ? *cd->username : auth::anonymous_username);
                 if (cd->scheduling_group_name) {
                     set_cell(cr.cells(), "scheduling_group", *cd->scheduling_group_name);
                 }

--- a/test/cluster/auth_cluster/test_transitional_auth_malformed_sasl.py
+++ b/test/cluster/auth_cluster/test_transitional_auth_malformed_sasl.py
@@ -1,0 +1,83 @@
+#
+# Copyright (C) 2026-present ScyllaDB
+#
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
+#
+
+import logging
+
+from cassandra import ConsistencyLevel
+from cassandra.auth import AuthProvider, Authenticator, PlainTextAuthProvider
+from cassandra.query import SimpleStatement
+
+from test.pylib.scylla_cluster_manager import ScyllaClusterManager
+from test.cluster.auth_cluster import extra_scylla_config_options as auth_config
+
+logger = logging.getLogger(__name__)
+
+TRANSITIONAL_AUTHENTICATOR = "com.scylladb.auth.TransitionalAuthenticator"
+TRANSITIONAL_AUTHORIZER = "com.scylladb.auth.TransitionalAuthorizer"
+
+# SASL PLAIN encodes credentials as authzId<NUL>authnId<NUL>password. None of
+# these carry a non-empty authnId (or password), so the server-side PLAIN parser
+# rejects them. In transitional mode that rejection is swallowed and the
+# challenge is reported complete, which used to leave the coordinator reading
+# credentials that were never parsed.
+MALFORMED_TOKENS = [b"", b"\x00", b"\x00\x00", b"onlypassword"]
+
+# The name every other path reports for a user that has none of its own.
+ANONYMOUS = "anonymous"
+
+
+class _MalformedSaslAuthenticator(Authenticator):
+    def __init__(self, token: bytes) -> None:
+        self._token = token
+
+    def initial_response(self):
+        return self._token
+
+    def evaluate_challenge(self, challenge):
+        return b""
+
+
+class _MalformedSaslAuthProvider(AuthProvider):
+    def __init__(self, token: bytes) -> None:
+        self._token = token
+
+    def new_authenticator(self, host) -> Authenticator:
+        return _MalformedSaslAuthenticator(self._token)
+
+
+# Reproduces SCYLLADB-4166
+async def test_transitional_auth_malformed_sasl_token(manager: ScyllaClusterManager) -> None:
+    server = await manager.server_add(config={**auth_config,
+                                              "authenticator": TRANSITIONAL_AUTHENTICATOR,
+                                              "authorizer": TRANSITIONAL_AUTHORIZER,
+                                              "audit": "table",
+                                              "audit_categories": "AUTH"})
+
+    for token in MALFORMED_TOKENS:
+        logger.info("offering malformed SASL token %r", token)
+        await manager.driver_connect(server=server, auth_provider=_MalformedSaslAuthProvider(token))
+        await manager.get_cql().run_async("SELECT release_version FROM system.local")
+        manager.driver_close()
+
+    logger.info("a well-formed login must still authenticate as itself")
+    await manager.driver_connect(server=server,
+                                 auth_provider=PlainTextAuthProvider(username="cassandra", password="cassandra"))
+    cql = manager.get_cql()
+
+    # The audit keyspace is created with RF=3, more than this cluster has nodes.
+    rows = list(await cql.run_async(SimpleStatement(
+        "SELECT username, error FROM audit.audit_log WHERE category = 'AUTH' AND operation = 'LOGIN' ALLOW FILTERING",
+        consistency_level=ConsistencyLevel.ONE)))
+    logger.info("audited logins: %s", sorted({(r.username, r.error) for r in rows}))
+
+    # A credential the authenticator could not parse is recorded under the name
+    # every other anonymous login is recorded under, and not as a failure:
+    # transitional mode accepted the connection.
+    anonymous_logins = [r for r in rows if r.username == ANONYMOUS]
+    assert len(anonymous_logins) >= len(MALFORMED_TOKENS)
+    assert not any(r.error for r in anonymous_logins)
+    assert all(r.username for r in rows)
+    assert any(r.username == "cassandra" for r in rows)


### PR DESCRIPTION
In transitional mode a malformed SASL PLAIN token is rejected by the
parser, but that rejection is swallowed and the challenge is reported
as complete. No credentials were parsed, yet the coordinator goes on
to read them while still handling an unauthenticated connection.

Transitional mode already degrades connections that cannot be
authenticated to the anonymous user, so fall back to it here instead
of reading the absent credentials, and refuse to hand out a user that
was never parsed. The connection is then indistinguishable from any
other anonymous one, down to the name it is recorded under.

Fixes: SCYLLADB-4166
Backport: none, a minor bugfix