### PR TITLE
utils/s3: make sts_assume_role_credentials_provider self-defending

### DIFF
--- a/test/boost/s3_test.cc
+++ b/test/boost/s3_test.cc
@@ -846,6 +846,15 @@ SEASTAR_THREAD_TEST_CASE(test_creds) {
     BOOST_REQUIRE_EQUAL(creds.session_token, "");
 }
 
+SEASTAR_THREAD_TEST_CASE(test_sts_provider_unconditional_empty_role_arn) {
+    // client.cc always builds sts_assume_role_credentials_provider(region, role_arn)
+    // with no check that role_arn is configured; with both left at their
+    // defaults (empty strings) this yields host "sts..amazonaws.com" and a
+    // guaranteed-to-fail request.
+    aws::sts_assume_role_credentials_provider provider("", "");
+    BOOST_REQUIRE_THROW(provider.get_aws_credentials().get(), std::exception);
+}
+
 BOOST_AUTO_TEST_CASE(s3_fqn_manipulation) {
     std::string bucket_name, object_name;
     // Empty input

--- a/test/boost/s3_test.cc
+++ b/test/boost/s3_test.cc
@@ -847,12 +847,17 @@ SEASTAR_THREAD_TEST_CASE(test_creds) {
 }
 
 SEASTAR_THREAD_TEST_CASE(test_sts_provider_unconditional_empty_role_arn) {
-    // client.cc always builds sts_assume_role_credentials_provider(region, role_arn)
-    // with no check that role_arn is configured; with both left at their
-    // defaults (empty strings) this yields host "sts..amazonaws.com" and a
-    // guaranteed-to-fail request.
-    aws::sts_assume_role_credentials_provider provider("", "");
-    BOOST_REQUIRE_THROW(provider.get_aws_credentials().get(), std::exception);
+    // client.cc always adds sts_assume_role_credentials_provider to the chain
+    // with no check that role_arn is configured. The provider must no-op
+    // rather than issue a doomed AssumeRole request when role_arn is empty;
+    // point it at the mock STS server so an issued request would be observable.
+    auto host = tests::getenv_safe("MOCK_S3_SERVER_HOST");
+    auto port = std::stoul(tests::getenv_safe("MOCK_S3_SERVER_PORT"));
+    aws::sts_assume_role_credentials_provider provider(host, port, false, make_test_retry_strategy, "");
+    auto creds = provider.get_aws_credentials().get();
+    BOOST_REQUIRE_EQUAL(creds.access_key_id, "");
+    BOOST_REQUIRE_EQUAL(creds.secret_access_key, "");
+    BOOST_REQUIRE_EQUAL(creds.session_token, "");
 }
 
 BOOST_AUTO_TEST_CASE(s3_fqn_manipulation) {

--- a/utils/s3/credentials_providers/sts_assume_role_credentials_provider.cc
+++ b/utils/s3/credentials_providers/sts_assume_role_credentials_provider.cc
@@ -24,8 +24,8 @@ namespace aws {
 static logging::logger sts_logger("sts");
 
 sts_assume_role_credentials_provider::sts_assume_role_credentials_provider(const std::string& _host, unsigned _port, bool _is_secured,
-        retry_strategy_factory retry_factory)
-    : sts_host(_host), port(_port), is_secured(_is_secured), _retry_factory(std::move(retry_factory)) {
+        retry_strategy_factory retry_factory, std::string _role_arn)
+    : sts_host(_host), role_arn(std::move(_role_arn)), port(_port), is_secured(_is_secured), _retry_factory(std::move(retry_factory)) {
 }
 
 sts_assume_role_credentials_provider::sts_assume_role_credentials_provider(const std::string& _region, const std::string& _role_arn)
@@ -38,6 +38,10 @@ future<> sts_assume_role_credentials_provider::reload() {
 }
 
 future<> sts_assume_role_credentials_provider::update_credentials() {
+    if (role_arn.empty()) {
+        // unconfigured role: no-op instead of a doomed AssumeRole request
+        co_return;
+    }
     auto req = http::request::make("POST", sts_host, "/");
     // Just set this version
     // https://github.com/aws/aws-sdk-cpp/blob/8d68be52dcad85095753e069a4355e241f1edb1c/generated/src/aws-cpp-sdk-sts/source/model/AssumeRoleRequest.cpp#L143

--- a/utils/s3/credentials_providers/sts_assume_role_credentials_provider.hh
+++ b/utils/s3/credentials_providers/sts_assume_role_credentials_provider.hh
@@ -17,7 +17,7 @@ namespace aws {
 class sts_assume_role_credentials_provider final : public aws_credentials_provider {
 public:
     sts_assume_role_credentials_provider(const std::string& _host, unsigned _port, bool _is_secured,
-            retry_strategy_factory retry_factory); // For tests
+            retry_strategy_factory retry_factory, std::string _role_arn = "test-role-arn"); // For tests
     sts_assume_role_credentials_provider(const std::string& _region, const std::string& _role_arn);
     [[nodiscard]] const char* get_name() const override { return "sts_assume_role_credentials_provider"; }
 


### PR DESCRIPTION
## Motivation

`s3::client`'s constructor unconditionally adds an `sts_assume_role_credentials_provider` to the credential chain, without checking that `role_arn`/region are actually set - both default to empty strings when `iam_role_arn` is absent from `object_storage.yaml`, the common case for key-based or instance-profile setups.
With an empty region the provider builds the host `sts..amazonaws.com` and unconditionally POSTs `AssumeRole` with an empty `RoleArn`: a request that can never succeed.
It costs nothing when credentials resolve normally (the chain returns earlier), but when resolution is already failing, every refetch pays one extra doomed connection attempt, and the real reason gets buried at `debug` level while `error` shows a generic message.
This is an amplifier of the credential-fetch caching bug fixed in #31459 (SCYLLADB-4169) - it adds one more contributor to the cost that fix already addresses.

**Related finding (does not change the fix, changes the framing):** `sts_assume_role_credentials_provider.cc` never SigV4-signs the STS request it builds - no Authorization/signing header is added anywhere in that file.
Real AWS STS rejects an unsigned `AssumeRole` call, so this provider is non-functional against real AWS even once `role_arn`/region are configured - it currently only "works" against the mock in `test/boost/s3_test.cc`.
This means the guard below is a hygiene fix (stops wasted round-trips on an already-broken path), not a functionality fix.
Whether this provider belongs in the production credential chain at all is a separate question worth raising, out of scope here (?!)

## Changes

`sts_assume_role_credentials_provider::update_credentials()` now returns early when `role_arn` is empty, instead of a constructor-side guard - chosen specifically because it stays safe against a separate, pre-existing bug where `update_config_sync()` doesn't rebuild providers on a live config change (a constructor-side guard would permanently disable STS for a node that later configures `role_arn` at runtime).

## Tests

Converted the reproducer to a hermetic form against a mock STS server, asserting no request is issued when `role_arn` is empty. Also required a small change to the test-only 4-arg provider constructor (added a default `role_arn`) since existing tests relied on it leaving `role_arn` empty.

## Results

Full `s3_test.cc` suite: 41 passed, 0 failed.

## Note

Semantically amplifies #31459 (SCYLLADB-4169) - no file overlap, but reads best landed together with or just after it.
Separately (out of scope): when `iam_role_arn` is set but AWS region is unset with no `AWS_DEFAULT_REGION`, there's a pre-existing risk of constructing `std::string` from a `getenv()` call that can return `nullptr` - noted for awareness, not addressed here.

Fixes: https://scylladb.atlassian.net/browse/SCYLLADB-4174
Backport: no, I think it's a benign bug.
