### PR TITLE
test/lib: fix aws kms fixture startup

### DIFF
--- a/test/lib/aws_kms_fixture.cc
+++ b/test/lib/aws_kms_fixture.cc
@@ -35,7 +35,8 @@ static future<std::tuple<tp::process_fixture, int>> start_fake_kms_server(const 
             if (line.find("Local KMS started on") != std::string::npos) {
                 return tp::service_parse_state::success;
             }
-            if (line.find("address already in use") != std::string::npos) {
+            if (line.find("address already in use") != std::string::npos || line.find("Address already in use") != std::string::npos ||
+                line.find("port is already allocated") != std::string::npos) {
                 return tp::service_parse_state::failed;
             }
             return tp::service_parse_state::cont;


### PR DESCRIPTION
The `aws_kms` fixture fails with `seastar::broken_promise` whenever the host port that the container runtime picks is already taken. Under rootless podman the conflict is reported by pasta as `Listen failed for HOST TCP port */NNNNN: Address already in use` — capital A — and the fixture's ready-line parser matches only the lowercase `address already in use`. The parse state therefore stays `cont`, the ready promise is destroyed without ever being set, and `start_docker_service` never enters its retry path, which would have launched the container on a fresh ephemeral port.

### Changes

`start_fake_kms_server` matches all three wordings the runtimes emit again: `address already in use` (generic Unix), `Address already in use` (podman/pasta), and `port is already allocated` (docker). The two dropped checks were lost in eb2dfe04e1 ("aws_kms_fixture: Modify to use docker helper"), which replaced the inline parser with a per-fixture callback; e40eb99252 restored them in `gcs_fixture`, but the identical parser in `aws_kms_fixture` kept only the lowercase variant, so the KMS tests still hit this.

Verified by shadowing docker with a podman shim so pasta emits the capital-A wording, and pinning the published host port to an occupied one. Before the change the fixture makes one attempt and dies with `broken_promise`, matching the CI failure in [build 32799](https://jenkins.scylladb.com/job/scylla-master/job/scylla-ci/32799/testReport/junit/boost.encryption_at_rest_test/cc/Unit_Tests_Custom___dev___aws_kms_test_commitlog_kms_encryption_with_slow_key_resolve_dev_12/); after it the retry path fires for all 8 attempts. The full `aws_kms` suite (5 cases) passes.

Fixes: https://scylladb.atlassian.net/browse/SCYLLADB-2899

Backport to 2026.2 and 2026.3, which carry the same lowercase-only parser. 2026.1 is not affected — it predates eb2dfe04e1 and still has the original inline parser with all three checks.
