### PR TITLE
test/pylib/rest_client: check build mode to fail tests with error injections in release mode

### DIFF
--- a/test/cluster/conftest.py
+++ b/test/cluster/conftest.py
@@ -77,6 +77,7 @@ def pytest_addoption(parser):
 
 @pytest.fixture(scope="module")
 async def _scylla_cluster_manager(request: pytest.FixtureRequest,
+                                  build_mode: str,
                                   suite_log_dir: Path,
                                   testpy_cluster_factory: ClusterFactory,
                                   testpy_uname: str) -> AsyncGenerator[ScyllaClusterManager]:
@@ -106,6 +107,7 @@ async def _scylla_cluster_manager(request: pytest.FixtureRequest,
             port=int(request.config.getoption('port')),
             use_ssl=bool(request.config.getoption('ssl')),
             auth_provider=auth_provider,
+            build_mode=build_mode,
         )
         try:
             await mgr.start()

--- a/test/pylib/rest_client.py
+++ b/test/pylib/rest_client.py
@@ -146,8 +146,13 @@ class TCPRESTClient(RESTClient):
 class ScyllaRESTAPIClient:
     """Async Scylla REST API client"""
 
-    def __init__(self, port: int = 10000):
+    def __init__(self, port: int = 10000, build_mode: str | None = None):
         self.client = TCPRESTClient(port)
+        # The build mode of the server this client talks to, or None when whoever
+        # created the client did not know it. A cluster test always reaches its
+        # servers through a client that knows the mode. Other clients, such as the
+        # one nodetool builds at import time, are created without it.
+        self.build_mode = build_mode
 
     async def get_host_id(self, server_ip: IPAddress) -> HostID:
         """Get server id (UUID)"""
@@ -241,6 +246,17 @@ class ScyllaRESTAPIClient:
         )
         assert isinstance(data, list)
         return data
+
+    def _fail_if_injections_unavailable(self, injection: str) -> None:
+        """Fail the test if error injections are compiled out, i.e. in release mode.
+
+           Does nothing when the client was not told the build mode, since then
+           there is nothing to check against.
+        """
+        if self.build_mode == "release":
+            pytest.fail(f"The error injection {injection} cannot be enabled because error "
+                        "injections are disabled in release mode, so the test must be marked "
+                        "with skip_mode(mode='release')")
 
     async def enable_injection(self, node_ip: str, injection: str, one_shot: bool, parameters: dict[str, Any] = {}) -> None:
         """Enable error injection named `injection` on `node_ip`. Depending on `one_shot`,
@@ -803,20 +819,21 @@ class InjectionHandler():
 async def inject_error(api: ScyllaRESTAPIClient, node_ip: IPAddress, injection: str,
                        parameters: dict[str, Any] = {}) -> AsyncIterator[InjectionHandler]:
     """Attempts to inject an error. Works only in specific build modes: debug,dev,sanitize.
-       It will fail a test if attempting to enable an injection has no effect.
+       It will fail a test that asks for an injection in release mode.
        Intended for suites that start their own Scylla (e.g. cluster), so the build mode
        is known. Suites that can run against a foreign server (e.g. cqlpy) should keep
        their own skipping helper.
        This is a context manager for enabling and disabling when done, therefore it can't be
        used for one shot.
     """
+    api._fail_if_injections_unavailable(injection)
     await api.enable_injection(node_ip, injection, False, parameters)
     enabled = await api.get_enabled_injections(node_ip)
     logging.info(f"Error injections enabled on {node_ip}: {enabled}")
+    # Sanity check for non-release modes.
     if injection not in enabled:
-        pytest.fail(f"Failed to enable the error injection {injection}. Error injections are "
-                    "disabled in release mode, so the test must be marked with "
-                    "skip_mode(mode='release')")
+        pytest.fail(f"Enabling the error injection {injection} on {node_ip} had no effect. "
+                    f"Error injections enabled on the node: {enabled}")
     try:
         yield InjectionHandler(api, injection, node_ip)
     finally:
@@ -826,19 +843,17 @@ async def inject_error(api: ScyllaRESTAPIClient, node_ip: IPAddress, injection: 
 
 async def inject_error_one_shot(api: ScyllaRESTAPIClient, node_ip: IPAddress, injection: str, parameters: dict[str, Any] = {}) -> InjectionHandler:
     """Attempts to inject an error. Works only in specific build modes: debug,dev,sanitize.
-       It will fail a test if attempting to enable an injection has no effect.
+       It will fail a test that asks for an injection in release mode.
        Intended for suites that start their own Scylla (e.g. cluster), so the build mode
        is known. Suites that can run against a foreign server (e.g. cqlpy) should keep
        their own skipping helper.
        This is a one-shot injection enable.
     """
+    api._fail_if_injections_unavailable(injection)
+    logger.info(f"Enabling one-shot error injection {injection} on {node_ip}")
     await api.enable_injection(node_ip, injection, True, parameters)
-    enabled = await api.get_enabled_injections(node_ip)
-    logging.info(f"Error injections enabled on {node_ip}: {enabled}")
-    if injection not in enabled:
-        pytest.fail(f"Failed to enable the error injection {injection}. Error injections are "
-                    "disabled in release mode, so the test must be marked with "
-                    "skip_mode(mode='release')")
+    # We can't do the sanity check from inject_error here because the one-shot
+    # injection might be entered and disabled at this point.
     return InjectionHandler(api, injection, node_ip)
 
 

--- a/test/pylib/scylla_cluster.py
+++ b/test/pylib/scylla_cluster.py
@@ -110,7 +110,7 @@ class ScyllaCluster:
         self.is_dirty: bool = False
         self.start_exception: Optional[Exception] = None
         self.keyspace_count = 0
-        self.api = ScyllaRESTAPIClient()
+        self.api = ScyllaRESTAPIClient(build_mode=self.mode)
         self.stop_lock = asyncio.Lock()
         # Cleanups a test registered through ScyllaClusterManager.add_teardown_callback(),
         # as (callback, name) pairs.  They are fired by run_teardown_callbacks()

--- a/test/pylib/scylla_cluster_manager.py
+++ b/test/pylib/scylla_cluster_manager.py
@@ -222,6 +222,7 @@ class ScyllaClusterManager:
         port: CQL port for driver connections
         use_ssl: use SSL for driver connections
         auth_provider: authentication provider for driver connections
+        build_mode: build mode of the Scylla servers, or None if unknown
     """
     # Per test, created by before_test() and removed by after_test().
     test_case_log_file: pathlib.Path
@@ -233,7 +234,8 @@ class ScyllaClusterManager:
                  base_dir: str,
                  port: int,
                  use_ssl: bool,
-                 auth_provider: Any | None) -> None:
+                 auth_provider: Any | None,
+                 build_mode: str | None = None) -> None:
         # The manager must be constructed on its own, always-running loop:
         # its operations run there (see manager_op), whichever loop or thread
         # they are called from.
@@ -258,7 +260,7 @@ class ScyllaClusterManager:
         # The suite's provider, restored per test: tests override
         # self.auth_provider to connect as someone else.
         self._suite_auth_provider = auth_provider
-        self.api = ScyllaRESTAPIClient()
+        self.api = ScyllaRESTAPIClient(build_mode=build_mode)
         self.metrics = ScyllaMetricsClient()
         self.thread_pool = ThreadPoolExecutor()
 


### PR DESCRIPTION
inject_error and inject_error_one_shot enable an injection and then read
the enabled set back to check if the error injection was enabled. That
logic is incorrect for inject_error_one_shot. A one-shot injection might
be entered and disabled before reading the enabled set. This has been
causing spurious test skips in non-release build modes for several
years, and now it's causing spurious test failures because we've just
merged commit 1d07247230 ("test/pylib/rest_client: fail instead of
skipping when an error injection can't be enabled").

We fix this issue by checking the build mode directly in
inject_error_one_shot. We do the same in inject_error for consistency.
ScyllaRESTAPIClient now carries the build mode of the server it talks
to, handed to it by the fixture that creates the cluster manager.

We keep the old check in inject_error as a sanity check to make sure we
notice a case where an error injection is really not enabled in
non-release mode.

Fixes: SCYLLADB-4222

No backport, the issue is only in master.