### PR TITLE
tablets: invalidate leaving replica's cache range early

### DIFF
--- a/locator/tablets.cc
+++ b/locator/tablets.cc
@@ -26,6 +26,7 @@
 #include <flat_set>
 #include <iterator>
 #include <chrono>
+#include <utility>
 
 #include <fmt/ranges.h>
 
@@ -347,6 +348,16 @@ bool is_post_cleanup(tablet_replica replica, const tablet_info& tinfo, const tab
         return trinfo.stage == locator::tablet_transition_stage::revert_migration;
     }
     return false;
+}
+
+bool is_leaving_replica_pending_early_cache_invalidation(tablet_replica replica, const tablet_info& tinfo, const tablet_transition_info& trinfo) {
+    if (replica != locator::get_leaving_replica(tinfo, trinfo)) {
+        return false;
+    }
+    // Stage ordinals increase along the migration path, so this also excludes
+    // the repair/restore stages, which have no leaving replica anyway.
+    return std::to_underlying(trinfo.stage) >= std::to_underlying(locator::tablet_transition_stage::write_both_read_new)
+        && std::to_underlying(trinfo.stage) < std::to_underlying(locator::tablet_transition_stage::cleanup);
 }
 
 tablet_replica_set get_new_replicas(const tablet_info& tinfo, const tablet_migration_info& mig) {

--- a/locator/tablets.hh
+++ b/locator/tablets.hh
@@ -441,6 +441,10 @@ std::optional<tablet_replica> get_leaving_replica(const tablet_info&, const tabl
 // where we clean up the tablet on the given replica.
 bool is_post_cleanup(tablet_replica replica, const tablet_info& tinfo, const tablet_transition_info& trinfo);
 
+// True if replica is the tablet's leaving replica, reads have moved off it
+// (stage is write_both_read_new or later), but real cleanup hasn't run yet.
+bool is_leaving_replica_pending_early_cache_invalidation(tablet_replica replica, const tablet_info& tinfo, const tablet_transition_info& trinfo);
+
 /// Represents intention to move a single tablet replica from src to dst.
 struct tablet_migration_info {
     locator::tablet_transition_kind kind;

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -812,6 +812,9 @@ class tablet_storage_group_manager final : public storage_group_manager {
     // Holds compaction reenabler which disables compaction temporarily during tablet merge
     std::vector<background_merge_guard> _compaction_reenablers_for_merging;
     std::vector<logstor::compaction_reenabler> _compaction_reenablers_for_logstor_merging;
+    // Tablets whose leaving-replica cache range was already invalidated early
+    // (ahead of real cleanup). Dedupes repeated invalidation across ERM updates.
+    std::unordered_set<size_t> _early_invalidated_leaving_tablets;
 private:
     const schema_ptr& schema() const {
         return _t.schema();
@@ -3903,6 +3906,7 @@ void tablet_storage_group_manager::update_effective_replication_map(
         if (!_storage_groups.contains(tid.value()) && tablet_migrates_in(transition_info)) {
             auto range = new_tablet_map->get_token_range(tid);
             _storage_groups[tid.value()] = allocate_storage_group(*new_tablet_map, tid, std::move(range));
+            _early_invalidated_leaving_tablets.erase(tid.value());
             tablet_migrating_in = true;
         } else if (_storage_groups.contains(tid.value()) && locator::is_post_cleanup(this_replica, new_tablet_map->get_tablet_info(tid), transition_info)) {
             // The storage group should be cleaned up and stopped at this point usually by the tablet cleanup stage,
@@ -3912,10 +3916,27 @@ void tablet_storage_group_manager::update_effective_replication_map(
             auto sg = _storage_groups[tid.value()];
 
             remove_storage_group(tid.value());
+            _early_invalidated_leaving_tablets.erase(tid.value());
 
             (void) with_gate(_t.async_gate(), [sg] {
                 return sg->stop("tablet post-cleanup").then([sg] {});
             });
+        } else if (_storage_groups.contains(tid.value())
+                   && locator::is_leaving_replica_pending_early_cache_invalidation(this_replica, new_tablet_map->get_tablet_info(tid), transition_info)
+                   && _early_invalidated_leaving_tablets.insert(tid.value()).second) {
+            // Reads already moved off this replica; sstables stay untouched until real
+            // cleanup, so a rollback can still repopulate the cache from disk.
+            auto range = new_tablet_map->get_token_range(tid);
+            auto p_range = dht::to_partition_range(range);
+            tlogger.debug("Invalidating range {} for tablet {} of table {}.{} early (leaving replica, stage={})",
+                          p_range, tid, schema()->ks_name(), schema()->cf_name(), transition_info.stage);
+            (void) with_gate(_t.async_gate(), [&t = _t, p_range = std::move(p_range)] {
+                return t.get_row_cache().invalidate(row_cache::external_updater([] {}), p_range);
+            });
+        } else if (_storage_groups.contains(tid.value()) && transition_info.stage == locator::tablet_transition_stage::revert_migration) {
+            // Migration was rolled back before cleanup; clear the dedup entry so a future
+            // retry of this tablet can early-invalidate the cache again.
+            _early_invalidated_leaving_tablets.erase(tid.value());
         }
     }
 

--- a/test/cluster/test_tablets_migration.py
+++ b/test/cluster/test_tablets_migration.py
@@ -528,6 +528,80 @@ async def test_tablet_back_and_forth_migration(manager: ScyllaClusterManager, fe
         await cql.run_async(f"INSERT INTO {ks}.test (pk, c) VALUES ({3}, {3});")
         await assert_rows(3)
 
+
+@pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
+async def test_tablet_migration_invalidates_leaving_cache_early(manager: ManagerClient):
+    """Verifies that the leaving replica's row-cache range for a migrating tablet is
+       invalidated as soon as the transition reaches write_both_read_new (when reads stop
+       being routed to it), rather than only later at the `cleanup` stage. This is checked
+       via the scylla_cache_partitions metric on the leaving replica's shard.
+    """
+    logger.info("Bootstrapping cluster")
+    cfg = {'enable_user_defined_functions': False, 'tablets_mode_for_new_keyspaces': 'enabled'}
+
+    servers = [await manager.server_add(config=cfg)]
+    await manager.disable_tablet_balancing()
+    cql = manager.get_cql()
+
+    async with new_test_keyspace(manager,
+            "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 1}") as ks:
+        await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int);")
+        servers.append(await manager.server_add(config=cfg))
+        host_ids = [await manager.get_host_id(s.server_id) for s in servers]
+
+        keys = range(100)
+        await asyncio.gather(*[cql.run_async(f"INSERT INTO {ks}.test (pk, c) VALUES ({k}, {k});") for k in keys])
+        # Flush to sstables, then populate the row cache on the current
+        # (soon to be leaving) replica by reading everything back.
+        await manager.api.flush_keyspace(servers[0].ip_addr, ks)
+        rows = await cql.run_async(f"SELECT * FROM {ks}.test")
+        assert len(rows) == len(keys)
+
+        replicas = await get_all_tablet_replicas(manager, servers[0], ks, 'test')
+        assert len(replicas) == 1 and len(replicas[0].replicas) == 1
+        old_replica = replicas[0].replicas[0]
+        assert old_replica[0] == host_ids[0]
+        old_server = servers[0]
+        last_token = replicas[0].last_token
+        new_replica = (host_ids[1], 0)
+
+        async def cache_partitions():
+            metrics = await manager.metrics.query(old_server.ip_addr)
+            return metrics.get('scylla_cache_partitions', {'shard': str(old_replica[1])})
+
+        before = await cache_partitions()
+        logger.info(f"Cached partitions on leaving replica before migration: {before}")
+        assert before is not None and before > 0
+
+        # Pause the migration right after the leaving replica observes write_both_read_new,
+        # before the coordinator ever reaches the `cleanup` stage.
+        await manager.api.enable_injection(old_server.ip_addr, "raft_topology_barrier_and_drain_fail", one_shot=False,
+                parameters={'keyspace': ks, 'table': 'test', 'last_token': last_token, 'stage': 'write_both_read_new'})
+        log = await manager.server_open_log(old_server.server_id)
+        mark = await log.mark()
+
+        migration_task = asyncio.create_task(
+            manager.api.move_tablet(servers[0].ip_addr, ks, "test", old_replica[0], old_replica[1],
+                                     new_replica[0], new_replica[1], 0))
+
+        await log.wait_for('raft_topology_cmd: barrier handler waits', from_mark=mark)
+
+        async def cache_dropped():
+            after = await cache_partitions()
+            return True if (after is None or after < before) else None
+
+        await wait_for(cache_dropped, time.time() + 30, label='leaving_replica_cache_dropped')
+
+        await manager.api.message_injection(old_server.ip_addr, "raft_topology_barrier_and_drain_fail")
+        await manager.api.disable_injection(old_server.ip_addr, "raft_topology_barrier_and_drain_fail")
+        await migration_task
+
+        # Migration completed normally (real `cleanup` ran on top of the already-invalidated
+        # cache) and the data is still fully readable from the new replica.
+        rows = await cql.run_async(f"SELECT * FROM {ks}.test")
+        assert len(rows) == len(keys)
+
+
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_staging_backlog_is_preserved_with_file_based_streaming(manager: ScyllaClusterManager):
     logger.info("Bootstrapping cluster")


### PR DESCRIPTION
## Problem

The leaving replica's row-cache range for a migrating tablet was only invalidated at the `cleanup` transition stage, alongside dropping its sstables and compaction groups.
Reads stop targeting the leaving replica much earlier, at `write_both_read_new` - so between that point and `cleanup` the shard's single `row_cache` keeps holding LRU weight for data it will never serve again, pressuring out other tablets' hot entries during heavy migration churn.

## Fix

Add a local, no-RPC invalidation triggered from the existing ERM-update handling in `tablet_storage_group_manager::update_effective_replication_map`:
once a shard sees itself as the leaving replica with the transition stage at `write_both_read_new` or later (`locator::is_leaving_replica_pending_early_cache_invalidation`), it invalidates just its row_cache range for that tablet.

sstables and compaction groups are left untouched until the real `cleanup` stage, so a rollback (`revert_migration`/`cleanup_target`) can still repopulate the cache from disk.
A small dedup set on the storage group manager keeps this idempotent across repeated ERM updates.

## Testing

New cluster test `test_tablet_migration_invalidates_leaving_cache_early`, using error injection to pause the migration right after `write_both_read_new` and asserting the `scylla_cache_partitions` metric on the leaving replica's shard drops before `cleanup` ever runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Fixes: SCYLLADB-4178
