### PR TITLE
Update seastar submodule

### DIFF
--- a/scylla-gdb.py
+++ b/scylla-gdb.py
@@ -2724,8 +2724,7 @@ class scylla_memory(gdb.Command):
         scylla_memory.print_replica_stats()
 
         gdb.write('Small pools:\n')
-        small_pools = cpu_mem['small_pools']
-        nr = small_pools['nr_small_pools']
+        nr, small_pools_a = scylla_small_objects.get_small_pools()
         gdb.write('{objsize:>5} {span_size:>6} {use_count:>10} {memory:>12} {unused:>12} {wasted_percent:>5}\n'
                   .format(objsize='objsz', span_size='spansz', use_count='usedobj', memory='memory',
                           unused='unused', wasted_percent='wst%'))
@@ -2733,7 +2732,7 @@ class scylla_memory(gdb.Command):
         sc = span_checker()
         free_object_size = gdb.parse_and_eval('sizeof(\'seastar::memory::free_object\')')
         for i in range(int(nr)):
-            sp = small_pools['_u']['a'][i]
+            sp = small_pools_a[i]
             object_size = int(sp['_object_size'])
             # Skip pools that are smaller than sizeof(free_object), they won't have any content
             if object_size < free_object_size:
@@ -5434,18 +5433,25 @@ class scylla_small_objects(gdb.Command):
         self._last_object_size = None
 
     @staticmethod
-    def get_object_sizes():
+    def get_small_pools():
         cpu_mem = thread_local_var('seastar::memory::cpu_mem')
         small_pools = cpu_mem['small_pools']
         nr = int(small_pools['nr_small_pools'])
-        return [int(small_pools['_u']['a'][i]['_object_size']) for i in range(nr)]
+        small_pools_a: list[dict] = []
+        try:
+            small_pools_a = small_pools['_pools']
+        except gdb.error:
+            small_pools_a = small_pools['_u']['a']
+        return nr, small_pools_a
+
+    @staticmethod
+    def get_object_sizes():
+        nr, small_pools_a = scylla_small_objects.get_small_pools()
+        return [int(small_pools_a[i]['_object_size']) for i in range(nr)]
 
     @staticmethod
     def find_small_pools(object_size):
-        cpu_mem = thread_local_var('seastar::memory::cpu_mem')
-        small_pools = cpu_mem['small_pools']
-        small_pools_a = small_pools['_u']['a']
-        nr = int(small_pools['nr_small_pools'])
+        nr, small_pools_a = scylla_small_objects.get_small_pools()
         return [small_pools_a[i]
                 for i in range(nr)
                 if int(small_pools_a[i]['_object_size']) == object_size]


### PR DESCRIPTION
* seastar 9135cbf4...23de3dcb (15):
  > Merge 'rpc: refuse to send on a stream connection once stream_close() has begun' from Benny Halevy
    rpc: document the stream shutdown contract
    rpc_test: reproduce a send racing stream_close()
    rpc: refuse to send on a stream connection once stream_close() has begun

Fixes https://scylladb.atlassian.net/browse/SCYLLADB-4034

  > Merge 'migrate fstream_test to coroutines' from Łukasz Kurowski
    tests: migrate fstream_test test_consume_skip_bytes to coroutines
    tests: migrate fstream_test pyramid tests to coroutines
  > thread: track context switches in the `ucontext` variant too
  > tests: migrate websocket_test helpers to coroutines
  > core: use a separate syscall thread for aio fallbacks
  > docs: fix broken links, invalid examples, and language issues
  > tests: migrate socket_on_close tests to coroutines
  > tests: migrate httpd_test test_transformer to coroutines
  > test: futures_test: add tests for when_all
  > Merge 'io_tester: fail on short I/O, and stop issuing requests that run off the end of the file' from Travis Downs
    io_tester: fail on short I/O
    io_tester: keep every request inside the file
  > Merge 'memory: modernize cpu_mem initialization' from Avi Kivity
    core/memory: remove get_cpu_mem()
    core/memory: constant-initialize cpu_mem
    core/memory: constant-initialize the small pool arrays
    core/memory: move small_pool constructor definition
    util/sampler: make sampler constant-initializable
    tests/unit/alloc_test: warm up per-thread state before measuring
  > cooking: pin the DPDK ingredient libdir to lib
  > core/reactor: add SIGFPE handler
  > docs: fix typo accross -> across
  > on_internal_error.hh: add missing include <cstdint>

* No backport required (nor applicable) for submodule updates