### PR TITLE
alternator: composite GSI follow-ups for #30818 and #31061

### DIFF
--- a/alternator/executor_read.cc
+++ b/alternator/executor_read.cc
@@ -933,9 +933,8 @@ static query::clustering_range calculate_ck_bound(schema_ptr schema, const colum
         return query::clustering_range::make(query::clustering_range::bound(ck), query::clustering_range::bound(upper_limit));
     }
     case comparison_operator_type::BEGINS_WITH: {
-        if (raw_value.empty()) {
-            return query::clustering_range::make_open_ended_both_sides();
-        }
+        // raw_value cannot be empty here - get_key_from_typed_value() above
+        // rejects empty key values.
         // NOTICE(sarna): A range starting with given prefix and ending (non-inclusively) with a string "incremented" by a single
         // character at the end. Throws for NUMBER instances.
         if (!ck_cdef.type->is_compatible_with(*utf8_type)) {

--- a/alternator/executor_read.cc
+++ b/alternator/executor_read.cc
@@ -580,10 +580,12 @@ static rjson::value encode_paging_state(const schema& schema, const service::pag
     }
     auto pos = paging_state.get_position_in_partition();
     if (pos.has_key()) {
-        // Base tables and LSIs have at most one clustering key column, but
-        // composite GSI range keys, as well as Alternator's
-        // internal access to system tables, may have multiple clustering key
-        // columns. So we need to handle that case here.
+        // A base table has at most one clustering key column, but the views
+        // backing GSIs and LSIs carry the base table's key columns as extra
+        // clustering key columns, composite GSI range keys have up to four,
+        // and Alternator's internal access to system tables may also see
+        // multiple clustering key columns. So we need to handle that case
+        // here.
         auto cdef_it = schema.clustering_key_columns().begin();
         for(const auto &exploded_ck : pos.key().explode()) {
             rjson::add_with_string_name(last_evaluated_key, std::string_view(cdef_it->name_as_text()), rjson::empty_object());
@@ -1316,6 +1318,10 @@ calculate_bounds_condition_expression(schema_ptr schema,
 
     std::optional<uint8_t> max_sk_index_set;
     std::optional<uint8_t> first_unset_idx;
+    // pk_size is at least 1 (every table has a partition key; a composite
+    // GSI HASH key has up to 4 columns), and restrictions.size() is pk_size
+    // plus up to 4 genuine RANGE key columns - so the backwards unsigned
+    // loop counter cannot wrap.
     for (uint8_t i = static_cast<uint8_t>(restrictions.size()) - 1; i >= pk_size; --i) {
         const key_restriction& r = restrictions[i];
         if (!r.eq_value && !r.range) {
@@ -1377,11 +1383,18 @@ calculate_bounds_condition_expression(schema_ptr schema,
             clustering_key prefix_bound_key = clustering_key::from_exploded(*schema, prefix_values);
             prefix_values.push_back(std::move(sk_range.value1));
             clustering_key ck = clustering_key::from_exploded(*schema, prefix_values);
-            // The bound from prefix_bound_key when prefix_values are empty is treated the same as unbounded.
-            // When there are prefix_values the range becomes:
-            // depends on flag in bounds constructor - "[" or "(" ck, (prefix_values, +inf, ..., +inf)]
-            // or
-            // [(prefix_values, -inf, ..., -inf), ck "]" or ")" - depends on flag in bounds constructor.
+            // One end of the range is ck = (prefix_values, value), inclusive
+            // or exclusive depending on the operator. The other end is
+            // prefix_bound_key = (prefix_values) alone: a clustering prefix
+            // used as an inclusive start bound means
+            // (prefix_values, -inf, ..., -inf) and as an inclusive end bound
+            // (prefix_values, +inf, ..., +inf), so it spans exactly the rows
+            // sharing prefix_values. The resulting ranges are:
+            //   col <  v: [(prefix_values, -inf, ..., -inf), ck)
+            //   col <= v: [(prefix_values, -inf, ..., -inf), ck]
+            //   col >  v: (ck, (prefix_values, +inf, ..., +inf)]
+            //   col >= v: [ck, (prefix_values, +inf, ..., +inf)]
+            // With empty prefix_values the other end of the range is unbounded.
             if ((sk_range.op == parsed::primitive_condition::type::LT && sk_range.toplevel_ind == 0) ||
                 (sk_range.op == parsed::primitive_condition::type::GT && sk_range.toplevel_ind == 1)) {
                 ck_bounds.push_back(query::clustering_range::make(query::clustering_range::bound(std::move(prefix_bound_key)), query::clustering_range::bound(std::move(ck), false)));
@@ -2177,12 +2190,14 @@ future<executor::request_return_type> executor::query(client_state& client_state
 
     // How many of the schema's leading clustering columns are the RANGE key
     // the user actually asked for. This is computed for every table we query,
-    // not just for GSIs: for a base table or an LSI it is simply that table's
-    // own sort key, so 0 or 1 columns and every clustering column is the
-    // user's. A GSI is where the two can differ - Scylla appends the base
-    // table's key columns to every view's key, because a view's key must
-    // contain the whole base key, so the view backing a GSI carries trailing
-    // clustering columns the user never asked for. Those exist solely for
+    // not just for GSIs: for a base table it is simply that table's own
+    // sort key, so 0 or 1 columns and every clustering column is the user's.
+    // Views are where the two can differ - Scylla appends the base table's
+    // key columns to every view's key, because a view's key must contain the
+    // whole base key, so the views backing GSIs and LSIs carry trailing
+    // clustering columns the user never asked for (for an LSI, which has no
+    // tag, genuine_range_key_count()'s fallback of at most one genuine range
+    // key is exactly right). Those exist solely for
     // materialized-view correctness and must stay invisible through the API.
     // The schema alone cannot tell the two apart - the count comes from a tag
     // written when the GSI was created (see genuine_range_key_count()).

--- a/alternator/executor_read.cc
+++ b/alternator/executor_read.cc
@@ -319,6 +319,12 @@ public:
     // used more than once in the filter.
     void for_filters_on(const noncopyable_function<void(std::string_view)>& func) const;
     operator bool() const { return bool(_imp); }
+    // Tells whether this filter came from the legacy QueryFilter/ScanFilter
+    // parameter rather than from FilterExpression. Used only to name the
+    // right parameter in error messages.
+    bool is_legacy_conditions() const {
+        return _imp && std::holds_alternative<conditions_filter>(*_imp);
+    }
 };
 
 filter::filter(parsed::expression_cache& parsed_expression_cache, const rjson::value& request, request_type rt,
@@ -2242,17 +2248,19 @@ future<executor::request_return_type> executor::query(client_state& client_state
     // A query is not allowed to filter on the partition key or the sort key.
     // The partition key may have up to 4 columns (composite GSI hash key);
     // the sort key may also have up to 4 genuine columns (composite GSI
-    // range key).
+    // range key). Like DynamoDB, name the offending parameter - the legacy
+    // QueryFilter or the newer FilterExpression - in the error message.
+    const char* filter_param = filter.is_legacy_conditions() ? "QueryFilter" : "Filter expression";
     for (const column_definition& cdef : schema->partition_key_columns()) {
         if (filter.filters_on(cdef.name_as_text())) {
             return make_ready_future<request_return_type>(api_error::validation(
-                    format("Filter expression can only contain non-primary key attributes: Partition key attribute: {}", cdef.name_as_text())));
+                    format("{} can only contain non-primary key attributes: Partition key attribute: {}", filter_param, cdef.name_as_text())));
         }
     }
     for (const column_definition& cdef : schema->clustering_key_columns() | std::views::take(number_of_user_specified_range_keys)) {
         if (filter.filters_on(cdef.name_as_text())) {
             return make_ready_future<request_return_type>(api_error::validation(
-                    format("Filter expression can only contain non-primary key attributes: Sort key attribute: {}", cdef.name_as_text())));
+                    format("{} can only contain non-primary key attributes: Sort key attribute: {}", filter_param, cdef.name_as_text())));
         }
     }
 

--- a/alternator/executor_read.cc
+++ b/alternator/executor_read.cc
@@ -1329,7 +1329,10 @@ calculate_bounds_condition_expression(schema_ptr schema,
         }
         if (r.range && max_sk_index_set) {
             throw api_error::validation(
-                    "KeyConditionExpression: only the last constrained RANGE key may skip the equality (=) condition");
+                    format("KeyConditionExpression: RANGE key attribute {} must have an equality (=) "
+                            "condition, because the later attribute {} has a condition",
+                            r.column->name_as_text(),
+                            restrictions[*max_sk_index_set].column->name_as_text()));
         }
         if ((r.eq_value || r.range) && !max_sk_index_set) {
             max_sk_index_set = i;
@@ -1338,8 +1341,10 @@ calculate_bounds_condition_expression(schema_ptr schema,
     if (first_unset_idx && max_sk_index_set
         && *first_unset_idx < *max_sk_index_set) {
         throw api_error::validation(
-                format("KeyConditionExpression: RANGE key {} must have an equality (=) condition",
-                        restrictions[*first_unset_idx].column->name_as_text()));
+                format("KeyConditionExpression: RANGE key attribute {} must have an equality (=) "
+                        "condition, because the later attribute {} has a condition",
+                        restrictions[*first_unset_idx].column->name_as_text(),
+                        restrictions[*max_sk_index_set].column->name_as_text()));
     }
 
     if (!max_sk_index_set) {

--- a/docs/alternator/compatibility.md
+++ b/docs/alternator/compatibility.md
@@ -414,14 +414,9 @@ they should be easy to detect. Here is a list of these unimplemented features:
 
 * The deprecated `KeyConditions` parameter of `Query` works only on
   single-attribute keys. Using it to query a composite GSI fails with a
-  `ValidationException`carrying this message:
-
-  ```
-  Legacy KeyConditions are not supported for composite key GSIs in Alternator
-  ```
-
-  Use `KeyConditionExpression` instead - AWS recommends it for all new
-  applications anyway.
+  `ValidationException`. Use `KeyConditionExpression` instead - AWS
+  recommends it for all new applications anyway.
+  <https://github.com/scylladb/scylladb/issues/31393>
 
 * DynamoDB's multi-item transaction feature (TransactWriteItems,
   TransactGetItems) is not supported. Note that the older single-item

--- a/test/alternator/test_gsi_composite_keys.py
+++ b/test/alternator/test_gsi_composite_keys.py
@@ -1775,7 +1775,7 @@ def test_gsi_composite_query_rk_begins_with_all_ff_does_not_leak_past_eq_prefix(
 # FilterExpression referencing a composite HASH attr - should fail.
 def test_gsi_composite_filter_on_hash_attr_rejected(test_table_gsi_2h2r):
     table = test_table_gsi_2h2r
-    with pytest.raises(ClientError, match="ValidationException.*[fF]ilter.*[kK]ey"):
+    with pytest.raises(ClientError, match="ValidationException.*Filter [Ee]xpression can only contain"):
         full_query(
             table,
             IndexName="idx_2h2r",
@@ -1789,7 +1789,7 @@ def test_gsi_composite_filter_on_hash_attr_rejected(test_table_gsi_2h2r):
 # FilterExpression referencing a composite RANGE attr - should fail.
 def test_gsi_composite_filter_on_range_attr_rejected(test_table_gsi_2h2r):
     table = test_table_gsi_2h2r
-    with pytest.raises(ClientError, match="ValidationException.*[fF]ilter.*[kK]ey"):
+    with pytest.raises(ClientError, match="ValidationException.*Filter [Ee]xpression can only contain"):
         full_query(
             table,
             IndexName="idx_2h2r",
@@ -1888,7 +1888,7 @@ def test_gsi_composite_query_key_condition_with_aliases(test_table_gsi_2h2r):
 # attribute of the queried index.
 def test_gsi_composite_filter_on_key_attr_with_alias_rejected(test_table_gsi_2h2r):
     table = test_table_gsi_2h2r
-    with pytest.raises(ClientError, match="ValidationException.*[fF]ilter.*[kK]ey"):
+    with pytest.raises(ClientError, match="ValidationException.*Filter [Ee]xpression can only contain"):
         full_query(
             table,
             IndexName="idx_2h2r",

--- a/test/alternator/test_gsi_composite_keys.py
+++ b/test/alternator/test_gsi_composite_keys.py
@@ -2089,6 +2089,132 @@ def test_gsi_composite_query_pagination_roundtrip(test_table_gsi_2h2r, limit):
     )
 
 
+# Full pagination roundtrip with ScanIndexForward=False. Unlike
+# test_gsi_composite_query_pagination_roundtrip above, which only checks
+# that a paginated Query loses no items, this test also verifies the
+# descending (r1, r2) order across pages - with r1 blocks spanning several
+# r2 values, inserted out of order. test_gsi_composite_scan_pagination
+# below is different again: it covers Scan, whose order between index
+# partitions is unspecified - within one partition items do come back in
+# sort-key order - so it checks only completeness.
+@pytest.mark.parametrize("limit", [1, 3, 10])
+def test_gsi_composite_query_pagination_roundtrip_reverse(test_table_gsi_2h2r, limit):
+    table = test_table_gsi_2h2r
+    h1_val, h2_val = random_string(), random_string()
+    range_keys = [
+        ("a", "a"),
+        ("c", "x"),
+        ("b", "b"),
+        ("a", "q"),
+        ("c", "c"),
+        ("b", "z"),
+        ("d", "d"),
+        ("c", "m"),
+        ("e", "e"),
+        ("d", "n"),
+    ]
+    items = []
+    for r1, r2 in range_keys:
+        item = {
+            "p": random_string(),
+            "h1": h1_val,
+            "h2": h2_val,
+            "r1": r1,
+            "r2": r2,
+        }
+        table.put_item(Item=item)
+        items.append(item)
+    # Wait for the index to converge before checking order.
+    assert_index_query(
+        table,
+        "idx_2h2r",
+        items,
+        KeyConditionExpression="h1 = :h1 AND h2 = :h2",
+        ExpressionAttributeValues={":h1": h1_val, ":h2": h2_val},
+    )
+    got = full_query(
+        table,
+        IndexName="idx_2h2r",
+        ConsistentRead=False,
+        Limit=limit,
+        ScanIndexForward=False,
+        KeyConditionExpression="h1 = :h1 AND h2 = :h2",
+        ExpressionAttributeValues={":h1": h1_val, ":h2": h2_val},
+    )
+    assert got == sorted(items, key=lambda i: (i["r1"], i["r2"]), reverse=True)
+
+
+# Select=COUNT on a composite GSI query returns just the item count.
+def test_gsi_composite_query_select_count(test_table_gsi_2h2r):
+    table = test_table_gsi_2h2r
+    h1_val, h2_val = random_string(), random_string()
+    items = []
+    for i in range(3):
+        item = {
+            "p": random_string(),
+            "h1": h1_val,
+            "h2": h2_val,
+            "r1": f"r1_{i}",
+            "r2": f"r2_{i}",
+        }
+        table.put_item(Item=item)
+        items.append(item)
+    # Wait for the index to converge before counting.
+    assert_index_query(
+        table,
+        "idx_2h2r",
+        items,
+        KeyConditionExpression="h1 = :h1 AND h2 = :h2",
+        ExpressionAttributeValues={":h1": h1_val, ":h2": h2_val},
+    )
+    got = table.query(
+        IndexName="idx_2h2r",
+        ConsistentRead=False,
+        Select="COUNT",
+        KeyConditionExpression="h1 = :h1 AND h2 = :h2",
+        ExpressionAttributeValues={":h1": h1_val, ":h2": h2_val},
+    )
+    assert got["Count"] == len(items)
+    assert "Items" not in got
+
+
+# ProjectionExpression on a composite GSI query returns only the requested
+# attributes.
+def test_gsi_composite_query_projection_expression(test_table_gsi_2h2r):
+    table = test_table_gsi_2h2r
+    h1_val, h2_val = random_string(), random_string()
+    items = []
+    for i in range(2):
+        item = {
+            "p": random_string(),
+            "h1": h1_val,
+            "h2": h2_val,
+            "r1": f"r1_{i}",
+            "r2": f"r2_{i}",
+            "z": random_string(),
+        }
+        table.put_item(Item=item)
+        items.append(item)
+    # Wait for the index to converge.
+    assert_index_query(
+        table,
+        "idx_2h2r",
+        items,
+        KeyConditionExpression="h1 = :h1 AND h2 = :h2",
+        ExpressionAttributeValues={":h1": h1_val, ":h2": h2_val},
+    )
+    got = full_query(
+        table,
+        IndexName="idx_2h2r",
+        ConsistentRead=False,
+        ProjectionExpression="r2, z",
+        KeyConditionExpression="h1 = :h1 AND h2 = :h2",
+        ExpressionAttributeValues={":h1": h1_val, ":h2": h2_val},
+    )
+    expected = [{"r2": item["r2"], "z": item["z"]} for item in items]
+    assert sorted(got, key=lambda i: i["r2"]) == expected
+
+
 # Scan pagination on composite GSI.
 @pytest.mark.parametrize("limit", [1, 2, 5, 8])
 def test_gsi_composite_scan_pagination(dynamodb, limit):

--- a/test/alternator/test_gsi_composite_keys.py
+++ b/test/alternator/test_gsi_composite_keys.py
@@ -552,7 +552,7 @@ def test_gsi_composite_swapped_hash_range_keys(dynamodb):
         # RANGE key here) and gives no equality condition on the actual
         # HASH key attributes r1, r2, so it must be rejected for missing
         # the mandatory HASH key equality condition.
-        with pytest.raises(ClientError, match="ValidationException.*HASH.*equality"):
+        with pytest.raises(ClientError, match="ValidationException.*HASH.*r1.*equality"):
             full_query(
                 table,
                 IndexName="gsi_swapped",
@@ -588,7 +588,7 @@ def test_gsi_composite_swapped_hash_range_keys(dynamodb):
 
 
         # Skipping the first RANGE attr (h1) on gsi_swapped is still rejected,
-        with pytest.raises(ClientError, match="ValidationException.*RANGE.*equality"):
+        with pytest.raises(ClientError, match="ValidationException.*RANGE.*h1.*equality.*h2"):
             full_query(
                 table,
                 IndexName="gsi_swapped",
@@ -1018,7 +1018,7 @@ def test_gsi_composite_query_all_hk_eq(test_table_gsi_2h2r):
 # Query specifying only one of two hash key attrs - should fail.
 def test_gsi_composite_query_missing_one_hk(test_table_gsi_2h2r):
     table = test_table_gsi_2h2r
-    with pytest.raises(ClientError, match="ValidationException.*HASH.*equality"):
+    with pytest.raises(ClientError, match="ValidationException.*HASH.*h2.*equality"):
         full_query(
             table,
             IndexName="idx_2h2r",
@@ -1031,7 +1031,7 @@ def test_gsi_composite_query_missing_one_hk(test_table_gsi_2h2r):
 # Inequality on a hash key attr - should fail.
 def test_gsi_composite_query_hk_inequality(test_table_gsi_2h2r):
     table = test_table_gsi_2h2r
-    with pytest.raises(ClientError, match="ValidationException.*HASH.*equality"):
+    with pytest.raises(ClientError, match="ValidationException.*HASH.*h2.*equality"):
         full_query(
             table,
             IndexName="idx_2h2r",
@@ -1088,7 +1088,7 @@ def test_gsi_composite_query_hk_wrong_type(test_table_gsi_2h2r):
 # BETWEEN on a hash key attr - should fail.
 def test_gsi_composite_query_hk_between_rejected(test_table_gsi_2h2r):
     table = test_table_gsi_2h2r
-    with pytest.raises(ClientError, match="ValidationException.*HASH.*equality"):
+    with pytest.raises(ClientError, match="ValidationException.*HASH.*h2.*equality"):
         full_query(
             table,
             IndexName="idx_2h2r",
@@ -1101,7 +1101,7 @@ def test_gsi_composite_query_hk_between_rejected(test_table_gsi_2h2r):
 # begins_with() on a hash key attr - should fail.
 def test_gsi_composite_query_hk_begins_with_rejected(test_table_gsi_2h2r):
     table = test_table_gsi_2h2r
-    with pytest.raises(ClientError, match="ValidationException.*HASH.*equality"):
+    with pytest.raises(ClientError, match="ValidationException.*HASH.*h2.*equality"):
         full_query(
             table,
             IndexName="idx_2h2r",
@@ -1209,16 +1209,9 @@ def test_gsi_composite_query_rk_all_eq(test_table_gsi_4h4r):
 
 
 # Skipping the first range key attr (querying r2 without r1) - should fail.
-# The regex below intentionally only checks for "RANGE" + "equality" rather
-# than a message that more specifically names the skipped/incomplete range
-# key attribute: composite-key validation isn't implemented in Alternator
-# yet, so the eventual error message is unknown, and guessing at a more
-# specific wording risks a spurious mismatch once it lands. Tighten this
-# match once the real implementation exists and the actual message is
-# known.
 def test_gsi_composite_query_rk_skip_first_rejected(test_table_gsi_2h2r):
     table = test_table_gsi_2h2r
-    with pytest.raises(ClientError, match="ValidationException.*RANGE.*equality"):
+    with pytest.raises(ClientError, match="ValidationException.*RANGE.*r1.*equality.*r2"):
         full_query(
             table,
             IndexName="idx_2h2r",
@@ -1231,7 +1224,7 @@ def test_gsi_composite_query_rk_skip_first_rejected(test_table_gsi_2h2r):
 # Gap in range key attrs (r1 and r3 but not r2) - should fail.
 def test_gsi_composite_query_rk_gap_rejected(test_table_gsi_4h4r):
     table = test_table_gsi_4h4r
-    with pytest.raises(ClientError, match="ValidationException.*RANGE.*equality"):
+    with pytest.raises(ClientError, match="ValidationException.*RANGE.*r2.*equality.*r3"):
         full_query(
             table,
             IndexName="idx_4h4r",
@@ -1349,7 +1342,7 @@ def test_gsi_composite_query_rk_inequality_last(test_table_gsi_2h2r):
 # Inequality on a non-last range key attr followed by equality - should fail.
 def test_gsi_composite_query_rk_inequality_not_last_rejected(test_table_gsi_2h2r):
     table = test_table_gsi_2h2r
-    with pytest.raises(ClientError, match="ValidationException.*RANGE.*equality"):
+    with pytest.raises(ClientError, match="ValidationException.*RANGE.*r1.*equality.*r2"):
         full_query(
             table,
             IndexName="idx_2h2r",
@@ -1362,6 +1355,9 @@ def test_gsi_composite_query_rk_inequality_not_last_rejected(test_table_gsi_2h2r
 # Using inequality operators on more than one range key attr at once - should fail
 def test_gsi_composite_query_rk_multiple_inequalities_rejected(test_table_gsi_2h2r):
     table = test_table_gsi_2h2r
+    # Unlike the neighbouring tests, Alternator rejects this shape while
+    # parsing the conditions, with a message that names no attribute, so the
+    # match here has to stay wording-agnostic.
     with pytest.raises(ClientError, match="ValidationException.*RANGE.*equality"):
         full_query(
             table,
@@ -1465,7 +1461,7 @@ def test_gsi_composite_query_rk_begins_with_last(test_table_gsi_2h2r):
 # begins_with() on a non-last range key attr followed by another condition - fail.
 def test_gsi_composite_query_rk_begins_with_not_last_rejected(test_table_gsi_2h2r):
     table = test_table_gsi_2h2r
-    with pytest.raises(ClientError, match="ValidationException.*RANGE.*equality"):
+    with pytest.raises(ClientError, match="ValidationException.*RANGE.*r1.*equality.*r2"):
         full_query(
             table,
             IndexName="idx_2h2r",

--- a/test/alternator/test_query_filter.py
+++ b/test/alternator/test_query_filter.py
@@ -106,6 +106,18 @@ def test_query_filter_sort_key(test_table_sn_with_data):
             KeyConditions={ 'p': { 'AttributeValueList': [p], 'ComparisonOperator': 'EQ' }},
             QueryFilter={ 'c': { 'AttributeValueList': [3], 'ComparisonOperator': 'EQ' }})
 
+# The error for a filter on a key attribute names the parameter which carried
+# that filter. Both DynamoDB and Alternator name the legacy parameter
+# "QueryFilter" here, as opposed to "Filter expression" for a FilterExpression
+# (see test_filter_expression.py), so pin the name down - the two branches are
+# easy to confuse.
+def test_query_filter_key_attribute_names_the_parameter(test_table_sn_with_data):
+    table, p, items = test_table_sn_with_data
+    with pytest.raises(ClientError, match='ValidationException.*QueryFilter can only contain'):
+        full_query(table,
+            KeyConditions={ 'p': { 'AttributeValueList': [p], 'ComparisonOperator': 'EQ' }},
+            QueryFilter={ 'c': { 'AttributeValueList': [3], 'ComparisonOperator': 'EQ' }})
+
 # Having a filter on a key column is the problem - it doesn't help if we
 # also have an additional filter on a non-key column.
 def test_query_filter_sort_key_2(test_table_sn_with_data):


### PR DESCRIPTION
Follow-ups from a post-merge review of #30818 (composite GSI KeyConditionExpression support) and #31061 (composite GSI docs):

- Fix comments in the composite GSI query code.
- Clarify validation message about placement of non-equality-conditioned RANGE keys.
- Filter-on-key-attribute errors now name the parameter actually used - "QueryFilter" vs. "Filter expression".
- Remove a dead empty-value check in `calculate_ck_bound()`.
- Add composite GSI Query tests for:
  1. pagination roundtrip with `ScanIndexForward=False` (completeness and descending order),
  2. `Select=COUNT`,
  3. `ProjectionExpression`.
- The docs shortened a bit.

The new tests were run against DynamoDB too.

Refs #30818
Refs #31393
Refs SCYLLADB-2629

No backport needed - follow-up to a feature merged for 2026.4.