### PR TITLE
test/lib/random_schema: construct the UTF-8 locale only once

### DIFF
--- a/test/lib/random_schema.cc
+++ b/test/lib/random_schema.cc
@@ -462,7 +462,9 @@ data_value generate_bytes_value(std::mt19937& engine, size_t min_size_in_bytes, 
 data_value generate_utf8_value(std::mt19937& engine, size_t min_size_in_bytes, size_t max_size_in_bytes) {
     auto wstr = generate_string_value<std::wstring>(engine, 0, 0x0FFF, min_size_in_bytes, max_size_in_bytes);
 
-    std::locale locale("en_US.utf8");
+    // Constructing a locale is expensive (it loads the locale category files
+    // every time), so do it only once.
+    static const std::locale locale("en_US.utf8");
     using codec = std::codecvt<wchar_t, char, std::mbstate_t>;
     auto& f = std::use_facet<codec>(locale);
 

--- a/vint-serialization.cc
+++ b/vint-serialization.cc
@@ -12,6 +12,7 @@
 
 #include <bit>
 #include <seastar/core/bitops.hh>
+#include <seastar/util/std-compat.hh>
 
 #include <algorithm>
 #include <array>


### PR DESCRIPTION
`multishard_query_test/fuzzy_test.debug` timed out and was SIGKILLed by the
test harness after 1800s (SCYLLADB-4091). It never reached the query it is
supposed to exercise: the `Running test workload with configuration: ...`
line, logged after the random data is generated and before the first scan, is
missing from the failing log. The test spent the whole run in random data
generation.

Root cause: `generate_utf8_value()` in `test/lib/random_schema.cc` constructs
`std::locale("en_US.utf8")` on every call. There is no locale archive in the
test image, so each construction opens the 13 locale category files, ~300us
per call in a debug build. Since the random schema generator learned `vector`
types (22b2d1893ad), a schema can nest `vector<UDT{text}>` several levels
deep, and one row then fans out to thousands of text leaves. The failing seed
(1066854306) draws exactly such a schema.

Reproduced by pinning the seed from the failing run and rebuilding
`combined_tests` in debug:

* unmodified tree: data generation took 91.6 minutes - well past the 1800s
  limit, which is the reported failure
* with the locale hoisted to a function-local static: 6.2 minutes, and the
  test then completes

Stack sampling of the hung process (`sudo gdb` against an unstripped
`combined_tests_g`) put 24 of 25 samples in `generate_utf8_value`, inside
locale construction or teardown, which is what pointed at the line.

The first commit is a prerequisite, not part of the fix. Once generation
finishes in minutes, the test reaches the query phase and dies under ASAN with
a heap-buffer-overflow in `unsigned_vint::deserialize()`. That read is an
intentional page-safe 8 byte overread, disabled when `SEASTAR_ASAN_ENABLED` is
defined - but that macro is only defined by `seastar/util/std-compat.hh`, and
seastar 2d6223ac2 ("treewide: cleanup unused includes") dropped that header
from `sstring.hh` and `temporary_buffer.hh`, so `vint-serialization.cc` stopped
seeing it after the seastar bump in 4f4029596aa. Verified by preprocessing the
translation unit before and after the bump. Including the header explicitly
restores the guard. This affects every ASAN build since the bump, not just
this test; it is kept as a separate commit and can be split into its own PR if
preferred.

Tests: `multishard_query_test/fuzzy_test` in debug, with the CI flags

* failing seed 1066854306 pinned: passes, 6.6 minutes, `No errors detected`
* 5 runs with random seeds: all pass in ~5s each

Backport: none. Both problems are master-only. The `vector` support that makes
the text fan-out reachable and the seastar bump that dropped the ASAN guard
are both on master and on no release branch. The locale line itself is old and
present on release branches, but without the vector-nested schemas it is not
expensive enough to hit the timeout there. If the same timeout is observed on
a release branch, the first commit backports cleanly on its own.

Fixes: SCYLLADB-4091
