### PR TITLE
storage_group_manager: guarantee cache invalidation on group removal

### DIFF
--- a/replica/compaction_group.hh
+++ b/replica/compaction_group.hh
@@ -474,10 +474,15 @@ using storage_group_map = absl::flat_hash_map<size_t, storage_group_ptr, absl::H
 
 class storage_group_manager {
 protected:
+    // The table owning this manager and its per-shard row_cache. Kept here (rather than only
+    // in each concrete manager) so that removal of a storage group can invalidate the cache
+    // for its range regardless of which concrete manager is in use.
+    replica::table& _t;
     storage_group_map _storage_groups;
 protected:
     virtual future<> stop() = 0;
 public:
+    explicit storage_group_manager(replica::table& t) : _t(t) {}
     virtual ~storage_group_manager();
 
     //    How concurrent loop and updates on the group map works without a lock:

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -682,11 +682,33 @@ void storage_group_manager::clear_storage_groups() {
 }
 
 void storage_group_manager::remove_storage_group(size_t id) {
-    if (auto it = _storage_groups.find(id); it != _storage_groups.end()) {
-        _storage_groups.erase(it);
-    } else {
+    auto it = _storage_groups.find(id);
+    if (it == _storage_groups.end()) {
         throw std::out_of_range(format("remove_storage_group: storage group with id={} not found", id));
     }
+    auto range = to_partition_range(it->second->token_range());
+    _storage_groups.erase(it);
+
+    // Guarantee the cache range owned by this storage group gets invalidated exactly once,
+    // right here, regardless of how we got here:
+    //  - the normal path (table::cleanup_tablet -> ... -> compaction_group::cleanup()) already
+    //    invalidated it atomically with clearing the sstable sets, so this is a cheap no-op;
+    //  - the racing path, where a concurrent ERM update finds the tablet already post-cleanup
+    //    and removes the storage group directly (see update_effective_replication_map below)
+    //    while cleanup_tablet is still mid-flight, never gets to invalidate the cache at all
+    //    once the group disappears from under it (maybe_storage_group_for_id() below returns
+    //    null). This is the only path that removes a group from _storage_groups, so it's the
+    //    right place to make the invalidation unconditional.
+    //
+    // Fire-and-forget: by the time a storage group is removed, routing has already moved this
+    // tablet off this shard, so nothing needs to wait for this synchronously -- only eventual
+    // invalidation for memory reclaim is required.
+    (void) with_gate(_t.async_gate(), [&t = _t, range] () -> future<> {
+        return t.get_row_cache().invalidate(row_cache::external_updater([] {}), range)
+                .handle_exception([range] (std::exception_ptr ex) {
+                    tlogger.warn("Failed to invalidate cache range {} for removed storage group: {}. Ignored", range, ex);
+                });
+    });
 }
 
 storage_group& storage_group_manager::storage_group_for_id(const schema_ptr& s, size_t i) const {
@@ -703,7 +725,6 @@ storage_group* storage_group_manager::maybe_storage_group_for_id(const schema_pt
 }
 
 class single_storage_group_manager final : public storage_group_manager {
-    replica::table& _t;
     storage_group_ptr _single_sg;
     compaction_group* _single_cg;
 
@@ -712,7 +733,7 @@ class single_storage_group_manager final : public storage_group_manager {
     }
 public:
     single_storage_group_manager(replica::table& t)
-        : _t(t)
+        : storage_group_manager(t)
     {
         storage_group_map r;
 
@@ -791,7 +812,6 @@ struct background_merge_guard {
 };
 
 class tablet_storage_group_manager final : public storage_group_manager {
-    replica::table& _t;
     locator::host_id _my_host_id;
     const locator::tablet_map* _tablet_map;
     future<> _stop_fut = make_ready_future();
@@ -909,7 +929,7 @@ private:
     }
 public:
     tablet_storage_group_manager(table& t, const locator::effective_replication_map& erm)
-        : _t(t)
+        : storage_group_manager(t)
         , _my_host_id(erm.get_token_metadata().get_my_id())
         , _tablet_map(&erm.get_token_metadata().tablets().get_tablet_map(schema()->id()))
         , _merge_completion_fiber(merge_completion_fiber())
@@ -5778,6 +5798,13 @@ future<> table::cleanup_tablet(database& db, db::system_keyspace& sys_ks, locato
 
     auto sgp = _sg_manager->maybe_storage_group_for_id(_schema, tid.value());
     if (!sgp) {
+        // A racing ERM update (e.g. another migration/split/merge on this table completing
+        // first) can find this tablet already post-cleanup and remove its storage group via
+        // storage_group_manager::remove_storage_group() before we get here. There's nothing
+        // left for us to clean up in that case, but unlike before, that isn't also our only
+        // chance to invalidate the cache: remove_storage_group() itself now guarantees the
+        // cache range is invalidated whenever a storage group is removed, so skipping the rest
+        // of cleanup here is safe.
         tlogger.warn("Storage group for tablet {} is deallocated. Ignore cleanup.", tid);
         co_return;
     }

--- a/test/boost/commitlog_cleanup_test.cc
+++ b/test/boost/commitlog_cleanup_test.cc
@@ -11,10 +11,13 @@
 #undef SEASTAR_TESTING_MAIN
 #include <seastar/testing/test_case.hh>
 #include "test/lib/cql_test_env.hh"
+#include "test/lib/eventually.hh"
+#include "test/boost/sstable_test.hh"
 #include "db/commitlog/commitlog_replayer.hh"
 #include "db/commitlog/commitlog.hh"
 #include "db/config.hh"
 #include "db/system_keyspace.hh"
+#include "replica/compaction_group.hh"
 
 BOOST_AUTO_TEST_SUITE(commitlog_cleanup_test)
 
@@ -221,6 +224,58 @@ SEASTAR_TEST_CASE(test_commitlog_cleanup_record_gc) {
         // the next cleanup should delete them, leaving only a single new cleanup entry.
         step_cf("cf2");
         BOOST_REQUIRE_EQUAL(get_num_records(), 1);
+    }, cfg);
+}
+
+// Reproduces the race described for storage_group_manager::remove_storage_group():
+// a racing effective-replication-map update can remove a tablet's storage group directly
+// (bypassing table::cleanup_tablet's own row-cache invalidation) whenever it finds the
+// tablet already past its cleanup stage. Before the fix, table::cleanup_tablet(), finding
+// no storage group left for the tablet, would just warn and return, leaving the cache
+// range never invalidated. remove_storage_group() must now guarantee that invalidation
+// itself, regardless of which path removes the group.
+SEASTAR_TEST_CASE(test_racing_storage_group_removal_invalidates_cache) {
+    auto cfg = cql_test_config();
+    cfg.db_config->tablets_mode_for_new_keyspaces.set(db::tablets_mode_t::mode::enabled);
+    cfg.initial_tablets = 1;
+
+    return do_with_cql_env_thread([](cql_test_env& e) {
+        e.execute_cql("create table ks.cf (pk int, ck int, primary key (pk, ck))").get();
+        e.execute_cql("insert into ks.cf (pk, ck) values (0, 0)").get();
+
+        auto& db = e.local_db();
+        auto& cf = db.find_column_family("ks", "cf");
+
+        // Flush so the subsequent read is served through the cache-populating path.
+        cf.flush().get();
+
+        // Populate the cache for the tablet's whole range (there's a single tablet).
+        e.execute_cql("select * from ks.cf;").get();
+        BOOST_REQUIRE(!cf.get_row_cache().empty());
+
+        // Simulate the race: a concurrent ERM update finds the tablet already
+        // post-cleanup and removes its storage group directly, before
+        // table::cleanup_tablet() ever gets a chance to run its own invalidation
+        // (see storage_group_manager::remove_storage_group() and its caller in
+        // tablet_storage_group_manager::update_effective_replication_map()).
+        //
+        // As in that real caller, keep a copy of the storage group alive across the
+        // removal and stop it explicitly: a storage group's compaction groups must be
+        // stopped (compaction disabled) before their last reference goes away, or their
+        // destructor fires a fatal "not disabled" internal error.
+        auto& sg_manager = column_family_test::get_storage_group_manager(cf);
+        auto sg = sg_manager->storage_groups().at(locator::tablet_id(0).value());
+        sg->stop("racing removal").get();
+        sg_manager->remove_storage_group(locator::tablet_id(0).value());
+
+        // remove_storage_group()'s own invalidation is fire-and-forget, so wait for it.
+        BOOST_REQUIRE(eventually_true([&] { return cf.get_row_cache().empty(); }));
+
+        // table::cleanup_tablet() now finds no storage group for the tablet and takes
+        // its early-return path. This must remain harmless: the cache was already
+        // invalidated above, and no exception should be thrown.
+        cf.cleanup_tablet(db, e.get_system_keyspace().local(), locator::tablet_id(0)).get();
+        BOOST_REQUIRE(cf.get_row_cache().empty());
     }, cfg);
 }
 

--- a/test/cluster/test_tablets_migration.py
+++ b/test/cluster/test_tablets_migration.py
@@ -37,6 +37,12 @@ async def await_api_task(task, allowed_exception: Optional[Type[Exception]]=None
             raise
 
 
+async def get_cache_partitions(manager: ScyllaClusterManager, server, shard: int) -> float:
+    """Returns the number of row-cache partitions currently cached on the given shard."""
+    metrics = await manager.metrics.query(server.ip_addr)
+    return metrics.get("scylla_cache_partitions", {"shard": str(shard)}) or 0.0
+
+
 @pytest.mark.parametrize("action", ['move', 'add_replica', 'del_replica'])
 async def test_tablet_transition_sanity(manager: ScyllaClusterManager, action):
     logger.info("Bootstrapping cluster")
@@ -716,6 +722,15 @@ async def test_restart_in_cleanup_stage_after_cleanup(manager: ScyllaClusterMana
     Migrate a tablet from one node to another, and restart the leaving replica during
     the tablet cleanup stage, after tablet cleanup is completed.
     Reproduces issue #24857
+
+    Also covers the row-cache invalidation guarantee of
+    storage_group_manager::remove_storage_group(): restarting the leaving replica right
+    after tablet cleanup but before the topology moves past the cleanup stage is the
+    realistic trigger for that race (see the "if the node was restarted after tablet
+    cleanup was run but before moving to the next stage" comment in
+    tablet_storage_group_manager::update_effective_replication_map()). This test asserts
+    that, once the migration completes, the leaving replica's row cache for the migrated
+    tablet's range has been invalidated.
     """
     keyspace_opts = feature_config.get_keyspace_opts(
         "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 2}")
@@ -730,7 +745,10 @@ async def test_restart_in_cleanup_stage_after_cleanup(manager: ScyllaClusterMana
         await cql.run_async(feature_config.get_table_opts(
             f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int) WITH tablets = {{'min_tablet_count': 8}};"))
 
-        total_keys = 10
+        # Enough keys to make it very likely that every one of the 8 tablets ends up
+        # with some cached data, so the migrated tablet's contribution to the shard's
+        # cache-partition count is not just noise.
+        total_keys = 80
         for pk in range(total_keys):
             await cql.run_async(f"INSERT INTO {ks}.test(pk, c) VALUES({pk}, {pk+1})")
         await manager.api.flush_keyspace(servers[0].ip_addr, ks)
@@ -746,6 +764,7 @@ async def test_restart_in_cleanup_stage_after_cleanup(manager: ScyllaClusterMana
             src_server, dst_host_id = servers[0], s1_host_id
         else:
             src_server, dst_host_id = servers[1], s0_host_id
+        src_shard = replica[1]
 
         await asyncio.gather(*[manager.api.enable_injection(s.ip_addr, "wait_after_tablet_cleanup", one_shot=False) for s in servers])
 
@@ -762,8 +781,29 @@ async def test_restart_in_cleanup_stage_after_cleanup(manager: ScyllaClusterMana
         await manager.server_start(src_server.server_id)
         await wait_for_cql_and_get_hosts(manager.get_cql(), servers, time.time() + 30)
 
+        # Warm up the row cache on the leaving replica's shard by reading all rows back,
+        # so that the migrated tablet's data (among others') is cached there. Done after
+        # the restart so the baseline reflects the post-restart cache state, not the
+        # unconditional drop to ~0 that a process restart causes on its own.
+        await cql.run_async(f"SELECT * FROM {ks}.test")
+        partitions_after_warmup = await get_cache_partitions(manager, src_server, src_shard)
+        assert partitions_after_warmup > 0, "expected the warm-up read to populate the row cache"
+
         await asyncio.gather(*[manager.api.message_injection(s.ip_addr, "wait_after_tablet_cleanup") for s in servers])
 
         await await_api_task(move_task, allowed_exception=ServerDisconnectedError)
 
         await manager.api.quiesce_topology(servers[0].ip_addr)
+
+        # The tablet's storage group must have been removed from the leaving replica by
+        # now (either at the normal cleanup stage, or -- before the fix for the race this
+        # test targets -- possibly via storage_group_manager::remove_storage_group()
+        # bypassing table::cleanup_tablet()'s own invalidation, if cleanup was still in
+        # flight around the restart). Either way, the row-cache range must end up
+        # invalidated: the shard's cached-partition count must have dropped from what the
+        # warm-up produced (other tablets remaining on the shard keep their own cached
+        # data, so this isn't expected to reach zero).
+        partitions_after_migration = await get_cache_partitions(manager, src_server, src_shard)
+        assert partitions_after_migration < partitions_after_warmup, \
+            f"expected cache partitions on shard {src_shard} of the leaving replica to " \
+            f"drop after tablet migration+cleanup, but {partitions_after_warmup} -> {partitions_after_migration}"


### PR DESCRIPTION
## Problem

`table::cleanup_tablet` is normally the only path that removes a tablet's storage group and invalidates its `row_cache` range, at the final `cleanup` transition stage (`compaction_group::cleanup()`).

A racing effective-replication-map update can find the tablet already post-cleanup and remove its storage group directly via `storage_group_manager::remove_storage_group()`, before `cleanup_tablet` gets there. When that happens, `cleanup_tablet` finds no storage group left, warns, and returns — silently skipping the cache invalidation that only it used to perform. The result is a stale/cold-but-never-cleared cache range left occupying LRU weight on the shard.

## Fix

Move the invalidation into `remove_storage_group()` itself — the one place every removal path funnels through — so it fires unconditionally regardless of who triggers the removal. `remove_storage_group()` now needs a `replica::table&` to reach the row cache, so the `_t` member both concrete `storage_group_manager` subclasses already carried is hoisted into the base class.

## Testing

- New boost test (`test_racing_storage_group_removal_invalidates_cache`) directly reproduces the race by simulating a concurrent removal ahead of `cleanup_tablet`.
- Extends the existing `test_restart_in_cleanup_stage_after_cleanup` cluster test to assert the leaving replica's cache-partition count drops after migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Fixes: SCYLLADB-4177
