### PR TITLE
test: Clean up redundant cql_test_env accessors and access chains

### DIFF
--- a/test/boost/network_topology_strategy_test.cc
+++ b/test/boost/network_topology_strategy_test.cc
@@ -1042,7 +1042,7 @@ SEASTAR_TEST_CASE(test_rack_list_rejected_when_feature_not_enabled) {
     cfg.db_config->tablets_mode_for_new_keyspaces(db::tablets_mode_t::mode::enabled);
     cfg.disabled_features.insert("RACK_LIST_RF");
     return do_with_cql_env_thread([] (auto& e) {
-        auto& topo = e.shared_token_metadata().local().get()->get_topology();
+        auto& topo = e.local_token_metadata_ptr()->get_topology();
         auto loc = topo.get_location();
         auto create_stmt = fmt::format("CREATE KEYSPACE test WITH REPLICATION = {{'class': 'NetworkTopologyStrategy',"
                     " '{}': ['{}']}}", loc.dc, loc.rack);
@@ -1094,7 +1094,7 @@ SEASTAR_TEST_CASE(test_altering_to_numeric_forbidden) {
 SEASTAR_TEST_CASE(test_rack_list_rejected_when_using_vnodes) {
     auto cfg = cql_test_config();
     return do_with_cql_env_thread([] (auto& e) {
-        auto& topo = e.shared_token_metadata().local().get()->get_topology();
+        auto& topo = e.local_token_metadata_ptr()->get_topology();
         auto loc = topo.get_location();
         auto create_stmt = [&] (bool tablets) {
             return fmt::format("CREATE KEYSPACE abc WITH REPLICATION = {{'class': 'NetworkTopologyStrategy',"

--- a/test/boost/network_topology_strategy_test.cc
+++ b/test/boost/network_topology_strategy_test.cc
@@ -1042,7 +1042,7 @@ SEASTAR_TEST_CASE(test_rack_list_rejected_when_feature_not_enabled) {
     cfg.db_config->tablets_mode_for_new_keyspaces(db::tablets_mode_t::mode::enabled);
     cfg.disabled_features.insert("RACK_LIST_RF");
     return do_with_cql_env_thread([] (auto& e) {
-        auto& topo = e.get_shared_token_metadata().local().get()->get_topology();
+        auto& topo = e.shared_token_metadata().local().get()->get_topology();
         auto loc = topo.get_location();
         auto create_stmt = fmt::format("CREATE KEYSPACE test WITH REPLICATION = {{'class': 'NetworkTopologyStrategy',"
                     " '{}': ['{}']}}", loc.dc, loc.rack);
@@ -1094,7 +1094,7 @@ SEASTAR_TEST_CASE(test_altering_to_numeric_forbidden) {
 SEASTAR_TEST_CASE(test_rack_list_rejected_when_using_vnodes) {
     auto cfg = cql_test_config();
     return do_with_cql_env_thread([] (auto& e) {
-        auto& topo = e.get_shared_token_metadata().local().get()->get_topology();
+        auto& topo = e.shared_token_metadata().local().get()->get_topology();
         auto loc = topo.get_location();
         auto create_stmt = [&] (bool tablets) {
             return fmt::format("CREATE KEYSPACE abc WITH REPLICATION = {{'class': 'NetworkTopologyStrategy',"

--- a/test/boost/sstable_set_test.cc
+++ b/test/boost/sstable_set_test.cc
@@ -314,7 +314,7 @@ SEASTAR_TEST_CASE(test_sstable_set_fast_forward_by_cache_reader_simulation) {
 
 static future<> guarantee_all_tablet_replicas_on_shard0(cql_test_env& env) {
     auto& ss = env.get_storage_service().local();
-    auto& stm = env.get_shared_token_metadata().local();
+    auto& stm = env.shared_token_metadata().local();
     auto my_host_id = ss.get_token_metadata_ptr()->get_topology().my_host_id();
 
     co_await ss.set_tablet_balancing_enabled(false);
@@ -330,7 +330,7 @@ static void mutate_tablet_map(cql_test_env& env,
                               seastar::noncopyable_function<future<>(locator::tablet_map&)> updater) {
     seastar::abort_source as;
     auto guard = env.get_raft_group0_client().start_operation(as).get();
-    auto& stm = env.get_shared_token_metadata().local();
+    auto& stm = env.shared_token_metadata().local();
     stm.mutate_token_metadata([table, updater = std::move(updater)] (auto& tm) mutable -> future<> {
         return tm.tablets().mutate_tablet_map_async(table, std::move(updater));
     }).get();
@@ -523,7 +523,7 @@ SEASTAR_TEST_CASE(test_tablet_sstable_set_preserves_arbitrary_boundaries) {
         auto& sgm = column_family_test::get_storage_group_manager(table);
         std::ranges::sort(emitted_keys, dht::decorated_key::less_comparator(s));
 
-        auto original_tmap = env.get_shared_token_metadata().local().get()->tablets().get_tablet_map(s->id()).clone();
+        auto original_tmap = env.shared_token_metadata().local().get()->tablets().get_tablet_map(s->id()).clone();
         auto last_tokens = original_tmap.get_sorted_tokens().get();
         auto raw_last_tokens = last_tokens
                 | std::views::transform([] (dht::token t) { return dht::raw_token(t); })

--- a/test/boost/sstable_set_test.cc
+++ b/test/boost/sstable_set_test.cc
@@ -523,7 +523,7 @@ SEASTAR_TEST_CASE(test_tablet_sstable_set_preserves_arbitrary_boundaries) {
         auto& sgm = column_family_test::get_storage_group_manager(table);
         std::ranges::sort(emitted_keys, dht::decorated_key::less_comparator(s));
 
-        auto original_tmap = env.shared_token_metadata().local().get()->tablets().get_tablet_map(s->id()).clone();
+        auto original_tmap = env.local_token_metadata_ptr()->tablets().get_tablet_map(s->id()).clone();
         auto last_tokens = original_tmap.get_sorted_tokens().get();
         auto raw_last_tokens = last_tokens
                 | std::views::transform([] (dht::token t) { return dht::raw_token(t); })

--- a/test/boost/tablets_test.cc
+++ b/test/boost/tablets_test.cc
@@ -2267,7 +2267,7 @@ void rebalance_tablets(cql_test_env& e,
     shared_load_stats local_stats;
     if (!load_stats) {
         // Provide default capacity for each node.
-        e.shared_token_metadata().local().get()->get_topology().for_each_node([&] (const auto& node) {
+        e.local_token_metadata_ptr()->get_topology().for_each_node([&] (const auto& node) {
             local_stats.set_capacity(node.host_id(), default_target_tablet_size * node.get_shard_count());
         });
         load_stats = &local_stats;
@@ -3596,7 +3596,7 @@ SEASTAR_THREAD_TEST_CASE(test_load_sketch_uses_correct_disk_capacity) {
 
         auto& stm = e.shared_token_metadata().local();
 
-        locator::host_id local_host = e.shared_token_metadata().local().get()->get_my_id();
+        locator::host_id local_host = e.local_token_metadata_ptr()->get_my_id();
         locator::host_id host1 = topo.add_node(node_state::normal, 1);
 
         load_stats stats;
@@ -5023,7 +5023,7 @@ SEASTAR_THREAD_TEST_CASE(test_size_based_load_balancing_table_load) {
         std::vector<host_id> hosts;
 
         // Add disk capacity for the default node. Add all subsequent nodes to the same DC/rack
-        e.shared_token_metadata().local().get()->get_topology().for_each_node([&] (const auto& node) {
+        e.local_token_metadata_ptr()->get_topology().for_each_node([&] (const auto& node) {
             dc_rack = node.dc_rack();
             auto host = node.host_id();
             auto num_shards = node.get_shard_count();

--- a/test/boost/tablets_test.cc
+++ b/test/boost/tablets_test.cc
@@ -2015,8 +2015,7 @@ future<> apply_resize_plan(token_metadata& tm, const migration_plan& plan) {
 static
 future<group0_guard> save_token_metadata(cql_test_env& e, group0_guard guard,
         locator::tablet_metadata_change_hint hint = {}) {
-    auto& stm = e.shared_token_metadata().local();
-    auto tm = stm.get();
+    auto tm = e.local_token_metadata_ptr();
 
     e.get_topology_state_machine().local()._topology.version = tm->get_version();
 
@@ -2279,8 +2278,7 @@ void rebalance_tablets(cql_test_env& e,
     // We should not introduce inconsistency between on-disk state and in-memory state
     // as that may violate invariants and cause failures in later operations
     // causing test flakiness.
-    auto& stm = e.shared_token_metadata().local();
-    save_tablet_metadata(e.local_db(), stm.get()->tablets(), guard.write_timestamp()).get();
+    save_tablet_metadata(e.local_db(), e.local_token_metadata_ptr()->tablets(), guard.write_timestamp()).get();
     e.get_storage_service().local().update_tablet_metadata({}).get();
 
     testlog.debug("rebalance_tablets(): done");
@@ -3119,8 +3117,7 @@ alter_result alter_replication(cql_test_env& e,
                                table_id table,
                                replication_strategy_config_options alter_options)
 {
-    auto& stm = e.shared_token_metadata().local();
-    auto tmptr = stm.get();
+    auto tmptr = e.local_token_metadata_ptr();
     auto& old_tablets = tmptr->tablets().get_tablet_map(table);
     auto& ks = e.local_db().find_keyspace(ks_name);
     auto& rs = ks.get_replication_strategy();
@@ -3182,8 +3179,7 @@ SEASTAR_THREAD_TEST_CASE(test_replica_allocation_with_rack_list_rf) {
 
             rebalance_tablets(e);
 
-            auto& stm = e.shared_token_metadata().local();
-            auto tmptr = stm.get();
+            auto tmptr = e.local_token_metadata_ptr();
             auto& tm_topo = tmptr->get_topology();
 
             check_rack_list(tm_topo, tmptr->tablets().get_tablet_map(table1), dc1, dc1_racks, bad_nodes);
@@ -3203,8 +3199,7 @@ SEASTAR_THREAD_TEST_CASE(test_replica_allocation_with_rack_list_rf) {
 
             rebalance_tablets(e);
 
-            auto& stm = e.shared_token_metadata().local();
-            auto tmptr = stm.get();
+            auto tmptr = e.local_token_metadata_ptr();
             auto& tm_topo = tmptr->get_topology();
 
             check_rack_list(tm_topo, tmptr->tablets().get_tablet_map(table1), dc1, rack_list{}, bad_nodes);
@@ -3225,8 +3220,7 @@ SEASTAR_THREAD_TEST_CASE(test_replica_allocation_with_rack_list_rf) {
 
             rebalance_tablets(e);
 
-            auto& stm = e.shared_token_metadata().local();
-            auto tmptr = stm.get();
+            auto tmptr = e.local_token_metadata_ptr();
             auto& tm_topo = tmptr->get_topology();
 
             check_rack_list(tm_topo, tmptr->tablets().get_tablet_map(table1), dc1, rack_list{rack1.rack}, bad_nodes);
@@ -3302,8 +3296,7 @@ SEASTAR_THREAD_TEST_CASE(test_per_shard_count_respected_with_rack_list) {
 
         rebalance_tablets(e);
 
-        auto& stm = e.shared_token_metadata().local();
-        auto tmptr = stm.get();
+        auto tmptr = e.local_token_metadata_ptr();
         auto& tm_topo = tmptr->get_topology();
 
         // Check that we respect the 10 tablets/shard goal when using a subset of racks.
@@ -3460,8 +3453,7 @@ SEASTAR_THREAD_TEST_CASE(test_per_shard_goal_size_scaling_is_not_order_dependent
 
             rebalance_tablets(e, &load_stats);
 
-            auto& stm = e.shared_token_metadata().local();
-            large_tablet_count = stm.get()->tablets().get_tablet_map(large_table).tablet_count();
+            large_tablet_count = e.local_token_metadata_ptr()->tablets().get_tablet_map(large_table).tablet_count();
         }, std::move(cfg)).get();
 
         return large_tablet_count;
@@ -3960,8 +3952,7 @@ SEASTAR_THREAD_TEST_CASE(test_table_creation_during_decommission) {
         auto table1 = add_table(e, ks_name).get();
         auto s = e.local_db().find_schema(table1);
 
-        auto& stm = e.shared_token_metadata().local();
-        auto& tmap = stm.get()->tablets().get_tablet_map(table1);
+        auto& tmap = e.local_token_metadata_ptr()->tablets().get_tablet_map(table1);
 
         // Verify we do not treat leaving nodes as having capacity.
         BOOST_REQUIRE_EQUAL(tmap.tablet_count(), 2);
@@ -3993,8 +3984,7 @@ SEASTAR_THREAD_TEST_CASE(test_table_creation_during_rack_decommission) {
 
         rebalance_tablets(e);
 
-        auto& stm = e.shared_token_metadata().local();
-        auto& tmap = stm.get()->tablets().get_tablet_map(table1);
+        auto& tmap = e.local_token_metadata_ptr()->tablets().get_tablet_map(table1);
 
         tmap.for_each_tablet([&](auto tid, auto& tinfo) {
             for (auto& replica : tinfo.replicas) {
@@ -4141,8 +4131,7 @@ SEASTAR_THREAD_TEST_CASE(test_decommission_rack_load_failure) {
             co_return;
         });
 
-        auto& stm = e.shared_token_metadata().local();
-        topo.get_shared_load_stats().set_default_tablet_sizes(stm.get());
+        topo.get_shared_load_stats().set_default_tablet_sizes(e.local_token_metadata_ptr());
 
         BOOST_REQUIRE_THROW(rebalance_tablets(e, &topo.get_shared_load_stats()), std::runtime_error);
     }).get();
@@ -4174,8 +4163,7 @@ SEASTAR_THREAD_TEST_CASE(test_decommission_rf_not_met) {
             co_return;
         });
 
-        auto& stm = e.shared_token_metadata().local();
-        topo.get_shared_load_stats().set_default_tablet_sizes(stm.get());
+        topo.get_shared_load_stats().set_default_tablet_sizes(e.local_token_metadata_ptr());
 
         BOOST_REQUIRE_THROW(rebalance_tablets(e, &topo.get_shared_load_stats()), std::runtime_error);
     }).get();
@@ -4577,8 +4565,7 @@ SEASTAR_THREAD_TEST_CASE(test_plan_fails_when_removing_last_replica) {
         });
 
         std::unordered_set<host_id> skiplist = {host1};
-        auto& stm = e.shared_token_metadata().local();
-        topo.get_shared_load_stats().set_default_tablet_sizes(stm.get());
+        topo.get_shared_load_stats().set_default_tablet_sizes(e.local_token_metadata_ptr());
         BOOST_REQUIRE_THROW(rebalance_tablets(e, &topo.get_shared_load_stats(), skiplist), std::runtime_error);
     }).get();
 }
@@ -4975,8 +4962,7 @@ static table_id create_table_and_set_tablet_sizes(cql_test_env& e, topology_buil
     auto& load_stats = topo.get_shared_load_stats();
     load_stats.set_size(table, table_size_bytes);
 
-    auto& stm = e.shared_token_metadata().local();
-    auto& tmap = stm.get()->tablets().get_tablet_map(table);
+    auto& tmap = e.local_token_metadata_ptr()->tablets().get_tablet_map(table);
     tmap.for_each_tablet([&] (tablet_id tid, const tablet_info& tinfo) {
         auto replicas = tinfo.replicas;
         for (auto& r : tinfo.replicas) {
@@ -5183,8 +5169,7 @@ SEASTAR_THREAD_TEST_CASE(test_per_shard_goal_mixed_dc_rf) {
         rebalance_tablets(e);
 
         {
-            auto& stm = e.shared_token_metadata().local();
-            auto tm = stm.get();
+            auto tm = e.local_token_metadata_ptr();
             // When pow2_count is switched to false, 256 should be changed to 200.
             BOOST_REQUIRE_EQUAL(tm->tablets().get_tablet_map(table1).tablet_count(), 256);
             BOOST_REQUIRE_EQUAL(tm->tablets().get_tablet_map(table2).tablet_count(), 64);
@@ -6911,8 +6896,7 @@ SEASTAR_THREAD_TEST_CASE(test_ensure_node_for_load_sketch) {
         topo.set_node_state(host1, node_state::removing);
 
         auto& talloc = e.get_tablet_allocator().local();
-        auto& stm = e.shared_token_metadata().local();
-        talloc.balance_tablets(stm.get(), nullptr, nullptr, topo.get_shared_load_stats().get()).get();
+        talloc.balance_tablets(e.local_token_metadata_ptr(), nullptr, nullptr, topo.get_shared_load_stats().get()).get();
     }).get();
 }
 

--- a/test/boost/tablets_test.cc
+++ b/test/boost/tablets_test.cc
@@ -1653,7 +1653,7 @@ SEASTAR_TEST_CASE(test_sharder) {
 
         auto table1 = table_id(utils::UUID_gen::get_time_UUID());
 
-        token_metadata tokm(e.get_shared_token_metadata().local(), token_metadata::config{ .topo_cfg{ .this_host_id = h1, .local_dc_rack = locator::endpoint_dc_rack::default_location } });
+        token_metadata tokm(e.shared_token_metadata().local(), token_metadata::config{ .topo_cfg{ .this_host_id = h1, .local_dc_rack = locator::endpoint_dc_rack::default_location } });
         tokm.get_topology().add_or_update_endpoint(h1);
 
         std::vector<tablet_id> tablet_ids;

--- a/test/boost/tablets_test.cc
+++ b/test/boost/tablets_test.cc
@@ -2015,7 +2015,7 @@ future<> apply_resize_plan(token_metadata& tm, const migration_plan& plan) {
 static
 future<group0_guard> save_token_metadata(cql_test_env& e, group0_guard guard,
         locator::tablet_metadata_change_hint hint = {}) {
-    auto& stm = e.local_db().get_shared_token_metadata();
+    auto& stm = e.shared_token_metadata().local();
     auto tm = stm.get();
 
     e.get_topology_state_machine().local()._topology.version = tm->get_version();
@@ -2289,7 +2289,7 @@ void rebalance_tablets(cql_test_env& e,
 static
 void rebalance_tablets_as_in_progress(cql_test_env& env, shared_load_stats& stats,
                                       std::function<bool(const migration_plan&)> stop = nullptr) {
-    auto& stm = env.local_db().get_shared_token_metadata();
+    auto& stm = env.shared_token_metadata().local();
     auto& talloc = env.get_tablet_allocator().local();
     auto& topology = env.get_topology_state_machine().local()._topology;
     auto& sys_ks = env.get_system_keyspace().local();

--- a/test/boost/test_audit.cc
+++ b/test/boost/test_audit.cc
@@ -37,7 +37,7 @@ SEASTAR_TEST_CASE(test_audit_storage_stop_drains_in_flight_write) {
     cfg.db_config->audit_keyspaces("ks");
 
     return do_with_cql_env_thread([] (cql_test_env& env) {
-        audit::audit::start_audit(env.db_config(), env.get_shared_token_metadata(), env.qp(), env.migration_manager()).get();
+        audit::audit::start_audit(env.db_config(), env.shared_token_metadata(), env.qp(), env.migration_manager()).get();
         auto audit_stop = defer([] noexcept {
             audit::audit::stop_audit().get();
         });
@@ -89,7 +89,7 @@ SEASTAR_TEST_CASE(test_audit_storage_stop_rejects_late_write) {
     cfg.db_config->audit_keyspaces("ks");
 
     return do_with_cql_env_thread([] (cql_test_env& env) {
-        audit::audit::start_audit(env.db_config(), env.get_shared_token_metadata(), env.qp(), env.migration_manager()).get();
+        audit::audit::start_audit(env.db_config(), env.shared_token_metadata(), env.qp(), env.migration_manager()).get();
         auto audit_stop = defer([] noexcept {
             audit::audit::stop_audit().get();
         });
@@ -136,7 +136,7 @@ SEASTAR_TEST_CASE(test_audit_write_awaits_table_recovery) {
     cfg.db_config->audit_keyspaces("ks");
 
     return do_with_cql_env_thread([] (cql_test_env& env) {
-        audit::audit::start_audit(env.db_config(), env.get_shared_token_metadata(), env.qp(), env.migration_manager()).get();
+        audit::audit::start_audit(env.db_config(), env.shared_token_metadata(), env.qp(), env.migration_manager()).get();
         auto audit_stop = defer([] noexcept {
             audit::audit::stop_audit().get();
         });

--- a/test/boost/vnodes_to_tablets_migration_test.cc
+++ b/test/boost/vnodes_to_tablets_migration_test.cc
@@ -50,7 +50,7 @@ static future<> test_tablet_map_creation(std::vector<int64_t> tokens) {
 
         e.get_storage_service().local().prepare_for_tablets_migration(ks_name).get();
 
-        auto& stm = e.local_db().get_shared_token_metadata();
+        auto& stm = e.shared_token_metadata().local();
         auto& tmap = stm.get()->tablets().get_tablet_map(tid);
 
         // Collect actual tablet boundaries.
@@ -154,7 +154,7 @@ SEASTAR_TEST_CASE(test_tablet_map_creation_already_pow2_layout) {
 
         e.get_storage_service().local().prepare_for_tablets_migration(ks_name).get();
 
-        auto& stm = e.local_db().get_shared_token_metadata();
+        auto& stm = e.shared_token_metadata().local();
         auto& tmap = stm.get()->tablets().get_tablet_map(tid);
 
         BOOST_REQUIRE(tmap.get_layout() == locator::tablet_layout::pow_of_2);

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -449,10 +449,6 @@ public:
         return _task_manager;
     }
 
-    virtual sharded<locator::shared_token_metadata>& get_shared_token_metadata() override {
-        return _token_metadata;
-    }
-
     virtual sharded<service::topology_state_machine>& get_topology_state_machine() override {
         return _topology_state_machine;
     }

--- a/test/lib/cql_test_env.hh
+++ b/test/lib/cql_test_env.hh
@@ -213,8 +213,6 @@ public:
 
     virtual sharded<tasks::task_manager>& get_task_manager() = 0;
 
-    virtual sharded<locator::shared_token_metadata>& get_shared_token_metadata() = 0;
-
     virtual sharded<service::topology_state_machine>& get_topology_state_machine() = 0;
 
     data_dictionary::database data_dictionary();

--- a/test/lib/cql_test_env.hh
+++ b/test/lib/cql_test_env.hh
@@ -164,6 +164,12 @@ public:
 
     virtual sharded<locator::shared_token_metadata>& shared_token_metadata() = 0;
 
+    // Convenience wrapper for the most common shared_token_metadata() access
+    // pattern: grab a token_metadata_ptr for the current shard.
+    locator::token_metadata_ptr local_token_metadata_ptr() {
+        return shared_token_metadata().local().get();
+    }
+
     virtual cql3::query_processor& local_qp() = 0;
 
     virtual sharded<replica::database>& db() = 0;

--- a/test/lib/topology_builder.hh
+++ b/test/lib/topology_builder.hh
@@ -364,7 +364,7 @@ public:
 
     void add_draining_request(locator::host_id id) {
         modify_group0([&](service::group0_guard& guard, utils::chunked_vector<canonical_mutation>& muts) {
-            auto& topo = _env.local_db().get_shared_token_metadata().get()->get_topology();
+            auto& topo = _env.shared_token_metadata().local().get()->get_topology();
             auto req = topo.get_node(id).is_excluded() ? service::topology_request::remove : service::topology_request::leave;
 
             service::topology_mutation_builder builder(guard.write_timestamp());

--- a/test/lib/topology_builder.hh
+++ b/test/lib/topology_builder.hh
@@ -364,7 +364,7 @@ public:
 
     void add_draining_request(locator::host_id id) {
         modify_group0([&](service::group0_guard& guard, utils::chunked_vector<canonical_mutation>& muts) {
-            auto& topo = _env.shared_token_metadata().local().get()->get_topology();
+            auto& topo = _env.local_token_metadata_ptr()->get_topology();
             auto req = topo.get_node(id).is_excluded() ? service::topology_request::remove : service::topology_request::leave;
 
             service::topology_mutation_builder builder(guard.write_timestamp());

--- a/test/perf/perf_simple_query.cc
+++ b/test/perf/perf_simple_query.cc
@@ -515,7 +515,7 @@ int scylla_simple_query_main(int argc, char** argv) {
             cfg.bypass_cache = app.configuration().contains("bypass-cache");
             cfg.shard_aware = app.configuration()["shard-aware"].as<bool>();
             cfg.consistency_level = db::consistency_level_from_string(app.configuration()["consistency-level"].as<std::string>());
-            audit::audit::start_audit(env.local_db().get_config(), env.get_shared_token_metadata(), env.qp(), env.migration_manager()).handle_exception([&] (auto&& e) {
+            audit::audit::start_audit(env.local_db().get_config(), env.shared_token_metadata(), env.qp(), env.migration_manager()).handle_exception([&] (auto&& e) {
                 fmt::print("audit start failed: {}", e);
             }).get();
             audit::audit::start_storage(env.local_db().get_config()).get();

--- a/test/perf/perf_tablets.cc
+++ b/test/perf/perf_tablets.cc
@@ -176,7 +176,7 @@ static future<> test_basic_operations(app_template& app) {
 
         utils::chunked_vector<canonical_mutation> muts;
         auto time_to_read_muts = duration_in_seconds([&] {
-            replica::read_tablet_mutations(e.local_qp().proxy().get_db(), [&] (canonical_mutation m) {
+            replica::read_tablet_mutations(e.db(), [&] (canonical_mutation m) {
                 muts.emplace_back(m);
             }).get();
         });

--- a/test/perf/tablet_load_balancing.cc
+++ b/test/perf/tablet_load_balancing.cc
@@ -444,7 +444,7 @@ future<results> test_load_balancing_with_many_tables(params p, bool tablet_aware
 
                 // Allocate tablet sizes to nodes
                 for (auto& [table, tablet_sizes]: tablet_sizes_in_rack.at(rack)) {
-                    load_sketch load(e.shared_token_metadata().local().get(), make_lw_shared<locator::load_stats>(stats));
+                    load_sketch load(e.local_token_metadata_ptr(), make_lw_shared<locator::load_stats>(stats));
 
                     // Add nodes to load_sketch and to the nodes_used heap
                     std::vector<node_used_size> nodes_used;

--- a/test/vector_search/vector_store_client_test.cc
+++ b/test/vector_search/vector_store_client_test.cc
@@ -266,7 +266,7 @@ SEASTAR_TEST_CASE(vector_store_client_ann_test_disabled) {
     co_await do_with_cql_env([](cql_test_env& env) -> future<> {
         auto as = abort_source_timeout();
         auto schema = co_await create_test_table(env, "ks", "vs");
-        auto& vs = env.local_qp().vector_store_client();
+        auto& vs = env.vector_store_client().local();
 
         auto keys = co_await vs.ann("ks", "idx", schema, std::vector<float>{0.1, 0.2, 0.3}, 2, rjson::empty_object(), as.reset());
         BOOST_REQUIRE(!keys);
@@ -281,7 +281,7 @@ SEASTAR_TEST_CASE(vector_store_client_test_ann_addr_unavailable) {
             [](cql_test_env& env) -> future<> {
                 auto schema = co_await create_test_table(env, "ks", "vs");
                 auto as = abort_source_timeout();
-                auto& vs = env.local_qp().vector_store_client();
+                auto& vs = env.vector_store_client().local();
                 configure(vs)
                         .with_dns_refresh_interval(seconds(1))
                         .with_dns({{"bad.authority.here", std::nullopt}})
@@ -304,7 +304,7 @@ SEASTAR_TEST_CASE(vector_store_client_test_ann_service_unavailable) {
             [&server](cql_test_env& env) -> future<> {
                 auto schema = co_await create_test_table(env, "ks", "vs");
                 auto as = abort_source_timeout();
-                auto& vs = env.local_qp().vector_store_client();
+                auto& vs = env.vector_store_client().local();
                 configure(vs).with_dns_refresh_interval(seconds(1)).with_dns({{"good.authority.here", server->host()}});
 
                 vs.start_background_tasks();
@@ -327,7 +327,7 @@ SEASTAR_TEST_CASE(vector_store_client_test_ann_service_aborted) {
             [&server](cql_test_env& env) -> future<> {
                 auto schema = co_await create_test_table(env, "ks", "vs");
                 auto as = abort_source_timeout();
-                auto& vs = env.local_qp().vector_store_client();
+                auto& vs = env.vector_store_client().local();
                 configure(vs).with_dns_refresh_interval(milliseconds(10)).with_dns_resolver([&server](auto const& host) -> future<std::optional<inet_address>> {
                     BOOST_CHECK_EQUAL(host, "good.authority.here");
                     co_await sleep(milliseconds(100));
@@ -355,7 +355,7 @@ SEASTAR_TEST_CASE(vector_store_client_test_ann_request) {
             [&server](cql_test_env& env) -> future<> {
                 auto schema = co_await create_test_table(env, "ks", "idx");
                 auto as = abort_source_timeout();
-                auto& vs = env.local_qp().vector_store_client();
+                auto& vs = env.vector_store_client().local();
                 configure(vs).with_dns_refresh_interval(seconds(1)).with_dns({{"good.authority.here", "127.0.0.1"}});
 
                 vs.start_background_tasks();
@@ -435,7 +435,7 @@ SEASTAR_TEST_CASE(vector_store_client_test_filtering_ann_request) {
             [&server](cql_test_env& env) -> future<> {
                 auto schema = co_await create_test_table(env, "ks", "idx");
                 auto as = abort_source_timeout();
-                auto& vs = env.local_qp().vector_store_client();
+                auto& vs = env.vector_store_client().local();
                 configure(vs).with_dns_refresh_interval(seconds(1)).with_dns({{"good.authority.here", "127.0.0.1"}});
 
                 vs.start_background_tasks();
@@ -469,7 +469,7 @@ SEASTAR_TEST_CASE(vector_store_client_test_filtering_ann_cql) {
                 co_await env.execute_cql("CREATE CUSTOM INDEX embedding_idx ON ks.idx (embedding) USING 'vector_index'");
                 co_await env.execute_cql("INSERT INTO ks.idx (pk1, pk2, ck1, ck2, embedding) VALUES (5, 7, 9, 2, [0.1, 0.2, 0.3])");
 
-                auto& vs = env.local_qp().vector_store_client();
+                auto& vs = env.vector_store_client().local();
                 configure(vs).with_dns({{"good.authority.here", "127.0.0.1"}});
                 vs.start_background_tasks();
 
@@ -570,7 +570,7 @@ SEASTAR_TEST_CASE(vector_store_client_uri_update) {
             [&](cql_test_env& env) -> future<> {
                 auto as = abort_source_timeout();
                 auto schema = co_await create_test_table(env, "ks", "idx");
-                auto& vs = env.local_qp().vector_store_client();
+                auto& vs = env.vector_store_client().local();
                 constexpr auto DNS_REFRESH_INTERVAL = std::chrono::milliseconds(10);
                 configure(vs).with_dns_refresh_interval(DNS_REFRESH_INTERVAL).with_dns({{"good.authority.here", "127.0.0.1"}});
 
@@ -605,7 +605,7 @@ SEASTAR_TEST_CASE(vector_store_client_multiple_ips_high_availability) {
             [&](cql_test_env& env) -> future<> {
                 auto as = abort_source_timeout();
                 auto schema = co_await create_test_table(env, "ks", "idx");
-                auto& vs = env.local_qp().vector_store_client();
+                auto& vs = env.vector_store_client().local();
                 configure(vs).with_dns({{"good.authority.here", std::vector<std::string>{unavail_s->host(), responding_s->host()}}});
                 vs.start_background_tasks();
                 std::expected<vector_store_client::primary_keys, vector_store_client::ann_error> keys;
@@ -639,7 +639,7 @@ SEASTAR_TEST_CASE(vector_store_client_multiple_ips_load_balancing) {
             [&](cql_test_env& env) -> future<> {
                 auto as = abort_source_timeout();
                 auto schema = co_await create_test_table(env, "ks", "idx");
-                auto& vs = env.local_qp().vector_store_client();
+                auto& vs = env.vector_store_client().local();
                 configure(vs).with_dns({{"good.authority.here", std::vector<std::string>{s1->host(), s2->host()}}});
                 vs.start_background_tasks();
 
@@ -670,7 +670,7 @@ SEASTAR_TEST_CASE(vector_store_client_multiple_uris_high_availability) {
             [&](cql_test_env& env) -> future<> {
                 auto as = abort_source_timeout();
                 auto schema = co_await create_test_table(env, "ks", "idx");
-                auto& vs = env.local_qp().vector_store_client();
+                auto& vs = env.vector_store_client().local();
                 configure(vs).with_dns({{"s1.node", std::vector<std::string>{unavail_s->host()}}, {"s2.node", std::vector<std::string>{responding_s->host()}}});
                 vs.start_background_tasks();
                 std::expected<vector_store_client::primary_keys, vector_store_client::ann_error> keys;
@@ -704,7 +704,7 @@ SEASTAR_TEST_CASE(vector_store_client_multiple_uris_load_balancing) {
             [&](cql_test_env& env) -> future<> {
                 auto as = abort_source_timeout();
                 auto schema = co_await create_test_table(env, "ks", "idx");
-                auto& vs = env.local_qp().vector_store_client();
+                auto& vs = env.vector_store_client().local();
                 configure(vs).with_dns({{"s1.node", std::vector<std::string>{s1->host()}}, {"s2.node", std::vector<std::string>{s2->host()}}});
                 vs.start_background_tasks();
 
@@ -734,7 +734,7 @@ SEASTAR_TEST_CASE(vector_search_metrics_test) {
                 auto schema = co_await create_test_table(env, "ks", "test");
                 auto result = co_await env.execute_cql("CREATE CUSTOM INDEX idx ON ks.test (embedding) USING 'vector_index'");
                 result.get()->throw_if_exception();
-                auto& vs = env.local_qp().vector_store_client();
+                auto& vs = env.vector_store_client().local();
                 configure{vs};
                 vs.start_background_tasks();
 
@@ -757,7 +757,7 @@ SEASTAR_TEST_CASE(vector_store_client_node_recovery_after_backoff) {
             [&](cql_test_env& env) -> future<> {
                 auto as = abort_source_timeout();
                 auto schema = co_await create_test_table(env, "ks", "idx");
-                auto& vs = env.local_qp().vector_store_client();
+                auto& vs = env.vector_store_client().local();
                 configure(vs).with_dns({{HOSTNAME, std::vector<std::string>{unavail_server->host()}}});
                 vs.start_background_tasks();
 
@@ -799,7 +799,7 @@ SEASTAR_TEST_CASE(vector_store_client_single_status_check_after_concurrent_failu
                 constexpr auto NUM_OF_PARALLEL_REQUESTS = 50;
                 auto as = abort_source_timeout();
                 auto schema = co_await create_test_table(env, "ks", "idx");
-                auto& vs = env.local_qp().vector_store_client();
+                auto& vs = env.vector_store_client().local();
                 configure(vs).with_dns({{"unavail.node", std::vector<std::string>{unavail_s->host()}}});
                 vs.start_background_tasks();
 
@@ -839,7 +839,7 @@ SEASTAR_TEST_CASE(vector_store_client_updates_backoff_max_time_from_read_connect
             [&](cql_test_env& env) -> future<> {
                 auto as = abort_source_timeout();
                 auto schema = co_await create_test_table(env, "ks", "idx");
-                auto& vs = env.local_qp().vector_store_client();
+                auto& vs = env.vector_store_client().local();
                 configure(vs).with_dns({{"unavail.node", std::vector<std::string>{unavail_s->host()}}});
                 vs.start_background_tasks();
 
@@ -887,7 +887,7 @@ SEASTAR_TEST_CASE(vector_store_client_secondary_uri) {
             [&](cql_test_env& env) -> future<> {
                 auto as = abort_source_timeout();
                 auto schema = co_await create_test_table(env, "ks", "idx");
-                auto& vs = env.local_qp().vector_store_client();
+                auto& vs = env.vector_store_client().local();
                 configure(vs).with_dns(
                         {{"primary.node", std::vector<std::string>{primary->host()}}, {"secondary.node", std::vector<std::string>{secondary->host()}}});
                 vs.start_background_tasks();
@@ -911,7 +911,7 @@ SEASTAR_TEST_CASE(vector_store_client_secondary_uri_only) {
             [&](cql_test_env& env) -> future<> {
                 auto as = abort_source_timeout();
                 auto schema = co_await create_test_table(env, "ks", "idx");
-                auto& vs = env.local_qp().vector_store_client();
+                auto& vs = env.vector_store_client().local();
                 configure(vs).with_dns({{"secondary.node", std::vector<std::string>{secondary->host()}}});
                 vs.start_background_tasks();
 
@@ -935,7 +935,7 @@ SEASTAR_TEST_CASE(vector_store_client_https) {
             [&](cql_test_env& env) -> future<> {
                 auto as = abort_source_timeout();
                 auto schema = co_await create_test_table(env, "ks", "idx");
-                auto& vs = env.local_qp().vector_store_client();
+                auto& vs = env.vector_store_client().local();
                 configure(vs).with_dns({{certs.server_cert_cn(), std::vector<std::string>{server->host()}}});
                 vs.start_background_tasks();
 
@@ -1017,7 +1017,7 @@ SEASTAR_TEST_CASE(vector_store_client_https_wrong_hostname) {
             [&](cql_test_env& env) -> future<> {
                 auto as = abort_source_timeout();
                 auto schema = co_await create_test_table(env, "ks", "idx");
-                auto& vs = env.local_qp().vector_store_client();
+                auto& vs = env.vector_store_client().local();
                 configure(vs).with_dns({{hostname, std::vector<std::string>{server->host()}}});
                 vs.start_background_tasks();
 
@@ -1043,7 +1043,7 @@ SEASTAR_TEST_CASE(vector_store_client_https_wrong_cacert_verification_error) {
             [&](cql_test_env& env) -> future<> {
                 auto as = abort_source_timeout();
                 auto schema = co_await create_test_table(env, "ks", "idx");
-                auto& vs = env.local_qp().vector_store_client();
+                auto& vs = env.vector_store_client().local();
                 configure(vs).with_dns({{certs.server_cert_cn(), std::vector<std::string>{server->host()}}});
                 vs.start_background_tasks();
 
@@ -1070,7 +1070,7 @@ SEASTAR_TEST_CASE(vector_store_client_https_wrong_cacert_verification_error_host
             [&](cql_test_env& env) -> future<> {
                 auto as = abort_source_timeout();
                 auto schema = co_await create_test_table(env, "ks", "idx");
-                auto& vs = env.local_qp().vector_store_client();
+                auto& vs = env.vector_store_client().local();
                 configure(vs).with_dns({{server->host(), std::vector<std::string>{server->host()}}});
                 vs.start_background_tasks();
 
@@ -1099,7 +1099,7 @@ SEASTAR_TEST_CASE(vector_store_client_high_availability_unreachable) {
     co_await do_with_cql_env(
             [&](cql_test_env& env) -> future<> {
                 auto schema = co_await create_test_table(env, "ks", "test");
-                auto& vs = env.local_qp().vector_store_client();
+                auto& vs = env.vector_store_client().local();
                 configure(vs).with_dns(
                         {{"unreachable.node", std::vector<std::string>{unreachable.host}}, {"server.node", std::vector<std::string>{server->host()}}});
                 vs.start_background_tasks();
@@ -1132,7 +1132,7 @@ SEASTAR_TEST_CASE(vector_store_client_abort_due_to_query_timeout) {
     co_await do_with_cql_env(
             [&](cql_test_env& env) -> future<> {
                 auto schema = co_await create_test_table(env, "ks", "test");
-                auto& vs = env.local_qp().vector_store_client();
+                auto& vs = env.vector_store_client().local();
                 configure(vs).with_dns({{"server.node", std::vector<std::string>{server->host()}}});
                 vs.start_background_tasks();
                 auto result = co_await env.execute_cql("CREATE CUSTOM INDEX idx ON ks.test (embedding) USING 'vector_index'");


### PR DESCRIPTION
\`cql_test_env\` had accumulated redundant ways to reach the same objects — duplicate accessor methods for one, and tests reaching services through longer detours than the direct accessor already available on the env for another. This cleans those up and adds a convenience accessor for the single most common access pattern.

Improving testing facilities, not backporting