### PR TITLE
cql3: validate table properties on every execution

### DIFF
--- a/cql3/statements/cf_prop_defs.cc
+++ b/cql3/statements/cf_prop_defs.cc
@@ -94,12 +94,6 @@ data_dictionary::keyspace cf_prop_defs::find_keyspace(const data_dictionary::dat
 }
 
 void cf_prop_defs::validate(const data_dictionary::database db, sstring ks_name, const schema::extensions_map& schema_extensions) const {
-    // Skip validation if the comapction strategy class is already set as it means we've already
-    // prepared (and redoing it would set strategyClass back to null, which we don't want)
-    if (_compaction_strategy_class) {
-        return;
-    }
-
     const auto& ks = find_keyspace(db, ks_name);
 
     static std::set<sstring> keywords({
@@ -130,7 +124,7 @@ void cf_prop_defs::validate(const data_dictionary::database db, sstring ks_name,
     }
 
     auto compaction_type_options = get_compaction_type_options();
-    if (!compaction_type_options.empty()) {
+    if (!_compaction_strategy_class && !compaction_type_options.empty()) {
         auto strategy = compaction_type_options.find(COMPACTION_STRATEGY_CLASS_KEY);
         if (strategy == compaction_type_options.end()) {
             throw exceptions::configuration_exception(sstring("Missing sub-option '") + COMPACTION_STRATEGY_CLASS_KEY + "' for the '" + KW_COMPACTION + "' option.");

--- a/test/cqlpy/test_alter_table.py
+++ b/test/cqlpy/test_alter_table.py
@@ -153,3 +153,18 @@ def test_valid_speculative_retry_values(cql, test_keyspace):
                 r = list(cql.execute(f"SELECT speculative_retry FROM system_schema.tables WHERE keyspace_name = '{ks}' AND table_name = '{cf}'"))
                 assert len(r) == 1
                 assert r[0].speculative_retry == canonical
+
+def test_prepared_alter_table_options_validated_on_every_execute(cql, test_keyspace):
+    """
+    A prepared ALTER TABLE with invalid options must be rejected on
+    every execution. Validation caches the compaction class in the
+    prepared statement after the first run, and that cache must not
+    skip the remaining checks on the second run. The same for views is
+    in test_materialized_view.py.
+    """
+    with new_test_table(cql, test_keyspace, "p int PRIMARY KEY") as table:
+        alter = cql.prepare(f"ALTER TABLE {table} WITH compaction = {{'class': 'SizeTieredCompactionStrategy'}}"
+                            " AND min_index_interval = 0")
+        for _ in range(2):
+            with pytest.raises(ConfigurationException, match="min_index_interval"):
+                cql.execute(alter)

--- a/test/cqlpy/test_create_table.py
+++ b/test/cqlpy/test_create_table.py
@@ -1,0 +1,20 @@
+# Copyright 2026-present ScyllaDB
+#
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
+
+# Tests for the CREATE TABLE statement
+
+import pytest
+
+from cassandra.protocol import ConfigurationException
+from .util import unique_name
+
+def test_prepared_create_table_options_validated(cql, test_keyspace):
+    """
+    CREATE TABLE validates its options when the statement is prepared,
+    so nothing is cached before the checks run and a later execution
+    cannot skip them.
+    """
+    with pytest.raises(ConfigurationException, match="min_index_interval"):
+        cql.prepare(f"CREATE TABLE {test_keyspace}.{unique_name()} (p int PRIMARY KEY)"
+                    " WITH compaction = {'class': 'SizeTieredCompactionStrategy'} AND min_index_interval = 0")

--- a/test/cqlpy/test_materialized_view.py
+++ b/test/cqlpy/test_materialized_view.py
@@ -1806,3 +1806,27 @@ def test_view_update_builder_does_not_lose_fragments_across_batches(cql, test_ke
             view_count = cql.execute(f'SELECT count(*) FROM {mv}').one().count
             assert base_count == 105
             assert view_count == 105
+
+# A prepared CREATE MATERIALIZED VIEW or ALTER MATERIALIZED VIEW with invalid
+# table options must be rejected on every execution. Validation caches the
+# compaction class in the prepared statement after the first run, and that
+# cache must not skip the remaining checks on the second run. The same for
+# ALTER TABLE is in test_alter_table.py.
+def test_prepared_view_options_validated_on_every_execute(cql, test_keyspace):
+    bad_options = " WITH compaction = {'class': 'SizeTieredCompactionStrategy'} AND min_index_interval = 0"
+
+    def rejected_twice(prepared):
+        for _ in range(2):
+            with pytest.raises(ConfigurationException, match="min_index_interval"):
+                cql.execute(prepared)
+
+    with new_test_table(cql, test_keyspace, "p int PRIMARY KEY, v int") as table:
+        mv = f"{test_keyspace}.{unique_name()}"
+        try:
+            rejected_twice(cql.prepare(f"CREATE MATERIALIZED VIEW {mv} AS SELECT * FROM {table}"
+                                       f" WHERE v IS NOT NULL AND p IS NOT NULL PRIMARY KEY (v, p){bad_options}"))
+        finally:
+            cql.execute(f"DROP MATERIALIZED VIEW IF EXISTS {mv}")
+
+        with new_materialized_view(cql, table, '*', 'v, p', 'v is not null and p is not null') as mv:
+            rejected_twice(cql.prepare(f"ALTER MATERIALIZED VIEW {mv}{bad_options}"))

--- a/test/cqlpy/test_secondary_index_properties.py
+++ b/test/cqlpy/test_secondary_index_properties.py
@@ -366,3 +366,15 @@ def test_create_vector_index_with_view_properties(cql, test_keyspace, scylla_onl
         index_name = unique_name()
         with pytest.raises(InvalidRequest, match="You cannot use view properties with a vector_index"):
             cql.execute(f"CREATE CUSTOM INDEX {index_name} ON {table}(v) USING 'vector_index' WITH gc_grace_seconds = 13")
+
+# A prepared CREATE INDEX with invalid view properties must be rejected on
+# every execution. Validation caches the compaction class in the prepared
+# statement after the first run, and that cache must not skip the remaining
+# checks on the second run.
+def test_prepared_create_index_options_validated_on_every_execute(cql, test_keyspace, scylla_only):
+    with new_test_table(cql, test_keyspace, "p int PRIMARY KEY, v int") as table:
+        create = cql.prepare(f"CREATE INDEX {unique_name()} ON {table}(v)"
+                             " WITH compaction = {'class': 'SizeTieredCompactionStrategy'} AND min_index_interval = 0")
+        for _ in range(2):
+            with pytest.raises(ConfigurationException, match="min_index_interval"):
+                cql.execute(create)


### PR DESCRIPTION
`cf_prop_defs::validate` returns early once the compaction strategy class is cached, and it caches the class before the later checks run. The cache lives in the prepared statement. `ALTER TABLE`, `CREATE MATERIALIZED VIEW` and `ALTER MATERIALIZED VIEW` validate their properties at execution, so a prepared statement that fails validation on its first execution skips every property check on the next one, and the invalid options are applied. `CREATE TABLE` is not affected: it validates its properties at prepare time.

The early return exists because the compaction block moves the class out of the options map and a second pass would not find it. Skip only that block once the class is cached. The other checks only read the options and run every time.

Fixes SCYLLADB-4193

Bug present for a long time. Backport to all active branches.