### PR TITLE
Vnodes-to-tablets migration: Fix table size estimation logic

### DIFF
--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -4212,11 +4212,13 @@ future<locator::tablet_map> storage_service::build_tablet_map_for_migration(
 }
 
 future<std::unordered_map<table_id, uint64_t>> storage_service::collect_table_sizes_for_migration(
-    const locator::token_metadata& tm,
+    const locator::static_effective_replication_map_ptr& erm,
     const locator::tablet_aware_replication_strategy* trs,
     const std::vector<std::pair<table_id, sstring>>& tables_to_estimate) {
 
     std::unordered_map<table_id, uint64_t> table_sizes;
+
+    const auto& tm = *erm->get_token_metadata_ptr();
 
     const auto& local_dc = tm.get_topology().get_location().dc;
     auto local_rf = trs->get_replication_factor(local_dc);
@@ -4227,12 +4229,25 @@ future<std::unordered_map<table_id, uint64_t>> storage_service::collect_table_si
 
     const auto local_host = tm.get_my_id();
 
+    // Compute the token ring fraction for which this node is a replica.
+    // (Same logic as in storage_service::effective_ownership(), but only for a single node.)
     double local_fraction = 0.0;
-    auto token_ownership = dht::token::describe_ownership(tm.sorted_tokens());
-    for (const auto& [tok, fraction] : token_ownership) {
-        if (tm.get_endpoint(tok) == local_host) {
-            local_fraction += fraction;
+    const auto token_ownership = dht::token::describe_ownership(tm.sorted_tokens());
+    const auto ranges = co_await erm->get_ranges(local_host);
+    for (const auto& r : ranges) {
+        // Corner case for wrap-around range:
+        // get_ranges() unwraps the wrapping range (t1, t0] as two ranges
+        // (t1, +inf) and (-inf, t0]. Skipping the former yields the same
+        // ownership as if the range were not split.
+        if (!r.end()) {
+            continue;
         }
+        auto end_token = r.end()->value();
+        auto it = token_ownership.find(end_token);
+        if (it == token_ownership.end()) {
+            on_internal_error(slogger, fmt::format("Cannot find token ownership for token {}", end_token));
+        }
+        local_fraction += it->second;
     }
 
     if (local_fraction <= 0) {
@@ -4246,7 +4261,7 @@ future<std::unordered_map<table_id, uint64_t>> storage_service::collect_table_si
         auto local_size = co_await _db.map_reduce0([tid] (replica::database& db) {
             return uint64_t(db.find_column_family(tid).get_stats().live_disk_space_used.on_disk);
         }, uint64_t(0), std::plus<uint64_t>());
-        auto estimated_total_size = static_cast<uint64_t>(local_size / local_fraction) / local_rf;
+        auto estimated_total_size = static_cast<uint64_t>(local_size / local_fraction);
         table_sizes.emplace(tid, estimated_total_size);
     }
 
@@ -4345,7 +4360,6 @@ future<> storage_service::prepare_for_tablets_migration(const sstring& ks_name) 
         //   |------------|-------------|-------------|------------|
 
         const auto tmptr = get_token_metadata_ptr();
-        const auto& tm = *tmptr;
 
         // Estimate table sizes when pow2 convergence is enabled.
         // The estimates are used by the tablet allocator to determine the
@@ -4361,7 +4375,8 @@ future<> storage_service::prepare_for_tablets_migration(const sstring& ks_name) 
         target_pow2_per_table_map target_pow2s;
         bool use_pow2_presplit = bool(_feature_service.tablet_pow2_convergence);
         if (use_pow2_presplit) {
-            auto estimated_sizes = co_await collect_table_sizes_for_migration(tm, trs, tables_to_migrate);
+            auto erm = ks.get_static_effective_replication_map();
+            auto estimated_sizes = co_await collect_table_sizes_for_migration(erm, trs, tables_to_migrate);
             target_pow2s = co_await _tablet_allocator.local().compute_migration_target_pow2s(trs, estimated_sizes);
         }
 

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -4212,6 +4212,7 @@ future<locator::tablet_map> storage_service::build_tablet_map_for_migration(
 }
 
 future<std::unordered_map<table_id, uint64_t>> storage_service::collect_table_sizes_for_migration(
+    const sstring& ks_name,
     const locator::static_effective_replication_map_ptr& erm,
     const locator::tablet_aware_replication_strategy* trs,
     const std::vector<std::pair<table_id, sstring>>& tables_to_estimate) {
@@ -4255,7 +4256,11 @@ future<std::unordered_map<table_id, uint64_t>> storage_service::collect_table_si
             "Cannot estimate table sizes for migration: local token ownership fraction is {}", local_fraction));
     }
 
-    for (const auto& [tid, ignored_cf_name] : tables_to_estimate) {
+    slogger.info("Estimating table sizes for migration of keyspace {} (dc={}, rf={}): "
+            "this node is a replica for {:.2f}% of the token ring",
+            ks_name, local_dc, local_rf, local_fraction * 100);
+
+    for (const auto& [tid, cf_name] : tables_to_estimate) {
         // Table statistics are per-shard, so the size of the local dataset is
         // the sum over all shards.
         auto local_size = co_await _db.map_reduce0([tid] (replica::database& db) {
@@ -4263,6 +4268,8 @@ future<std::unordered_map<table_id, uint64_t>> storage_service::collect_table_si
         }, uint64_t(0), std::plus<uint64_t>());
         auto estimated_total_size = static_cast<uint64_t>(local_size / local_fraction);
         table_sizes.emplace(tid, estimated_total_size);
+        slogger.info("Estimated size of table {}.{}: {} byte(s) (local data set is {} byte(s))",
+                ks_name, cf_name, estimated_total_size, local_size);
     }
 
     co_return table_sizes;
@@ -4376,7 +4383,7 @@ future<> storage_service::prepare_for_tablets_migration(const sstring& ks_name) 
         bool use_pow2_presplit = bool(_feature_service.tablet_pow2_convergence);
         if (use_pow2_presplit) {
             auto erm = ks.get_static_effective_replication_map();
-            auto estimated_sizes = co_await collect_table_sizes_for_migration(erm, trs, tables_to_migrate);
+            auto estimated_sizes = co_await collect_table_sizes_for_migration(ks_name, erm, trs, tables_to_migrate);
             target_pow2s = co_await _tablet_allocator.local().compute_migration_target_pow2s(trs, estimated_sizes);
         }
 

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -4241,8 +4241,11 @@ future<std::unordered_map<table_id, uint64_t>> storage_service::collect_table_si
     }
 
     for (const auto& [tid, ignored_cf_name] : tables_to_estimate) {
-        auto& cf = _db.local().find_column_family(tid);
-        auto local_size = static_cast<uint64_t>(cf.get_stats().live_disk_space_used.on_disk);
+        // Table statistics are per-shard, so the size of the local dataset is
+        // the sum over all shards.
+        auto local_size = co_await _db.map_reduce0([tid] (replica::database& db) {
+            return uint64_t(db.find_column_family(tid).get_stats().live_disk_space_used.on_disk);
+        }, uint64_t(0), std::plus<uint64_t>());
         auto estimated_total_size = static_cast<uint64_t>(local_size / local_fraction) / local_rf;
         table_sizes.emplace(tid, estimated_total_size);
     }

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -4114,9 +4114,9 @@ future<> storage_service::update_tablet_metadata(const locator::tablet_metadata_
 }
 
 future<locator::tablet_map> storage_service::build_tablet_map_for_migration(
-        locator::token_metadata_ptr tm,
         const locator::static_effective_replication_map_ptr& erm,
         size_t target_pow2) {
+    const auto& tm = erm->get_token_metadata_ptr();
     const auto& sorted_tokens = tm->sorted_tokens();
 
     // Construct token boundaries: union of vnode tokens + optional pow2 boundaries.
@@ -4366,8 +4366,6 @@ future<> storage_service::prepare_for_tablets_migration(const sstring& ks_name) 
         //  min           P1            P2            P3          max
         //   |------------|-------------|-------------|------------|
 
-        const auto tmptr = get_token_metadata_ptr();
-
         // Estimate table sizes when pow2 convergence is enabled.
         // The estimates are used by the tablet allocator to determine the
         // target pow2 tablet count per table.
@@ -4422,11 +4420,11 @@ future<> storage_service::prepare_for_tablets_migration(const sstring& ks_name) 
                     if (auto it = target_pow2s.find(tid); it != target_pow2s.end()) {
                         target_pow2 = it->second;
                     }
-                    auto tmap = co_await build_tablet_map_for_migration(tmptr, erm, target_pow2);
+                    auto tmap = co_await build_tablet_map_for_migration(erm, target_pow2);
                     co_await append_tablet_map_mutations(tid, cf_name, tmap, target_pow2);
                 }
             } else {
-                auto shared_tmap = co_await build_tablet_map_for_migration(tmptr, erm, 0);
+                auto shared_tmap = co_await build_tablet_map_for_migration(erm, 0);
                 for (const auto& [tid, cf_name] : tables_to_migrate) {
                     co_await append_tablet_map_mutations(tid, cf_name, shared_tmap, 0);
                 }

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -388,7 +388,7 @@ public:
             size_t target_pow2 = 0);
 private:
     future<std::unordered_map<table_id, uint64_t>> collect_table_sizes_for_migration(
-        const locator::token_metadata& tm,
+        const locator::static_effective_replication_map_ptr& erm,
         const locator::tablet_aware_replication_strategy* trs,
         const std::vector<std::pair<table_id, sstring>>& tables_to_estimate);
 

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -386,13 +386,14 @@ public:
     static future<locator::tablet_map> build_tablet_map_for_migration(
             const locator::static_effective_replication_map_ptr& erm,
             size_t target_pow2 = 0);
-private:
+
     future<std::unordered_map<table_id, uint64_t>> collect_table_sizes_for_migration(
         const sstring& ks_name,
         const locator::static_effective_replication_map_ptr& erm,
         const locator::tablet_aware_replication_strategy* trs,
         const std::vector<std::pair<table_id, sstring>>& tables_to_estimate);
 
+private:
     future<mutable_token_metadata_ptr> get_mutable_token_metadata_ptr() noexcept {
         return _shared_token_metadata.get()->clone_async().then([this] (token_metadata tm) {
             // bump the token_metadata ring_version

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -383,7 +383,7 @@ public:
     // Builds the initial tablet map for a vnodes-to-tablets migration. Depends on
     // nothing but its arguments, so it is static and can be driven directly with a
     // synthetic topology.
-    static future<locator::tablet_map> build_tablet_map_for_migration(locator::token_metadata_ptr tm,
+    static future<locator::tablet_map> build_tablet_map_for_migration(
             const locator::static_effective_replication_map_ptr& erm,
             size_t target_pow2 = 0);
 private:

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -388,6 +388,7 @@ public:
             size_t target_pow2 = 0);
 private:
     future<std::unordered_map<table_id, uint64_t>> collect_table_sizes_for_migration(
+        const sstring& ks_name,
         const locator::static_effective_replication_map_ptr& erm,
         const locator::tablet_aware_replication_strategy* trs,
         const std::vector<std::pair<table_id, sstring>>& tables_to_estimate);

--- a/test/boost/test_config.yaml
+++ b/test/boost/test_config.yaml
@@ -56,6 +56,9 @@ custom_args:
     # Purely CPU-bound, single-threaded, and it allocates nothing but its own buffers.
     stream_compressor_test:
         - '-c1 -m512M'
+    # Required for test_table_size_estimate_singlenode_many_shards.
+    vnodes_to_tablets_migration_test:
+        - '-c2 -m2G'
 run_in_debug:
     - logalloc_standard_allocator_segment_pool_backend_test
 # Tests skipped in debug/sanitize modes because they use many iterations

--- a/test/boost/vnodes_to_tablets_migration_test.cc
+++ b/test/boost/vnodes_to_tablets_migration_test.cc
@@ -201,7 +201,7 @@ static locator::tablet_map build_map(const std::vector<locator::host_id>& hosts,
             "NetworkTopologyStrategy", params, stm.get()->get_topology());
     auto erm = locator::calculate_vnode_effective_replication_map(rs, stm.get()).get();
 
-    return service::storage_service::build_tablet_map_for_migration(stm.get(), erm, 0).get();
+    return service::storage_service::build_tablet_map_for_migration(erm, 0).get();
 }
 
 static locator::tablet_map build_single_node_map(locator::host_id host, unsigned shard_count,

--- a/test/boost/vnodes_to_tablets_migration_test.cc
+++ b/test/boost/vnodes_to_tablets_migration_test.cc
@@ -165,7 +165,73 @@ SEASTAR_TEST_CASE(test_tablet_map_creation_already_pow2_layout) {
 
 namespace {
 
-// Builds a single-node topology with the given shard count, places vnode tokens at
+// One node in a synthetic topology: where it sits, and which vnode tokens it owns.
+//
+// Positions are in unbiased token space, so `ring_percent` below expresses them as
+// hundredths of the ring.
+struct node_spec {
+    locator::host_id host;
+    locator::endpoint_dc_rack location = locator::endpoint_dc_rack::default_location;
+    std::vector<uint64_t> vnode_positions;
+};
+
+// Builds a topology from `nodes`, with `rf_per_dc` giving each DC's replication
+// factor, and invokes `func` with the resulting effective replication map and the
+// tablet-aware view of the replication strategy.
+//
+// The ERM points into the token metadata built here, so it is passed to `func`
+// rather than returned: everything stays on this frame and is torn down in order
+// once `func` is done.
+//
+// `local_host_idx` selects which node the callee should see itself as. Both the host
+// id and the location come from that one node, so the "local" node cannot drift from
+// the DC and rack the caller intended it to be in.
+//
+// Must run in a seastar thread.
+static void with_topology(
+        const std::vector<node_spec>& nodes,
+        const std::map<sstring, size_t>& rf_per_dc,
+        unsigned shard_count,
+        size_t local_host_idx,
+        std::function<void(const locator::static_effective_replication_map_ptr&,
+                           const locator::tablet_aware_replication_strategy*)> func) {
+    BOOST_REQUIRE(local_host_idx < nodes.size());
+
+    locator::token_metadata::config tm_cfg;
+    tm_cfg.topo_cfg.this_host_id = nodes[local_host_idx].host;
+    tm_cfg.topo_cfg.local_dc_rack = nodes[local_host_idx].location;
+    locator::shared_token_metadata stm([] () noexcept { return db::schema_tables::hold_merge_lock(); }, tm_cfg);
+    auto stop_stm = deferred_stop(stm);
+
+    stm.mutate_token_metadata([&] (locator::token_metadata& tm) -> future<> {
+        for (const auto& node : nodes) {
+            std::unordered_set<dht::token> tokens;
+            for (auto pos : node.vnode_positions) {
+                tokens.insert(dht::bias(pos));
+            }
+            tm.get_topology().add_or_update_endpoint(node.host, node.location,
+                                                     locator::node::state::normal, shard_count);
+            co_await tm.update_normal_tokens(tokens, node.host);
+        }
+    }).get();
+
+    std::map<sstring, locator::replication_strategy_config_option> options;
+    for (const auto& [dc, rf] : rf_per_dc) {
+        options.emplace(dc, fmt::to_string(rf));
+    }
+    locator::replication_strategy_params params(options, std::nullopt, std::nullopt);
+    auto rs = locator::abstract_replication_strategy::create_replication_strategy(
+            "NetworkTopologyStrategy", params, stm.get()->get_topology());
+    auto erm = locator::calculate_vnode_effective_replication_map(rs, stm.get()).get();
+
+    // Same cast as in prepare_for_tablets_migration().
+    const auto* trs = dynamic_cast<const locator::tablet_aware_replication_strategy*>(&*rs);
+    BOOST_REQUIRE(trs);
+
+    func(erm, trs);
+}
+
+// Builds a single-DC topology with the given shard count, places vnode tokens at
 // the given positions in unbiased token space, and runs the migration tablet map
 // builder over it.
 //
@@ -175,33 +241,19 @@ namespace {
 static locator::tablet_map build_map(const std::vector<locator::host_id>& hosts, unsigned shard_count,
                                      const std::vector<std::vector<uint64_t>>& vnode_positions_of,
                                      size_t rf) {
-    locator::token_metadata::config tm_cfg;
-    tm_cfg.topo_cfg.this_host_id = hosts[0];
-    tm_cfg.topo_cfg.local_dc_rack = locator::endpoint_dc_rack::default_location;
-    locator::shared_token_metadata stm([] () noexcept { return db::schema_tables::hold_merge_lock(); }, tm_cfg);
-    auto stop_stm = deferred_stop(stm);
+    std::vector<node_spec> nodes;
+    for (size_t n = 0; n < hosts.size(); ++n) {
+        nodes.push_back({.host = hosts[n], .vnode_positions = vnode_positions_of[n]});
+    }
 
-    stm.mutate_token_metadata([&] (locator::token_metadata& tm) -> future<> {
-        for (size_t n = 0; n < hosts.size(); ++n) {
-            std::unordered_set<dht::token> tokens;
-            for (auto pos : vnode_positions_of[n]) {
-                tokens.insert(dht::bias(pos));
-            }
-            tm.get_topology().add_or_update_endpoint(hosts[n], locator::endpoint_dc_rack::default_location,
-                                                     locator::node::state::normal, shard_count);
-            co_await tm.update_normal_tokens(tokens, hosts[n]);
-        }
-    }).get();
-
-    std::map<sstring, locator::replication_strategy_config_option> options = {
-        { locator::endpoint_dc_rack::default_location.dc, fmt::to_string(rf) },
-    };
-    locator::replication_strategy_params params(options, std::nullopt, std::nullopt);
-    auto rs = locator::abstract_replication_strategy::create_replication_strategy(
-            "NetworkTopologyStrategy", params, stm.get()->get_topology());
-    auto erm = locator::calculate_vnode_effective_replication_map(rs, stm.get()).get();
-
-    return service::storage_service::build_tablet_map_for_migration(erm, 0).get();
+    // The tablet map is a value that does not point back at the token metadata, so
+    // unlike the ERM it can safely outlive with_topology().
+    std::optional<locator::tablet_map> tmap;
+    with_topology(nodes, {{locator::endpoint_dc_rack::default_location.dc, rf}}, shard_count, 0,
+            [&] (const auto& erm, const auto*) {
+        tmap = service::storage_service::build_tablet_map_for_migration(erm, 0).get();
+    });
+    return std::move(*tmap);
 }
 
 static locator::tablet_map build_single_node_map(locator::host_id host, unsigned shard_count,

--- a/test/boost/vnodes_to_tablets_migration_test.cc
+++ b/test/boost/vnodes_to_tablets_migration_test.cc
@@ -382,4 +382,174 @@ SEASTAR_THREAD_TEST_CASE(test_shard_assignment_across_nodes_with_replicas) {
     }
 }
 
+// Tests for storage_service::collect_table_sizes_for_migration():
+
+namespace {
+
+constexpr const char* estimate_ks = "test_migration_ks";
+constexpr const char* estimate_cf = "t";
+
+table_id create_vnode_table(cql_test_env& e) {
+    e.execute_cql(format("CREATE KEYSPACE {} "
+            "WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor': 1}} "
+            "AND tablets = {{'enabled': false}}", estimate_ks)).get();
+    e.execute_cql(format("CREATE TABLE {}.{} (pk int PRIMARY KEY)", estimate_ks, estimate_cf)).get();
+    return e.local_db().find_schema(estimate_ks, estimate_cf)->id();
+}
+
+// Fakes the table's per-shard on-disk size and returns the total across all shards.
+//
+// Note: This must not be followed by a flush or compaction: table::rebuild_statistics()
+//       recomputes live_disk_space_used from the real compaction groups, which
+//       would discard these values.
+uint64_t set_local_table_size(cql_test_env& e, uint64_t size_per_shard) {
+    e.db().invoke_on_all([size_per_shard] (replica::database& db) {
+        auto& cf = db.find_column_family(estimate_ks, estimate_cf);
+        cf.get_stats().live_disk_space_used.on_disk = int64_t(size_per_shard);
+    }).get();
+
+    return size_per_shard * this_smp_shard_count();
+}
+
+// Runs the estimator over the given topology and returns the estimated size.
+uint64_t estimate_table_size(cql_test_env& e, table_id tid,
+                              const locator::static_effective_replication_map_ptr& erm,
+                              const locator::tablet_aware_replication_strategy* trs) {
+    auto sizes = e.get_storage_service().local().collect_table_sizes_for_migration(
+            estimate_ks, erm, trs, {{tid, estimate_cf}}).get();
+    auto it = sizes.find(tid);
+    BOOST_REQUIRE(it != sizes.end());
+    return it->second;
+}
+
+// Asserts the estimate matches `expected`, within a small relative tolerance.
+void check_estimate(uint64_t estimate, uint64_t expected, const sstring& context = {}) {
+    BOOST_CHECK_MESSAGE(std::abs(double(estimate) - double(expected)) <= double(expected) * 0.00001,
+            fmt::format("expected {}, got {}{}", expected, estimate,
+                        context.empty() ? std::string() : fmt::format(" ({})", context)));
+}
+
+node_spec make_node(const sstring& dc, const sstring& rack, std::vector<uint64_t> vnode_positions) {
+    return node_spec{
+        .host = locator::host_id(utils::UUID_gen::get_time_UUID()),
+        .location = locator::endpoint_dc_rack{dc, rack},
+        .vnode_positions = std::move(vnode_positions),
+    };
+}
+
+} // anonymous namespace
+
+// Reproducer for https://scylladb.atlassian.net/browse/SCYLLADB-3736
+// Table statistics are per-shard, but `collect_table_sizes_for_migration()`
+// was reading the size of the local dataset from shard 0 alone, so it came out
+// roughly a factor of smp too small. It should be summing over all shards.
+//
+// Test this on a single-node cluster with multiple shards and a dataset that
+// is evenly distributed across shards.
+SEASTAR_TEST_CASE(test_table_size_estimate_singlenode_many_shards) {
+    return do_with_cql_env_thread([] (cql_test_env& e) {
+        BOOST_REQUIRE_MESSAGE(this_smp_shard_count() > 1,
+                "needs more than one shard to make sure all shards are summed");
+
+        auto tid = create_vnode_table(e);
+        auto local_size = set_local_table_size(e, 1 * 1024 * 1024);
+
+        auto node = make_node("dc1", "rack1", {100 * ring_percent});
+        with_topology({node}, {{"dc1", 1}}, this_smp_shard_count(), 0, [&] (const auto& erm, const auto* trs) {
+            auto expected_global_size = local_size;
+            auto estimated_global_size = estimate_table_size(e, tid, erm, trs);
+            check_estimate(estimated_global_size, expected_global_size);
+        });
+    });
+}
+
+// Reproducer for https://scylladb.atlassian.net/browse/SCYLLADB-3760
+// `collect_table_sizes_for_migration()` provided bad estimates in case of
+// racks with different number of nodes. The formula was:
+//
+//   local_size / (local_fraction * local_rf)
+//
+// where
+//   local_size: the size of the local dataset,
+//   local_fraction: this node's primary token ownership fraction,
+//   local_rf: the replication factor of the local datacenter.
+//
+// Consider a cluster with 2 racks, with 1 and 2 nodes respectively, and RF=2.
+// The node in the small rack holds 100% of the data, but above formula would
+// give us: local_fraction * local_rf = 1/3 * 2 = 2/3 = 66%, an underestimate.
+//
+// Test the above cluster setup with a uniformly distributed dataset and token
+// ring. Expect the single-node rack to store 100% of the dataset.
+SEASTAR_TEST_CASE(test_table_size_estimate_singledc_uneven_racks) {
+    return do_with_cql_env_thread([] (cql_test_env& e) {
+        auto tid = create_vnode_table(e);
+        auto local_size = set_local_table_size(e, 1 * 1024 * 1024);
+
+        // rack1 holds the local node, rack2 holds two, so primary ownership is a third each.
+        std::vector<node_spec> nodes{
+            make_node("dc1", "rack1", {33 * ring_percent}),
+            make_node("dc1", "rack2", {66 * ring_percent}),
+            make_node("dc1", "rack2", {100 * ring_percent}),
+        };
+        with_topology(nodes, {{"dc1", 2}}, this_smp_shard_count(), 0, [&] (const auto& erm, const auto* trs) {
+            auto expected_global_size = local_size;
+            auto estimated_global_size = estimate_table_size(e, tid, erm, trs);
+            check_estimate(estimated_global_size, expected_global_size);
+        });
+    });
+}
+
+// Reproducer for https://scylladb.atlassian.net/browse/SCYLLADB-3760
+// Yet another case of bad estimation by `collect_table_sizes_for_migration()`:
+//
+// In multi-DC clusters, the old formula (see comment in previous test case)
+// would underestimate the `local_fraction` because it is computed with respect
+// to the whole ring, rather than just the local datacenter's portion of the
+// ring.
+//
+// Consider a cluster with 2 DCs, each with one node and RF=1.
+// Each node holds 100% of the data, but the old formula would give us:
+// local_fraction * local_rf = 1/2 * 1 = 50%, an underestimate.
+//
+// Test this case with a uniformly distributed dataset and token ring.
+// Expect each node to store 100% of the dataset.
+SEASTAR_TEST_CASE(test_table_size_estimate_multidc) {
+    return do_with_cql_env_thread([] (cql_test_env& e) {
+        auto tid = create_vnode_table(e);
+        auto local_size = set_local_table_size(e, 1 * 1024 * 1024);
+
+        std::vector<node_spec> nodes{
+            make_node("dc1", "rack1", {50 * ring_percent}),
+            make_node("dc2", "rack1", {100 * ring_percent}),
+        };
+        with_topology(nodes, {{"dc1", 1}, {"dc2", 1}}, this_smp_shard_count(), 0, [&] (const auto& erm, const auto* trs) {
+            auto expected_global_size = local_size;
+            auto estimated_global_size = estimate_table_size(e, tid, erm, trs);
+            check_estimate(estimated_global_size, expected_global_size);
+        });
+    });
+}
+
+// A node whose DC does not replicate the keyspace cannot estimate its size.
+// Make sure the estimation function throws.
+SEASTAR_TEST_CASE(test_table_size_estimate_fails_on_rf_0_dc) {
+    return do_with_cql_env_thread([] (cql_test_env& e) {
+        auto tid = create_vnode_table(e);
+        set_local_table_size(e, 1 * 1024 * 1024);
+
+        std::vector<node_spec> nodes{
+            make_node("dc1", "rack1", {50 * ring_percent}),
+            make_node("dc2", "rack1", {100 * ring_percent}),
+        };
+        // Set `local_host_idx` to DC2 node, which has RF=0.
+        with_topology(nodes, {{"dc1", 1}, {"dc2", 0}}, this_smp_shard_count(), 1, [&] (const auto& erm, const auto* trs) {
+            BOOST_REQUIRE_EXCEPTION(
+                    estimate_table_size(e, tid, erm, trs), std::runtime_error,
+                    [] (const std::runtime_error& ex) {
+                        return sstring(ex.what()).find("replication factor for local DC") != sstring::npos;
+                    });
+        });
+    });
+}
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
The vnodes-to-tablets migration needs to estimate the sizes of migrating tables in order to calculate target tablet counts that adhere to the tablet load balancer's sizing policy. This logic was introduced in 1cdee1577059, but the current estimator has two flaws:

* [SCYLLADB-3736] It reads the on-disk table size from `table::get_stats()`, which is shard-local rather than node-local, so the local dataset is underestimated by a factor equal to the node's shard count.

* [SCYLLADB-3760] It extrapolates the local dataset to the whole cluster using the node's primary token ownership times its DC's replication factor. That product assumes replicas are spread evenly over the nodes, which does not hold when racks are uneven or when the cluster spans multiple datacenters.

Both flaws distort the target tablet counts chosen by the migration, breaking the invariant that the tablet load balancer will have no more resize work to do after post-migration pow2 convergence is finished.

Fix the first by summing the on-disk size over all shards, and the second by finding the node's effective replica ownership fraction. Cover both bugs with unit tests.

Fixes SCYLLADB-3736.
Fixes SCYLLADB-3760.

[SCYLLADB-3736]: https://scylladb.atlassian.net/browse/SCYLLADB-3736?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SCYLLADB-3760]: https://scylladb.atlassian.net/browse/SCYLLADB-3760?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

The bug makes the load balancer perform an unnecessary tablet resize round. Backport is needed.