### PR TITLE
Make the alter_table_with_tablet_hints service parameters remove_unset and wait_balancer bool_class instead of plain bool

### DIFF
--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -3173,14 +3173,14 @@ future<> storage_service::alter_table_with_tablet_hints(table_id tid,
                                                         std::optional<size_t> min_tablet_count,
                                                         std::optional<size_t> max_tablet_count,
                                                         wait_balancer wait_for_balancer,
-                                                        bool remove_unset) {
+                                                        remove_unset erase_unset) {
     if (this_shard_id() != 0) {
         co_return co_await container().invoke_on(0, [&] (auto& ss) {
-            return ss.alter_table_with_tablet_hints(tid, min_tablet_count, max_tablet_count, wait_for_balancer, remove_unset);
+            return ss.alter_table_with_tablet_hints(tid, min_tablet_count, max_tablet_count, wait_for_balancer, erase_unset);
         });
     }
 
-    if (!min_tablet_count && !max_tablet_count && !remove_unset) {
+    if (!min_tablet_count && !max_tablet_count && !erase_unset) {
         slogger.info("alter_table_with_tablet_hints: the tablet hints passed are both nullopt, nothing to update");
         co_return;
     }
@@ -3205,12 +3205,12 @@ future<> storage_service::alter_table_with_tablet_hints(table_id tid,
         auto tablet_options = schema->raw_tablet_options();
         if (min_tablet_count) {
             tablet_options["min_tablet_count"] = to_sstring(*min_tablet_count);
-        } else if (remove_unset) {
+        } else if (erase_unset) {
             tablet_options.erase("min_tablet_count");
         }
         if (max_tablet_count) {
             tablet_options["max_tablet_count"] = to_sstring(*max_tablet_count);
-        } else if (remove_unset) {
+        } else if (erase_unset) {
             tablet_options.erase("max_tablet_count");
         }
 
@@ -3221,8 +3221,8 @@ future<> storage_service::alter_table_with_tablet_hints(table_id tid,
         auto ts = group0_guard.write_timestamp();
         sstring description = format("Altering table {}.{} with tablet count hints min_tablet_count={} max_tablet_count={}",
             schema->ks_name(), schema->cf_name(),
-            min_tablet_count ? to_sstring(*min_tablet_count) : (remove_unset ? "removed" : "unchanged"),
-            max_tablet_count ? to_sstring(*max_tablet_count) : (remove_unset ? "removed" : "unchanged"));
+            min_tablet_count ? to_sstring(*min_tablet_count) : (erase_unset ? "removed" : "unchanged"),
+            max_tablet_count ? to_sstring(*max_tablet_count) : (erase_unset ? "removed" : "unchanged"));
 
         auto mutations = co_await prepare_column_family_update_announcement(sp, modified_schema, /*view_updates=*/{}, ts);
 

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -3172,11 +3172,11 @@ future<> storage_service::wait_for_topology_not_busy() {
 future<> storage_service::alter_table_with_tablet_hints(table_id tid,
                                                         std::optional<size_t> min_tablet_count,
                                                         std::optional<size_t> max_tablet_count,
-                                                        bool wait_balancer,
+                                                        wait_balancer wait_for_balancer,
                                                         bool remove_unset) {
     if (this_shard_id() != 0) {
         co_return co_await container().invoke_on(0, [&] (auto& ss) {
-            return ss.alter_table_with_tablet_hints(tid, min_tablet_count, max_tablet_count, wait_balancer, remove_unset);
+            return ss.alter_table_with_tablet_hints(tid, min_tablet_count, max_tablet_count, wait_for_balancer, remove_unset);
         });
     }
 
@@ -3185,7 +3185,7 @@ future<> storage_service::alter_table_with_tablet_hints(table_id tid,
         co_return;
     }
 
-    if (wait_balancer && (!min_tablet_count || !max_tablet_count || *min_tablet_count != *max_tablet_count)) {
+    if (wait_for_balancer && (!min_tablet_count || !max_tablet_count || *min_tablet_count != *max_tablet_count)) {
         throw std::invalid_argument(format(
             "wait_balancer requires both min_tablet_count and max_tablet_count to be provided and equal, got min={} max={}",
             min_tablet_count ? to_sstring(*min_tablet_count) : "nullopt",
@@ -3236,7 +3236,7 @@ future<> storage_service::alter_table_with_tablet_hints(table_id tid,
         }
     }
 
-    if (!wait_balancer) {
+    if (!wait_for_balancer) {
         co_return;
     }
 

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -146,6 +146,7 @@ class node_ops_meta_data;
 
 using start_hint_manager = seastar::bool_class<class start_hint_manager_tag>;
 using loosen_constraints = seastar::bool_class<class loosen_constraints_tag>;
+using wait_balancer = seastar::bool_class<class wait_balancer_tag>;
 
 struct token_metadata_change {
     std::vector<locator::mutable_token_metadata_ptr> pending_token_metadata_ptr{this_smp_shard_count()};
@@ -1115,7 +1116,7 @@ public:
     future<> alter_table_with_tablet_hints(table_id tid,
                                            std::optional<size_t> min_tablet_count,
                                            std::optional<size_t> max_tablet_count,
-                                           bool wait_balancer = true,
+                                           wait_balancer wait_for_balancer = wait_balancer::yes,
                                            bool remove_unset = false);
 
     friend class join_node_rpc_handshaker;

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -147,6 +147,7 @@ class node_ops_meta_data;
 using start_hint_manager = seastar::bool_class<class start_hint_manager_tag>;
 using loosen_constraints = seastar::bool_class<class loosen_constraints_tag>;
 using wait_balancer = seastar::bool_class<class wait_balancer_tag>;
+using remove_unset = seastar::bool_class<class remove_unset_tag>;
 
 struct token_metadata_change {
     std::vector<locator::mutable_token_metadata_ptr> pending_token_metadata_ptr{this_smp_shard_count()};
@@ -1117,7 +1118,7 @@ public:
                                            std::optional<size_t> min_tablet_count,
                                            std::optional<size_t> max_tablet_count,
                                            wait_balancer wait_for_balancer = wait_balancer::yes,
-                                           bool remove_unset = false);
+                                           remove_unset erase_unset = remove_unset::no);
 
     friend class join_node_rpc_handshaker;
     friend class node_ops::node_ops_virtual_task;

--- a/sstables_loader.cc
+++ b/sstables_loader.cc
@@ -1360,7 +1360,7 @@ protected:
             // remove_unset: the table saved nullopt because it had no hint of its own, and
             // passing nullopt back would leave it pinned at min == max forever.
             co_await loader._ss.local().alter_table_with_tablet_hints(_tid, min_tablet_count, max_tablet_count,
-                    service::wait_balancer::no, true);
+                    service::wait_balancer::no, service::remove_unset::yes);
         } catch (...) {
             llog.error("Failed to restore original schema for table_id {}. Error: {}", _tid, std::current_exception());
         }

--- a/sstables_loader.cc
+++ b/sstables_loader.cc
@@ -1359,7 +1359,8 @@ protected:
             llog.info("Restoring table with tid {} to the original schema", _tid);
             // remove_unset: the table saved nullopt because it had no hint of its own, and
             // passing nullopt back would leave it pinned at min == max forever.
-            co_await loader._ss.local().alter_table_with_tablet_hints(_tid, min_tablet_count, max_tablet_count, false, true);
+            co_await loader._ss.local().alter_table_with_tablet_hints(_tid, min_tablet_count, max_tablet_count,
+                    service::wait_balancer::no, true);
         } catch (...) {
             llog.error("Failed to restore original schema for table_id {}. Error: {}", _tid, std::current_exception());
         }

--- a/test/boost/tablet_aware_restore_test.cc
+++ b/test/boost/tablet_aware_restore_test.cc
@@ -433,8 +433,8 @@ SEASTAR_TEST_CASE(test_restore_alter_table_with_tablet_hints_removes_unset, *boo
 
         // Put the saved hints back - both disengaged, because the table had none. The pin has
         // to go away, otherwise the table is left permanently pinned at min == max.
-        ss.alter_table_with_tablet_hints(tid, std::nullopt, std::nullopt, /*wait_balancer=*/false,
-                                         /*remove_unset=*/true).get();
+        ss.alter_table_with_tablet_hints(tid, std::nullopt, std::nullopt,
+                                         service::wait_balancer::no, /*remove_unset=*/true).get();
         verify_tablet_options(env, tid, desired_count, false);
     }, false, db_cfg_ptr, 10);
 }
@@ -452,10 +452,10 @@ SEASTAR_TEST_CASE(test_restore_alter_table_with_tablet_hints_rejects_waiting_wit
         auto& ss = env.get_storage_service().local();
 
         BOOST_REQUIRE_THROW(ss.alter_table_with_tablet_hints(tid, std::nullopt, std::nullopt,
-                                                             /*wait_balancer=*/true, /*remove_unset=*/true).get(),
+                                                             service::wait_balancer::yes, /*remove_unset=*/true).get(),
                             std::invalid_argument);
         BOOST_REQUIRE_THROW(ss.alter_table_with_tablet_hints(tid, std::nullopt, desired_count,
-                                                             /*wait_balancer=*/true, /*remove_unset=*/true).get(),
+                                                             service::wait_balancer::yes, /*remove_unset=*/true).get(),
                             std::invalid_argument);
 
         // Rejected before anything was announced.

--- a/test/boost/tablet_aware_restore_test.cc
+++ b/test/boost/tablet_aware_restore_test.cc
@@ -434,7 +434,7 @@ SEASTAR_TEST_CASE(test_restore_alter_table_with_tablet_hints_removes_unset, *boo
         // Put the saved hints back - both disengaged, because the table had none. The pin has
         // to go away, otherwise the table is left permanently pinned at min == max.
         ss.alter_table_with_tablet_hints(tid, std::nullopt, std::nullopt,
-                                         service::wait_balancer::no, /*remove_unset=*/true).get();
+                                         service::wait_balancer::no, service::remove_unset::yes).get();
         verify_tablet_options(env, tid, desired_count, false);
     }, false, db_cfg_ptr, 10);
 }
@@ -452,10 +452,10 @@ SEASTAR_TEST_CASE(test_restore_alter_table_with_tablet_hints_rejects_waiting_wit
         auto& ss = env.get_storage_service().local();
 
         BOOST_REQUIRE_THROW(ss.alter_table_with_tablet_hints(tid, std::nullopt, std::nullopt,
-                                                             service::wait_balancer::yes, /*remove_unset=*/true).get(),
+                                                             service::wait_balancer::yes, service::remove_unset::yes).get(),
                             std::invalid_argument);
         BOOST_REQUIRE_THROW(ss.alter_table_with_tablet_hints(tid, std::nullopt, desired_count,
-                                                             service::wait_balancer::yes, /*remove_unset=*/true).get(),
+                                                             service::wait_balancer::yes, service::remove_unset::yes).get(),
                             std::invalid_argument);
 
         // Rejected before anything was announced.


### PR DESCRIPTION
Backport is not required, it is an improvement change.