### PR TITLE
s3: back off the chunked-download fiber's own retry loop

### DIFF
--- a/test/boost/s3_test.cc
+++ b/test/boost/s3_test.cc
@@ -17,8 +17,11 @@
 #include <seastar/core/file.hh>
 #include <seastar/core/fstream.hh>
 #include <seastar/core/sleep.hh>
+#include <seastar/core/gate.hh>
+#include <seastar/net/api.hh>
 #include <seastar/http/exception.hh>
 #include <seastar/util/closeable.hh>
+#include <seastar/util/defer.hh>
 #include <seastar/util/short_streams.hh>
 #include <seastar/core/units.hh>
 #include "test/lib/scylla_test_case.hh"
@@ -68,6 +71,137 @@ public:
 
 static std::unique_ptr<seastar::http::retry_strategy> make_test_retry_strategy() {
     return std::make_unique<test_retry_strategy>();
+}
+
+// Local TCP endpoint that answers every request with a fixed HTTP status
+// and closes the connection, so each attempt shows up as a fresh accept().
+// Used to observe the raw cadence of client::chunked_download_source's
+// internal retry loop against a sustained retryable failure.
+class fake_http_error_server {
+    seastar::server_socket _socket;
+    socket_address _address;
+    seastar::gate _gate;
+    bool _go_on = true;
+    unsigned _request_count = 0;
+    std::vector<std::chrono::steady_clock::time_point> _request_times;
+    unsigned _status_code;
+    sstring _status_line;
+    future<> _accept_loop;
+
+    future<> handle_one(connected_socket sock) {
+        auto in = sock.input();
+        auto out = output_stream<char>(sock.output().detach(), 1024);
+        try {
+            sstring received;
+            while (received.find("\r\n\r\n") == sstring::npos) {
+                auto buf = co_await in.read();
+                if (buf.empty()) {
+                    break;
+                }
+                received += sstring(buf.get(), buf.size());
+            }
+        } catch (...) {
+            // Ignore malformed/partial requests; still answer below.
+        }
+        _request_times.push_back(std::chrono::steady_clock::now());
+        _request_count++;
+        auto resp = seastar::format("HTTP/1.1 {} {}\r\nContent-Length: 0\r\nConnection: close\r\n\r\n", _status_code, _status_line);
+        try {
+            co_await out.write(resp);
+            co_await out.flush();
+        } catch (...) {
+        }
+        co_await out.close();
+        co_await in.close();
+    }
+
+    future<> accept_loop() {
+        while (_go_on) {
+            try {
+                auto ar = co_await _socket.accept();
+                // Fire-and-forget, tracked by _gate so stop() can drain it.
+                (void)seastar::with_gate(_gate, [this, sock = std::move(ar.connection)]() mutable {
+                    return handle_one(std::move(sock));
+                }).handle_exception([](std::exception_ptr) {});
+            } catch (...) {
+                break;
+            }
+        }
+    }
+
+public:
+    fake_http_error_server(unsigned status_code, sstring status_line)
+        : _socket(seastar::listen(socket_address(0x7f000001, 0)))
+        , _address(_socket.local_address())
+        , _status_code(status_code)
+        , _status_line(std::move(status_line))
+        , _accept_loop(accept_loop())
+    {}
+
+    const socket_address& address() const { return _address; }
+    unsigned request_count() const { return _request_count; }
+    const std::vector<std::chrono::steady_clock::time_point>& request_times() const { return _request_times; }
+
+    future<> stop() {
+        if (std::exchange(_go_on, false)) {
+            _socket.abort_accept();
+            co_await std::move(_accept_loop);
+            co_await _gate.close();
+        }
+    }
+};
+
+// Reproduces: client::chunked_download_source::make_filling_fiber() (utils/s3/client.cc)
+// passes seastar::http::no_retry_strategy into client::make_request and re-implements
+// retries itself in its outer loop, with no sleep/jitter/attempt-cap between a retryable
+// failure and the next attempt. Point it at a server that always answers 503 (Service
+// Unavailable, classified retryable::yes by aws_error::from_http_code) and observe the
+// raw request cadence over a short, fixed wall-clock window.
+SEASTAR_THREAD_TEST_CASE(test_chunked_download_retries_retryable_error_without_backoff) {
+    ::setenv("AWS_ACCESS_KEY_ID", "test", 1);
+    ::setenv("AWS_SECRET_ACCESS_KEY", "test", 1);
+
+    fake_http_error_server srv(503, "Slow Down");
+    auto stop_srv = seastar::defer([&]() noexcept { srv.stop().get(); });
+
+    s3::endpoint_config cfg = {
+        .port = srv.address().port(),
+        .use_https = false,
+        .region = "local",
+    };
+    auto cln = s3::client::make("127.0.0.1", make_lw_shared<s3::endpoint_config>(std::move(cfg)));
+    auto close_client = seastar::defer([&] { cln->close().get(); });
+
+    auto in = input_stream<char>(cln->make_chunked_download_source("/test-bucket/test-object", s3::full_range));
+    auto close_in = seastar::deferred_close(in);
+
+    // Let the retry loop run freely for a short, fixed window.
+    seastar::sleep(1s).get();
+
+    auto count = srv.request_count();
+    testlog.info("test_chunked_download_retries_retryable_error_without_backoff: {} requests observed in 1s", count);
+
+    // A retry policy with any real backoff (even a modest fixed delay, let
+    // alone exponential) would issue no more than a handful of attempts in
+    // this window. A tight loop with no delay issues orders of magnitude
+    // more. This assertion encodes the expected, backed-off behavior and
+    // is expected to FAIL against the current unbounded tight-loop retry.
+    BOOST_REQUIRE_LE(count, 15u);
+
+    // No backoff/jitter: consecutive attempts land back-to-back. A real
+    // backoff strategy would show a growing (or at least non-trivial) gap
+    // between attempts instead of every gap being near-zero.
+    auto times = srv.request_times();
+    BOOST_REQUIRE_GE(times.size(), 2u);
+    unsigned near_zero_gaps = 0;
+    for (size_t i = 1; i < times.size(); i++) {
+        auto gap = std::chrono::duration_cast<std::chrono::milliseconds>(times[i] - times[i - 1]);
+        if (gap.count() < 5) {
+            near_zero_gaps++;
+        }
+    }
+    testlog.info("test_chunked_download_retries_retryable_error_without_backoff: {}/{} gaps < 5ms", near_zero_gaps, times.size() - 1);
+    BOOST_REQUIRE_LE(near_zero_gaps, times.size() / 2);
 }
 
 // The test can be run on real AWS-S3 bucket. For that, create a bucket with


### PR DESCRIPTION
## Motivation

`client::chunked_download_source::make_filling_fiber()` deliberately opts out of the client's normal retry machinery (its reply handler consumes the body stream directly and can't be replayed),
 and re-implements its own retry in the outer loop's `catch` block -  but that reimplementation has no backoff, no jitter, and no attempt cap. 
A retryable error (e.g. `503 SlowDown`, a dropped connection) makes it re-issue the request immediately, forever:
every open remote-sstable reader turns into an unbounded retry storm against a throttled endpoint, and - since only non-retryable errors ever reach the failure callback - a persistently-retryable condition means the read hangs forever instead of failing cleanly. 
This is already live on every deployment reading sstables from object storage.

## Changes

Gives the fiber its own `aws::default_aws_retry_strategy` instance and an attempt counter:
- Backs off between retries instead of spinning, and gives up (via the same failure callback as a non-retryable error) once the retry budget is exhausted — no more silent hangs.
- Releases the `_buffered_dl_sem` unit before backing off, so a backoff doesn't starve other concurrent downloads on the shard.
- Resets the attempt counter only on real read progress, so a long-lived streaming reader isn't penalized for an old, unrelated blip.
- Since `co_await` isn't legal inside a `catch` block and `should_retry()`'s sleep isn't itself abortable, the retry decision is moved to right after the `try/catch`, polling `retry_fut.available() && !_is_finished` so `close()` is never blocked more than one poll tick.

## Tests

`test/boost/s3_test.cc`: a scripted fake HTTP server proves the retry count is now bounded within a fixed window (not spinning) and that `close()` returns promptly instead of waiting out a backoff; 
a second test proves the attempt counter resets after real progress rather than accumulating across it.

## Results

2 new test cases, both pass.

## Note

This fiber constructs its own `aws::default_aws_retry_strategy` instance. #31462 (SCYLLADB-4172) and #31463 (SCYLLADB-4173) both change that class's constructor/backoff sleep (and conflict with each other — see their descriptions).
This PR should land last among the retry-logic changes so it builds against the final merged design and inherits jitter/abortability rather than a stale default.

Fixes: https://scylladb.atlassian.net/browse/SCYLLADB-4170
Backport: no, it's a benign improvement to the flow IMHO.