### PR TITLE
encryption: add missing seastar/core/align.hh include

### DIFF
--- a/ent/encryption/encrypted_file_impl.cc
+++ b/ent/encryption/encrypted_file_impl.cc
@@ -9,6 +9,7 @@
 
 #include <fcntl.h>
 #include <fmt/format.h>
+#include <seastar/core/align.hh>
 #include <seastar/core/file.hh>
 #include <seastar/core/byteorder.hh>
 #include <seastar/core/iostream.hh>


### PR DESCRIPTION
encrypted_file_impl.cc uses align_up()/align_down() but relied on the precompiled header (stdafx.hh) to pull in <seastar/core/align.hh>. Builds configured with --disable-precompiled-header fail with "use of undeclared identifier 'align_down'", since seastar's file.hh no longer includes align.hh transitively.

Include it explicitly.

No backport: Broken in the recent master.