### PR TITLE
test/cluster: disable tablet_allocator_shuffle before decommission in test_topology_changes

### DIFF
--- a/test/cluster/test_tablets2.py
+++ b/test/cluster/test_tablets2.py
@@ -229,6 +229,10 @@ async def test_topology_changes(manager: ScyllaClusterManager):
         time.sleep(5) # Give load balancer some time to do work
         await check()
 
+        # Shuffle mode never converges, competing with decommission's own
+        # migrations and blowing its timeout if left enabled.
+        await disable_injection_on(manager, "tablet_allocator_shuffle", servers)
+
         await manager.decommission_node(servers[0].server_id)
 
         await check()


### PR DESCRIPTION
## Summary

`test_topology_changes` enables the `tablet_allocator_shuffle` error injection to stress the tablet load balancer while nodes are added, but never disables it before the test's final `decommission_node()` call.
Shuffle mode has no convergence/exit condition (it only stops on load-limit or running out of candidates), so it keeps generating a continuous stream of migrations that compete with decommission's own migrations, occasionally pushing the decommission past `TOPOLOGY_TIMEOUT` and failing the test.

Fix: disable the injection (`disable_injection_on`, already defined in the same file) right before the decommission call.

Reproduced locally under `dbuild` before the fix:
```
FAILED test/cluster/test_tablets2.py::test_topology_changes.dev.1 - TimeoutError
======================== 1 failed in 1102.78s (0:18:22) ========================
```
After the fix:
```
1 passed in 25.09s
```

Fixes: SCYLLADB-4255

## Test plan
- [x] Reproduced the failure locally (dev build) under `dbuild`
- [x] Applied the fix and reran the same test under `dbuild`: passes in 25s (was 18m22s timeout)

Backport: I donno, apparently no one complained thus far (which makes me suspicious of the whole thing in the 1st place!)