### PR TITLE
size_estimates_virtual_reader: cache local ranges per reader

### DIFF
--- a/db/size_estimates_virtual_reader.cc
+++ b/db/size_estimates_virtual_reader.cc
@@ -262,8 +262,10 @@ future<> size_estimates_mutation_reader::get_next_partition() {
         co_return;
     }
     auto guard = reader_permit::awaits_guard(_permit);
-    auto ranges = co_await get_local_ranges(_db, _sys_ks);
-    auto estimates = co_await this->estimates_for_current_keyspace(std::move(ranges));
+    if (!_local_ranges) {
+        _local_ranges = co_await get_local_ranges(_db, _sys_ks);
+    }
+    auto estimates = co_await this->estimates_for_current_keyspace(*_local_ranges);
     auto mutations = db::system_keyspace::make_size_estimates_mutation(*_current_partition, std::move(estimates));
     ++_current_partition;
     utils::chunked_vector<mutation> ms;
@@ -308,6 +310,7 @@ future<> size_estimates_mutation_reader::fast_forward_to(const dht::partition_ra
     clear_buffer();
     _prange = &pr;
     _keyspaces = std::nullopt;
+    _local_ranges.reset();
     _end_of_stream = false;
     return close_partition_reader();
 }

--- a/db/size_estimates_virtual_reader.hh
+++ b/db/size_estimates_virtual_reader.hh
@@ -38,6 +38,7 @@ class size_estimates_mutation_reader final : public mutation_reader::impl {
     ks_range::const_iterator _current_partition;
     streamed_mutation::forwarding _fwd;
     mutation_reader_opt _partition_reader;
+    std::optional<std::vector<token_range>> _local_ranges;
 public:
     size_estimates_mutation_reader(replica::database& db, db::system_keyspace& sys_ks, schema_ptr, reader_permit, const dht::partition_range&, const query::partition_slice&, streamed_mutation::forwarding);
 

--- a/test/boost/virtual_reader_test.cc
+++ b/test/boost/virtual_reader_test.cc
@@ -164,6 +164,17 @@ SEASTAR_TEST_CASE(test_query_size_estimates_virtual_table) {
         rs = e.execute_cql(fmt::format("select * from system.size_estimates where keyspace_name = 'ks' "
                                       "and (table_name, range_start) < ('cf2', '{}');", start_token1)).get();
         assert_that(rs).is_rows().with_size(259);
+
+        // Regression check: a scan spanning multiple keyspaces must reuse the cached
+        // local ranges correctly for each keyspace, not just the first one visited.
+        e.execute_cql("create keyspace ks2 with replication = { 'class' : 'NetworkTopologyStrategy', 'replication_factor' : 1 };").discard_result().get();
+        e.execute_cql("create table ks2.cf3(pk text PRIMARY KEY, v int);").discard_result().get();
+
+        rs = e.execute_cql("select * from system.size_estimates where keyspace_name in ('ks', 'ks2');").get();
+        assert_that(rs).is_rows().with_size(512 + 256);
+
+        rs = e.execute_cql("select * from system.size_estimates where keyspace_name = 'ks2';").get();
+        assert_that(rs).is_rows().with_size(256);
     });
 }
 


### PR DESCRIPTION
## Context
Virtual tables (`db/virtual_table.hh`, wired via `db/virtual_tables.cc`) bypass the normal read path entirely (row cache, sstables, compaction groups), so their memory/CPU cost is paid fresh on every query.
This PR is one of two independent, separately-mergeable pieces from an investigation into reducing that cost at cluster scale (more tablets, more nodes, more keyspaces).
The companion PR, #31493 ("virtual_tables: migrate group0_virtual_table to streaming_virtual_table"), addresses the other hotspot found (`system.tablet_sizes`/`system.load_per_node`); neither depends on the other.

**Table affected by this PR:** `system.size_estimates`.

## Motivation
`size_estimates_mutation_reader::get_next_partition()` recomputed `get_local_ranges()` - an O(#tokens) `token_metadata` lookup - once per keyspace partition visited during a `system.size_estimates` scan, even though the result is identical across every keyspace within a single scan (local tokens don't change mid-query).
This is pure wasted CPU, worst on clusters with many keyspaces/tables and many tokens/tablets.

## Changes
- Cache the result of `get_local_ranges()` once per `size_estimates_mutation_reader` instance instead of recomputing it on every partition.
- Invalidate the cache in `fast_forward_to(const dht::partition_range&)`, which already resets `_keyspaces` for the same reason (a reader instance could conceivably span a meaningfully different scan).
- No interface or behavioral change: same values, computed once instead of N times per scan.

## Tests
Extended `test/boost/virtual_reader_test.cc`'s `test_query_size_estimates_virtual_table` with a regression check that a scan spanning multiple keyspaces (`ks`, `ks2`) still returns correct, complete results for each keyspace after caching - proving the cached ranges are reused correctly rather than just for the first keyspace visited.

## Results
Purely a CPU-savings change (no memory/latency claims made for this PR specifically - see the companion PR "virtual_tables: migrate group0_virtual_table to streaming_virtual_table" for benchmarked memory/latency numbers on the related `tablet_sizes`/`load_per_node` work).
Correctness verified via the boost test suite above; no behavior change to existing `system.size_estimates` query results.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Backport: no, an improvement.
