### PR TITLE
sstables: fix refresh deleting sstables another shard is still creating

### DIFF
--- a/replica/distributed_loader.cc
+++ b/replica/distributed_loader.cc
@@ -77,6 +77,14 @@ distributed_loader::process_sstable_dir(sharded<sstables::sstable_directory>& di
         co_await d.prepare(flags);
     });
 
+    // The directory listing must complete on all shards before any shard starts
+    // processing what it found. process_sstable_dir() creates and removes files in
+    // the very directory being listed -- e.g. when mutating the SSTable level, which
+    // hard-links the SSTable into a new generation -- and a shard that lists another
+    // shard's in-flight SSTable takes ownership of it and schedules its components
+    // for removal.
+    co_await dir.invoke_on_all(&sstables::sstable_directory::scan_sstable_dir);
+
     co_await dir.invoke_on_all([&dir, flags] (sstables::sstable_directory& d) -> future<> {
         // Supposed to be called with the node either down or on behalf of maintenance tasks
         // like nodetool refresh

--- a/sstables/sstable_directory.cc
+++ b/sstables/sstable_directory.cc
@@ -344,14 +344,18 @@ future<> sstable_directory::process_sstable_dir(process_flags flags) {
     return _lister->process(*this, flags);
 }
 
-future<> sstable_directory::filesystem_components_lister::process(sstable_directory& directory, process_flags flags) {
+future<> sstable_directory::scan_sstable_dir() {
+    return _lister->scan(*this);
+}
+
+future<> sstable_directory::filesystem_components_lister::scan(sstable_directory& directory) {
     if (directory._state == sstable_state::quarantine) {
         if (!co_await file_exists(_directory.native())) {
             co_return;
         }
     }
 
-    dirlog.debug("Start processing directory {} for SSTables", _directory);
+    dirlog.debug("Start scanning directory {} for SSTables", _directory);
     // It seems wasteful that each shard is repeating this scan, and to some extent it is.
     // However, we still want to open the files and especially call process_dir() in a distributed
     // fashion not to overload any shard. Also in the common case the SSTables will all be
@@ -396,8 +400,12 @@ future<> sstable_directory::filesystem_components_lister::process(sstable_direct
         _state->descriptors.erase(desc.generation);
     }
 
-    auto msg = format("After {} scanned, {} descriptors found, {} different files found",
+    dirlog.debug("After {} scanned, {} descriptors found, {} different files found",
             _directory, _state->descriptors.size(), _state->generations_found.size());
+}
+
+future<> sstable_directory::filesystem_components_lister::process(sstable_directory& directory, process_flags flags) {
+    dirlog.debug("Start processing directory {} for SSTables", _directory);
 
     // _descriptors is everything with a TOC. So after we remove this, what's left is
     // SSTables for which a TOC was not found.
@@ -424,6 +432,12 @@ future<> sstable_directory::filesystem_components_lister::process(sstable_direct
     }
 }
 
+future<> sstable_directory::sstables_registry_components_lister::scan(sstable_directory& directory) {
+    // Nothing to scan: the components are enumerated from the sstables registry
+    // by process() below, not from a directory that process() also writes to.
+    return make_ready_future<>();
+}
+
 future<> sstable_directory::sstables_registry_components_lister::process(sstable_directory& directory, process_flags flags) {
     dirlog.debug("Start processing registry entry {}.{} (state {})", _table_id, _node_owner, directory._state);
     return _sstables_registry.sstables_registry_list(_table_id, _node_owner, [this, flags, &directory] (sstring status, sstable_state state, entry_descriptor desc) {
@@ -442,6 +456,11 @@ future<> sstable_directory::sstables_registry_components_lister::process(sstable
         return directory.process_descriptor(std::move(desc), flags,
                                             [&directory] { return *directory._storage_opts; });
     });
+}
+
+future<> sstable_directory::restore_components_lister::scan(sstable_directory& directory) {
+    // Nothing to scan: the components to process are given upfront in _toc_filenames.
+    return make_ready_future<>();
 }
 
 future<> sstable_directory::restore_components_lister::process(sstable_directory& directory, process_flags flags) {

--- a/sstables/sstable_directory.cc
+++ b/sstables/sstable_directory.cc
@@ -23,6 +23,7 @@
 #include "sstable_directory.hh"
 #include "utils/assert.hh"
 #include "utils/lister.hh"
+#include "utils/error_injection.hh"
 #include "utils/overloaded_functor.hh"
 #include "utils/directories.hh"
 #include "utils/s3/client.hh"
@@ -355,6 +356,18 @@ future<> sstable_directory::filesystem_components_lister::scan(sstable_directory
         }
     }
 
+    static const auto* injection_name = "sstable_directory_pause_scan";
+    co_await utils::get_local_injector().inject(injection_name, [] (auto& handler) -> future<> {
+        // Only park the shard the test asked for, so that the other shards can go
+        // on and process what they found while this one is still listing.
+        if (std::atoll(handler.get("shard")->data()) != this_shard_id()) {
+            co_return;
+        }
+        dirlog.info("{}: hit", injection_name);
+        co_await handler.wait_for_message(std::chrono::steady_clock::now() + std::chrono::minutes{5});
+        dirlog.info("{}: continue", injection_name);
+    });
+
     dirlog.debug("Start scanning directory {} for SSTables", _directory);
     // It seems wasteful that each shard is repeating this scan, and to some extent it is.
     // However, we still want to open the files and especially call process_dir() in a distributed
@@ -402,6 +415,9 @@ future<> sstable_directory::filesystem_components_lister::scan(sstable_directory
 
     dirlog.debug("After {} scanned, {} descriptors found, {} different files found",
             _directory, _state->descriptors.size(), _state->generations_found.size());
+
+    // Lets tests wait until the listing is over on every shard.
+    utils::get_local_injector().inject("sstable_directory_scan_done", [] { });
 }
 
 future<> sstable_directory::filesystem_components_lister::process(sstable_directory& directory, process_flags flags) {

--- a/sstables/sstable_directory.hh
+++ b/sstables/sstable_directory.hh
@@ -89,6 +89,12 @@ public:
 
     class components_lister {
     public:
+        /// enumerate the SSTable components found in the underlying storage
+        ///
+        /// Must complete on all shards before any shard calls process(), which
+        /// creates and removes files in the very storage being enumerated.
+        virtual future<> scan(sstable_directory& directory) = 0;
+
         /// process all SSTable components found by the lister
         ///
         /// @li process all the listed valid TOC components with the given @c directory
@@ -134,6 +140,7 @@ public:
         filesystem_components_lister(std::filesystem::path dir);
         filesystem_components_lister(std::filesystem::path dir, sstables_manager&, const data_dictionary::storage_options::object_storage&);
 
+        virtual future<> scan(sstable_directory& directory) override;
         virtual future<> process(sstable_directory& directory, process_flags flags) override;
         virtual future<> commit() override;
         virtual future<> prepare(sstable_directory&, process_flags, storage&) override;
@@ -149,6 +156,7 @@ public:
     public:
         sstables_registry_components_lister(sstables::sstables_registry& sstables_registry, table_id tid, locator::host_id node_owner);
 
+        virtual future<> scan(sstable_directory& directory) override;
         virtual future<> process(sstable_directory& directory, process_flags flags) override;
         virtual future<> commit() override;
         virtual future<> prepare(sstable_directory&, process_flags, storage&) override;
@@ -158,6 +166,7 @@ public:
         std::vector<sstring> _toc_filenames;
     public:
         restore_components_lister(const data_dictionary::storage_options::value_type& options, std::vector<sstring> toc_filenames);
+        virtual future<> scan(sstable_directory& directory) override;
         virtual future<> process(sstable_directory& directory, process_flags flags) override;
         virtual future<> commit() override;
         virtual future<> prepare(sstable_directory&, process_flags, storage&) override;
@@ -270,7 +279,19 @@ public:
     // This function doesn't change on-storage state. If files are to be removed, a separate call
     // (commit_file_removals()) has to be issued. This is to make sure that all instances of this
     // class in a sharded service have the opportunity to validate its files.
+    //
+    // scan_sstable_dir() must have completed on all instances of this class in a sharded
+    // service before this is called on any of them. See scan_sstable_dir() below.
     future<> process_sstable_dir(process_flags flags);
+
+    // Enumerates the directory, recording the SSTable components found in it.
+    //
+    // This is a separate step from process_sstable_dir() because the latter creates and
+    // removes files in this very directory (e.g. when mutating the SSTable level), while
+    // the generation-based sharding of the listing means every shard lists every file.
+    // A shard that lists another shard's in-flight SSTable would take ownership of it and
+    // schedule its components for removal.
+    future<> scan_sstable_dir();
 
     // If files were scheduled to be removed, they will be removed after this call.
     future<> commit_directory_changes();

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -1709,6 +1709,12 @@ future<shared_sstable> sstable::link_with_rewritten_component(std::function<shar
 
         std::unordered_set<component_type> excluded_components = {component, component_type::Scylla};
         _storage->link_with_excluded_components(*this, generation, excluded_components, *sid).get();
+
+        // The destination sstable is fully linked but not sealed yet: it has a
+        // TemporaryTOC and no TOC. Let tests hold the directory in that state.
+        utils::get_local_injector().inject("pause_sstable_component_rewrite",
+                utils::wait_for_message(std::chrono::minutes{5})).get();
+
         new_sst->copy_components(*this).get();
 
         new_sst->_metadata_size_on_disk = _metadata_size_on_disk;

--- a/test/cluster/test_refresh.py
+++ b/test/cluster/test_refresh.py
@@ -6,6 +6,7 @@
 
 #!/usr/bin/env python3
 
+import contextlib
 import os
 import glob
 import logging
@@ -268,3 +269,119 @@ async def test_refresh_generates_view_updates(manager: ScyllaClusterManager, tab
             await wait_for_row_count_on_host(cql, host, ks, cf, expected_rows)
             await wait_for_row_count_on_host(cql, host, ks, mv, expected_rows)
             await wait_for_row_count_on_host(cql, host, ks, f'{idx}_index', expected_rows)
+
+
+@pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
+async def test_refresh_does_not_claim_sstables_created_by_another_shard(manager: ScyllaClusterManager):
+    '''
+    A regular refresh mutates the level of every uploaded sstable, which hard-links
+    it into a new generation in the very upload directory that all shards are
+    listing.  Generations carry no shard affinity, so a shard whose listing is
+    still running can claim another shard's in-flight sstable and schedule all of
+    its components for removal.
+
+    Park shard 1 at the beginning of its listing and shard 0 in the middle of its
+    rewrites, so that shard 1 gets to list a directory full of unsealed sstables
+    belonging to shard 0, and check that the refresh still succeeds.
+
+    Tablets are disabled on purpose: with tablets, refresh is auto-promoted to
+    load-and-stream, which does not mutate the sstable level and so never writes
+    into the directory being listed.
+    '''
+    pause_scan = 'sstable_directory_pause_scan'
+    scan_done = 'sstable_directory_scan_done'
+    pause_rewrite = 'pause_sstable_component_rewrite'
+    cf = 'cf'
+    # A high loading concurrency keeps many rewrites in flight, and thus many
+    # unsealed sstables in the upload directory, when shard 0 parks.
+    server = await manager.server_add(cmdline=['--smp=2'],
+                                      config={'initial_sstable_loading_concurrency': 16})
+    cql = manager.get_cql()
+
+    async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', "
+                                          "'replication_factor': 1} AND tablets = {'enabled': false}") as ks:
+        # Leveled compaction with a tiny sstable size, so that the data ends up in
+        # many sstables above level 0.  Level 0 sstables are not rewritten, and the
+        # more of them are rewritten the likelier shard 1 is to claim one.
+        await cql.run_async(f"CREATE TABLE {ks}.{cf} (pk int PRIMARY KEY, value blob) WITH compaction = "
+                            "{'class': 'LeveledCompactionStrategy', 'sstable_size_in_mb': 1}")
+        insert_stmt = cql.prepare(f"INSERT INTO {ks}.{cf} (pk, value) VALUES (?, ?)")
+        keys = range(16384)
+        for begin in range(0, len(keys), 1024):
+            await asyncio.gather(*(cql.run_async(insert_stmt, (k, random.randbytes(1024)))
+                                   for k in keys[begin:begin + 1024]))
+            await manager.api.keyspace_flush(server.ip_addr, ks, cf)
+        await manager.api.keyspace_compaction(server.ip_addr, ks, cf)
+
+        async def sstable_levels():
+            info = await manager.api.get_sstable_info(server.ip_addr, ks, cf)
+            return [sst['level'] for entry in info for sst in entry['sstables']]
+
+        async def enough_sstables_above_level_zero():
+            return True if len([l for l in await sstable_levels() if l > 0]) >= 8 else None
+        await wait_for(enough_sstables_above_level_zero, time.time() + 60)
+
+        # Freeze the sstable set: leveled compaction keeps running in the
+        # background, and what is checked here has to be what gets snapshotted.
+        await manager.api.disable_autocompaction(server.ip_addr, ks, cf)
+        levels = await sstable_levels()
+        logger.info(f'SSTable levels: {levels}')
+        # Only sstables above level 0 are rewritten by refresh, so without them
+        # the test would not exercise anything.
+        assert len([l for l in levels if l > 0]) >= 8, f'expected sstables above level 0, got {levels}'
+
+        workdir = await manager.server_get_workdir(server.server_id)
+        cf_dir = os.path.join(f'{workdir}/data/{ks}', os.listdir(f'{workdir}/data/{ks}')[0])
+        upload_dir = os.path.join(cf_dir, 'upload')
+
+        snap_name, _ = await take_snapshot(ks, [server], manager, logger)
+        snapshot_dir = os.path.join(cf_dir, 'snapshots', snap_name)
+
+        logger.info('Clear data by truncating')
+        cql.execute(f'TRUNCATE TABLE {ks}.{cf};')
+
+        logger.info(f'Copy sstables from {snapshot_dir} to {upload_dir}')
+        os.makedirs(upload_dir, exist_ok=True)
+        for item in os.listdir(snapshot_dir):
+            if item not in ['manifest.json', 'schema.cql']:
+                shutil.copy2(os.path.join(snapshot_dir, item), os.path.join(upload_dir, item))
+
+        await manager.api.enable_injection(server.ip_addr, pause_scan, one_shot=False, parameters={'shard': '1'})
+        await manager.api.enable_injection(server.ip_addr, scan_done, one_shot=False)
+        await manager.api.enable_injection(server.ip_addr, pause_rewrite, one_shot=False)
+        try:
+            refresh = asyncio.create_task(
+                manager.api.load_new_sstables(server.ip_addr, ks, cf, load_and_stream=False))
+            # Both shards enter the scan injection; only shard 1 parks in it.
+            await manager.api.wait_for_injection_enter(server.ip_addr, pause_scan, threshold=2)
+            # Shard 0 is free to run ahead and park inside its rewrites, leaving
+            # unsealed sstables -- a TemporaryTOC and no TOC -- in the upload
+            # directory.  That is the state shard 1 has to list, and every one of
+            # them is a chance for it to claim a generation that hashes to it, so
+            # wait for a good number rather than for the first.  With the listing
+            # and the processing properly separated shard 0 cannot get that far:
+            # it waits for shard 1 to finish listing first, so this times out.
+            def unsealed_sstables():
+                return [f for f in os.listdir(upload_dir) if f.endswith('-TOC.txt.tmp')]
+
+            async def enough_unsealed_sstables():
+                return True if len(unsealed_sstables()) >= 6 else None
+            with contextlib.suppress(AssertionError):  # times out on a fixed build
+                await wait_for(enough_unsealed_sstables, time.time() + 10)
+            logger.info(f'{len(unsealed_sstables())} unsealed sstables in the upload dir')
+            logger.info('Releasing the listing on shard 1')
+            await manager.api.message_injection(server.ip_addr, pause_scan)
+            # Shard 0 is done listing long before shard 1 is released, so both
+            # shards having reached the end of the listing means shard 1 has
+            # walked the directory the rewrites are parked in.  Only then let
+            # them complete and seal.
+            await manager.api.wait_for_injection_enter(server.ip_addr, scan_done, threshold=2)
+            await manager.api.disable_injection(server.ip_addr, pause_rewrite)
+            await refresh
+        finally:
+            await manager.api.disable_injection(server.ip_addr, pause_scan)
+            await manager.api.disable_injection(server.ip_addr, scan_done)
+            await manager.api.disable_injection(server.ip_addr, pause_rewrite)
+
+        assert {row.pk for row in cql.execute(f"SELECT pk FROM {ks}.{cf}")} == set(keys)
+        await wait_for_upload_dir_empty(upload_dir)

--- a/tools/read_mutation.cc
+++ b/tools/read_mutation.cc
@@ -85,6 +85,9 @@ mutation_opt read_mutation_from_table_offline(sharded<sstable_manager_service>& 
         sharded_parameter([] { return default_io_error_handler_gen(); })).get();
     auto stop_sst_dirs = deferred_stop(sst_dirs);
 
+    // Must complete on all shards before any of them starts processing what it found.
+    sst_dirs.invoke_on_all(&sstables::sstable_directory::scan_sstable_dir).get();
+
     using open_infos_t = std::vector<sstables::foreign_sstable_open_info>;
     auto sstable_open_infos = sst_dirs.map_reduce0(
         [] (sstables::sstable_directory& sst_dir) -> future<std::vector<sstables::foreign_sstable_open_info>> {


### PR DESCRIPTION
process_sstable_dir() creates and removes files in the very directory it
is listing: with need_mutate_level set, process_descriptor() hard-links
each sstable into a new generation in place, leaving a transient
TOC.txt.tmp behind until the new sstable is sealed.

Every shard lists every file and claims the ones whose generation hashes
to it, and generations minted by sstable_generation_generator have no
shard affinity. So a shard still inside its listing loop can observe
another shard's in-flight sstable, take ownership of it and schedule all
of its components for removal. commit_directory_changes() then removes
the live components and fails with ENOENT on the TOC.txt.tmp that seal()
has meanwhile renamed, which surfaces as a 500 from nodetool refresh.

Split the listing out into a scan() phase and let
distributed_loader::process_sstable_dir() complete it on all shards
before any shard starts processing what it found, so the directory stays
quiescent while it is being enumerated.

Fixes: [SCYLLADB-3966](https://scylladb.atlassian.net/browse/SCYLLADB-3966)
Fixes: [SCYLLADB-4080](https://scylladb.atlassian.net/browse/SCYLLADB-4080)

[SCYLLADB-3966]: https://scylladb.atlassian.net/browse/SCYLLADB-3966?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

Backporting to vulnerable branches.