### PR TITLE
test.py: make the cluster manager and its cluster per test

### DIFF
--- a/docs/dev/testing.md
+++ b/docs/dev/testing.md
@@ -331,13 +331,8 @@ manager, an in-process Python object running on its own event
 loop; calls are bridged to that loop. This guarantees that the
 test framework is fully aware of all topology operations and can
 clean up resources, including added servers, when tests end.
-`test.py` automatically detects if a cluster can not be shared with a
-subsequent test because it was manipulated with. Today the check
-is quite simple: any cluster that has nodes added or removed,
-started or stopped, even if it ended up in the same state
-as it was at the beginning of the test, is considered "dirty".
-Such clusters are not reused by the next test case: they are destroyed
-and a new cluster is created instead.
+Every test gets its own cluster, created when the test starts and
+destroyed when it ends, so tests never share or reuse a cluster.
 
 ## Test metrics
 

--- a/test/cluster/conftest.py
+++ b/test/cluster/conftest.py
@@ -6,40 +6,41 @@
 # This file configures pytest for all tests in this directory, and also
 # defines common test fixtures for all of them to use
 
-from __future__ import annotations
-
 import asyncio
 import sys
 import tempfile
+import logging
 from pathlib import Path
 from typing import TYPE_CHECKING
+
+import pytest
+from cassandra.cluster import Session
+from cassandra.connection import DRIVER_NAME, DRIVER_VERSION
+
 from test import TOP_SRC_DIR, MODES_TIMEOUT_FACTOR, path_to
-from test.pylib.runner import PHASE_REPORT_KEY, MANAGER_LOGS_KEY, make_failed_test_dir
-from test.cluster.object_store.conftest import make_object_storage
-from test.pylib.random_tables import RandomTables
-from test.pylib.skip_types import skip_env
-from test.pylib.util import unique_name
 from test.pylib.async_cql import run_async
-from test.pylib.scylla_cluster_manager import ScyllaClusterManager
-from test.pylib.scylla_server import ScyllaVersionDescription, get_scylla_2025_1_description
 from test.pylib.connect_options import add_cql_connection_options, add_s3_options
 from test.pylib.encryption_provider import KeyProvider, make_key_provider_factory
-import logging
-import pytest
-from cassandra.cluster import Session                                    # type: ignore # pylint: disable=no-name-in-module
-from cassandra.connection import DRIVER_NAME       # type: ignore # pylint: disable=no-name-in-module
-from cassandra.connection import DRIVER_VERSION    # type: ignore # pylint: disable=no-name-in-module
-from collections.abc import AsyncIterator
+from test.pylib.object_storage import Storage, StorageFactory, StorageKind, create_gs_server, create_s3_server
+from test.pylib.random_tables import RandomTables
+from test.pylib.runner import PHASE_REPORT_KEY, MANAGER_LOGS_KEY, make_failed_test_dir
+from test.pylib.scylla_cluster_manager import ScyllaClusterManager
+from test.pylib.scylla_server import ScyllaVersionDescription, get_scylla_2025_1_description
+from test.pylib.skip_types import skip_env
+from test.pylib.util import unique_name
 
 SCRIPTS_DIR = str(TOP_SRC_DIR / "scripts")
 if SCRIPTS_DIR not in sys.path:
     sys.path.insert(0, SCRIPTS_DIR)
 
 if TYPE_CHECKING:
-    from collections.abc import AsyncGenerator
-
+    from collections.abc import AsyncGenerator, AsyncIterator, Callable
+    from typing import Any
 
     from test.pylib.scylla_cluster import ClusterFactory
+
+
+type TeardownCallback = Callable[[], Any]
 
 
 Session.run_async = run_async     # patch Session for convenience
@@ -72,13 +73,71 @@ def pytest_addoption(parser):
 
 
 @pytest.fixture
+async def scylla_cluster_teardowns() -> AsyncGenerator[list[TeardownCallback]]:
+    """Cleanups to run once the test's cluster is gone.
+
+    The manager fixture depends on this one, so pytest runs these after
+    its teardown has disposed of the cluster: a resource the servers use -- an
+    object storage bucket, say -- must not be disposed of while they can
+    still touch it (SCYLLADB-2471).  Fired in LIFO order; a failure is
+    logged and swallowed so one cleanup cannot abort the rest.
+    """
+    teardowns = []
+    yield teardowns
+    for teardown in reversed(teardowns):
+        try:
+            result = teardown()
+            if asyncio.iscoroutine(result):
+                await result
+        except Exception:
+            logger.warning("Cluster teardown %s failed",
+                           getattr(teardown, "__qualname__", repr(teardown)), exc_info=True)
+
+
+@pytest.fixture
+async def object_storage_factory(request: pytest.FixtureRequest,
+                                 suite_log_dir: Path,
+                                 scylla_cluster_teardowns: list[TeardownCallback]) -> StorageFactory:
+    """A factory of object-storage backends for a test.
+
+    The bucket is destroyed and the server stopped by the scylla_cluster teardowns, that is after the
+    harness has disposed of the cluster.
+    """
+    async def make_object_storage(kind: StorageKind) -> Storage:
+        match kind:
+            case "gs":
+                server = create_gs_server(suite_log_dir)
+            case "s3":
+                server = create_s3_server(request.config, request.getfixturevalue("tmpdir"), suite_log_dir)
+            case _:
+                raise RuntimeError(f"Unknown storage kind {kind}")
+
+        await server.start()
+
+        # Appended first so that it runs last: the bucket delete below needs the server.
+        scylla_cluster_teardowns.append(server.stop)
+
+        server.create_test_bucket(request.node.name)
+
+        # Emptying the bucket while a node is still running can abort an in-flight
+        # compaction, tablet migration or streaming operation (SCYLLADB-2471), so
+        # it is deferred until the cluster is down.
+        scylla_cluster_teardowns.append(server.destroy_test_bucket)
+
+        return server
+    return make_object_storage
+
+
+@pytest.fixture
 async def manager(request: pytest.FixtureRequest,
                   testpy_cluster_factory: ClusterFactory,
                   testpy_logger: logging.Logger,
-                  testpy_test_name: str) -> AsyncGenerator[ScyllaClusterManager]:
+                  testpy_test_name: str,
+                  scylla_cluster_teardowns: list[TeardownCallback]) -> AsyncGenerator[ScyllaClusterManager]:
     """
     Per test cluster manager: connects the driver, and on teardown checks the
-    server logs and reports the test's verdict to the manager.
+    server logs and reports the test's verdict to the manager.  Depends on
+    scylla_cluster_teardowns so those cleanups run once the cluster is gone.
     """
     test_case_name = request.node.name
 
@@ -204,6 +263,7 @@ async def random_tables(request, manager):
     yield RandomTables(request.node.name, manager, unique_name(),
                        replication_factor, None, enable_tablets)
 
+
 @pytest.fixture(scope="function")
 def internet_dependency_enabled(request) -> None:
     if request.config.getoption('skip_internet_dependent_tests'):
@@ -225,16 +285,14 @@ async def key_provider(request, tmpdir, suite_log_dir, scylla_binary):
 def failure_detector_timeout(build_mode):
     return 5000 * MODES_TIMEOUT_FACTOR[build_mode]
 
-@pytest.fixture(params=[None, 's3', 'gs'], ids=['local', 's3', 'gs'])
-async def storage(request, pytestconfig, tmpdir, suite_log_dir, manager: ScyllaClusterManager):
+
+@pytest.fixture(params=[None, "s3", "gs"], ids=["local", "s3", "gs"])
+async def storage(request: pytest.FixtureRequest, object_storage_factory: StorageFactory) -> Storage | None:
     """Parametrize tests over local / S3 / GCS storage.
 
     When storage is None the test runs with local (filesystem) storage.
-    Otherwise the fixture yields an object-storage server handle.
+    Otherwise, the fixture returns an object-storage server handle.
     """
     if request.param is None:
-        yield None
-        return
-
-    async with make_object_storage(request.param, pytestconfig, tmpdir, suite_log_dir, request.node.name, manager) as server:
-        yield server
+        return None
+    return await object_storage_factory(request.param)

--- a/test/cluster/conftest.py
+++ b/test/cluster/conftest.py
@@ -23,7 +23,7 @@ from test.pylib.connect_options import add_cql_connection_options, add_s3_option
 from test.pylib.encryption_provider import KeyProvider, make_key_provider_factory
 from test.pylib.object_storage import Storage, StorageFactory, StorageKind, create_gs_server, create_s3_server
 from test.pylib.random_tables import RandomTables
-from test.pylib.runner import PHASE_REPORT_KEY, MANAGER_LOGS_KEY, make_failed_test_dir
+from test.pylib.runner import PHASE_REPORT_KEY, make_failed_test_dir
 from test.pylib.scylla_cluster_manager import ScyllaClusterManager
 from test.pylib.scylla_server import ScyllaVersionDescription, get_scylla_2025_1_description
 from test.pylib.skip_types import skip_env
@@ -37,7 +37,7 @@ if TYPE_CHECKING:
     from collections.abc import AsyncGenerator, AsyncIterator, Callable
     from typing import Any
 
-    from test.pylib.scylla_cluster import ClusterFactory
+    from test.pylib.scylla_cluster import ClusterFactory, ScyllaCluster
 
 
 type TeardownCallback = Callable[[], Any]
@@ -76,8 +76,8 @@ def pytest_addoption(parser):
 async def scylla_cluster_teardowns() -> AsyncGenerator[list[TeardownCallback]]:
     """Cleanups to run once the test's cluster is gone.
 
-    The manager fixture depends on this one, so pytest runs these after
-    its teardown has disposed of the cluster: a resource the servers use -- an
+    The scylla_cluster fixture depends on this one, so pytest runs these
+    after the cluster's own teardown: a resource the servers use -- an
     object storage bucket, say -- must not be disposed of while they can
     still touch it (SCYLLADB-2471).  Fired in LIFO order; a failure is
     logged and swallowed so one cleanup cannot abort the rest.
@@ -92,6 +92,22 @@ async def scylla_cluster_teardowns() -> AsyncGenerator[list[TeardownCallback]]:
         except Exception:
             logger.warning("Cluster teardown %s failed",
                            getattr(teardown, "__qualname__", repr(teardown)), exc_info=True)
+
+
+@pytest.fixture
+async def scylla_cluster(request: pytest.FixtureRequest,
+                         testpy_cluster_factory: ClusterFactory,
+                         testpy_test_name: str,
+                         scylla_cluster_teardowns: list[TeardownCallback]) -> AsyncGenerator[ScyllaCluster]:
+    """A fresh empty ScyllaCluster for each test.
+
+    Overrides the module-scoped fixture of the same name: every test in
+    test/cluster gets its own cluster, disposed of by the factory.
+    Depends on scylla_cluster_teardowns so those cleanups run once the
+    cluster is gone.
+    """
+    async with testpy_cluster_factory(request.node, testpy_test_name) as cluster:
+        yield cluster
 
 
 @pytest.fixture
@@ -130,22 +146,17 @@ async def object_storage_factory(request: pytest.FixtureRequest,
 
 @pytest.fixture
 async def manager(request: pytest.FixtureRequest,
-                  testpy_cluster_factory: ClusterFactory,
-                  testpy_logger: logging.Logger,
-                  testpy_test_name: str,
-                  scylla_cluster_teardowns: list[TeardownCallback]) -> AsyncGenerator[ScyllaClusterManager]:
+                  scylla_cluster: ScyllaCluster,
+                  testpy_test_name: str) -> AsyncGenerator[ScyllaClusterManager]:
     """
     Per test cluster manager: connects the driver, and on teardown checks the
-    server logs and reports the test's verdict to the manager.  Depends on
-    scylla_cluster_teardowns so those cleanups run once the cluster is gone.
+    server logs and reports the test's verdict to the manager.
     """
     test_case_name = request.node.name
 
-    cluster = await testpy_cluster_factory(testpy_logger)
-
     async with ScyllaClusterManager(
             test_name=testpy_test_name,
-            cluster=cluster,
+            cluster=scylla_cluster,
             port=int(request.config.getoption("--port")),
             use_ssl=bool(request.config.getoption("--ssl")),
             auth_username=request.config.getoption("--auth_username", default=None),
@@ -159,42 +170,33 @@ async def manager(request: pytest.FixtureRequest,
         if mgr.cql is None and await mgr.running_servers():
             await mgr.driver_connect()  # Connect driver to the test's cluster
 
-        # Publish what pytest_runtest_makereport needs to attach this test's logs on
-        # failure (single source of truth), so it doesn't re-derive these paths.
-        request.node.stash[MANAGER_LOGS_KEY] = {
-            "manager": mgr,
-            "logs": {},
-        }
         yield mgr
+
         # `request.node.stash` contains reports stored per phase in `pytest_runtest_makereport`
         # from where we can retrieve test failure.
-        cluster_status = None
-        found_errors = {}
-        failed = False
+        reports = request.node.stash[PHASE_REPORT_KEY]
+        call_report = reports.get("call")
+        failed = call_report is not None and call_report.failed
+
+        # Check if the test has the check_nodes_for_errors marker
+        found_errors = await mgr.check_all_errors(
+            all_errors=request.node.get_closest_marker("check_nodes_for_errors") is not None,
+        )
+
         failed_test_dir_path = None
-        try:
-            reports = request.node.stash[PHASE_REPORT_KEY]
-            call_report = reports.get("call")
-            failed = call_report is not None and call_report.failed
+        if failed or found_errors:
+            failed_test_dir_path = make_failed_test_dir(request.config, mgr.cluster.mode, test_case_name)
+            # Gather the server logs while the manager is alive and the logs
+            # still exist; the stacktrace and links are attached by
+            # pytest_runtest_makereport.
+            try:
+                await mgr.gather_related_logs(failed_test_dir_path)
+            except Exception:
+                logger.warning("Failed to gather logs for failed test %s", test_case_name, exc_info=True)
 
-            # Check if the test has the check_nodes_for_errors marker
-            found_errors = await mgr.check_all_errors(all_errors=(request.node.get_closest_marker("check_nodes_for_errors") is not None))
-
-            if failed or found_errors:
-                # Server logs / traceback / links are attached by pytest_runtest_makereport;
-                # here we only need the dir for the manager-specific found_errors files below.
-                failed_test_dir_path = make_failed_test_dir(request.config, mgr.cluster.mode, test_case_name)
-
-        finally:
-            # Drop the stash entry before closing the driver so a teardown-phase
-            # failure report doesn't gather logs through a manager being stopped.
-            request.node.stash[MANAGER_LOGS_KEY] = None
-
-        # Close the driver before after_test(): the session is this test's, and
-        # nothing in after_test() needs it -- the keyspace count post-condition
-        # uses each server's own control connection.  after_test() runs even if
-        # closing fails: it detaches this test's log handler and hands the
-        # cluster back.
+        # Close the driver before after_test(): nothing in after_test() needs
+        # it.  after_test() runs even if closing fails: it reports what the
+        # test left behind.
         try:
             mgr.driver_close()
         finally:
@@ -203,9 +205,11 @@ async def manager(request: pytest.FixtureRequest,
             cluster_status = await mgr.after_test(success=not failed)
             logger.info("Cluster after test %s (success: %s): %s", test_case_name, not failed, cluster_status)
 
-        if cluster_status is not None and cluster_status["tasks_leaked"] and not failed:
-            failed = True
-            pytest.fail(
+        # Collect the teardown-detected failures and report them all at once,
+        # so leaked tasks don't hide the found-errors report or vice versa.
+        teardown_failures = []
+        if cluster_status is not None and cluster_status["tasks_leaked"]:
+            teardown_failures.append(
                 f"test case {test_case_name} left unfinished tasks on the cluster manager: {cluster_status["message"]}"
             )
         if found_errors:
@@ -242,8 +246,20 @@ async def manager(request: pytest.FixtureRequest,
 
             with open(failed_test_dir_path / "found_errors.txt", "w") as f:
                 f.write("\n".join(full_message))
+            teardown_failures.extend(full_message)
+
+        if teardown_failures:
+            if failed_test_dir_path is None:
+                # A leaked-tasks-only failure surfaces here, after the gather
+                # above; copy the logs now, before recycle() deletes them.
+                failed_test_dir_path = make_failed_test_dir(request.config, mgr.cluster.mode, test_case_name)
+                try:
+                    await mgr.gather_related_logs(failed_test_dir_path)
+                except Exception:
+                    logger.warning("Failed to gather logs for failed test %s", test_case_name, exc_info=True)
             if not failed:
-                pytest.fail(f"\n{'\n'.join(full_message)}")
+                pytest.fail(f"\n{'\n'.join(teardown_failures)}")
+
 
 # "cql" fixture: set up client object for communicating with the CQL API.
 # Since connection is managed by manager just return that object

--- a/test/cluster/conftest.py
+++ b/test/cluster/conftest.py
@@ -256,29 +256,16 @@ def cql(manager):
     yield manager.cql
 
 # "random_tables" fixture: Creates and returns a temporary RandomTables object
-# used in tests to make schema changes. Tables are dropped after test finishes
-# unless the cluster is dirty or the test has failed.
+# used in tests to make schema changes.  Nothing is dropped afterwards: the
+# cluster lives only as long as the test.
 @pytest.fixture(scope="function")
 async def random_tables(request, manager):
     rf_marker = request.node.get_closest_marker("replication_factor")
     replication_factor = rf_marker.args[0] if rf_marker is not None else 3  # Default 3
     enable_tablets = request.node.get_closest_marker("enable_tablets")
     enable_tablets = enable_tablets.args[0] if enable_tablets is not None else None
-    tables = RandomTables(request.node.name, manager, unique_name(),
-                          replication_factor, None, enable_tablets)
-    yield tables
-
-    # Don't drop tables at the end if we failed or the cluster is dirty - it may be impossible
-    # (e.g. the cluster is completely dead) and it doesn't matter (we won't reuse the cluster
-    # anyway).
-    # The cluster will be marked as dirty if the test failed, but that happens
-    # at the end of `manager` fixture which we depend on (so these steps will be
-    # executed after us) - so at this point, we need to check for failure ourselves too.
-    reports = request.node.stash[PHASE_REPORT_KEY]
-    call_report = reports.get("call")
-    failed = call_report is not None and call_report.failed
-    if not failed and not await manager.is_dirty():
-        tables.drop_all()
+    yield RandomTables(request.node.name, manager, unique_name(),
+                       replication_factor, None, enable_tablets)
 
 @pytest.fixture(scope="function", autouse=True)
 async def prepare_3_nodes_cluster(request, manager):

--- a/test/cluster/conftest.py
+++ b/test/cluster/conftest.py
@@ -75,13 +75,13 @@ def pytest_addoption(parser):
                      help='Skip tests which depend on artifacts from the internet')
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture
 async def _scylla_cluster_manager(request: pytest.FixtureRequest,
                                   build_mode: str,
                                   suite_log_dir: Path,
                                   testpy_cluster_factory: ClusterFactory,
                                   testpy_uname: str) -> AsyncGenerator[ScyllaClusterManager]:
-    """Run the cluster manager on its own thread and event loop.
+    """Run a per-test cluster manager on its own thread and event loop.
 
     The manager owns loop-bound state -- the Scylla subprocess transports and
     the per-server asyncio locks -- so all of its coroutines have to run on one
@@ -191,28 +191,26 @@ async def manager(request: pytest.FixtureRequest,
 
     finally:
         # Drop the stash entry before closing the driver so a teardown-phase
-        # failure report doesn't gather logs through a fenced-off manager.
+        # failure report doesn't gather logs through a manager being stopped.
         request.node.stash[MANAGER_LOGS_KEY] = None
 
-    # Close the driver before after_test() raises the fence: the session is
-    # this test's, and nothing in after_test() needs it -- the keyspace count
-    # post-condition uses each server's own control connection.  after_test()
-    # runs even if closing fails: it is what raises the fence, detaches this
-    # test's log handler and hands the cluster back.
+    # Close the driver before after_test(): the session is this test's, and
+    # nothing in after_test() needs it -- the keyspace count post-condition
+    # uses each server's own control connection.  after_test() runs even if
+    # closing fails: it detaches this test's log handler and hands the
+    # cluster back.
     try:
         _scylla_cluster_manager.driver_close()
     finally:
         # Tear down (after test): notify the manager that the test finished.
-        # This also cuts off manager access for tasks leaked by the test.
         logger.debug("after_test for %s (success: %s)", test_case_name, not failed)
         cluster_status = await _scylla_cluster_manager.after_test(success=not failed)
         logger.info("Cluster after test %s (success: %s): %s", test_case_name, not failed, cluster_status)
 
-    if cluster_status is not None and cluster_status["server_broken"] and not failed:
+    if cluster_status is not None and cluster_status["tasks_leaked"] and not failed:
         failed = True
         pytest.fail(
-            f"test case {test_case_name} left unfinished tasks on Scylla server. Server marked as broken,"
-            f" server_broken_reason: {cluster_status["message"]}"
+            f"test case {test_case_name} left unfinished tasks on the cluster manager: {cluster_status["message"]}"
         )
     if found_errors:
         full_message = []

--- a/test/cluster/conftest.py
+++ b/test/cluster/conftest.py
@@ -78,7 +78,6 @@ def pytest_addoption(parser):
 @pytest.fixture
 async def _scylla_cluster_manager(request: pytest.FixtureRequest,
                                   build_mode: str,
-                                  suite_log_dir: Path,
                                   testpy_cluster_factory: ClusterFactory,
                                   testpy_uname: str) -> AsyncGenerator[ScyllaClusterManager]:
     """Run a per-test cluster manager on its own thread and event loop.
@@ -103,7 +102,6 @@ async def _scylla_cluster_manager(request: pytest.FixtureRequest,
         mgr = ScyllaClusterManager(
             test_uname=testpy_uname,
             create_cluster=testpy_cluster_factory,
-            base_dir=str(suite_log_dir),
             port=int(request.config.getoption('port')),
             use_ssl=bool(request.config.getoption('ssl')),
             auth_provider=auth_provider,
@@ -167,7 +165,7 @@ async def manager(request: pytest.FixtureRequest,
     # failed test's properties by record_failed_test_artifacts().
     request.node.stash[MANAGER_LOGS_KEY] = {
         "manager": _scylla_cluster_manager,
-        "logs": {"test_py.log": _scylla_cluster_manager.test_case_log_file},
+        "logs": {},
     }
     yield _scylla_cluster_manager
     # `request.node.stash` contains reports stored per phase in `pytest_runtest_makereport`

--- a/test/cluster/conftest.py
+++ b/test/cluster/conftest.py
@@ -9,11 +9,8 @@
 from __future__ import annotations
 
 import asyncio
-import concurrent.futures
-import threading
 import sys
 import tempfile
-from concurrent.futures.thread import ThreadPoolExecutor
 from pathlib import Path
 from typing import TYPE_CHECKING
 from test import TOP_SRC_DIR, MODES_TIMEOUT_FACTOR, path_to
@@ -29,7 +26,6 @@ from test.pylib.connect_options import add_cql_connection_options, add_s3_option
 from test.pylib.encryption_provider import KeyProvider, make_key_provider_factory
 import logging
 import pytest
-from cassandra.auth import PlainTextAuthProvider                         # type: ignore # pylint: disable=no-name-in-module
 from cassandra.cluster import Session                                    # type: ignore # pylint: disable=no-name-in-module
 from cassandra.connection import DRIVER_NAME       # type: ignore # pylint: disable=no-name-in-module
 from cassandra.connection import DRIVER_VERSION    # type: ignore # pylint: disable=no-name-in-module
@@ -76,176 +72,119 @@ def pytest_addoption(parser):
 
 
 @pytest.fixture
-async def _scylla_cluster_manager(request: pytest.FixtureRequest,
-                                  build_mode: str,
-                                  testpy_cluster_factory: ClusterFactory,
-                                  testpy_uname: str) -> AsyncGenerator[ScyllaClusterManager]:
-    """Run a per-test cluster manager on its own thread and event loop.
-
-    The manager owns loop-bound state -- the Scylla subprocess transports and
-    the per-server asyncio locks -- so all of its coroutines have to run on one
-    loop, and that loop has to keep running: tests reach the manager from
-    pytest's event loops and, in dtest, from plain worker threads.  Hence, a
-    dedicated thread whose loop is idle but alive until teardown.
-    """
-    auth_username = request.config.getoption('auth_username', default=None)
-    auth_password = request.config.getoption('auth_password', default=None)
-    if auth_username is not None and auth_password is not None:
-        auth_provider = PlainTextAuthProvider(username=auth_username, password=auth_password)
-    else:
-        auth_provider = None
-
-    ready: concurrent.futures.Future[ScyllaClusterManager] = concurrent.futures.Future()
-    stop_event = threading.Event()
-
-    async def run_manager() -> None:
-        mgr = ScyllaClusterManager(
-            test_uname=testpy_uname,
-            create_cluster=testpy_cluster_factory,
-            port=int(request.config.getoption('port')),
-            use_ssl=bool(request.config.getoption('ssl')),
-            auth_provider=auth_provider,
-            build_mode=build_mode,
-        )
-        try:
-            await mgr.start()
-        except BaseException:
-            # Dispose of a partially started manager, e.g. a cluster
-            # created before the API site failed to start.
-            await mgr.stop()
-            raise
-        ready.set_result(mgr)
-        try:
-            await asyncio.get_running_loop().run_in_executor(None, stop_event.wait)
-        finally:
-            await mgr.stop()
-
-    with ThreadPoolExecutor(max_workers=1, thread_name_prefix="cluster-manager") as executor:
-        future = executor.submit(asyncio.run, run_manager())
-        # Fail instead of waiting forever when the manager dies before it
-        # signals readiness, e.g. because creating the first cluster failed.
-        # The callback fires only once the future is done, so reaching it
-        # without a result always means a startup failure.
-        future.add_done_callback(
-            lambda f: None if ready.done() else ready.set_exception(
-                f.exception() or RuntimeError("ScyllaClusterManager exited before signaling readiness")))
-        # ready.result() blocks, so hand it to a thread rather than stalling
-        # the loop this fixture runs on.
-        server = await asyncio.get_running_loop().run_in_executor(None, ready.result)
-        try:
-            yield server
-        finally:
-            stop_event.set()
-            # Wait for the manager thread off the event loop.  Stopping the
-            # manager recycles the cluster, and recycling runs teardown
-            # callbacks that belong to this loop; blocking it here would
-            # deadlock them.
-            await asyncio.get_running_loop().run_in_executor(None, future.result)
-
-
-@pytest.fixture(scope="function")
 async def manager(request: pytest.FixtureRequest,
-                  _scylla_cluster_manager: ScyllaClusterManager,
-                  build_mode: str) -> AsyncGenerator[ScyllaClusterManager]:
+                  testpy_cluster_factory: ClusterFactory,
+                  testpy_logger: logging.Logger,
+                  testpy_test_name: str) -> AsyncGenerator[ScyllaClusterManager]:
     """
-    Per test fixture to notify the manager when tests begin so it can perform checks for cluster state.
+    Per test cluster manager: connects the driver, and on teardown checks the
+    server logs and reports the test's verdict to the manager.
     """
     test_case_name = request.node.name
 
-    logger.debug("before_test for %s", test_case_name)
-    cluster_str = await _scylla_cluster_manager.before_test(test_case_name)
-    logger.info(f"Using cluster: {cluster_str} for test {test_case_name}")
-    if _scylla_cluster_manager.cql is None and await _scylla_cluster_manager.running_servers():
-        await _scylla_cluster_manager.driver_connect()  # Connect driver to the leased cluster
+    cluster = await testpy_cluster_factory(testpy_logger)
 
-    # Publish what pytest_runtest_makereport needs to attach this test's logs on
-    # failure (single source of truth), so it doesn't re-derive these paths.
-    # The pytest session log is not listed here: it is written per xdist worker
-    # (see PYTEST_LOG_FILE in test/pylib/runner.py) and is already linked from the
-    # failed test's properties by record_failed_test_artifacts().
-    request.node.stash[MANAGER_LOGS_KEY] = {
-        "manager": _scylla_cluster_manager,
-        "logs": {},
-    }
-    yield _scylla_cluster_manager
-    # `request.node.stash` contains reports stored per phase in `pytest_runtest_makereport`
-    # from where we can retrieve test failure.
-    cluster_status = None
-    found_errors = {}
-    failed = False
-    failed_test_dir_path = None
-    try:
-        reports = request.node.stash[PHASE_REPORT_KEY]
-        call_report = reports.get("call")
-        failed = call_report is not None and call_report.failed
+    async with ScyllaClusterManager(
+            test_name=testpy_test_name,
+            cluster=cluster,
+            port=int(request.config.getoption("--port")),
+            use_ssl=bool(request.config.getoption("--ssl")),
+            auth_username=request.config.getoption("--auth_username", default=None),
+            auth_password=request.config.getoption("--auth_password", default=None),
+    ).run_in_thread() as mgr:
+        if request.node.get_closest_marker("prepare_3_nodes_cluster"):
+            await mgr.servers_add(3)
+        if request.node.get_closest_marker("prepare_3_racks_cluster"):
+            await mgr.servers_add(3, auto_rack_dc="dc1")
 
-        # Check if the test has the check_nodes_for_errors marker
-        found_errors = await _scylla_cluster_manager.check_all_errors(all_errors=(request.node.get_closest_marker("check_nodes_for_errors") is not None))
+        if mgr.cql is None and await mgr.running_servers():
+            await mgr.driver_connect()  # Connect driver to the test's cluster
 
-        if failed or found_errors:
-            # Server logs / traceback / links are attached by pytest_runtest_makereport;
-            # here we only need the dir for the manager-specific found_errors files below.
-            failed_test_dir_path = make_failed_test_dir(request.config, build_mode, test_case_name)
+        # Publish what pytest_runtest_makereport needs to attach this test's logs on
+        # failure (single source of truth), so it doesn't re-derive these paths.
+        request.node.stash[MANAGER_LOGS_KEY] = {
+            "manager": mgr,
+            "logs": {},
+        }
+        yield mgr
+        # `request.node.stash` contains reports stored per phase in `pytest_runtest_makereport`
+        # from where we can retrieve test failure.
+        cluster_status = None
+        found_errors = {}
+        failed = False
+        failed_test_dir_path = None
+        try:
+            reports = request.node.stash[PHASE_REPORT_KEY]
+            call_report = reports.get("call")
+            failed = call_report is not None and call_report.failed
 
-    finally:
-        # Drop the stash entry before closing the driver so a teardown-phase
-        # failure report doesn't gather logs through a manager being stopped.
-        request.node.stash[MANAGER_LOGS_KEY] = None
+            # Check if the test has the check_nodes_for_errors marker
+            found_errors = await mgr.check_all_errors(all_errors=(request.node.get_closest_marker("check_nodes_for_errors") is not None))
 
-    # Close the driver before after_test(): the session is this test's, and
-    # nothing in after_test() needs it -- the keyspace count post-condition
-    # uses each server's own control connection.  after_test() runs even if
-    # closing fails: it detaches this test's log handler and hands the
-    # cluster back.
-    try:
-        _scylla_cluster_manager.driver_close()
-    finally:
-        # Tear down (after test): notify the manager that the test finished.
-        logger.debug("after_test for %s (success: %s)", test_case_name, not failed)
-        cluster_status = await _scylla_cluster_manager.after_test(success=not failed)
-        logger.info("Cluster after test %s (success: %s): %s", test_case_name, not failed, cluster_status)
+            if failed or found_errors:
+                # Server logs / traceback / links are attached by pytest_runtest_makereport;
+                # here we only need the dir for the manager-specific found_errors files below.
+                failed_test_dir_path = make_failed_test_dir(request.config, mgr.cluster.mode, test_case_name)
 
-    if cluster_status is not None and cluster_status["tasks_leaked"] and not failed:
-        failed = True
-        pytest.fail(
-            f"test case {test_case_name} left unfinished tasks on the cluster manager: {cluster_status["message"]}"
-        )
-    if found_errors:
-        full_message = []
-        for server, data in found_errors.items():
-            summary = []
-            detailed = []
+        finally:
+            # Drop the stash entry before closing the driver so a teardown-phase
+            # failure report doesn't gather logs through a manager being stopped.
+            request.node.stash[MANAGER_LOGS_KEY] = None
 
-            if criticals := data.get("critical", []):
-                summary.append(f"{len(criticals)} critical error(s)")
-                detailed.extend(map(str.rstrip, criticals))
+        # Close the driver before after_test(): the session is this test's, and
+        # nothing in after_test() needs it -- the keyspace count post-condition
+        # uses each server's own control connection.  after_test() runs even if
+        # closing fails: it detaches this test's log handler and hands the
+        # cluster back.
+        try:
+            mgr.driver_close()
+        finally:
+            # Tear down (after test): notify the manager that the test finished.
+            logger.debug("after_test for %s (success: %s)", test_case_name, not failed)
+            cluster_status = await mgr.after_test(success=not failed)
+            logger.info("Cluster after test %s (success: %s): %s", test_case_name, not failed, cluster_status)
 
-            if backtraces := data.get("backtraces", []):
-                summary.append(f"{len(backtraces)} backtrace(s)")
-                with open(failed_test_dir_path / f"scylla-{server.server_id}-backtraces.txt", "w") as bt_file:
-                    for backtrace in backtraces:
-                        bt_file.write(backtrace + "\n\n")
-                        decoded_bt = await decode_backtrace(build_mode, backtrace)
-                        bt_file.write(decoded_bt + "\n\n")
-                    detailed.append(f"{len(backtraces)} backtrace(s) saved in {Path(bt_file.name).name}")
+        if cluster_status is not None and cluster_status["tasks_leaked"] and not failed:
+            failed = True
+            pytest.fail(
+                f"test case {test_case_name} left unfinished tasks on the cluster manager: {cluster_status["message"]}"
+            )
+        if found_errors:
+            full_message = []
+            for server, data in found_errors.items():
+                summary = []
+                detailed = []
 
-            if errors := data.get("error", []):
-                summary.append(f"{len(errors)} error(s)")
-                detailed.extend(map(str.rstrip, errors))
+                if criticals := data.get("critical", []):
+                    summary.append(f"{len(criticals)} critical error(s)")
+                    detailed.extend(map(str.rstrip, criticals))
 
-            if cores := data.get("cores", []):
-                summary.append(f"{len(cores)} core(s): {', '.join(cores)}")
+                if backtraces := data.get("backtraces", []):
+                    summary.append(f"{len(backtraces)} backtrace(s)")
+                    with open(failed_test_dir_path / f"scylla-{server.server_id}-backtraces.txt", "w") as bt_file:
+                        for backtrace in backtraces:
+                            bt_file.write(backtrace + "\n\n")
+                            decoded_bt = await decode_backtrace(mgr.cluster.mode, backtrace)
+                            bt_file.write(decoded_bt + "\n\n")
+                        detailed.append(f"{len(backtraces)} backtrace(s) saved in {Path(bt_file.name).name}")
 
-            if summary:
-                summary_line = f"Server {server.server_id}: found {', '.join(summary)} (log: { data['log']})"
-                detailed = [f"  {line}" for line in detailed]
-                full_message.append(summary_line)
-                full_message.extend(detailed)
+                if errors := data.get("error", []):
+                    summary.append(f"{len(errors)} error(s)")
+                    detailed.extend(map(str.rstrip, errors))
 
-        with open(failed_test_dir_path / "found_errors.txt", "w") as f:
-            f.write("\n".join(full_message))
-        if not failed:
-            pytest.fail(f"\n{'\n'.join(full_message)}")
+                if cores := data.get("cores", []):
+                    summary.append(f"{len(cores)} core(s): {', '.join(cores)}")
+
+                if summary:
+                    summary_line = f"Server {server.server_id}: found {', '.join(summary)} (log: { data['log']})"
+                    detailed = [f"  {line}" for line in detailed]
+                    full_message.append(summary_line)
+                    full_message.extend(detailed)
+
+            with open(failed_test_dir_path / "found_errors.txt", "w") as f:
+                f.write("\n".join(full_message))
+            if not failed:
+                pytest.fail(f"\n{'\n'.join(full_message)}")
 
 # "cql" fixture: set up client object for communicating with the CQL API.
 # Since connection is managed by manager just return that object
@@ -264,18 +203,6 @@ async def random_tables(request, manager):
     enable_tablets = enable_tablets.args[0] if enable_tablets is not None else None
     yield RandomTables(request.node.name, manager, unique_name(),
                        replication_factor, None, enable_tablets)
-
-@pytest.fixture(scope="function", autouse=True)
-async def prepare_3_nodes_cluster(request, manager):
-    if request.node.get_closest_marker("prepare_3_nodes_cluster"):
-        await manager.servers_add(3)
-
-
-@pytest.fixture(scope="function", autouse=True)
-async def prepare_3_racks_cluster(request, manager):
-    if request.node.get_closest_marker("prepare_3_racks_cluster"):
-        await manager.servers_add(3, auto_rack_dc="dc1")
-
 
 @pytest.fixture(scope="function")
 def internet_dependency_enabled(request) -> None:

--- a/test/cluster/object_store/conftest.py
+++ b/test/cluster/object_store/conftest.py
@@ -4,89 +4,26 @@
 # SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
 #
 
-
-from contextlib import asynccontextmanager
-
 import pytest
 
 from test.pylib.connect_options import add_s3_options
-from test.pylib.scylla_cluster_manager import ScyllaClusterManager
-from test.pylib.object_storage import (
-    format_tuples,
-    keyspace_options,
-    create_s3_server,
-    create_gs_server,
-    GSFront,
-    GSServer,
-    S3Server,
-    S3_Server,
-    MinioWrapper,
-)
+from test.pylib.object_storage import Storage, StorageFactory
 
 
 def pytest_addoption(parser):
     add_s3_options(parser)
 
 
-@asynccontextmanager
-async def make_object_storage(kind, pytestconfig, tmpdir, log_dir, test_name, manager: ScyllaClusterManager):
-    """Start an object-storage backend for a test.
-
-    `tmpdir` holds the server's scratch data (per-test, discarded by CI), while
-    `log_dir` must be a CI-archived directory (testlog) so that container logs
-    survive for post-mortem analysis.
-
-    The bucket is destroyed and the server stopped from teardown callbacks,
-    that is after the harness has stopped the cluster, not on exit from this
-    context manager.
-    """
-    if kind == 'gs':
-        server = create_gs_server(log_dir)
-    else:
-        server = create_s3_server(pytestconfig, tmpdir, log_dir)
-
-    await server.start()
-    # Registered first so that it fires last, since the deletes below need the
-    # server.  Nothing else frees the server until it is registered, hence the
-    # eager stop.
-    try:
-        await manager.add_teardown_callback(server.stop, 'stop object storage server')
-    except BaseException:
-        await server.stop()
-        raise
-
-    server.create_test_bucket(test_name)
-    # Emptying the bucket while a node is still running can abort an in-flight
-    # compaction, tablet migration or streaming operation (SCYLLADB-2471), so
-    # destroy it from a callback instead: it fires once the cluster is down.
-    try:
-        await manager.add_teardown_callback(server.destroy_test_bucket, 'destroy test bucket')
-    except BaseException:
-        # A failed registration does not say whether the manager got as far as
-        # recording the callback -- _call() shields the operation, so a
-        # timed-out or cancelled caller leaves it running.  Destroy the bucket
-        # here regardless: no node has been told about it yet, so this races
-        # with nothing, and destroy_test_bucket() is a no-op the second time if
-        # the callback did register and fires later.
-        server.destroy_test_bucket()
-        raise
-
-    yield server
+@pytest.fixture(params=["s3", "gs"])
+async def object_storage(request: pytest.FixtureRequest, object_storage_factory: StorageFactory) -> Storage:
+    return await object_storage_factory(request.param)
 
 
-@pytest.fixture(scope="function", params=['s3', 'gs'])
-async def object_storage(request, pytestconfig, tmpdir, suite_log_dir, manager: ScyllaClusterManager):
-    async with make_object_storage(request.param, pytestconfig, tmpdir, suite_log_dir, request.node.name, manager) as server:
-        yield server
+@pytest.fixture
+async def s3_storage(object_storage_factory: StorageFactory) -> Storage:
+    return await object_storage_factory("s3")
 
 
-@pytest.fixture(scope="function")
-async def s3_storage(request, pytestconfig, tmpdir, suite_log_dir, manager: ScyllaClusterManager):
-    async with make_object_storage('s3', pytestconfig, tmpdir, suite_log_dir, request.node.name, manager) as server:
-        yield server
-
-
-@pytest.fixture(scope="function")
-async def gs_storage(request, pytestconfig, tmpdir, suite_log_dir, manager: ScyllaClusterManager):
-    async with make_object_storage('gs', pytestconfig, tmpdir, suite_log_dir, request.node.name, manager) as server:
-        yield server
+@pytest.fixture
+async def gs_storage(object_storage_factory: StorageFactory) -> Storage:
+    return await object_storage_factory("gs")

--- a/test/cluster/object_store/test_atomic_delete.py
+++ b/test/cluster/object_store/test_atomic_delete.py
@@ -12,7 +12,7 @@ import pytest
 from test.pylib.scylla_cluster_manager import ScyllaClusterManager
 from test.pylib.rest_client import inject_error_one_shot, inject_error
 from test.cluster.util import reconnect_driver, new_test_keyspace
-from test.cluster.object_store.conftest import keyspace_options
+from test.pylib.object_storage import keyspace_options
 
 logger = logging.getLogger(__name__)
 

--- a/test/cluster/test_config.yaml
+++ b/test/cluster/test_config.yaml
@@ -1,5 +1,3 @@
-cluster:
-  initial_size: 0
 extra_scylla_config_options:
     authenticator: AllowAllAuthenticator
     authorizer: AllowAllAuthorizer

--- a/test/cluster/test_mutation_schema_change.py
+++ b/test/cluster/test_mutation_schema_change.py
@@ -35,7 +35,6 @@ async def test_mutation_schema_change(manager, random_tables):
     t = await random_tables.add_table(ncolumns=5, pks=1)
     manager.driver_close()
     # Reduce the snapshot thresholds
-    await manager.mark_dirty()
     errs = [inject_error_one_shot(manager.api, s.ip_addr, "raft_server_set_snapshot_thresholds",
                                   parameters={'snapshot_threshold': '3', 'snapshot_trailing': '1'})
             for s in [server_a, server_b, server_c]]
@@ -98,7 +97,6 @@ async def test_mutation_schema_change_restart(manager, random_tables):
     t = await random_tables.add_table(ncolumns=5, pks=1)
     manager.driver_close()
     # Reduce the snapshot thresholds
-    await manager.mark_dirty()
     errs = [inject_error_one_shot(manager.api, s.ip_addr, "raft_server_set_snapshot_thresholds",
                                   parameters={'snapshot_threshold': '3', 'snapshot_trailing': '1'})
             for s in [server_a, server_b, server_c]]

--- a/test/cluster/test_snapshot.py
+++ b/test/cluster/test_snapshot.py
@@ -26,7 +26,6 @@ async def test_snapshot(manager, random_tables):
         Then stop A B C and query D to check it sees the correct table schema (verify_schema).
     """
     server_a, server_b, server_c = await manager.running_servers()
-    await manager.mark_dirty()
     # Reduce the snapshot thresholds
     errs = [inject_error_one_shot(manager.api, s.ip_addr, "raft_server_set_snapshot_thresholds",
                                   parameters={'snapshot_threshold': '3', 'snapshot_trailing': '1'})

--- a/test/cluster/test_tablet_snapshot.py
+++ b/test/cluster/test_tablet_snapshot.py
@@ -200,4 +200,3 @@ async def test_tablet_snapshot_taken_after_replace_before_rebuild(manager: Scyll
             # The window is all this test needs. Letting the replace finish would cost most of
             # the runtime, so the half joined cluster is thrown away instead.
             replace_task.cancel()
-            await manager.mark_dirty()

--- a/test/cqlpy/test_config.yaml
+++ b/test/cqlpy/test_config.yaml
@@ -1,5 +1,3 @@
-dirties_cluster:
-  - test_native_transport
 extra_scylla_cmdline_options:
   - '--rf-rack-valid-keyspaces=1'
   - '--experimental-features=udf'

--- a/test/pylib/object_storage.py
+++ b/test/pylib/object_storage.py
@@ -10,19 +10,26 @@ Classes, factory functions, and shared pytest fixtures used by
 test/cluster/object_store/ and test/cqlpy/ tests.
 """
 
-import os
 import logging
+import os
 import re
 import uuid
+from collections.abc import Awaitable, Callable
+from operator import attrgetter
+from typing import Literal
 
-from test.pylib.minio_server import MinioServer
+import boto3
+import pytest
+import requests
+
 from test.pylib.dockerized_service import DockerizedServer
 from test.pylib.host_registry import HostRegistry
-from operator import attrgetter
+from test.pylib.minio_server import MinioServer
 
-import pytest
-import boto3
-import requests
+
+type StorageKind = Literal["s3", "gs"]
+type Storage = S3Server | GSFront
+type StorageFactory = Callable[[StorageKind], Awaitable[Storage]]
 
 
 def format_tuples(tuples=None, **kwargs):

--- a/test/pylib/runner.py
+++ b/test/pylib/runner.py
@@ -18,6 +18,7 @@ import time
 import urllib.parse
 from argparse import BooleanOptionalAction
 from collections import defaultdict
+from contextlib import asynccontextmanager
 from itertools import chain, count
 from functools import cache, cached_property
 from random import randint
@@ -126,9 +127,13 @@ def pytest_addoption(parser: pytest.Parser) -> None:
 # outcome of each phase (setup / call / teardown) independently.
 PHASE_REPORT_KEY = pytest.StashKey[dict[str, pytest.CollectReport]]()
 
-# Set by the `manager` fixture so the log collector in pytest_runtest_makereport
-# can gather manager-owned logs: {"manager": ScyllaClusterManager, "logs": {name: path}}.
-MANAGER_LOGS_KEY = pytest.StashKey[dict[str, object]]()
+# The cluster a fixture created, stashed on the fixture's node: the test item
+# for `manager`, the module for `scylla_cluster`.  pytest_runtest_makereport
+# copies its server logs into the failed-test dir when the test fails.  The
+# factory resets the entry to None once the cluster is recycled, so a non-None
+# entry at session finish marks a cluster the sweep in
+# recycle_leftover_clusters() still has to dispose of.
+CLUSTER_KEY = pytest.StashKey[ScyllaCluster | None]()
 
 FAILED_TEST_DIR = "failed_test"
 
@@ -322,7 +327,8 @@ def scale_timeout(build_mode: str) -> Callable[[int | float], int | float]:
 def testpy_cluster_factory(request: pytest.FixtureRequest,
                            build_mode: str,
                            suite_log_dir: pathlib.Path,
-                           scylla_binary: str) -> ClusterFactory:
+                           scylla_binary: str,
+                           testpy_logger: logging.Logger) -> ClusterFactory:
     """A factory of Scylla clusters configured for the current suite and build mode."""
     suite_config = get_params_stash(node=request.node)[TEST_SUITE]
     options = request.config.option
@@ -338,13 +344,11 @@ def testpy_cluster_factory(request: pytest.FixtureRequest,
         # ref: https://clang.llvm.org/docs/SourceBasedCodeCoverage.html#running-the-instrumented-program
         base_env["LLVM_PROFILE_FILE"] = str(coverage_dir(suite_log_dir) / suite_config.name / "%m.profraw")
 
-    cluster_size = suite_config.cfg.get("cluster", {}).get("initial_size", 1)
-
-    async def create_cluster(logger: logging.Logger | logging.LoggerAdapter) -> ScyllaCluster:
-        cluster = ScyllaCluster(
-            logger=logger,
+    @asynccontextmanager
+    async def cluster_for_test(node: _pytest.nodes.Node, test_name: str) -> AsyncGenerator[ScyllaCluster]:
+        node.stash[CLUSTER_KEY] = cluster = ScyllaCluster(
+            logger=testpy_logger,
             vardir=suite_log_dir,
-            replicas=cluster_size,
             mode=build_mode,
             cmdline_options=suite_config.cfg.get("extra_scylla_cmdline_options", []),
             cmdline_options_override=options.extra_scylla_cmdline_options.split(),
@@ -353,36 +357,18 @@ def testpy_cluster_factory(request: pytest.FixtureRequest,
             scylla_exe=scylla_binary,
             save_log_on_success=options.save_log_on_success,
         )
+        testpy_logger.info("Created Scylla cluster %s for test %s", cluster, test_name)
+        try:
+            yield cluster
+        except Exception as exc:
+            testpy_logger.info("Test %s failed: %s", test_name, exc)
+            raise
+        finally:
+            testpy_logger.info("Test %s finished", test_name)
+            await cluster.recycle()
+            node.stash[CLUSTER_KEY] = None
 
-        async def stop() -> None:
-            await cluster.stop()
-
-        artifacts.add_exit_artifact(stop)
-
-        if not options.save_log_on_success:
-            # recycle() already deletes a cluster's directories; this is the
-            # fallback for one that is never recycled, e.g. because the run
-            # was interrupted.
-            async def uninstall() -> None:
-                await cluster.uninstall()
-
-            artifacts.add_exit_artifact(uninstall)
-
-        await cluster.install_and_start()
-        # If cluster failed to start, raise the exception immediately
-        # so a broken cluster is never handed out to tests
-        if cluster.start_exception is not None:
-            # Clean up the broken cluster before raising
-            try:
-                await cluster.recycle()
-            except Exception:
-                # Report it and raise the start failure, which is the more
-                # useful of the two.
-                logger.warning("Failed to recycle the cluster that failed to start", exc_info=True)
-            raise cluster.start_exception
-        return cluster
-
-    return create_cluster
+    return cluster_for_test
 
 
 @pytest.fixture(scope="module")
@@ -398,25 +384,13 @@ def scylla_binary(request: pytest.FixtureRequest, build_mode: str) -> str:
 @pytest.fixture(scope="module")
 async def scylla_cluster(request: pytest.FixtureRequest,
                          testpy_cluster_factory: ClusterFactory,
-                         testpy_uname: str,
-                         testpy_logger: logging.Logger) -> AsyncGenerator[ScyllaCluster]:
-    """Create a ScyllaCluster for the tests in a module.
+                         testpy_uname: str) -> AsyncGenerator[ScyllaCluster]:
+    """A ScyllaCluster with one server, shared by the tests in a module."""
 
-    Builds a cluster with the suite's factory and yields it to the module's
-    tests. Once the module is done the cluster is recycled, so a later module
-    always starts from a fresh one.
-    """
-    cluster = await testpy_cluster_factory(testpy_logger)
-    try:
-        testpy_logger.info("Leasing Scylla cluster %s for test %s", cluster, testpy_uname)
+    async with testpy_cluster_factory(request.node, testpy_uname) as cluster:
+        await cluster.add_server()
         cluster.take_log_savepoint()
         yield cluster
-    except Exception as exc:
-        testpy_logger.info("Test %s failed: %s", testpy_uname, exc)
-        raise
-    finally:
-        testpy_logger.info("Test %s finished", testpy_uname)
-        await cluster.recycle()
 
 
 def pytest_collection_modifyitems(items: list[pytest.Item], config: pytest.Config) -> None:
@@ -514,13 +488,23 @@ def pytest_runtest_logreport(report):
         node_reporter.__reporter_modified = True
 
 
+@pytest.hookimpl(trylast=True)
 def pytest_sessionfinish(session: pytest.Session) -> None:
+    # After pytest's own pytest_sessionfinish, which runs the fixture
+    # finalizers an interrupted run still owes: the sweep below is the last
+    # resort for what they leave behind, and it must not overlap with a
+    # manager whose operations are still in flight.
     if session.config.getoption("--collect-only"):
         return
 
+    swept = asyncio.run(recycle_leftover_clusters(session))
+
     # If all tests passed, remove the log file to save space and avoid confusion with logs from failed runs.
     # We check this at the end of the session to ensure that we have the complete log available for any failed tests.
-    if session.testsfailed == 0 and not session.config.getoption("--save-log-on-success"):
+    # An interrupted session counts no failures, and a sweep that had to dispose of a cluster is
+    # recorded nowhere else, so the log stays in both cases.
+    if (session.testsfailed == 0 and session.exitstatus == 0 and not swept
+            and not session.config.getoption("--save-log-on-success")):
         # Use missing_ok=True because the log file is only created on first write,
         # so it may never have been written if nothing was logged.
         pathlib.Path(session.config.stash[PYTEST_LOG_FILE]).unlink(missing_ok=True)
@@ -641,6 +625,44 @@ def pytest_collect_file(file_path: pathlib.Path,
     return collectors
 
 
+def get_cluster_from_pytest_node(node: _pytest.nodes.Node) -> ScyllaCluster | None:
+    if CLUSTER_KEY in node.stash:
+        return node.stash[CLUSTER_KEY]
+    return None if node.parent is None else get_cluster_from_pytest_node(node.parent)
+
+
+async def recycle_leftover_clusters(session: pytest.Session) -> int:
+    """Dispose of the clusters whose fixtures never got to recycle them, e.g.
+    because the run was interrupted: their CLUSTER_KEY stash entry is still
+    set, since the factory clears it only after a successful recycle().
+
+    Returns the number of clusters disposed of.
+    """
+    swept = 0
+    seen: set[_pytest.nodes.Node] = set()
+    for item in getattr(session, "items", []):
+        for node in (item, *item.iter_parents()):
+            if node in seen:
+                continue
+            seen.add(node)
+            if cluster := node.stash.get(CLUSTER_KEY, None):
+                swept += 1
+                logger.warning("Cluster %s was never recycled, disposing of it at exit", cluster)
+                try:
+                    # The servers are killed here even if waiting for them to
+                    # exit fails: that wait belongs to the loop that spawned
+                    # them, which is gone by now.
+                    await cluster.stop()
+                except Exception:
+                    logger.warning("Stopping leftover cluster %s did not complete cleanly", cluster, exc_info=True)
+                try:
+                    # stop() is a no-op now, the rest is loop-free.
+                    await cluster.recycle()
+                except Exception:
+                    logger.warning("Failed to recycle leftover cluster %s", cluster, exc_info=True)
+    return swept
+
+
 @pytest.hookimpl(tryfirst=True, hookwrapper=True)
 def pytest_runtest_makereport(item, call):
     """Post-test hook to store test result in stash and optionally save logs.
@@ -648,8 +670,6 @@ def pytest_runtest_makereport(item, call):
     Stores each phase's report in item.stash[PHASE_REPORT_KEY][phase] so
     fixtures and hooks can access the test outcome per phase.  `item.stash`
     is the same stash as `request.node.stash` in pytest fixtures.
-
-    When --test-py-init is set, also saves failed test details to log files.
     """
     outcome = yield
     report = outcome.get_result()
@@ -658,39 +678,29 @@ def pytest_runtest_makereport(item, call):
     item.stash.setdefault(PHASE_REPORT_KEY, {})[report.when] = report
 
     # Optionally save test failure logs to files
-    pytest_tests_logs = pathlib.Path(item.config.getoption("--tmpdir")).absolute() / PYTEST_TESTS_LOGS_FOLDER
     if report.failed or item.config.getoption("--save-log-on-success"):
-        with open(pytest_tests_logs / f"{item._nodeid.replace('::', '-').replace('/', '-')}-{report.when}-{HOST_ID}.log", 'a') as f:
+        log_file = (
+            pathlib.Path(item.config.getoption("--tmpdir")).absolute() /
+            PYTEST_TESTS_LOGS_FOLDER /
+            f"{item._nodeid.replace('::', '-').replace('/', '-')}-{report.when}-{HOST_ID}.log"
+        )
+        with log_file.open("a", encoding="utf-8") as f:
             f.write(report.longreprtext + "\n")
             for section in report.sections:
                 f.write(section[0] + "\n")
                 f.write(section[1] + "\n")
 
-    # Single source of truth for attaching failed-test logs. cqlpy/alternator
-    # expose a `scylla_cluster`; topology suites publish MANAGER_LOGS_KEY.
     if report.failed:
-        # C++ items (and early setup failures) lack `funcargs`; nothing to collect.
-        funcargs = getattr(item, "funcargs", {})
-        build_mode = funcargs.get("build_mode")
-        cluster = funcargs.get("scylla_cluster")
-        # Published by the manager fixture (even when pulled in indirectly),
-        # so we don't re-derive its log paths or re-resolve the fixture here.
-        manager_logs = item.stash.get(MANAGER_LOGS_KEY, None)
-        if build_mode is not None and (cluster is not None or manager_logs is not None):
+        if cluster := get_cluster_from_pytest_node(item):
             try:
-                failed_test_dir_path = make_failed_test_dir(item.config, build_mode, item.name)
-
-                if cluster is not None:
-                    # Copy the server log before the cluster teardown closes it.
-                    server_log = cluster.server_log_filename()
-                    if server_log is not None and pathlib.Path(server_log).is_file():
-                        shutil.copyfile(server_log, failed_test_dir_path / pathlib.Path(server_log).name)
-
-                if manager_logs is not None:
-                    # Manager owns the servers; gather via ScyllaClusterManager (sync-callable
-                    # since ScyllaClusterManager is universalasync-wrapped).
-                    manager_logs["manager"].gather_related_logs(failed_test_dir_path, manager_logs["logs"])
-
+                failed_test_dir_path = make_failed_test_dir(item.config, item.stash[BUILD_MODE], item.name)
+                # For a call-phase failure the manager fixture's teardown
+                # copies the server logs again (and attaches them to allure);
+                # the copy here also covers the phases with no manager to
+                # gather them, e.g. a failure during fixture setup.
+                for server in cluster.servers.values():
+                    if server.log_filename.is_file():
+                        shutil.copyfile(server.log_filename, failed_test_dir_path / server.log_filename.name)
                 record_failed_test_artifacts(
                     config=item.config,
                     properties=item.user_properties,

--- a/test/pylib/runner.py
+++ b/test/pylib/runner.py
@@ -299,6 +299,12 @@ def testpy_uname(request: pytest.FixtureRequest, testpy_shortname: str) -> str:
 
 
 @pytest.fixture(scope="module")
+def testpy_logger(testpy_uname: str) -> logging.Logger:
+    """Logger for the module's cluster activity, named by the module's unique name."""
+    return logging.getLogger(testpy_uname)
+
+
+@pytest.fixture(scope="module")
 def scale_timeout(build_mode: str) -> Callable[[int | float], int | float]:
     def scale_timeout_inner(timeout: int | float) -> int | float:
         return scale_timeout_by_mode(build_mode, timeout)
@@ -386,17 +392,16 @@ def scylla_binary(request: pytest.FixtureRequest, build_mode: str) -> str:
 @pytest.fixture(scope="module")
 async def scylla_cluster(request: pytest.FixtureRequest,
                          testpy_cluster_factory: ClusterFactory,
-                         build_mode: str,
                          testpy_shortname: str,
-                         testpy_uname: str) -> AsyncGenerator[ScyllaCluster]:
+                         testpy_uname: str,
+                         testpy_logger: logging.Logger) -> AsyncGenerator[ScyllaCluster]:
     """Create a ScyllaCluster for the tests in a module.
 
     Builds a cluster with the suite's factory, runs the before-test hook and
     yields it to the module's tests. Once the module is done the cluster is
     recycled, so a later module always starts from a fresh one.
     """
-    logger_prefix = f"{build_mode}/"
-    cluster_logger = LogPrefixAdapter(logging.getLogger(logger_prefix), {"prefix": logger_prefix})
+    cluster_logger = testpy_logger
     cluster: ScyllaCluster | None = None
     server_log_filename: pathlib.Path | None = None
     testpy_name = os.path.join(get_params_stash(node=request.node)[TEST_SUITE].name, testpy_shortname.split('.')[0])

--- a/test/pylib/runner.py
+++ b/test/pylib/runner.py
@@ -304,6 +304,12 @@ def testpy_logger(testpy_uname: str) -> logging.Logger:
     return logging.getLogger(testpy_uname)
 
 
+@pytest.fixture
+def testpy_test_name(request: pytest.FixtureRequest, testpy_uname: str) -> str:
+    """The test case's full unique name, e.g. test_topology.1::test_add_server_add_column."""
+    return f"{testpy_uname}::{request.node.name}"
+
+
 @pytest.fixture(scope="module")
 def scale_timeout(build_mode: str) -> Callable[[int | float], int | float]:
     def scale_timeout_inner(timeout: int | float) -> int | float:
@@ -392,45 +398,25 @@ def scylla_binary(request: pytest.FixtureRequest, build_mode: str) -> str:
 @pytest.fixture(scope="module")
 async def scylla_cluster(request: pytest.FixtureRequest,
                          testpy_cluster_factory: ClusterFactory,
-                         testpy_shortname: str,
                          testpy_uname: str,
                          testpy_logger: logging.Logger) -> AsyncGenerator[ScyllaCluster]:
     """Create a ScyllaCluster for the tests in a module.
 
-    Builds a cluster with the suite's factory, runs the before-test hook and
-    yields it to the module's tests. Once the module is done the cluster is
-    recycled, so a later module always starts from a fresh one.
+    Builds a cluster with the suite's factory and yields it to the module's
+    tests. Once the module is done the cluster is recycled, so a later module
+    always starts from a fresh one.
     """
-    cluster_logger = testpy_logger
-    cluster: ScyllaCluster | None = None
-    server_log_filename: pathlib.Path | None = None
-    testpy_name = os.path.join(get_params_stash(node=request.node)[TEST_SUITE].name, testpy_shortname.split('.')[0])
-    is_before_test_ok = False
-    is_after_test_ok = False
+    cluster = await testpy_cluster_factory(testpy_logger)
     try:
-        cluster = await testpy_cluster_factory(cluster_logger)
-        cluster.before_test(testpy_uname)
-        cluster_logger.info("Leasing Scylla cluster %s for test %s", cluster, testpy_uname)
-        server_log_filename = cluster.server_log_filename()
-        is_before_test_ok = True
+        testpy_logger.info("Leasing Scylla cluster %s for test %s", cluster, testpy_uname)
         cluster.take_log_savepoint()
-
         yield cluster
-
-        cluster.after_test(testpy_uname)
-        is_after_test_ok = True
     except Exception as exc:
-        if not is_before_test_ok:
-            logger.info("Test %s pre-check failed: %s\ncheck server logs: %s", testpy_name, exc, server_log_filename)
-            cluster_logger.info("Discarding cluster after failed start for test %s...", testpy_name)
-        elif not is_after_test_ok:
-            logger.info("Test %s post-check failed: %s\ncheck server logs: %s", testpy_name, exc, server_log_filename)
-            cluster_logger.info("Discarding cluster after failed test %s...", testpy_name)
+        testpy_logger.info("Test %s failed: %s", testpy_uname, exc)
         raise
     finally:
-        if cluster is not None:
-            cluster_logger.info("Test %s finished", testpy_uname)
-            await cluster.recycle()
+        testpy_logger.info("Test %s finished", testpy_uname)
+        await cluster.recycle()
 
 
 def pytest_collection_modifyitems(items: list[pytest.Item], config: pytest.Config) -> None:

--- a/test/pylib/runner.py
+++ b/test/pylib/runner.py
@@ -523,7 +523,7 @@ def pytest_sessionfinish(session: pytest.Session) -> None:
     if session.testsfailed == 0 and not session.config.getoption("--save-log-on-success"):
         # Use missing_ok=True because the log file is only created on first write,
         # so it may never have been written if nothing was logged.
-        pathlib.Path(_pytest_config.stash[PYTEST_LOG_FILE]).unlink(missing_ok=True)
+        pathlib.Path(session.config.stash[PYTEST_LOG_FILE]).unlink(missing_ok=True)
 
     asyncio.run(artifacts.cleanup_before_exit())
 
@@ -658,49 +658,48 @@ def pytest_runtest_makereport(item, call):
     item.stash.setdefault(PHASE_REPORT_KEY, {})[report.when] = report
 
     # Optionally save test failure logs to files
-    if _pytest_config:
-        pytest_tests_logs = pathlib.Path(_pytest_config.getoption("--tmpdir")).absolute() / PYTEST_TESTS_LOGS_FOLDER
-        if report.failed or _pytest_config.getoption("--save-log-on-success"):
-            with open(pytest_tests_logs / f"{item._nodeid.replace('::', '-').replace('/', '-')}-{report.when}-{HOST_ID}.log", 'a') as f:
-                f.write(report.longreprtext + "\n")
-                for section in report.sections:
-                    f.write(section[0] + "\n")
-                    f.write(section[1] + "\n")
+    pytest_tests_logs = pathlib.Path(item.config.getoption("--tmpdir")).absolute() / PYTEST_TESTS_LOGS_FOLDER
+    if report.failed or item.config.getoption("--save-log-on-success"):
+        with open(pytest_tests_logs / f"{item._nodeid.replace('::', '-').replace('/', '-')}-{report.when}-{HOST_ID}.log", 'a') as f:
+            f.write(report.longreprtext + "\n")
+            for section in report.sections:
+                f.write(section[0] + "\n")
+                f.write(section[1] + "\n")
 
-        # Single source of truth for attaching failed-test logs. cqlpy/alternator
-        # expose a `scylla_cluster`; topology suites publish MANAGER_LOGS_KEY.
-        if report.failed:
-            # C++ items (and early setup failures) lack `funcargs`; nothing to collect.
-            funcargs = getattr(item, "funcargs", {})
-            build_mode = funcargs.get("build_mode")
-            cluster = funcargs.get("scylla_cluster")
-            # Published by the manager fixture (even when pulled in indirectly),
-            # so we don't re-derive its log paths or re-resolve the fixture here.
-            manager_logs = item.stash.get(MANAGER_LOGS_KEY, None)
-            if build_mode is not None and (cluster is not None or manager_logs is not None):
-                try:
-                    failed_test_dir_path = make_failed_test_dir(item.config, build_mode, item.name)
+    # Single source of truth for attaching failed-test logs. cqlpy/alternator
+    # expose a `scylla_cluster`; topology suites publish MANAGER_LOGS_KEY.
+    if report.failed:
+        # C++ items (and early setup failures) lack `funcargs`; nothing to collect.
+        funcargs = getattr(item, "funcargs", {})
+        build_mode = funcargs.get("build_mode")
+        cluster = funcargs.get("scylla_cluster")
+        # Published by the manager fixture (even when pulled in indirectly),
+        # so we don't re-derive its log paths or re-resolve the fixture here.
+        manager_logs = item.stash.get(MANAGER_LOGS_KEY, None)
+        if build_mode is not None and (cluster is not None or manager_logs is not None):
+            try:
+                failed_test_dir_path = make_failed_test_dir(item.config, build_mode, item.name)
 
-                    if cluster is not None:
-                        # Copy the server log before the cluster teardown closes it.
-                        server_log = cluster.server_log_filename()
-                        if server_log is not None and pathlib.Path(server_log).is_file():
-                            shutil.copyfile(server_log, failed_test_dir_path / pathlib.Path(server_log).name)
+                if cluster is not None:
+                    # Copy the server log before the cluster teardown closes it.
+                    server_log = cluster.server_log_filename()
+                    if server_log is not None and pathlib.Path(server_log).is_file():
+                        shutil.copyfile(server_log, failed_test_dir_path / pathlib.Path(server_log).name)
 
-                    if manager_logs is not None:
-                        # Manager owns the servers; gather via ScyllaClusterManager (sync-callable
-                        # since ScyllaClusterManager is universalasync-wrapped).
-                        manager_logs["manager"].gather_related_logs(failed_test_dir_path, manager_logs["logs"])
+                if manager_logs is not None:
+                    # Manager owns the servers; gather via ScyllaClusterManager (sync-callable
+                    # since ScyllaClusterManager is universalasync-wrapped).
+                    manager_logs["manager"].gather_related_logs(failed_test_dir_path, manager_logs["logs"])
 
-                    record_failed_test_artifacts(
-                        config=item.config,
-                        properties=item.user_properties,
-                        failed_test_dir_path=failed_test_dir_path,
-                        longreprtext=report.longreprtext,
-                        when=report.when,
-                    )
-                except Exception:
-                    logger.warning("Failed to collect logs for failed test %s", item.name, exc_info=True)
+                record_failed_test_artifacts(
+                    config=item.config,
+                    properties=item.user_properties,
+                    failed_test_dir_path=failed_test_dir_path,
+                    longreprtext=report.longreprtext,
+                    when=report.when,
+                )
+            except Exception:
+                logger.warning("Failed to collect logs for failed test %s", item.name, exc_info=True)
 
 
 class TestSuiteConfig:

--- a/test/pylib/scylla_cluster.py
+++ b/test/pylib/scylla_cluster.py
@@ -9,7 +9,6 @@
 import asyncio
 import copy
 import importlib
-import itertools
 import logging
 import pathlib
 import uuid
@@ -443,25 +442,6 @@ class ScyllaCluster:
     def starting_servers(self) -> list[ServerInfo]:
         """Get a list of tuples of server ids and IP address of servers which are currently starting (not yet running)"""
         return [server.server_info() for server in self.starting.values()]
-
-    def before_test(self, name) -> None:
-        """Check that  the cluster is ready for a test. If
-        there was a start error, throw it here - the cluster is started
-        outside of any specific test, so throwing it at start time
-        wouldn't be attributed to a test."""
-        if self.start_exception:
-            raise Exception(f'Exception when starting cluster {self}:\n{self.start_exception}')
-
-        for server in self.running.values():
-            server.write_log_marker(f"------ Starting test {name} ------\n")
-
-    def after_test(self, name: str) -> None:
-        """Mark the end of the test in the server logs.  The log files are
-        closed by recycle(), which always follows: the cluster is destroyed
-        after every test."""
-        assert self.start_exception is None
-        for server in itertools.chain(self.running.values(), self.stopped.values()):
-            server.write_log_marker(f"------ Ending test {name} ------\n")
 
     async def server_stop(self, server_id: ServerNum, gracefully: bool) -> None:
         """Stop a server. No-op if already stopped."""

--- a/test/pylib/scylla_cluster.py
+++ b/test/pylib/scylla_cluster.py
@@ -614,15 +614,6 @@ class ScyllaCluster:
         assert server_id in self.servers, f"Server {server_id} unknown"
         self.servers[server_id].update_cmdline(cmdline_options)
 
-    def setLogger(self, logger: logging.LoggerAdapter):
-        """Change the logger used by the cluster.
-           Called when a cluster is reused between tests so that logs during the new test
-           are prefixed appropriately with the corresponding test's name.
-        """
-        self.logger = logger
-        for srv in self.servers.values():
-            srv.setLogger(self.logger)
-
     async def change_ip(self, server_id: ServerNum) -> IPAddress:
         """Lease a new IP address and update conf/scylla.yaml with it. The
         original IP is released at the end of the test to avoid an

--- a/test/pylib/scylla_cluster.py
+++ b/test/pylib/scylla_cluster.py
@@ -14,7 +14,7 @@ import pathlib
 import uuid
 from collections import ChainMap
 from functools import reduce
-from typing import Any, Awaitable, Callable, Dict, List, NamedTuple, Optional, Set, Tuple, Union
+from typing import Any, Awaitable, Callable, Dict, List, NamedTuple, Optional, Set, Union
 
 import psutil
 
@@ -33,28 +33,6 @@ from test.pylib.util import gather_safely, graceful_stop_timeout
 
 
 type ClusterFactory = Callable[[logging.Logger | logging.LoggerAdapter], Awaitable[ScyllaCluster]]
-
-
-def bind_to_current_loop(callback: Callable[[], Any]) -> Callable[[], Awaitable[None]]:
-    """Wrap `callback` so that it can be awaited from any loop.
-
-    A cluster is recycled on the ScyllaClusterManager's own loop, in its own
-    thread, while the teardown callbacks own objects the fixtures created on a
-    different loop -- a subprocess handle awaited from the wrong loop hangs
-    instead of failing.  Binding here lets the cluster keep a plain awaitable
-    and fire it without knowing which loop is underneath.
-    """
-    owner = asyncio.get_running_loop()
-
-    async def invoke() -> None:
-        res = callback()
-        if asyncio.iscoroutine(res):
-            if asyncio.get_running_loop() is owner:
-                await res
-            else:
-                await asyncio.wrap_future(asyncio.run_coroutine_threadsafe(res, owner))
-
-    return invoke
 
 
 class ReplaceConfig(NamedTuple):
@@ -108,10 +86,6 @@ class ScyllaCluster:
         self.start_exception: Optional[Exception] = None
         self.api = ScyllaRESTAPIClient(build_mode=self.mode)
         self.stop_lock = asyncio.Lock()
-        # Cleanups a test registered through ScyllaClusterManager.add_teardown_callback(),
-        # as (callback, name) pairs.  They are fired by run_teardown_callbacks()
-        # when this cluster is recycled.
-        self.teardown_callbacks: List[Tuple[Callable[[], Awaitable[None]], str]] = []
         self.logger.info("Created new cluster %s", self.name)
 
     async def install_and_start(self) -> None:
@@ -147,9 +121,6 @@ class ScyllaCluster:
            by a failed test.
         """
         await self.stop()
-        # The servers are down, so a callback may now dispose of a resource
-        # they were using without racing against them.
-        await self.run_teardown_callbacks()
         for srv in self.servers.values():
             if srv.log_file is not None:
                 srv.log_file.close()
@@ -165,39 +136,6 @@ class ScyllaCluster:
             # again.  Delete now rather than at exit, so that a long run
             # doesn't keep the directories of thousands of clusters on disk.
             await gather_safely(*(srv.uninstall() for srv in self.servers.values()))
-
-    def add_teardown_callback(self, callback: Callable[[], Awaitable[None]], name: str) -> None:
-        """Register a cleanup to run when this cluster is recycled.
-
-        The callback arrives already bound to the loop it was registered on, so
-        this end only tracks which callbacks belong to this cluster and in what
-        order they were registered.
-        """
-        self.logger.info("Cluster %s registers teardown callback %s", self, name)
-        self.teardown_callbacks.append((callback, name))
-
-    async def run_teardown_callbacks(self) -> None:
-        """Fire the registered teardown callbacks in LIFO order.
-
-        Called from recycle(), once the servers are stopped, so that a callback
-        disposing of a resource they were using cannot race with them: an
-        object storage bucket an in-flight tablet migration could otherwise
-        still read from (SCYLLADB-2471).
-
-        An exception in one callback is logged and swallowed, so that it
-        neither hides the others nor aborts the rest of the teardown.
-        """
-        assert not self.running, \
-            f"Cluster {self} still has running servers, teardown callbacks must fire after it is stopped"
-        while self.teardown_callbacks:
-            callback, name = self.teardown_callbacks.pop()
-            self.logger.info("Cluster %s running teardown callback %s", self, name)
-            try:
-                await callback()
-            except Exception as e:
-                self.logger.warning("Cluster %s teardown callback %s failed: %s", self, name, e)
-            else:
-                self.logger.info("Cluster %s teardown callback %s done", self, name)
 
     async def release_ips(self) -> None:
         """Release all IPs leased from the host registry by this cluster.

--- a/test/pylib/scylla_cluster.py
+++ b/test/pylib/scylla_cluster.py
@@ -106,10 +106,7 @@ class ScyllaCluster:
         self.initial_seed: Optional[IPAddress] = None
         # cluster is started (but it might not have running servers)
         self.is_running: bool = False
-        # cluster was modified in a way it should not be used in subsequent tests
-        self.is_dirty: bool = False
         self.start_exception: Optional[Exception] = None
-        self.keyspace_count = 0
         self.api = ScyllaRESTAPIClient(build_mode=self.mode)
         self.stop_lock = asyncio.Lock()
         # Cleanups a test registered through ScyllaClusterManager.add_teardown_callback(),
@@ -124,18 +121,15 @@ class ScyllaCluster:
         try:
             if self.replicas > 0:
                 await self.add_servers(self.replicas)
-                self.keyspace_count = self._get_keyspace_count()
         except Exception as exc:
             # If start fails, swallow the error to throw later,
             # at test time.
             self.start_exception = exc
         self.is_running = True
         self.logger.info("Created cluster %s", self)
-        self.is_dirty = False
 
     async def uninstall(self) -> None:
         """Stop running servers and uninstall all servers"""
-        self.is_dirty = True
         self.logger.info("Uninstalling cluster %s", self)
         await self.stop()
         await gather_safely(*(srv.uninstall() for srv in self.stopped.values()))
@@ -224,7 +218,6 @@ class ScyllaCluster:
             if self.is_running:
                 self.is_running = False
                 self.logger.info("Cluster %s stopping", self)
-                self.is_dirty = True
                 # If self.running is empty, no-op
                 await gather_safely(*(server.stop() for server in self.running.values()))
                 self.stopped.update(self.running)
@@ -235,7 +228,6 @@ class ScyllaCluster:
         if self.is_running:
             self.is_running = False
             self.logger.info("Cluster %s stopping gracefully", self)
-            self.is_dirty = True
             # If self.running is empty, no-op
             await gather_safely(*(server.stop_gracefully(graceful_stop_timeout(self.mode))
                                   for server in self.running.values()))
@@ -259,7 +251,6 @@ class ScyllaCluster:
                          expected_error: Optional[str] = None,
                          expected_server_up_state: ServerUpState = ServerUpState.SERVING) -> ServerInfo:
         """Add a new server to the cluster"""
-        self.is_dirty = True
 
         assert start or not expected_error, \
             f"add_server: cannot add a stopped server and expect an error"
@@ -453,55 +444,24 @@ class ScyllaCluster:
         """Get a list of tuples of server ids and IP address of servers which are currently starting (not yet running)"""
         return [server.server_info() for server in self.starting.values()]
 
-    def _get_keyspace_count(self) -> int:
-        """Get the current keyspace count"""
-        assert self.start_exception is None
-        assert self.running, "No active nodes left"
-        server = next(iter(self.running.values()))
-        self.logger.debug("_get_keyspace_count() using server %s", server)
-        assert server.control_connection is not None
-        rows = server.control_connection.execute(
-               "select count(*) as c from system_schema.keyspaces")
-        keyspace_count = int(rows.one()[0])
-        return keyspace_count
-
     def before_test(self, name) -> None:
         """Check that  the cluster is ready for a test. If
         there was a start error, throw it here - the cluster is started
         outside of any specific test, so throwing it at start time
         wouldn't be attributed to a test."""
         if self.start_exception:
-            # Mark as dirty so further test cases don't try to reuse this cluster.
-            self.is_dirty = True
             raise Exception(f'Exception when starting cluster {self}:\n{self.start_exception}')
 
         for server in self.running.values():
             server.write_log_marker(f"------ Starting test {name} ------\n")
 
-    def after_test(self, name: str, success: bool | None = None) -> None:
-        """Mark the cluster as dirty after a failed test.
-        If the cluster is not dirty, check that it's still alive and the test
-        hasn't left any garbage."""
+    def after_test(self, name: str) -> None:
+        """Mark the end of the test in the server logs.  The log files are
+        closed by recycle(), which always follows: the cluster is destroyed
+        after every test."""
         assert self.start_exception is None
-        if not success:
-            if success is not None:
-                self.logger.debug(f"Test failed using cluster {self.name}, marking the cluster as dirty")
-            self.is_dirty = True
-        if self.is_dirty:
-            self.logger.info(f"The cluster {self.name} is dirty, not checking"
-                             f" keyspace count post-condition")
-        else:
-            if self.running and self._get_keyspace_count() != self.keyspace_count:
-                raise RuntimeError(f"Test post-condition on cluster {self.name} failed, "
-                                   f"the test must drop all keyspaces it creates.")
         for server in itertools.chain(self.running.values(), self.stopped.values()):
             server.write_log_marker(f"------ Ending test {name} ------\n")
-            # Only close log files when the cluster is dirty (will be destroyed).
-            # If the cluster is clean and will be reused, keep the log file open
-            # so that write_log_marker() and take_log_savepoint() work in the
-            # next test's before_test().
-            if self.is_dirty and not server.log_file.closed:
-                server.log_file.close()
 
     async def server_stop(self, server_id: ServerNum, gracefully: bool) -> None:
         """Stop a server. No-op if already stopped."""
@@ -509,7 +469,6 @@ class ScyllaCluster:
         if server_id in self.stopped:
             return
         assert server_id in self.running or server_id in self.starting, f"Server {server_id} unknown"
-        self.is_dirty = True
         if server_id in self.running:
             server = self.running[server_id]
         else:
@@ -551,7 +510,6 @@ class ScyllaCluster:
         if server_id in self.running:
             return
         assert server_id in self.stopped, f"Server {server_id} unknown"
-        self.is_dirty = True
         server = self.stopped.pop(server_id)
         self.logger.info("Cluster %s starting server %s ip %s", self,
                          server_id, server.ip_addr)
@@ -587,7 +545,6 @@ class ScyllaCluster:
         """Pause a running server process."""
         self.logger.info("Cluster %s pausing server %s", self.name, server_id)
         assert server_id in self.running
-        self.is_dirty = True
         server = self.running[server_id]
         server.pause()
 
@@ -603,7 +560,6 @@ class ScyllaCluster:
         self.logger.info("Cluster %s upgrading server %s to executable %s", self.name, server_id, path)
         server = self.servers[server_id]
         assert not server.is_running, f"Server {server_id} is running: stop it first and then change its executable"
-        self.is_dirty = True
         server.exe = pathlib.Path(path).resolve()
         server.check_scylla_executable()
 
@@ -637,31 +593,25 @@ class ScyllaCluster:
         """Update conf/scylla.yaml of the given server with `config_options` dict.
 
         If the server is running, reload the config with a SIGHUP.
-        Mark the cluster as dirty.
         Fail if the server cannot be found.
         """
         assert server_id in self.servers, f"Server {server_id} unknown"
-        self.is_dirty = True
         self.servers[server_id].update_config(config_options=config_options)
 
     def remove_config_option(self, server_id: ServerNum, key: str) -> None:
         """Remove an option from conf/scylla.yaml of the given server.
 
         If the server is running, reload the config with a SIGHUP.
-        Mark the cluster as dirty.
         Fail if the server cannot be found.
         """
         assert server_id in self.servers, f"Server {server_id} unknown"
-        self.is_dirty = True
         self.servers[server_id].remove_config_option(key=key)
 
     def update_cmdline(self, server_id: ServerNum, cmdline_options: List[str]) -> None:
         """Update the command-line options of the given server by merging the new options into the existing ones.
            The update only takes effect after restart.
-           Marks the cluster as dirty.
            Fails if the server cannot be found."""
         assert server_id in self.servers, f"Server {server_id} unknown"
-        self.is_dirty = True
         self.servers[server_id].update_cmdline(cmdline_options)
 
     def setLogger(self, logger: logging.LoggerAdapter):
@@ -681,7 +631,6 @@ class ScyllaCluster:
         assert server_id in self.servers, f"Server {server_id} unknown"
         server = self.servers[server_id]
         assert not server.is_running, f"Server {server_id} is running: stop it first and then change its ip"
-        self.is_dirty = True
         ip_addr = IPAddress(await self.host_registry.lease_host())
         self.leased_ips.add(ip_addr)
         logging.info("Cluster %s changed server %s IP from %s to %s", self.name,
@@ -697,7 +646,6 @@ class ScyllaCluster:
         assert server_id in self.servers, f"Server {server_id} unknown"
         server = self.servers[server_id]
         assert not server.is_running, f"Server {server_id} is running: stop it first and then change its ip"
-        self.is_dirty = True
         rpc_address = IPAddress(await self.host_registry.lease_host())
         self.leased_ips.add(rpc_address)
         logging.info("Cluster %s changed server %s RPC IP from %s to %s", self.name,
@@ -710,7 +658,6 @@ class ScyllaCluster:
         assert server_id in self.servers, f"Server {server_id} unknown"
         server = self.servers[server_id]
         assert not server.is_running, f"Server {server_id} is running: stop it first and then delete its files"
-        self.is_dirty = True
         server.wipe_sstables(keyspace, table)
 
     def get_sstables_disk_usage(self, server_id: ServerNum, keyspace: str, table: str) -> int:

--- a/test/pylib/scylla_cluster.py
+++ b/test/pylib/scylla_cluster.py
@@ -14,7 +14,7 @@ import pathlib
 import uuid
 from collections import ChainMap
 from functools import reduce
-from typing import Any, Awaitable, Callable, Dict, List, NamedTuple, Optional, Set, Union
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, NamedTuple, Optional, Set, Union
 
 import psutil
 
@@ -32,7 +32,15 @@ from test.pylib.scylla_server import (
 from test.pylib.util import gather_safely, graceful_stop_timeout
 
 
-type ClusterFactory = Callable[[logging.Logger | logging.LoggerAdapter], Awaitable[ScyllaCluster]]
+if TYPE_CHECKING:
+    from contextlib import AbstractAsyncContextManager
+
+    import _pytest.nodes
+
+
+# Returns a context manager leasing a cluster to one test: entering it creates
+# the cluster and stashes it on the given node, exiting recycles it.
+type ClusterFactory = Callable[[_pytest.nodes.Node, str], AbstractAsyncContextManager[ScyllaCluster]]
 
 
 class ReplaceConfig(NamedTuple):
@@ -50,7 +58,6 @@ class ScyllaCluster:
     def __init__(self,
                  logger: Union[logging.Logger, logging.LoggerAdapter],
                  vardir: pathlib.Path,
-                 replicas: int,
                  mode: str,
                  cmdline_options: str | list[str],
                  cmdline_options_override: list[str],
@@ -70,7 +77,6 @@ class ScyllaCluster:
         self.host_registry = HostRegistry()
         self.leased_ips = set[IPAddress]()
         self.name = str(uuid.uuid1())
-        self.replicas = replicas
         # Every ScyllaServer is in one of self.running, self.stopped.
         # These dicts are disjoint.
         # A server ID present in self.removed may be either in self.running or in self.stopped.
@@ -81,84 +87,47 @@ class ScyllaCluster:
         self.starting: Dict[ServerNum, ScyllaServer] = {}       # servers starting right now, not yet running (and not included in "servers").
         # The first IP assigned to a server added to the cluster.
         self.initial_seed: Optional[IPAddress] = None
-        # cluster is started (but it might not have running servers)
-        self.is_running: bool = False
-        self.start_exception: Optional[Exception] = None
+        # cluster is started (but it might not have running servers);
+        # cleared by stop(), which is a no-op when it is False
+        self.is_running: bool = True
         self.api = ScyllaRESTAPIClient(build_mode=self.mode)
-        self.stop_lock = asyncio.Lock()
         self.logger.info("Created new cluster %s", self.name)
 
-    async def install_and_start(self) -> None:
-        """Setup initial servers and start them.
-           Catch and save any startup exception"""
-        try:
-            if self.replicas > 0:
-                await self.add_servers(self.replicas)
-        except Exception as exc:
-            # If start fails, swallow the error to throw later,
-            # at test time.
-            self.start_exception = exc
-        self.is_running = True
-        self.logger.info("Created cluster %s", self)
-
-    async def uninstall(self) -> None:
-        """Stop running servers and uninstall all servers"""
-        self.logger.info("Uninstalling cluster %s", self)
-        await self.stop()
-        await gather_safely(*(srv.uninstall() for srv in self.stopped.values()))
-        # Close API client to release connector resources
-        if self.api is not None:
-            self.api.close()
-            self.api = None
-        await gather_safely(*(self.host_registry.release_host(Host(ip))
-                               for ip in self.leased_ips))
-
     async def recycle(self) -> None:
-        """Dispose of the cluster once it's no longer needed: stop it, close the
-           server log files and sockets and release the used IPs. We don't
-           necessarily uninstall() it, which would delete the log file and
-           directory - we might want to preserve these if the cluster was used
-           by a failed test.
+        """Dispose of the cluster once it's no longer needed: stop it, close
+           the server log files and sockets, release the used IPs and, unless
+           --save-log-on-success asks to keep everything, delete the servers'
+           directories and log files.
         """
         await self.stop()
-        for srv in self.servers.values():
-            if srv.log_file is not None:
-                srv.log_file.close()
-            srv.maintenance_socket_dir.cleanup()
-        # Close API client to release connector resources
-        if self.api is not None:
-            self.api.close()
-            self.api = None
-        await self.release_ips()
-        if not self.save_log_on_success:
+        if self.save_log_on_success:
+            for srv in self.servers.values():
+                if srv.log_file is not None:
+                    srv.log_file.close()
+                srv.maintenance_socket_dir.cleanup()
+        else:
             # The cluster has served its purpose: a failed test's logs were
             # copied to failed_test/ when it failed, and nothing here is read
             # again.  Delete now rather than at exit, so that a long run
             # doesn't keep the directories of thousands of clusters on disk.
             await gather_safely(*(srv.uninstall() for srv in self.servers.values()))
 
-    async def release_ips(self) -> None:
-        """Release all IPs leased from the host registry by this cluster.
-        Call this function only if the cluster is stopped and will not be started again."""
-        assert not self.running
-        self.logger.info("Cluster %s releases ips %s", self, self.leased_ips)
-        while self.leased_ips:
-            ip = self.leased_ips.pop()
-            await self.host_registry.release_host(Host(ip))
+        # Close API client to release connector resources
+        if self.api is not None:
+            self.api.close()
+            self.api = None
+        await gather_safely(*(self.host_registry.release_host(Host(ip)) for ip in self.leased_ips))
+        self.leased_ips.clear()
 
     async def stop(self) -> None:
         """Stop all running servers ASAP"""
-        # FIXME: the lock is necessary because test.py calls `stop()` and `uninstall()` concurrently
-        # (from exit artifacts), which leads to issues (#15755). A more elegant solution would be
-        # to prevent that instead of using a lock here.
-        async with self.stop_lock:
-            if self.is_running:
-                self.is_running = False
-                self.logger.info("Cluster %s stopping", self)
-                # If self.running is empty, no-op
-                await gather_safely(*(server.stop() for server in self.running.values()))
-                self.stopped.update(self.running)
-                self.running.clear()
+        if self.is_running:
+            self.is_running = False
+            self.logger.info("Cluster %s stopping", self)
+            # If self.running is empty, no-op
+            await gather_safely(*(server.stop() for server in self.running.values()))
+            self.stopped.update(self.running)
+            self.running.clear()
 
     async def stop_gracefully(self) -> None:
         """Stop all running servers in a clean way"""
@@ -291,6 +260,19 @@ class ScyllaCluster:
                 await server.install_and_start(self.api, expected_error, expected_server_up_state)
             else:
                 await server.install()
+        except asyncio.CancelledError:
+            if server is not None:
+                # Cancelled mid-start, e.g. by the manager loop shutting down
+                # on an interrupted run, possibly after the cluster's stop()
+                # already ran: kill the process here, and keep the server in
+                # the cluster so recycle() uninstalls it and releases its IP.
+                if server.cmd is not None and server.cmd.returncode is None:
+                    try:
+                        server.cmd.kill()
+                    except ProcessLookupError:
+                        pass
+                self.running[server.server_id] = server
+            raise
         except Exception as exc:
             workdir = '<unknown>' if server is None else server.workdir.name
             self.logger.error("Failed to start Scylla server at host %s in %s: %s",

--- a/test/pylib/scylla_cluster_manager.py
+++ b/test/pylib/scylla_cluster_manager.py
@@ -49,7 +49,7 @@ from test.pylib.driver_utils import safe_driver_shutdown
 from test.pylib.internal_types import ServerNum, IPAddress, HostID, ServerInfo, ServerUpState
 from test.pylib.log_browsing import ScyllaLogFile
 from test.pylib.rest_client import HTTPError, ScyllaMetricsClient, ScyllaRESTAPIClient
-from test.pylib.scylla_cluster import ReplaceConfig, ScyllaCluster, bind_to_current_loop
+from test.pylib.scylla_cluster import ReplaceConfig, ScyllaCluster
 from test.pylib.scylla_server import ScyllaServer, ScyllaVersionDescription
 from test.pylib.util import (
     Host,
@@ -284,10 +284,7 @@ class ScyllaClusterManager:
                 yield self
             finally:
                 stop_event.set()
-                # Wait for the manager thread off the event loop.  Stopping
-                # the manager recycles the cluster, and recycling runs
-                # teardown callbacks that belong to the caller's loop;
-                # blocking it here would deadlock them.
+                # Wait for the manager thread off the event loop.
                 try:
                     await asyncio.get_running_loop().run_in_executor(None, future.result)
                 finally:
@@ -430,36 +427,6 @@ class ScyllaClusterManager:
         """Unpause the specified server."""
 
         self.cluster.server_unpause(server_id)
-
-    async def add_teardown_callback(self, callback: Callable[[], Any], name: str | None = None) -> None:
-        """Register a callback to run once the cluster used by this test has
-        been stopped.
-
-        The callbacks belong to the cluster and fire from its
-        run_teardown_callbacks(), which recycle() calls right after the servers
-        are stopped.  They therefore run against a cluster that is down, and
-        may dispose of a resource it was using without racing against it: an
-        object storage bucket that an in-flight tablet migration could
-        otherwise still read from (SCYLLADB-2471).
-
-        One consequence of firing that late is worth knowing: the resource
-        the callback disposes of has to stay alive past the fixture that
-        created it.
-
-        Callbacks fire in LIFO order; both plain callables and coroutine
-        functions are accepted.  Register them from a fixture rather than from
-        a test body, so that a coroutine is handed back to a loop that is still
-        alive when it is awaited.  `name` is what the cluster log calls this
-        callback, and defaults to the callable's qualified name.
-        """
-        # bind_to_current_loop() has to run here, on the caller's loop, not
-        # inside the operation, which runs on the manager's.
-        await self._add_teardown_callback(bind_to_current_loop(callback),
-                                          name or getattr(callback, "__qualname__", repr(callback)))
-
-    @manager_op
-    async def _add_teardown_callback(self, callback: Callable[[], Awaitable[None]], name: str) -> None:
-        self.cluster.add_teardown_callback(callback, name)
 
     @manager_op(timeout=None)
     async def _server_add(self,

--- a/test/pylib/scylla_cluster_manager.py
+++ b/test/pylib/scylla_cluster_manager.py
@@ -173,8 +173,9 @@ class ScyllaClusterManager:
     Parallel requests are not supported.
 
     The manager lives for one test: the fixture starts it before the test and
-    stops it right after, recycling the cluster.  after_test() drains what
-    the test left running and reports what it leaked.
+    stops it right after, stopping the servers; the cluster fixture then
+    recycles the cluster.  after_test() drains what the test left running
+    and reports what it leaked.
 
     A method that awaits cluster or server internals must be a @manager_op --
     those objects belong to the manager's loop -- and the CQL driver, the REST
@@ -235,14 +236,18 @@ class ScyllaClusterManager:
         return out
 
     async def stop(self) -> None:
-        """Dispose of the cluster if present."""
+        """Stop the cluster's servers if present.
 
+        Only the loop-bound part of the cluster's disposal: the server
+        subprocess transports belong to the manager's loop, so they have to be
+        awaited here.  The cluster fixture recycles and uninstalls afterwards.
+        """
         self.logger.info("ScyllaManager stopping for test %s", self.test_name)
         self.driver_close()
         self.thread_pool.shutdown(wait=False)
         if self.cluster:
             self.logger.info("ScyllaManager: stopping Scylla cluster %s after %s", self.cluster, self.test_name)
-            await self.cluster.recycle()
+            await self.cluster.stop()
             self.cluster = None
 
     @asynccontextmanager
@@ -889,20 +894,11 @@ class ScyllaClusterManager:
                 server_cores[server] = found_cores
         return server_cores
 
-    async def gather_related_logs(self, failed_test_path_dir: Path, logs: dict[str, Path]) -> None:
+    async def gather_related_logs(self, failed_test_path_dir: Path) -> None:
         for server in await self.all_servers():
             log_file = await self.server_open_log(server_id=server.server_id)
             shutil.copyfile(log_file.file, failed_test_path_dir / f"{pathlib.Path(log_file.file).name}")
             allure.attach(log_file.file.read_bytes(), name=log_file.file.name, attachment_type=allure.attachment_type.TEXT)
-        for name, log in logs.items():
-            # A log is missing when the handler that writes it was never installed, e.g. the
-            # test failed before before-test ran. Skip it: the caller collects the rest of the
-            # artifacts after this returns, so raising here would lose them all.
-            if not log.is_file():
-                self.logger.warning("Log %s (%s) does not exist, not attaching it", name, log)
-                continue
-            allure.attach(log.read_bytes(), name=name, attachment_type=allure.attachment_type.TEXT)
-            shutil.copyfile(log, failed_test_path_dir / name)
 
     async def all_servers_by_host_id(self) -> dict[HostID, ServerInfo]:
         result = dict()

--- a/test/pylib/scylla_cluster_manager.py
+++ b/test/pylib/scylla_cluster_manager.py
@@ -50,7 +50,6 @@ from test.pylib.scylla_cluster import ClusterFactory, ReplaceConfig, ScyllaClust
 from test.pylib.scylla_server import ScyllaServer, ScyllaVersionDescription
 from test.pylib.util import (
     Host,
-    LogPrefixAdapter,
     gather_safely,
     graceful_stop_timeout,
     universalasync_typed_wrap,
@@ -107,7 +106,7 @@ def manager_op[**P, R](entry_point: ManagerAsyncFn[P, R] | None = None,
     A waiter that times out or is cancelled abandons the operation instead of
     killing it: the operation is shielded, stays in tasks_history and
     after_test() drains it from there.  Failures are logged with their
-    traceback into the per-test cluster log.
+    traceback through the cluster's logger.
 
     Every entry point works on the current cluster, so that is asserted here.
     """
@@ -186,20 +185,14 @@ class ScyllaClusterManager:
     Args:
         test_uname: name of the test module the manager serves
         create_cluster: factory of Scylla clusters
-        base_dir: directory for the per-test-case cluster logs
         port: CQL port for driver connections
         use_ssl: use SSL for driver connections
         auth_provider: authentication provider for driver connections
         build_mode: build mode of the Scylla servers, or None if unknown
     """
-    # Per test, created by before_test() and removed by after_test().
-    test_case_log_file: pathlib.Path
-    test_case_log_fh: logging.FileHandler
-
     def __init__(self,
                  test_uname: str,
                  create_cluster: ClusterFactory,
-                 base_dir: str,
                  port: int,
                  use_ssl: bool,
                  auth_provider: Any | None,
@@ -209,9 +202,7 @@ class ScyllaClusterManager:
         # they are called from.
         self._loop = asyncio.get_running_loop()
         self.test_uname = test_uname
-        self.base_dir = base_dir
-        logger = logging.getLogger(self.test_uname)
-        self.logger = LogPrefixAdapter(logger, {"prefix": self.test_uname})
+        self.logger = logging.getLogger(self.test_uname)
         self.cluster: ScyllaCluster | None = None
         self.create_cluster = create_cluster
         self.is_running = False
@@ -255,7 +246,6 @@ class ScyllaClusterManager:
             return
         self.cluster = await self.create_cluster(self.logger)
         self.logger.info("First Scylla cluster: %s", self.cluster)
-        self.cluster.setLogger(self.logger)
         self.is_running = True
 
     @manager_op(timeout=600)
@@ -272,17 +262,7 @@ class ScyllaClusterManager:
         self.load_balancing_policy = RoundRobinPolicy()
         self.auth_provider = self._suite_auth_provider
         self.current_test_case_full_name = f"{self.test_uname}::{test_case_name}"
-        root_logger = logging.getLogger()
-        parent_test_name = pathlib.Path(self.test_uname.replace("/", "_")).stem
-        self.test_case_log_file = pathlib.Path(self.base_dir) / f"{parent_test_name}.{test_case_name}_cluster.log"
-        self.test_case_log_fh = logging.FileHandler(self.test_case_log_file)
-        self.test_case_log_fh.setLevel(root_logger.getEffectiveLevel())
-        # to have the custom formatter with a timestamp that used in a test.py but for each testcase's log, we need to
-        # extract it from the root logger and apply to the handler
-        self.test_case_log_fh.setFormatter(root_logger.handlers[0].formatter)
-        root_logger.addHandler(self.test_case_log_fh)
         self.logger.info("Setting up %s", self.current_test_case_full_name)
-        self.cluster.setLogger(self.logger)
         self.logger.info("Leasing Scylla cluster %s for test %s", self.cluster, self.current_test_case_full_name)
         self.cluster.before_test(self.current_test_case_full_name)
         self.cluster.take_log_savepoint()
@@ -390,9 +370,6 @@ class ScyllaClusterManager:
         try:
             self.cluster.after_test(self.current_test_case_full_name)
         finally:
-            logging.getLogger().removeHandler(self.test_case_log_fh)
-            if success:
-                self.test_case_log_file.unlink()
             self.current_test_case_full_name = ""
         cluster_str = str(self.cluster)
 

--- a/test/pylib/scylla_cluster_manager.py
+++ b/test/pylib/scylla_cluster_manager.py
@@ -86,44 +86,18 @@ type ManagerFn[**P, R] = Callable[Concatenate[ScyllaClusterManager, P], R]
 type ManagerAsyncFn[**P, R] = ManagerFn[P, Awaitable[R]]
 
 
-def fenced[**P, R](fn: ManagerFn[P, R]) -> ManagerFn[P, R]:
-    """Refuse the call once the test that leased the manager has finished.
-
-    manager_op applies it to operations (fence=True); the driver methods carry
-    it directly, since the session lives on this module-scoped manager and a
-    leaked caller could close the one the running test is using.  The check
-    happens on the caller's side, before a coroutine is even created.
-    """
-    @wraps(fn)
-    def wrapper(self: ScyllaClusterManager, *args: P.args, **kwargs: P.kwargs) -> R:
-        if self._test_finished:
-            raise RuntimeError("ScyllaClusterManager is not accessible after the test finished")
-        return fn(self, *args, **kwargs)
-
-    if inspect.iscoroutinefunction(fn):
-        # The wrapper is a plain function returning fn's coroutine; universalasync
-        # keys off iscoroutinefunction to make operations callable from a thread.
-        inspect.markcoroutinefunction(wrapper)
-
-    return wrapper
-
-
 @overload
 def manager_op[**P, R](entry_point: ManagerAsyncFn[P, R]) -> ManagerAsyncFn[P, R]: ...
 @overload
 def manager_op[**P, R](*,
-                       blockable: bool = ...,
-                       fence: bool = ...,
                        timeout: float | None = ...) -> Callable[[ManagerAsyncFn[P, R]], ManagerAsyncFn[P, R]]: ...
 def manager_op[**P, R](entry_point: ManagerAsyncFn[P, R] | None = None,
                        *,
-                       blockable: bool = False,
-                       fence: bool = True,
                        timeout: float | None = DEFAULT_OP_TIMEOUT,
                        ) -> ManagerAsyncFn[P, R] | Callable[[ManagerAsyncFn[P, R]], ManagerAsyncFn[P, R]]:
     """Run a ScyllaClusterManager entry point on the manager's loop, as its own tracked task.
 
-    Usable bare, as @manager_op, or with arguments, as @manager_op(blockable=True).
+    Usable bare, as @manager_op, or with arguments, as @manager_op(timeout=600).
 
     The manager's state -- subprocess transports, per-server locks -- belongs to
     its loop, so an operation always runs there, whichever loop or thread calls
@@ -136,8 +110,6 @@ def manager_op[**P, R](entry_point: ManagerAsyncFn[P, R] | None = None,
     traceback into the per-test cluster log.
 
     Every entry point works on the current cluster, so that is asserted here.
-    fence=True refuses the call once the test finished (see fenced),
-    blockable=True refuses it on a manager an earlier test broke.
     """
     def decorator(fn: ManagerAsyncFn[P, R]) -> ManagerAsyncFn[P, R]:
         # The bridge does not consume a timeout argument; a timeout is either
@@ -151,8 +123,6 @@ def manager_op[**P, R](entry_point: ManagerAsyncFn[P, R] | None = None,
         async def run_op(self: ScyllaClusterManager, *args: P.args, **kwargs: P.kwargs) -> R:
             """The operation itself; always runs on the manager's loop."""
             assert self.cluster, "ScyllaClusterManager is not running"
-            if blockable:
-                self.check_not_broken()
             descr = f"{fn.__name__}{args}"
             op = asyncio.ensure_future(fn(self, *args, **kwargs))
 
@@ -189,24 +159,22 @@ def manager_op[**P, R](entry_point: ManagerAsyncFn[P, R] | None = None,
                 return await asyncio.wrap_future(future)
         # The bridge adds no parameters, so the decorated entry point keeps
         # its exact signature.
-        return fenced(wrapper) if fence else wrapper
+        return wrapper
     return decorator if entry_point is None else decorator(entry_point)
 
 
 @universalasync_typed_wrap
 class ScyllaClusterManager:
-    """Manages a Scylla cluster for a test module and serves the test API.
+    """Manages a Scylla cluster for a single test and serves the test API.
 
     Parallel requests are not supported.
 
-    The manager outlives every test in the module, so state belonging to one
-    test -- the driver session, the log patterns to ignore -- is reset by
-    before_test(), while after_test() raises the leaked-task fence and drains
-    what the test left running.  That fence only covers the teardown window,
-    since the next before_test() lifts it; what keeps a leaked caller out of a
-    later test is the per-test event loop cancelling its tasks, after_test()'s
-    drain plus break_manager(), and per-process-unique server ids failing an
-    assertion.
+    The manager lives for one test: the fixture starts it before the test and
+    stops it right after, recycling the cluster.  State belonging to the test
+    -- the driver session, the log patterns to ignore -- is reset by
+    before_test(), while after_test() drains what the test left running.  A
+    task leaked past the test finds the manager's loop closed and gets a
+    RuntimeError.
 
     A method that awaits cluster or server internals must be a @manager_op --
     those objects belong to the manager's loop -- and the CQL driver, the REST
@@ -250,10 +218,6 @@ class ScyllaClusterManager:
         # tasks_history holds the running test's operations: after_test()
         # drains it, and whatever is left over is the leak it reports.
         self.tasks_history: dict[asyncio.Task, str] = {}
-        # Sticky on purpose: a manager broken by one test keeps failing the
-        # rest of the module, so nothing resets these between tests.
-        self.server_broken_event = asyncio.Event()
-        self.server_broken_reason = ""
         # Per-module: configuration and helpers that outlive every test.
         self.port = port
         self.use_ssl = use_ssl
@@ -264,11 +228,8 @@ class ScyllaClusterManager:
         self.metrics = ScyllaMetricsClient()
         self.thread_pool = ThreadPoolExecutor()
 
-        # Per-test: before_test() resets the fence, the patterns and the
-        # policy, and the fixture's driver_close() drops the session.  State
-        # added here that a test can change has to be reset there too, or it
-        # leaks into the next test -- the manager itself outlives them.
-        self._test_finished = False
+        # Per-test: before_test() resets the patterns and the policy, and the
+        # fixture's driver_close() drops the session.
         # The currently running test case with self.test_uname prepended, e.g.
         # test_topology.1::test_add_server_add_column
         self.current_test_case_full_name = ""
@@ -297,10 +258,7 @@ class ScyllaClusterManager:
         self.cluster.setLogger(self.logger)
         self.is_running = True
 
-    # fence=False: the fence is still up from the previous test when this runs,
-    # and lifting it is this operation's own job.  The manager fixture is the
-    # only caller.
-    @manager_op(blockable=True, fence=False, timeout=600)
+    @manager_op(timeout=600)
     async def before_test(self, test_case_name: str) -> str:
         """Before-test hook of the manager fixture: reset the per-test state
         and lease a cluster for the test.
@@ -334,16 +292,13 @@ class ScyllaClusterManager:
         self.logger.info("Leasing Scylla cluster %s for test %s", self.cluster, self.current_test_case_full_name)
         self.cluster.before_test(self.current_test_case_full_name)
         self.cluster.take_log_savepoint()
-        # Lower the fence last: recycling above replaces self.cluster, and a
-        # task the previous test leaked must not reach the one being disposed.
-        self._test_finished = False
         return str(self.cluster)
 
     async def stop(self) -> None:
         """Dispose of the last cluster if present."""
 
         self.logger.info("ScyllaManager stopping for test %s", self.test_uname)
-        self._driver_close()
+        self.driver_close()
         self.thread_pool.shutdown(wait=False)
         if self.cluster:
             self.logger.info("ScyllaManager: stopping Scylla cluster %s after %s",
@@ -394,26 +349,18 @@ class ScyllaClusterManager:
         except Exception as exc:
             raise RuntimeError(f"Failed to get local host id address for server {server_id}") from exc
 
-    # fence=False: this operation raises the fence itself, and has to stay
-    # reachable afterwards to report what the test left behind.
     # timeout=None: the drain below carries its own budget, which scales with
     # the build mode and so can exceed DEFAULT_OP_TIMEOUT.  A bridge cap
     # shorter than the drain would abandon the cleanup half-way through.
-    @manager_op(fence=False, timeout=None)
+    @manager_op(timeout=None)
     async def after_test(self, success: bool) -> dict[str, Any]:
         """After-test hook of the manager fixture.
 
-        Fences the manager off, so a task leaked by the test cannot reach it
-        anymore (see manager_op), then drains the operations the test left
-        running and reports the result to the cluster.
-
-        The fence goes up even when the manager is broken, which is why the
-        broken check is here and not in the decorator: a test that cannot be
-        torn down still must not leave its tasks a way in.
+        Drains the operations the test left running and reports the result to
+        the cluster.
         """
-        self._test_finished = True
-        self.check_not_broken()
         assert self.current_test_case_full_name
+        tasks_leaked = ""
         self.logger.info(self.repr_tasks_history())
         # Drop our own entry: the drain below must not wait for itself.
         current = asyncio.current_task()
@@ -434,7 +381,7 @@ class ScyllaClusterManager:
                 try:
                     await asyncio.wait_for(task, timeout=drain_timeout)
                 except asyncio.TimeoutError:
-                    self.break_manager(f"error on waiting coro {task.get_name()}", self.current_test_case_full_name)
+                    tasks_leaked = f"timed out waiting for coro {task.get_name()}"
                     break
                 except Exception:
                     # The operation failed after its caller went away.  It was
@@ -446,9 +393,10 @@ class ScyllaClusterManager:
         # tasks_history, so anything left after the drain is a new operation
         # started behind our back while the test was already over.
         await asyncio.sleep(0.1)
-        if self.tasks_history:
-            self.break_manager(f"tasks leakage found  {self.tasks_history}", self.current_test_case_full_name)
-
+        if not tasks_leaked and self.tasks_history:
+            tasks_leaked = f"tasks leakage found  {self.tasks_history}"
+        if tasks_leaked:
+            self.logger.error("%s, test case %s", tasks_leaked, self.current_test_case_full_name)
         self.logger.info("Test %s %s, cluster: %s",
                          self.current_test_case_full_name, "SUCCEEDED" if success else "FAILED", self.cluster)
         try:
@@ -462,41 +410,27 @@ class ScyllaClusterManager:
 
         return {
             "cluster_str": cluster_str,
-            "server_broken": self.server_broken_event.is_set(),
-            "message": self.server_broken_reason,
+            "tasks_leaked": bool(tasks_leaked),
+            "message": tasks_leaked,
         }
 
-    def check_not_broken(self) -> None:
-        """Refuse to run when a previous test broke the manager."""
-
-        if self.server_broken_event.is_set():
-            raise RuntimeError(f"ScyllaClusterManager BROKEN, Previous test broke ScyllaClusterManager server,"
-                               f" server_broken_reason: {self.server_broken_reason}")
-
-    def break_manager(self, reason: str, test: str) -> None:
-        """Make ScyllaClusterManager not operable from client side."""
-
-        self.server_broken_reason = f"{reason}, test case {test} BROKE ScyllaClusterManager"
-        self.logger.error(self.server_broken_reason)
-        self.server_broken_event.set()
-
-    @manager_op(blockable=True)
+    @manager_op
     async def mark_dirty(self) -> None:
         """Mark current cluster dirty."""
 
         self.cluster.is_dirty = True
 
-    @manager_op(blockable=True)
+    @manager_op
     async def _server_stop(self, server_id: ServerNum) -> None:
         """Stop a server. No-op if already stopped."""
 
         await self.cluster.server_stop(server_id, gracefully=False)
 
-    @manager_op(blockable=True, timeout=None)
+    @manager_op(timeout=None)
     async def _server_stop_gracefully(self, server_id: ServerNum) -> None:
         await self.cluster.server_stop(server_id, gracefully=True)
 
-    @manager_op(blockable=True, timeout=None)
+    @manager_op(timeout=None)
     async def _server_start(self,
                             server_id: ServerNum,
                             *,
@@ -518,13 +452,13 @@ class ScyllaClusterManager:
             auth_provider=auth_provider,
         )
 
-    @manager_op(blockable=True)
+    @manager_op
     async def server_pause(self, server_id: ServerNum) -> None:
         """Pause the specified server."""
 
         self.cluster.server_pause(server_id)
 
-    @manager_op(blockable=True)
+    @manager_op
     async def server_unpause(self, server_id: ServerNum) -> None:
         """Unpause the specified server."""
 
@@ -558,11 +492,11 @@ class ScyllaClusterManager:
         await self._add_teardown_callback(bind_to_current_loop(callback),
                                           name or getattr(callback, "__qualname__", repr(callback)))
 
-    @manager_op(blockable=True)
+    @manager_op
     async def _add_teardown_callback(self, callback: Callable[[], Awaitable[None]], name: str) -> None:
         self.cluster.add_teardown_callback(callback, name)
 
-    @manager_op(blockable=True, timeout=None)
+    @manager_op(timeout=None)
     async def _server_add(self,
                          replace_cfg: ReplaceConfig | None = None,
                          cmdline: list[str] | None = None,
@@ -589,7 +523,7 @@ class ScyllaClusterManager:
             expected_server_up_state=expected_server_up_state,
         )
 
-    @manager_op(blockable=True, timeout=None)
+    @manager_op(timeout=None)
     async def _servers_add(self,
                            servers_num: int = 1,
                            cmdline: list[str] | None = None,
@@ -605,7 +539,7 @@ class ScyllaClusterManager:
         return await self.cluster.add_servers(servers_num, cmdline, config, version, property_file,
                                               start, seeds, server_encryption, expected_error)
 
-    @manager_op(blockable=True, timeout=None)
+    @manager_op(timeout=None)
     async def _remove_node(self,
                            initiator_id: ServerNum,
                            server_id: ServerNum,
@@ -653,7 +587,7 @@ class ScyllaClusterManager:
             self.logger.info("removenode (initiator: %s, to_remove: %s, ignore_dead: %s) succeeded",
                              initiator, to_remove, ignore_dead)
 
-    @manager_op(blockable=True, timeout=None)
+    @manager_op(timeout=None)
     async def _decommission_node(self, server_id: ServerNum, expected_error: str | None) -> None:
         """Run decommission node on Scylla REST API for a specified server."""
 
@@ -685,7 +619,7 @@ class ScyllaClusterManager:
 
         await self.cluster.server_stop(server_id, gracefully=True)
 
-    @manager_op(blockable=True, timeout=None)
+    @manager_op(timeout=None)
     async def _rebuild_node(self, server_id: ServerNum, expected_error: str | None) -> None:
         """Run rebuild node on Scylla REST API for a specified server."""
 
@@ -720,7 +654,7 @@ class ScyllaClusterManager:
 
         return self.cluster.get_config(server_id)
 
-    @manager_op(blockable=True)
+    @manager_op
     async def server_update_config(self,
                                    server_id: ServerNum,
                                    key: str | None = None,
@@ -744,7 +678,7 @@ class ScyllaClusterManager:
             raise RuntimeError(f"`config_options` is expected to be a dict, not {type(config_options)}")
         self.cluster.update_config(server_id=server_id, config_options=config_options)
 
-    @manager_op(blockable=True)
+    @manager_op
     async def server_remove_config_option(self, server_id: ServerNum, key: str) -> None:
         """Remove an option from conf/scylla.yaml of the given server.
 
@@ -753,7 +687,7 @@ class ScyllaClusterManager:
         """
         self.cluster.remove_config_option(server_id=server_id, key=key)
 
-    @manager_op(blockable=True)
+    @manager_op
     async def server_update_cmdline(self, server_id: ServerNum, cmdline_options: list[str]) -> None:
         """Update the command-line options of the given server by merging the new options into the existing ones.
 
@@ -762,7 +696,7 @@ class ScyllaClusterManager:
         """
         self.cluster.update_cmdline(server_id, cmdline_options)
 
-    @manager_op(blockable=True)
+    @manager_op
     async def server_switch_executable(self, server_id: ServerNum, path: str) -> None:
         """Switch the executable of the server to the one specified by 'path'.
 
@@ -770,13 +704,13 @@ class ScyllaClusterManager:
         """
         self.cluster.server_switch_executable(server_id, path)
 
-    @manager_op(blockable=True)
+    @manager_op
     async def server_change_ip(self, server_id: ServerNum) -> IPAddress:
         """Pass change_ip command for the given server to the cluster."""
 
         return await self.cluster.change_ip(server_id)
 
-    @manager_op(blockable=True)
+    @manager_op
     async def server_change_rpc_address(self, server_id: ServerNum) -> IPAddress:
         """Pass change_rpc_address command for the given server to the cluster."""
 
@@ -808,7 +742,7 @@ class ScyllaClusterManager:
         cmd = self.cluster.server(server_id).cmd
         return cmd is not None and cmd.returncode is None
 
-    @manager_op(blockable=True)
+    @manager_op
     async def server_wipe_sstables(self, server_id: ServerNum, keyspace: str, table: str) -> None:
         return self.cluster.wipe_sstables(server_id, keyspace, table)
 
@@ -886,14 +820,13 @@ class ScyllaClusterManager:
             connection_class=CustomConnection,
         )
 
-    @fenced
     async def driver_connect(self, server: ServerInfo | None = None, auth_provider: AuthProvider | None = None) -> None:
         """Connect to cluster."""
 
         targets = [server] if server else await self.running_servers()
         servers = [s_info.rpc_address for s_info in targets]
         # avoids leaking connections if driver wasn't closed before
-        self._driver_close()
+        self.driver_close()
         self.logger.debug("driver connecting to %s", servers)
         self.ccluster = self.con_gen(
             servers,
@@ -904,14 +837,8 @@ class ScyllaClusterManager:
         )
         self.cql = self.ccluster.connect()
 
-    @fenced
     def driver_close(self) -> None:
         """Disconnect from cluster."""
-
-        self._driver_close()
-
-    def _driver_close(self) -> None:
-        """Disconnect from cluster, also when no test is running (see stop())."""
 
         for cluster in self.exclusive_clusters:
             safe_driver_shutdown(cluster)
@@ -922,7 +849,6 @@ class ScyllaClusterManager:
             self.ccluster = None
         self.cql = None
 
-    @fenced
     def get_cql(self) -> CassandraSession:
         """Precondition: driver is connected."""
 
@@ -937,7 +863,6 @@ class ScyllaClusterManager:
         hosts = await wait_for_cql_and_get_hosts(cql, servers, time() + 60)
         return cql, hosts
 
-    @fenced
     async def get_cql_exclusive(self,
                                 server: ServerInfo,
                                 auth_provider: AuthProvider | None = None) -> CassandraSession:

--- a/test/pylib/scylla_cluster_manager.py
+++ b/test/pylib/scylla_cluster_manager.py
@@ -18,15 +18,18 @@ import ssl
 import traceback
 import uuid
 from collections import defaultdict
+import concurrent.futures
+import threading
 from concurrent.futures import ThreadPoolExecutor
+from contextlib import asynccontextmanager
 from functools import wraps
 from pathlib import Path
 from time import time
-from typing import Any, Awaitable, Callable, Concatenate, cast, overload
+from typing import Any, AsyncIterator, Awaitable, Callable, Concatenate, cast, overload
 
 import allure
 from cassandra import ConsistencyLevel
-from cassandra.auth import AuthProvider
+from cassandra.auth import AuthProvider, PlainTextAuthProvider
 from cassandra.cluster import (
     EXEC_PROFILE_DEFAULT,
     Cluster as CassandraCluster,
@@ -46,7 +49,7 @@ from test.pylib.driver_utils import safe_driver_shutdown
 from test.pylib.internal_types import ServerNum, IPAddress, HostID, ServerInfo, ServerUpState
 from test.pylib.log_browsing import ScyllaLogFile
 from test.pylib.rest_client import HTTPError, ScyllaMetricsClient, ScyllaRESTAPIClient
-from test.pylib.scylla_cluster import ClusterFactory, ReplaceConfig, ScyllaCluster, bind_to_current_loop
+from test.pylib.scylla_cluster import ReplaceConfig, ScyllaCluster, bind_to_current_loop
 from test.pylib.scylla_server import ScyllaServer, ScyllaVersionDescription
 from test.pylib.util import (
     Host,
@@ -146,6 +149,7 @@ def manager_op[**P, R](entry_point: ManagerAsyncFn[P, R] | None = None,
 
         @wraps(fn)
         async def wrapper(self: ScyllaClusterManager, *args: P.args, **kwargs: P.kwargs) -> R:
+            assert self._loop is not None, "ScyllaClusterManager is not running"
             if asyncio.get_running_loop() is self._loop:
                 # Already on the manager's loop, i.e. one operation calling
                 # another -- which no operation does today.  There is nothing
@@ -169,11 +173,8 @@ class ScyllaClusterManager:
     Parallel requests are not supported.
 
     The manager lives for one test: the fixture starts it before the test and
-    stops it right after, recycling the cluster.  State belonging to the test
-    -- the driver session, the log patterns to ignore -- is reset by
-    before_test(), while after_test() drains what the test left running.  A
-    task leaked past the test finds the manager's loop closed and gets a
-    RuntimeError.
+    stops it right after, recycling the cluster.  after_test() drains what
+    the test left running and reports what it leaked.
 
     A method that awaits cluster or server internals must be a @manager_op --
     those objects belong to the manager's loop -- and the CQL driver, the REST
@@ -183,54 +184,49 @@ class ScyllaClusterManager:
     operation behind a public wrapper holding that work.
 
     Args:
-        test_uname: name of the test module the manager serves
-        create_cluster: factory of Scylla clusters
+        test_name: unique name of the served test case, e.g.
+            test_topology.1::test_add_server_add_column
+        cluster: the cluster the manager serves to the test
         port: CQL port for driver connections
         use_ssl: use SSL for driver connections
-        auth_provider: authentication provider for driver connections
-        build_mode: build mode of the Scylla servers, or None if unknown
+        auth_username: user name for driver connections
+        auth_password: password for driver connections
     """
     def __init__(self,
-                 test_uname: str,
-                 create_cluster: ClusterFactory,
+                 test_name: str,
+                 cluster: ScyllaCluster,
                  port: int,
                  use_ssl: bool,
-                 auth_provider: Any | None,
-                 build_mode: str | None = None) -> None:
-        # The manager must be constructed on its own, always-running loop:
-        # its operations run there (see manager_op), whichever loop or thread
-        # they are called from.
-        self._loop = asyncio.get_running_loop()
-        self.test_uname = test_uname
-        self.logger = logging.getLogger(self.test_uname)
-        self.cluster: ScyllaCluster | None = None
-        self.create_cluster = create_cluster
-        self.is_running = False
-        # tasks_history holds the running test's operations: after_test()
-        # drains it, and whatever is left over is the leak it reports.
-        self.tasks_history: dict[asyncio.Task, str] = {}
-        # Per-module: configuration and helpers that outlive every test.
+                 auth_username: str | None = None,
+                 auth_password: str | None = None) -> None:
+        self.test_name = test_name
+        self.cluster = cluster
         self.port = port
         self.use_ssl = use_ssl
-        # The suite's provider, restored per test: tests override
-        # self.auth_provider to connect as someone else.
-        self._suite_auth_provider = auth_provider
-        self.api = ScyllaRESTAPIClient(build_mode=build_mode)
+        self.auth_provider: AuthProvider | None = None
+        if auth_username is not None and auth_password is not None:
+            self.auth_provider = PlainTextAuthProvider(username=auth_username, password=auth_password)
+
+        self.logger = cluster.logger
+        self.api: ScyllaRESTAPIClient = cluster.api
         self.metrics = ScyllaMetricsClient()
         self.thread_pool = ThreadPoolExecutor()
-
-        # Per-test: before_test() resets the patterns and the policy, and the
-        # fixture's driver_close() drops the session.
-        # The currently running test case with self.test_uname prepended, e.g.
-        # test_topology.1::test_add_server_add_column
-        self.current_test_case_full_name = ""
         self.load_balancing_policy = RoundRobinPolicy()
-        self.auth_provider = self._suite_auth_provider
-        self.ignore_log_patterns: list[str] = []  # patterns to ignore in server logs when checking for errors
-        self.ignore_cores_log_patterns: list[str] = []  # patterns to ignore in server logs when checking for core files
+
         self.ccluster: CassandraCluster | None = None
         self.cql: CassandraSession | None = None
         self.exclusive_clusters: list[CassandraCluster] = []
+        self.ignore_log_patterns: list[str] = []  # patterns to ignore in server logs when checking for errors
+        self.ignore_cores_log_patterns: list[str] = []  # patterns to ignore in server logs when checking for core files
+
+        # The manager's own loop, claimed by run_in_thread(): its operations
+        # run there (see manager_op), whichever loop or thread they are
+        # called from.
+        self._loop: asyncio.AbstractEventLoop | None = None
+
+        # tasks_history holds the running test's operations: after_test()
+        # drains it, and whatever is left over is the leak it reports.
+        self.tasks_history: dict[asyncio.Task, str] = {}
 
     def repr_tasks_history(self) -> str:
         out = "Cluster_history"
@@ -238,48 +234,67 @@ class ScyllaClusterManager:
             out += f"\n{val}:\t\t{repr(key)}"
         return out
 
-    async def start(self) -> None:
-        """Get first cluster."""
-
-        if self.is_running:
-            self.logger.warning("ScyllaClusterManager already running")
-            return
-        self.cluster = await self.create_cluster(self.logger)
-        self.logger.info("First Scylla cluster: %s", self.cluster)
-        self.is_running = True
-
-    @manager_op(timeout=600)
-    async def before_test(self, test_case_name: str) -> str:
-        """Before-test hook of the manager fixture: reset the per-test state
-        and lease a cluster for the test.
-
-        The driver is connected by the fixture afterwards: the session is used
-        from the test's loop, and connecting blocks for as long as the driver's
-        connect timeout, so it has no business running on the manager's.
-        """
-        self.ignore_log_patterns = []
-        self.ignore_cores_log_patterns = []
-        self.load_balancing_policy = RoundRobinPolicy()
-        self.auth_provider = self._suite_auth_provider
-        self.current_test_case_full_name = f"{self.test_uname}::{test_case_name}"
-        self.logger.info("Setting up %s", self.current_test_case_full_name)
-        self.logger.info("Leasing Scylla cluster %s for test %s", self.cluster, self.current_test_case_full_name)
-        self.cluster.before_test(self.current_test_case_full_name)
-        self.cluster.take_log_savepoint()
-        return str(self.cluster)
-
     async def stop(self) -> None:
-        """Dispose of the last cluster if present."""
+        """Dispose of the cluster if present."""
 
-        self.logger.info("ScyllaManager stopping for test %s", self.test_uname)
+        self.logger.info("ScyllaManager stopping for test %s", self.test_name)
         self.driver_close()
         self.thread_pool.shutdown(wait=False)
         if self.cluster:
-            self.logger.info("ScyllaManager: stopping Scylla cluster %s after %s",
-                             self.cluster, self.test_uname)
+            self.logger.info("ScyllaManager: stopping Scylla cluster %s after %s", self.cluster, self.test_name)
             await self.cluster.recycle()
             self.cluster = None
-        self.is_running = False
+
+    @asynccontextmanager
+    async def run_in_thread(self) -> AsyncIterator[ScyllaClusterManager]:
+        """Run this manager on its own thread and event loop.
+
+        The manager owns loop-bound state -- the Scylla subprocess transports
+        and the per-server asyncio locks -- so all of its coroutines have to
+        run on one loop, and that loop has to keep running: tests reach the
+        manager from pytest's event loops and, in dtest, from plain worker
+        threads.  Hence, a dedicated thread whose loop is idle but alive
+        until the context exits.
+        """
+        ready: concurrent.futures.Future[None] = concurrent.futures.Future()
+        stop_event = threading.Event()
+
+        async def run_manager() -> None:
+            self.logger.info("Setting up %s", self.test_name)
+            self._loop = asyncio.get_running_loop()
+            ready.set_result(None)
+            try:
+                await asyncio.get_running_loop().run_in_executor(None, stop_event.wait)
+            finally:
+                await self.stop()
+
+        with ThreadPoolExecutor(max_workers=1, thread_name_prefix="cluster-manager") as executor:
+            future = executor.submit(asyncio.run, run_manager())
+            # Fail instead of waiting forever when the manager dies before it
+            # signals readiness.  The callback fires only once the future is
+            # done, so reaching it without a result always means a startup
+            # failure.
+            future.add_done_callback(
+                lambda f: None if ready.done() else ready.set_exception(
+                    f.exception() or RuntimeError("ScyllaClusterManager exited before signaling readiness")))
+            # ready.result() blocks, so hand it to a thread rather than
+            # stalling the caller's loop.
+            await asyncio.get_running_loop().run_in_executor(None, ready.result)
+            try:
+                yield self
+            finally:
+                stop_event.set()
+                # Wait for the manager thread off the event loop.  Stopping
+                # the manager recycles the cluster, and recycling runs
+                # teardown callbacks that belong to the caller's loop;
+                # blocking it here would deadlock them.
+                try:
+                    await asyncio.get_running_loop().run_in_executor(None, future.result)
+                finally:
+                    # The loop is gone with the thread; let manager_op's
+                    # not-running assert catch a leaked caller instead of a
+                    # cryptic "Event loop is closed".
+                    self._loop = None
 
     @manager_op
     async def running_servers(self) -> list[ServerInfo]:
@@ -324,10 +339,9 @@ class ScyllaClusterManager:
     async def after_test(self, success: bool) -> dict[str, Any]:
         """After-test hook of the manager fixture.
 
-        Drains the operations the test left running and reports the result to
-        the cluster.
+        Drains the operations the test left running and returns what the test
+        leaked.
         """
-        assert self.current_test_case_full_name
         tasks_leaked = ""
         self.logger.info(self.repr_tasks_history())
         # Drop our own entry: the drain below must not wait for itself.
@@ -364,17 +378,11 @@ class ScyllaClusterManager:
         if not tasks_leaked and self.tasks_history:
             tasks_leaked = f"tasks leakage found  {self.tasks_history}"
         if tasks_leaked:
-            self.logger.error("%s, test case %s", tasks_leaked, self.current_test_case_full_name)
-        self.logger.info("Test %s %s, cluster: %s",
-                         self.current_test_case_full_name, "SUCCEEDED" if success else "FAILED", self.cluster)
-        try:
-            self.cluster.after_test(self.current_test_case_full_name)
-        finally:
-            self.current_test_case_full_name = ""
-        cluster_str = str(self.cluster)
+            self.logger.error("%s, test case %s", tasks_leaked, self.test_name)
+        self.logger.info("Test %s %s, cluster: %s", self.test_name, "SUCCEEDED" if success else "FAILED", self.cluster)
 
         return {
-            "cluster_str": cluster_str,
+            "cluster_str": str(self.cluster),
             "tasks_leaked": bool(tasks_leaked),
             "message": tasks_leaked,
         }
@@ -434,11 +442,9 @@ class ScyllaClusterManager:
         object storage bucket that an in-flight tablet migration could
         otherwise still read from (SCYLLADB-2471).
 
-        Two consequences of firing that late are worth knowing.  The resource
+        One consequence of firing that late is worth knowing: the resource
         the callback disposes of has to stay alive past the fixture that
-        created it, and a failure inside a callback is reported against the
-        test case that recycled the cluster, not necessarily the one that
-        registered the callback.
+        created it.
 
         Callbacks fire in LIFO order; both plain callables and coroutine
         functions are accepted.  Register them from a fixture rather than from
@@ -1226,7 +1232,7 @@ class ScyllaClusterManager:
         servers, you should use multiple server_add calls.
         """
         assert servers_num > 0, f"servers_add: cannot add {servers_num} servers, servers_num must be positive"
-        assert not (property_file and auto_rack_dc), f"Either property_file or auto_rack_dc can be provided, but not both"
+        assert not (property_file and auto_rack_dc), "Either property_file or auto_rack_dc can be provided, but not both"
 
         if expected_error is not None:
             self.ignore_log_patterns.append(re.escape(expected_error))

--- a/test/pylib/scylla_cluster_manager.py
+++ b/test/pylib/scylla_cluster_manager.py
@@ -282,12 +282,6 @@ class ScyllaClusterManager:
         self.test_case_log_fh.setFormatter(root_logger.handlers[0].formatter)
         root_logger.addHandler(self.test_case_log_fh)
         self.logger.info("Setting up %s", self.current_test_case_full_name)
-        if self.cluster.is_dirty:
-            self.logger.info("Current cluster %s is dirty after test %s, replacing with a new one...",
-                             self.cluster.name, self.current_test_case_full_name)
-            await self.cluster.recycle()
-            self.cluster = await self.create_cluster(self.logger)
-            self.logger.info("Got new Scylla cluster: %s", self.cluster.name)
         self.cluster.setLogger(self.logger)
         self.logger.info("Leasing Scylla cluster %s for test %s", self.cluster, self.current_test_case_full_name)
         self.cluster.before_test(self.current_test_case_full_name)
@@ -306,12 +300,6 @@ class ScyllaClusterManager:
             await self.cluster.recycle()
             self.cluster = None
         self.is_running = False
-
-    @manager_op
-    async def is_dirty(self) -> bool:
-        """Report if current cluster is dirty."""
-
-        return self.cluster.is_dirty
 
     @manager_op
     async def running_servers(self) -> list[ServerInfo]:
@@ -400,7 +388,7 @@ class ScyllaClusterManager:
         self.logger.info("Test %s %s, cluster: %s",
                          self.current_test_case_full_name, "SUCCEEDED" if success else "FAILED", self.cluster)
         try:
-            self.cluster.after_test(self.current_test_case_full_name, success)
+            self.cluster.after_test(self.current_test_case_full_name)
         finally:
             logging.getLogger().removeHandler(self.test_case_log_fh)
             if success:
@@ -413,12 +401,6 @@ class ScyllaClusterManager:
             "tasks_leaked": bool(tasks_leaked),
             "message": tasks_leaked,
         }
-
-    @manager_op
-    async def mark_dirty(self) -> None:
-        """Mark current cluster dirty."""
-
-        self.cluster.is_dirty = True
 
     @manager_op
     async def _server_stop(self, server_id: ServerNum) -> None:
@@ -666,7 +648,6 @@ class ScyllaClusterManager:
         You can update a single option by providing the (key, value) pair, or multiple options
         using config_options.
         If the server is running, reload the config with a SIGHUP.
-        Mark the cluster as dirty.
         """
         if key is not None:
             if value is None:
@@ -683,7 +664,6 @@ class ScyllaClusterManager:
         """Remove an option from conf/scylla.yaml of the given server.
 
         If the server is running, reload the config with a SIGHUP.
-        Mark the cluster as dirty.
         """
         self.cluster.remove_config_option(server_id=server_id, key=key)
 
@@ -692,7 +672,6 @@ class ScyllaClusterManager:
         """Update the command-line options of the given server by merging the new options into the existing ones.
 
         The update only takes effect after restart.
-        Marks the cluster as dirty.
         """
         self.cluster.update_cmdline(server_id, cmdline_options)
 
@@ -700,7 +679,6 @@ class ScyllaClusterManager:
     async def server_switch_executable(self, server_id: ServerNum, path: str) -> None:
         """Switch the executable of the server to the one specified by 'path'.
 
-        Marks the cluster as dirty.
         """
         self.cluster.server_switch_executable(server_id, path)
 

--- a/test/pylib/scylla_server.py
+++ b/test/pylib/scylla_server.py
@@ -1085,13 +1085,6 @@ class ScyllaServer:
         self.log_file.write(msg.encode())
         self.log_file.flush()
 
-    def setLogger(self, logger: logging.LoggerAdapter):
-        """Change the logger used by the server.
-           Called when a cluster is reused between tests so that logs during the new test
-           are prefixed appropriately with the corresponding test's name.
-        """
-        self.logger = logger
-
     def __str__(self):
         host_id = getattr(self, '_host_id', 'undefined id')
         return f"ScyllaServer({self.server_id}, {self.ip_addr}, {host_id})"

--- a/test/pylib/scylla_server.py
+++ b/test/pylib/scylla_server.py
@@ -1077,7 +1077,10 @@ class ScyllaServer:
         except FileNotFoundError:
             pass
         self.log_filename.unlink(missing_ok=True)
-        self.log_file = None
+        if self.log_file:
+            self.log_file.close()
+            self.log_file = None
+        self.maintenance_socket_dir.cleanup()
 
     def write_log_marker(self, msg) -> None:
         """Write a message to the server's log file (e.g. separator/marker)"""

--- a/test/pylib_test/test_add_server_failure.py
+++ b/test/pylib_test/test_add_server_failure.py
@@ -32,7 +32,6 @@ async def test_add_server_reports_why_the_server_was_not_built(tmp_path: pathlib
     cluster = ScyllaCluster(
         logger=logging.getLogger(__name__),
         vardir=tmp_path,
-        replicas=0,
         mode="dev",
         cmdline_options=[],
         cmdline_options_override=[],

--- a/test/pylib_test/test_cluster_lifecycle.py
+++ b/test/pylib_test/test_cluster_lifecycle.py
@@ -1,0 +1,125 @@
+#
+# Copyright (C) 2026-present ScyllaDB
+#
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
+#
+
+"""Tests for the two guarantees of the per-test cluster lifecycle that only
+show when something has already gone wrong, and that the default test run
+never exercises:
+
+- the after-cluster cleanups of test/cluster's scylla_cluster_teardowns run
+  once the cluster is recycled (SCYLLADB-2471);
+- a cluster whose fixture never recycled it is swept up at session finish.
+"""
+
+import asyncio
+import textwrap
+from types import SimpleNamespace
+
+import pytest
+
+from test.pylib.runner import CLUSTER_KEY, recycle_leftover_clusters
+
+pytest_plugins = ["pytester"]
+
+
+def test_cluster_teardowns_run_after_the_cluster_is_recycled(pytester: pytest.Pytester) -> None:
+    """The real scylla_cluster/scylla_cluster_teardowns fixtures, with the
+    cluster factory stubbed: the cleanups must observe a recycled cluster,
+    and fire in LIFO order."""
+    pytester.makeconftest(textwrap.dedent("""\
+        from contextlib import asynccontextmanager
+        import pytest
+        # Registers the two fixtures under test with this conftest.
+        from test.cluster.conftest import scylla_cluster, scylla_cluster_teardowns
+
+        class StubCluster:
+            recycled = False
+
+            async def recycle(self):
+                self.recycled = True
+
+        @pytest.fixture
+        def testpy_cluster_factory():
+            @asynccontextmanager
+            async def lease(node, test_name):
+                cluster = StubCluster()
+                try:
+                    yield cluster
+                finally:
+                    await cluster.recycle()
+            return lease
+
+        @pytest.fixture
+        def testpy_test_name():
+            return "stub::test"
+        """))
+    pytester.makeini(
+        "[pytest]\n"
+        "addopts = -p no:sugar -p no:xdist\n"
+        "asyncio_mode = auto\n"
+        "asyncio_default_fixture_loop_scope = session\n"
+    )
+    pytester.makepyfile(textwrap.dedent("""\
+        import pathlib
+
+        async def test_it(scylla_cluster, scylla_cluster_teardowns):
+            log = pathlib.Path("teardowns.log")
+
+            def record(name):
+                def cleanup():
+                    with log.open("a") as f:
+                        f.write(f"{name} recycled={scylla_cluster.recycled}\\n")
+                return cleanup
+
+            scylla_cluster_teardowns.append(record("first"))
+            scylla_cluster_teardowns.append(record("second"))
+        """))
+    result = pytester.runpytest()
+    result.assert_outcomes(passed=1)
+    assert (pytester.path / "teardowns.log").read_text().splitlines() == [
+        "second recycled=True",
+        "first recycled=True",
+    ]
+
+
+class StubCluster:
+    """Records the sweep's calls; optionally fails stop() the way a wait on
+    a foreign loop does."""
+
+    def __init__(self, fail_stop: bool = False) -> None:
+        self.fail_stop = fail_stop
+        self.stops = 0
+        self.recycles = 0
+
+    async def stop(self) -> None:
+        self.stops += 1
+        if self.fail_stop:
+            raise RuntimeError("attached to a different loop")
+
+    async def recycle(self) -> None:
+        self.recycles += 1
+
+
+def test_leftover_clusters_are_recycled_at_session_finish(pytester: pytest.Pytester) -> None:
+    """Clusters still stashed on a test item or its module get stopped and
+    recycled exactly once; a stop() failure does not prevent the recycle;
+    an entry the factory already reset to None is left alone."""
+    pytester.makeini("[pytest]\nasyncio_default_fixture_loop_scope = session\n")
+    item_a, item_b = pytester.getitems(textwrap.dedent("""\
+        def test_a(): pass
+        def test_b(): pass
+        """))
+    per_test = StubCluster()
+    shared = StubCluster(fail_stop=True)
+    item_a.stash[CLUSTER_KEY] = per_test
+    item_a.parent.stash[CLUSTER_KEY] = shared   # the module node, shared by both items
+    item_b.stash[CLUSTER_KEY] = None            # recycled normally: nothing to do
+
+    swept = asyncio.run(recycle_leftover_clusters(SimpleNamespace(items=[item_a, item_b])))
+
+    assert swept == 2
+
+    assert (per_test.stops, per_test.recycles) == (1, 1)
+    assert (shared.stops, shared.recycles) == (1, 1)

--- a/test/pylib_test/test_manager_op_bridge.py
+++ b/test/pylib_test/test_manager_op_bridge.py
@@ -16,7 +16,6 @@ decorator and the bridge under test are the production ones.
 
 import asyncio
 import concurrent.futures
-import inspect
 import logging
 import threading
 from collections.abc import Iterator
@@ -25,7 +24,7 @@ import pytest
 
 from test.pylib.internal_types import ServerNum
 from test.pylib.util import LogPrefixAdapter
-from test.pylib.scylla_cluster_manager import ScyllaClusterManager, fenced
+from test.pylib.scylla_cluster_manager import ScyllaClusterManager
 
 
 SERVER_ID = ServerNum(1)
@@ -187,63 +186,3 @@ async def test_exception_keeps_its_type(manager) -> None:
 
     with pytest.raises(ValueError, match="stop failed"):
         await mgr.server_stop(SERVER_ID, convict=False)
-
-
-async def test_broken_manager_refuses_mutations(manager) -> None:
-    """A manager fenced off by a previous test rejects further changes."""
-    mgr, cluster, manager_loop = manager
-    async def do_break() -> None:
-        mgr.break_manager("leaked task", "some_test")
-
-    await asyncio.wrap_future(
-        asyncio.run_coroutine_threadsafe(do_break(), manager_loop))
-
-    with pytest.raises(RuntimeError, match="BROKEN"):
-        await mgr.server_stop(SERVER_ID, convict=False)
-    assert not cluster.entered.is_set(), "a broken manager still ran the operation"
-
-    # Reads stay available so that after-test bookkeeping can still run.
-    assert await mgr.is_dirty() is False
-
-
-async def test_finished_test_fences_the_manager_off(manager) -> None:
-    """After after_test(), a task leaked by the test cannot reach the manager.
-
-    before_test() lifts the fence again for the next test.
-    """
-    mgr, cluster, _ = manager
-
-    mgr._test_finished = True
-    with pytest.raises(Exception, match="not accessible after the test finished"):
-        await mgr.is_dirty()
-    assert not cluster.entered.is_set()
-
-    mgr._test_finished = False
-    assert await mgr.is_dirty() is False
-
-
-async def test_driver_methods_are_fenced_off(manager) -> None:
-    """The driver lives on the shared manager, so a leaked caller must not
-    reach it -- but teardown still has to be able to close the session."""
-    mgr, _, _ = manager
-
-    mgr._test_finished = True
-    with pytest.raises(RuntimeError, match="not accessible after the test finished"):
-        mgr.driver_close()
-    with pytest.raises(RuntimeError, match="not accessible after the test finished"):
-        mgr.get_cql()
-    with pytest.raises(RuntimeError, match="not accessible after the test finished"):
-        await mgr.driver_connect()
-
-    mgr._driver_close()   # what stop() uses at module teardown; must not raise
-
-
-def test_fenced_keeps_the_kind_of_what_it_decorates() -> None:
-    """universalasync makes a method callable from a plain thread only if
-    iscoroutinefunction says it is one, so fenced must not change that answer.
-    """
-    async def operation(self) -> None: ...
-    def plain(self) -> None: ...
-
-    assert inspect.iscoroutinefunction(fenced(operation))
-    assert not inspect.iscoroutinefunction(fenced(plain))

--- a/test/pylib_test/test_manager_op_bridge.py
+++ b/test/pylib_test/test_manager_op_bridge.py
@@ -48,7 +48,6 @@ class StubCluster:
         self._release = loop.create_future()
         self.entered = threading.Event()      # readable from any thread
         self.stopped: list[ServerNum] = []
-        self.is_dirty = False
 
     async def server_stop(self, server_id: ServerNum, gracefully: bool) -> None:
         self.entered.set()

--- a/test/pylib_test/test_manager_op_bridge.py
+++ b/test/pylib_test/test_manager_op_bridge.py
@@ -16,14 +16,12 @@ decorator and the bridge under test are the production ones.
 
 import asyncio
 import concurrent.futures
-import logging
 import threading
 from collections.abc import Iterator
 
 import pytest
 
 from test.pylib.internal_types import ServerNum
-from test.pylib.util import LogPrefixAdapter
 from test.pylib.scylla_cluster_manager import ScyllaClusterManager
 
 
@@ -75,12 +73,10 @@ def manager() -> Iterator[tuple[ScyllaClusterManager, StubCluster, asyncio.Abstr
         mgr = ScyllaClusterManager(
             test_uname="test_manager_op_bridge",
             create_cluster=None,
-            base_dir="",
             port=9042,
             use_ssl=False,
             auth_provider=None,
         )
-        mgr.logger = LogPrefixAdapter(logging.getLogger("test_manager_op_bridge"), {"prefix": "test"})
         mgr.cluster = StubCluster(asyncio.get_running_loop())
         ready.set_result((mgr, asyncio.get_running_loop()))
         await asyncio.get_running_loop().run_in_executor(None, stop_event.wait)

--- a/test/pylib_test/test_manager_op_bridge.py
+++ b/test/pylib_test/test_manager_op_bridge.py
@@ -15,9 +15,9 @@ decorator and the bridge under test are the production ones.
 """
 
 import asyncio
-import concurrent.futures
+import logging
 import threading
-from collections.abc import Iterator
+from collections.abc import AsyncIterator
 
 import pytest
 
@@ -41,58 +41,49 @@ class StubCluster:
     entered.
     """
 
-    def __init__(self, loop: asyncio.AbstractEventLoop) -> None:
-        self._loop = loop
-        self._release = loop.create_future()
+    def __init__(self) -> None:
+        self._loop: asyncio.AbstractEventLoop | None = None
+        self._release: asyncio.Future | None = None
         self.entered = threading.Event()      # readable from any thread
         self.stopped: list[ServerNum] = []
+        # The manager borrows the cluster's REST client and logger.
+        self.api = None
+        self.logger = logging.getLogger("test_manager_op_bridge")
 
     async def server_stop(self, server_id: ServerNum, gracefully: bool) -> None:
+        # The future belongs to the loop the operation runs on -- the
+        # manager's -- like a real server's subprocess transport.
+        self._loop = asyncio.get_running_loop()
+        self._release = self._loop.create_future()
         self.entered.set()
         await self._release
         self.stopped.append(server_id)
 
+    async def recycle(self) -> None:
+        pass
+
     def release(self) -> None:
         """Let a suspended server_stop() finish; callable from any thread."""
-        self._loop.call_soon_threadsafe(
-            lambda: None if self._release.done() else self._release.set_result(None))
+        if self._loop is not None:
+            self._loop.call_soon_threadsafe(
+                lambda: None if self._release.done() else self._release.set_result(None))
 
 
 @pytest.fixture
-def manager() -> Iterator[tuple[ScyllaClusterManager, StubCluster, asyncio.AbstractEventLoop]]:
-    """A ScyllaClusterManager running on its own thread and loop.
-
-    Mirrors the _scylla_cluster_manager fixture in test/cluster/conftest.py: the loop
-    stays alive but idle until teardown, so callers on other loops and threads
-    have something to hand work to.
-    """
-    ready: concurrent.futures.Future = concurrent.futures.Future()
-    stop_event = threading.Event()
-
-    async def run_manager() -> None:
-        mgr = ScyllaClusterManager(
-            test_uname="test_manager_op_bridge",
-            create_cluster=None,
-            port=9042,
-            use_ssl=False,
-            auth_provider=None,
-        )
-        mgr.cluster = StubCluster(asyncio.get_running_loop())
-        ready.set_result((mgr, asyncio.get_running_loop()))
-        await asyncio.get_running_loop().run_in_executor(None, stop_event.wait)
-
-    with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
-        future = executor.submit(asyncio.run, run_manager())
-        future.add_done_callback(
-            lambda f: None if ready.done() else ready.set_exception(
-                f.exception() or RuntimeError("manager exited before signaling readiness")))
-        mgr, loop = ready.result(timeout=TIMEOUT)
+async def manager() -> AsyncIterator[tuple[ScyllaClusterManager, StubCluster, asyncio.AbstractEventLoop]]:
+    """A ScyllaClusterManager running on its own thread and loop, with a stub cluster."""
+    stub = StubCluster()
+    mgr = ScyllaClusterManager(
+        test_name="test_manager_op_bridge::stub",
+        cluster=stub,
+        port=9042,
+        use_ssl=False,
+    )
+    async with mgr.run_in_thread():
         try:
-            yield mgr, mgr.cluster, loop
+            yield mgr, stub, mgr._loop
         finally:
-            mgr.cluster.release()   # don't strand an operation on shutdown
-            stop_event.set()
-            future.result(timeout=TIMEOUT)
+            stub.release()   # don't strand an operation on shutdown
 
 
 async def test_operation_runs_on_the_managers_loop(manager) -> None:

--- a/test/pylib_test/test_manager_op_bridge.py
+++ b/test/pylib_test/test_manager_op_bridge.py
@@ -59,7 +59,7 @@ class StubCluster:
         await self._release
         self.stopped.append(server_id)
 
-    async def recycle(self) -> None:
+    async def stop(self) -> None:
         pass
 
     def release(self) -> None:


### PR DESCRIPTION
`ScyllaClusterManager` lived per module while tests live per test, for one
reason: to hand a clean cluster to the next test in the module. Measured on
a full CI run of master, that reuse is negligible: of 6550 leases, 5117
replaced a dirty cluster and 38 (0.58%) reused a clean one, all of them
empty clusters of tests that never touched the managed cluster. This is by
construction: test/cluster starts its clusters empty and `add_server()` marks
them dirty, so only an empty cluster can ever be reused, and replacing one
costs nothing.

This series gives every test its own manager, thread, event loop and cluster,
and deletes the machinery that existed only to protect the next test in the
module.

What the framework looks like afterwards:

- **One manager per test.** The `manager` fixture creates it, handles the
  `prepare_3_nodes_cluster`/`prepare_3_racks_cluster` markers (formerly two
  autouse fixtures every test paid for), connects the driver, and on teardown
  reads the verdict, checks the server logs and fails the test on leaked tasks
  or found errors, all in one `pytest.fail` so neither hides the other.
  `run_in_thread()` on the class runs the manager on its own thread and loop,
  the shape dtest's synchronous callers need; the bridge tests reuse it.
- **The cluster factory is a context manager.** `testpy_cluster_factory()`
  returns an async context manager that creates the cluster, stashes it on the
  pytest node under `CLUSTER_KEY` and recycles it on exit. `recycle()` is the
  sole disposal: stop the servers, delete their directories (since
  00a689677a, unless `--save-log-on-success`), release the IPs.
  `install_and_start()`, `uninstall()`, `release_ips()`, `replicas`,
  `initial_size`, `start_exception` and `stop_lock` go with it. test/cluster
  overrides `scylla_cluster` with a function-scoped, empty cluster; cqlpy and
  alternator keep their module-scoped one, which now adds its single server
  explicitly.
- **Evidence for a failed test comes from the stash.**
  `pytest_runtest_makereport` finds the cluster through `CLUSTER_KEY` and
  copies its server logs into `failed_test/<test>/` for any failed phase.
  That covers a failure during fixture setup (funcargs do not exist yet) and
  the module-scoped cqlpy/alternator cluster. `MANAGER_LOGS_KEY` and its
  publish/revoke protocol go.
- **Teardown callbacks are fixture ordering.** `scylla_cluster_teardowns` is a
  list fixture the cluster fixture depends on, so pytest runs its entries once
  the cluster is gone. The object-storage fixtures share an
  `object_storage_factory` that starts a backend and enqueues its stop and
  bucket delete there. `add_teardown_callback()`, `bind_to_current_loop()`
  and the cluster-side callback list go.
- **Nothing guards the next test anymore, because there is none.** The
  finished-test fence (`fenced()`, `_test_finished`, `fence=`),
  `break_manager()`/`check_not_broken()`/`blockable=`, `is_dirty`,
  `mark_dirty()`, `before_test()`'s dirty-replace path, the keyspace-count
  post-condition (which never ran: every added server dirtied the cluster)
  and `random_tables`' conditional `drop_all()` are deleted. `after_test()`
  still drains the test's in-flight operations and reports what it leaked,
  which fails the test; a caller leaked past the test gets
  "ScyllaClusterManager is not running".
- **Interrupted runs are swept.** A cluster whose fixture never recycled it
  is disposed of in `pytest_sessionfinish`, after pytest has run the
  finalizers an interrupted run still owes. A cancelled in-flight
  `add_server()` kills its half-started process and parks the server for
  `recycle()`. The worker's pytest log is kept whenever the sweep disposed of
  something or the session was interrupted.
- **Log attribution by logger name.** The per-test `<test>_cluster.log`, a
  second root-logger `FileHandler` whose content was a slice of the worker's
  pytest log, is gone; cluster records carry the module's unique name via a
  `testpy_logger` fixture. The `setLogger()` relabelling goes with it.

Changes visible to whoever writes tests:

- `manager.mark_dirty()` is gone; its four call sites are removed.
- `manager.add_teardown_callback()` is gone. A cleanup that must run after
  the cluster requests the `scylla_cluster_teardowns` fixture and appends to
  it; the object-storage fixtures show the pattern.
- A test only gets a manager if it (or a fixture it uses) requests one. The
  `prepare_3_*` markers still work through the `manager` fixture; every
  marked test in the tree reaches it.
- `random_tables` no longer drops tables afterwards: the cluster is destroyed
  with the test.
- `failed_test/<test>/` holds the server logs, the stacktrace and
  `found_errors.txt`; the framework's own records for the test are in the
  worker's `pytest_log/pytest_gw<N>.log` and in
  `pytest_tests_logs/<nodeid>-<phase>.log`.
- `cluster: initial_size` in `test/cluster/test_config.yaml` and
  `dirties_cluster` in `test/cqlpy/test_config.yaml` are removed;
  `docs/dev/testing.md` describes the per-test cluster.

Fixes SCYLLADB-3853