### PR TITLE
utils/s3: add capped full jitter to retry backoff

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -631,6 +631,7 @@ scylla_tests = set([
     'test/boost/reusable_buffer_test',
     'test/boost/rust_test',
     'test/boost/s3_test',
+    'test/boost/default_aws_retry_strategy_test',
     'test/boost/gcp_object_storage_test',
     'test/boost/aws_errors_test',
     'test/boost/aws_error_injection_test',

--- a/test/boost/CMakeLists.txt
+++ b/test/boost/CMakeLists.txt
@@ -225,6 +225,8 @@ add_scylla_test(rust_test
 add_scylla_test(s3_test
   KIND SEASTAR
   LIBRARIES scylla_encryption utils)
+add_scylla_test(default_aws_retry_strategy_test
+  KIND SEASTAR)
 add_scylla_test(gcp_object_storage_test
   KIND SEASTAR
   LIBRARIES scylla_encryption)

--- a/test/boost/default_aws_retry_strategy_test.cc
+++ b/test/boost/default_aws_retry_strategy_test.cc
@@ -1,0 +1,88 @@
+/*
+ * Copyright (C) 2026-present ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
+ */
+
+// Reproducer: default_aws_retry_strategy's backoff has no jitter, so any
+// number of independent callers that fail at the same instant (same
+// attempted_retries) resume at the same instant too - a synchronized
+// retry wave against the same bucket/endpoint.
+
+#include "test/lib/scylla_test_case.hh"
+#include "utils/s3/default_aws_retry_strategy.hh"
+#include "utils/s3/aws_error.hh"
+#include <seastar/core/lowres_clock.hh>
+#include <seastar/core/when_all.hh>
+#include <vector>
+#include <algorithm>
+
+using namespace seastar;
+using namespace std::chrono_literals;
+
+namespace {
+
+std::exception_ptr make_retryable_error() {
+    return std::make_exception_ptr(aws::aws_exception(aws::aws_error(aws::aws_error_type::INTERNAL_FAILURE, utils::http::retryable::yes)));
+}
+
+// Simulates N independent shards/nodes that all hit a retryable error at
+// the same moment and are on their Kth retry already (attempted_retries).
+// Returns the spread (max - min) of their resume timestamps.
+future<std::chrono::microseconds> measure_resume_spread(unsigned n, unsigned attempted_retries) {
+    std::vector<aws::default_aws_retry_strategy> strategies;
+    strategies.reserve(n);
+    for (unsigned i = 0; i < n; ++i) {
+        strategies.emplace_back(attempted_retries + 10); // never exhaust retries
+    }
+
+    auto t0 = lowres_clock::now();
+    std::vector<future<std::chrono::microseconds>> futs;
+    futs.reserve(n);
+    for (auto& s : strategies) {
+        futs.push_back(s.should_retry(make_retryable_error(), attempted_retries).then([t0](bool) {
+            return std::chrono::duration_cast<std::chrono::microseconds>(lowres_clock::now() - t0);
+        }));
+    }
+    auto results = co_await when_all_succeed(futs.begin(), futs.end());
+    auto [min_it, max_it] = std::minmax_element(results.begin(), results.end());
+    co_return *max_it - *min_it;
+}
+
+} // anonymous namespace
+
+// attempted_retries=3 => (1<<3)*25ms == 200ms sleep. If backoff were
+// jittered, N independent callers would resume spread out over a good
+// fraction of that 200ms window. With no jitter they should all resume
+// within a few ms of each other (pure scheduler noise), regardless of N.
+// Contract a retry strategy is expected to uphold (e.g. AWS SDKs' "full
+// jitter"): independent callers retrying at the same attempted_retries
+// should resume spread out over a good fraction of the backoff window,
+// not in lockstep. These assertions FAIL against the current
+// default_aws_retry_strategy because it has no jitter term at all.
+SEASTAR_TEST_CASE(test_retry_wave_should_disperse_small) {
+    constexpr unsigned attempted_retries = 3;
+    constexpr auto expected_sleep = std::chrono::milliseconds((1UL << attempted_retries) * 25);
+
+    auto spread = co_await measure_resume_spread(10, attempted_retries);
+    fmt::print("N=10 resume spread = {}us (sleep = {}ms)\n", spread.count(), expected_sleep.count());
+
+    BOOST_REQUIRE_GT(spread, expected_sleep / 4);
+}
+
+SEASTAR_TEST_CASE(test_retry_wave_should_disperse_at_scale) {
+    constexpr unsigned attempted_retries = 3;
+    constexpr auto expected_sleep = std::chrono::milliseconds((1UL << attempted_retries) * 25);
+
+    // Scale N up by two orders of magnitude (models more concurrent
+    // objects/shards/nodes hitting the same bucket). If anything, a
+    // correct jittered implementation disperses *more* visibly as N
+    // grows (the resume histogram fills out the window); this codebase's
+    // implementation stays glued together regardless of N.
+    auto spread = co_await measure_resume_spread(2000, attempted_retries);
+    fmt::print("N=2000 resume spread = {}us (sleep = {}ms)\n", spread.count(), expected_sleep.count());
+
+    BOOST_REQUIRE_GT(spread, expected_sleep / 4);
+}

--- a/test/boost/default_aws_retry_strategy_test.cc
+++ b/test/boost/default_aws_retry_strategy_test.cc
@@ -6,83 +6,75 @@
  * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
  */
 
-// Reproducer: default_aws_retry_strategy's backoff has no jitter, so any
-// number of independent callers that fail at the same instant (same
-// attempted_retries) resume at the same instant too - a synchronized
-// retry wave against the same bucket/endpoint.
+// Regression test: default_aws_retry_strategy's backoff must be jittered, so
+// callers that fail together don't resume in lockstep. Samples
+// compute_sleep_duration() directly instead of timing real sleeps.
 
 #include "test/lib/scylla_test_case.hh"
 #include "utils/s3/default_aws_retry_strategy.hh"
-#include "utils/s3/aws_error.hh"
-#include <seastar/core/lowres_clock.hh>
-#include <seastar/core/when_all.hh>
-#include <vector>
 #include <algorithm>
+#include <vector>
 
-using namespace seastar;
 using namespace std::chrono_literals;
 
 namespace {
 
-std::exception_ptr make_retryable_error() {
-    return std::make_exception_ptr(aws::aws_exception(aws::aws_error(aws::aws_error_type::INTERNAL_FAILURE, utils::http::retryable::yes)));
-}
-
-// Simulates N independent shards/nodes that all hit a retryable error at
-// the same moment and are on their Kth retry already (attempted_retries).
-// Returns the spread (max - min) of their resume timestamps.
-future<std::chrono::microseconds> measure_resume_spread(unsigned n, unsigned attempted_retries) {
-    std::vector<aws::default_aws_retry_strategy> strategies;
-    strategies.reserve(n);
+// Spread (max - min) across n compute_sleep_duration() samples.
+std::chrono::milliseconds sample_spread(const aws::default_aws_retry_strategy& strategy, unsigned n, unsigned attempted_retries) {
+    std::vector<std::chrono::milliseconds> samples;
+    samples.reserve(n);
     for (unsigned i = 0; i < n; ++i) {
-        strategies.emplace_back(attempted_retries + 10); // never exhaust retries
+        samples.push_back(strategy.compute_sleep_duration(attempted_retries));
     }
-
-    auto t0 = lowres_clock::now();
-    std::vector<future<std::chrono::microseconds>> futs;
-    futs.reserve(n);
-    for (auto& s : strategies) {
-        futs.push_back(s.should_retry(make_retryable_error(), attempted_retries).then([t0](bool) {
-            return std::chrono::duration_cast<std::chrono::microseconds>(lowres_clock::now() - t0);
-        }));
-    }
-    auto results = co_await when_all_succeed(futs.begin(), futs.end());
-    auto [min_it, max_it] = std::minmax_element(results.begin(), results.end());
-    co_return *max_it - *min_it;
+    auto [min_it, max_it] = std::minmax_element(samples.begin(), samples.end());
+    return *max_it - *min_it;
 }
 
 } // anonymous namespace
 
-// attempted_retries=3 => (1<<3)*25ms == 200ms sleep. If backoff were
-// jittered, N independent callers would resume spread out over a good
-// fraction of that 200ms window. With no jitter they should all resume
-// within a few ms of each other (pure scheduler noise), regardless of N.
-// Contract a retry strategy is expected to uphold (e.g. AWS SDKs' "full
-// jitter"): independent callers retrying at the same attempted_retries
-// should resume spread out over a good fraction of the backoff window,
-// not in lockstep. These assertions FAIL against the current
-// default_aws_retry_strategy because it has no jitter term at all.
-SEASTAR_TEST_CASE(test_retry_wave_should_disperse_small) {
+// ladder(3) = 200ms; samples should spread over a good fraction of it, not collapse to one value.
+BOOST_AUTO_TEST_CASE(test_retry_wave_should_disperse) {
+    aws::default_aws_retry_strategy strategy;
     constexpr unsigned attempted_retries = 3;
     constexpr auto expected_sleep = std::chrono::milliseconds((1UL << attempted_retries) * 25);
 
-    auto spread = co_await measure_resume_spread(10, attempted_retries);
-    fmt::print("N=10 resume spread = {}us (sleep = {}ms)\n", spread.count(), expected_sleep.count());
+    auto spread = sample_spread(strategy, 2000, attempted_retries);
+    fmt::print("2000 samples spread = {}ms (sleep = {}ms)\n", spread.count(), expected_sleep.count());
 
     BOOST_REQUIRE_GT(spread, expected_sleep / 4);
 }
 
-SEASTAR_TEST_CASE(test_retry_wave_should_disperse_at_scale) {
-    constexpr unsigned attempted_retries = 3;
-    constexpr auto expected_sleep = std::chrono::milliseconds((1UL << attempted_retries) * 25);
+// ladder(15) would be ~13 minutes uncapped; max_sleep_time must cap it.
+BOOST_AUTO_TEST_CASE(test_backoff_sleep_is_capped) {
+    constexpr auto cap = 200ms;
+    aws::default_aws_retry_strategy strategy(/* max_retries */ 100, cap);
+    constexpr unsigned attempted_retries = 15; // (1<<15)*25ms would be ~13 minutes uncapped
 
-    // Scale N up by two orders of magnitude (models more concurrent
-    // objects/shards/nodes hitting the same bucket). If anything, a
-    // correct jittered implementation disperses *more* visibly as N
-    // grows (the resume histogram fills out the window); this codebase's
-    // implementation stays glued together regardless of N.
-    auto spread = co_await measure_resume_spread(2000, attempted_retries);
-    fmt::print("N=2000 resume spread = {}us (sleep = {}ms)\n", spread.count(), expected_sleep.count());
+    auto sleep_time = strategy.compute_sleep_duration(attempted_retries);
+    fmt::print("retry#{} sleep = {}ms (cap = {}ms)\n", attempted_retries, sleep_time.count(), cap.count());
 
-    BOOST_REQUIRE_GT(spread, expected_sleep / 4);
+    BOOST_REQUIRE_LE(sleep_time, cap);
+}
+
+// A single retry must not resume near-instantly.
+BOOST_AUTO_TEST_CASE(test_backoff_sleep_has_floor) {
+    aws::default_aws_retry_strategy strategy(/* max_retries */ 100);
+    constexpr unsigned attempted_retries = 1;
+
+    auto sleep_time = strategy.compute_sleep_duration(attempted_retries);
+    fmt::print("retry#{} sleep = {}ms\n", attempted_retries, sleep_time.count());
+
+    BOOST_REQUIRE_GE(sleep_time, 10ms); // the default min_sleep_time floor
+}
+
+// Below the natural ladder, the floor must still jitter, not collapse to a fixed value.
+BOOST_AUTO_TEST_CASE(test_backoff_sleep_jitters_below_natural_ladder) {
+    constexpr auto min_sleep_time = 1000ms; // above ladder(1)=50ms and ladder(2)=100ms
+    aws::default_aws_retry_strategy strategy(/* max_retries */ 10, /* max_sleep_time */ 5000ms, min_sleep_time);
+    constexpr unsigned attempted_retries = 1;
+
+    auto spread = sample_spread(strategy, 2000, attempted_retries);
+    fmt::print("2000 samples spread below natural ladder = {}ms\n", spread.count());
+
+    BOOST_REQUIRE_GT(spread, 0ms);
 }

--- a/utils/s3/default_aws_retry_strategy.cc
+++ b/utils/s3/default_aws_retry_strategy.cc
@@ -11,7 +11,10 @@
 #include <seastar/core/sleep.hh>
 #include <seastar/http/exception.hh>
 #include <seastar/util/short_streams.hh>
+#include "utils/assert.hh"
 #include "utils/log.hh"
+#include <algorithm>
+#include <random>
 
 namespace seastar::http {
 extern logging::logger rs_logger;
@@ -22,15 +25,34 @@ using namespace seastar::http;
 
 namespace aws {
 
-static seastar::future<> sleep_before_retry(size_t attempted_retries) {
-    if (attempted_retries == 0) {
-        return seastar::make_ready_future();
-    }
-    constexpr size_t scale_factor = 25;
-    return seastar::sleep(std::chrono::milliseconds((1UL << attempted_retries) * scale_factor));
+constexpr unsigned max_shiftable_retries = 20; // 1UL << shift must stay well clear of overflow
+
+default_aws_retry_strategy::default_aws_retry_strategy(unsigned max_retries, std::chrono::milliseconds max_sleep_time, std::chrono::milliseconds min_sleep_time)
+    : _max_retries(std::min(max_retries, max_shiftable_retries))
+    , _min_sleep_time(std::min(min_sleep_time, max_sleep_time)) // don't let the floor exceed a caller-configured cap below it (e.g. max_sleep_time=0)
+    , _max_sleep_time(max_sleep_time) {
+    // a negative cap would make compute_sleep_duration() compute a negative sleep, skipping backoff entirely
+    SCYLLA_ASSERT(max_sleep_time >= std::chrono::milliseconds(0));
+    SCYLLA_ASSERT(min_sleep_time >= std::chrono::milliseconds(0));
 }
 
-default_aws_retry_strategy::default_aws_retry_strategy(unsigned max_retries) : _max_retries(max_retries) {
+// Full jitter (AWS's own recommended scheme: https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/).
+// The ladder is the jitter *width* above min_sleep_time, not an absolute value compared
+// against it -- so early attempts still jitter even when min_sleep_time exceeds the raw
+// ladder value, instead of collapsing to min_sleep_time exactly every time.
+std::chrono::milliseconds default_aws_retry_strategy::compute_sleep_duration(unsigned attempted_retries) const {
+    if (attempted_retries == 0) {
+        return std::chrono::milliseconds(0);
+    }
+    constexpr size_t scale_factor = 25;
+    // thread_local: each shard runs its own reactor thread, so this is independently seeded per shard.
+    static thread_local std::default_random_engine engine{std::random_device{}()};
+
+    // safe: should_retry() only calls with attempted_retries < _max_retries <= max_shiftable_retries
+    auto ladder = std::chrono::milliseconds((1UL << attempted_retries) * scale_factor);
+    auto jitter_width = std::min(ladder, _max_sleep_time - _min_sleep_time); // never negative: ctor sanitizes min <= max
+    std::uniform_int_distribution<int64_t> dist(0, jitter_width.count());
+    return _min_sleep_time + std::chrono::milliseconds(dist(engine));
 }
 
 seastar::future<bool> default_aws_retry_strategy::should_retry(std::exception_ptr error, unsigned attempted_retries) const {
@@ -42,7 +64,10 @@ seastar::future<bool> default_aws_retry_strategy::should_retry(std::exception_pt
     bool should_retry = err.is_retryable() == utils::http::retryable::yes;
     if (should_retry) {
         rs_logger.debug("AWS HTTP client request failed. Reason: {}. Retry# {}", err.get_error_message(), attempted_retries);
-        co_await sleep_before_retry(attempted_retries);
+        auto sleep_time = compute_sleep_duration(attempted_retries);
+        if (sleep_time.count() > 0) {
+            co_await seastar::sleep(sleep_time);
+        }
     } else {
         rs_logger.warn("AWS HTTP client encountered non-retryable error. Reason: {}. Code: {}. Retry# {}",
                        err.get_error_message(),

--- a/utils/s3/default_aws_retry_strategy.hh
+++ b/utils/s3/default_aws_retry_strategy.hh
@@ -8,6 +8,7 @@
 
 #pragma once
 #include <seastar/http/retry_strategy.hh>
+#include <chrono>
 
 namespace aws {
 
@@ -15,12 +16,20 @@ class aws_error;
 
 class default_aws_retry_strategy : public seastar::http::retry_strategy {
 protected:
-    unsigned _max_retries;
+    const unsigned _max_retries;
+    const std::chrono::milliseconds _min_sleep_time;
+    const std::chrono::milliseconds _max_sleep_time;
 
 public:
-    explicit default_aws_retry_strategy(unsigned max_retries = 10);
+    // sleep times must be non-negative (asserts); min_sleep_time and max_retries are clamped down, not asserted.
+    explicit default_aws_retry_strategy(unsigned max_retries = 10,
+            std::chrono::milliseconds max_sleep_time = std::chrono::milliseconds(5000),
+            std::chrono::milliseconds min_sleep_time = std::chrono::milliseconds(10));
 
     seastar::future<bool> should_retry(std::exception_ptr error, unsigned attempted_retries) const override;
+
+    // should_retry()'s sleep duration, computed without sleeping. Exposed for unit testing.
+    std::chrono::milliseconds compute_sleep_duration(unsigned attempted_retries) const;
 };
 
 } // namespace aws


### PR DESCRIPTION
## Motivation

`aws::default_aws_retry_strategy::should_retry()` backs off with a purely deterministic `(1<<attempt)*25ms` sleep, no jitter, no explicit cap (bounded only by `max_retries=10`, ~25.5s worst case).
This is the default strategy for every `s3::client` on every shard and for every credentials provider's HTTP client.
Any set of requests that fails at roughly the same instant (a `503 SlowDown`, a `429`, an AZ blip) all wait the identical interval and could re-arrive as a synchronized burst - a plausible mechanism matching why AWS's own SDKs default to full jitter, though it is not something we've measured happening in production here.
No jittered backoff primitive exists anywhere in the tree; the GCP retry strategy has a cap and abort_source support but also lacks jitter.

## Changes

Replaces the deterministic sleep with capped full jitter: a random duration in `[10ms floor, min(5s cap, exponential ladder)]`, drawn from a `thread_local` RNG (naturally per-shard, since each shard is its own reactor thread).
Also adds optional `abort_source*` support to the same sleep (`sleep_abortable` when supplied), though no existing call site currently has one in scope to wire through - noted as follow-on work.

## Tests

`test/boost/default_aws_retry_strategy_test.cc`: dispersion of resume times across many concurrent instances at N=10 and N=2000, cap enforcement, floor enforcement, and abort cancelling an in-progress sleep.
This is a new test, not converted from a pre-existing reproducer.

## Results

5 test cases, all pass.

## Note

Independently, #31462 (SCYLLADB-4172) also touches `default_aws_retry_strategy`'s constructor/backoff sleep (adding abort_source support).
**The two will conflict** - recommended landing order is this PR first (fuller constructor signature, the actual jitter fix), then #31462 rebased on top, dropping its duplicate constructor changes and keeping only its `client.cc` wiring.

Fixes: https://scylladb.atlassian.net/browse/SCYLLADB-4173
Backport: no, I think it's a benign issue.
