### PR TITLE
 strong_consistency: fix write reordering between begin_mutate and add_entry

### DIFF
--- a/service/strong_consistency/coordinator.cc
+++ b/service/strong_consistency/coordinator.cc
@@ -355,6 +355,17 @@ future<value_or_redirect<>> coordinator::mutate(schema_ptr schema,
         auto disposition_result = get<raft_server::timestamp_with_term>(disposition);
         std::tie(ts, term) = {disposition_result.timestamp, disposition_result.term};
 
+        // Nothing between begin_mutate() above and add_entry() below may
+        // suspend this coroutine, not even a co_await on a ready future
+        // (Seastar suspends on those too when the task quota is exhausted).
+        // begin_mutate() hands out timestamps in call order and raft appends
+        // entries in add_entry() call order. If another write could slip in
+        // between, the raft log order and the timestamp order would diverge:
+        // a reader could observe the first log entry alone, and then, after
+        // the second entry with the lower timestamp is applied, a state in
+        // which cells from the second entry are visible while the first entry
+        // still wins on the cells they share. Such a history is not
+        // linearizable.
         const raft_command command {
             .mutation{mutation_gen(ts)}
         };
@@ -363,9 +374,6 @@ future<value_or_redirect<>> coordinator::mutate(schema_ptr schema,
 
         logger.debug("mutate(): add_entry({}), term {}",
             command.mutation.pretty_printer(schema), term);
-
-        co_await utils::get_local_injector().inject("sc_coordinator_wait_before_add_entry",
-            utils::wait_for_message(5min));
 
         future<> add_entry_result = co_await coroutine::as_future(
             op.raft_server.server().add_entry(std::move(raft_cmd),

--- a/service/strong_consistency/coordinator.cc
+++ b/service/strong_consistency/coordinator.cc
@@ -21,6 +21,7 @@
 #include "gms/gossiper.hh"
 #include "utils/chain_abort_source.hh"
 #include "utils/histogram_metrics_helper.hh"
+#include "utils/abstract_formatter.hh"
 
 namespace service::strong_consistency {
 
@@ -270,8 +271,23 @@ future<value_or_redirect<>> coordinator::mutate(schema_ptr schema,
     lc.start();
     auto mark_write_latency = defer([this, &lc] noexcept { _stats.write.mark(lc.stop().latency()); });
 
-    locator::tablet_id tid{-1};
-    raft::term_t term;
+    // State of the request as it advances through its stages. Each pointer
+    // is null until the corresponding stage has been reached, so log messages
+    // never print stale or uninitialized values.
+    operation_ctx* op = nullptr;
+    const raft_server::timestamp_with_term* ts_with_term = nullptr;
+
+    // Rendered only when a log line is actually emitted.
+    const auto state_fmt = lambda_formatter([&] (fmt::format_context& ctx) {
+        if (!op) {
+            fmt::format_to(ctx.out(), "no operation context yet");
+        } else if (!ts_with_term) {
+            fmt::format_to(ctx.out(), "tablet {}, no timestamp yet", op->tablet_id);
+        } else {
+            fmt::format_to(ctx.out(), "tablet {}, term {}, timestamp {}",
+                    op->tablet_id, ts_with_term->term, ts_with_term->timestamp);
+        }
+    });
 
     auto filter_error = [&] (std::exception_ptr ex) -> std::exception_ptr {
         // Unfortunately, timeouts can materialize in different forms depending
@@ -291,13 +307,13 @@ future<value_or_redirect<>> coordinator::mutate(schema_ptr schema,
             if (!_db.column_family_exists(schema->id())) {
                 return std::make_exception_ptr(replica::no_such_column_family(schema->ks_name(), schema->cf_name()));
             }
-            logger.trace("mutate(): request timed out with error {}, table {}.{}, token {}",
-                ex, schema->ks_name(), schema->cf_name(), token);
+            logger.trace("mutate(): request timed out with error {}, table {}.{}, token {}, {}",
+                ex, schema->ks_name(), schema->cf_name(), token, state_fmt);
             ++_stats.write_errors_timeout;
             return std::make_exception_ptr(write_timeout(schema->ks_name(), schema->cf_name()));
         } else if (try_catch<raft::commit_status_unknown>(ex)) {
-            logger.debug("mutate(): add_entry, got commit_status_unknown {}, table {}.{}, tablet {}, term {}",
-                ex, schema->ks_name(), schema->cf_name(), tid, term);
+            logger.debug("mutate(): add_entry, got commit_status_unknown {}, table {}.{}, {}",
+                ex, schema->ks_name(), schema->cf_name(), state_fmt);
 
             ++_stats.write_errors_status_unknown;
             // FIXME: use a dedicated ERROR_CODE instead of SERVER_ERROR
@@ -306,8 +322,8 @@ future<value_or_redirect<>> coordinator::mutate(schema_ptr schema,
                 "Retrying the statement may be necessary."));
         } else {
             ++_stats.write_errors_other;
-            logger.trace("mutate(): unknown exception {}, table {}.{}, token {}",
-                ex, schema->ks_name(), schema->cf_name(), token);
+            logger.trace("mutate(): unknown exception {}, table {}.{}, token {}, {}",
+                ex, schema->ks_name(), schema->cf_name(), token, state_fmt);
             // We know nothing about other errors. Let the CQL server convert them to SERVER_ERROR.
             return ex;
         }
@@ -325,23 +341,27 @@ future<value_or_redirect<>> coordinator::mutate(schema_ptr schema,
     if (auto* redirect = get_if<need_redirect>(&op_result)) {
         co_return std::move(*redirect);
     }
-    auto& op = get<operation_ctx>(op_result);
+    op = &get<operation_ctx>(op_result);
 
     while (true) {
+        // `disposition` below is local to one iteration, so the pointer into
+        // it must not survive into the next one.
+        ts_with_term = nullptr;
+
         co_await utils::get_local_injector().inject("sc_coordinator_wait_before_begin_mutate",
             utils::wait_for_message(5min));
 
-        auto disposition = op.raft_server.begin_mutate(aoe.abort_source());
+        auto disposition = op->raft_server.begin_mutate(aoe.abort_source());
         if (const auto* not_a_leader = get_if<raft::not_a_leader>(&disposition)) {
             const auto leader_host_id = locator::host_id{not_a_leader->leader.uuid()};
-            const auto* target = find_replica(op.tablet_info, leader_host_id);
+            const auto* target = find_replica(op->tablet_info, leader_host_id);
             if (!target) {
                 on_internal_error(logger,
                     ::format("table {}.{}, tablet {}, current leader {} is not a replica, replicas {}",
-                        schema->ks_name(), schema->cf_name(), op.tablet_id,
-                        leader_host_id, op.tablet_info.replicas));
+                        schema->ks_name(), schema->cf_name(), op->tablet_id,
+                        leader_host_id, op->tablet_info.replicas));
             }
-            co_return redirect_to_leader(*target, _groups_manager, op.raft_info.group_id);
+            co_return redirect_to_leader(*target, _groups_manager, op->raft_info.group_id);
         }
         if (auto* wait_for_leader = get_if<raft_server::need_wait_for_leader>(&disposition)) {
             auto f = co_await coroutine::as_future(std::move(wait_for_leader->future));
@@ -351,9 +371,7 @@ future<value_or_redirect<>> coordinator::mutate(schema_ptr schema,
             continue;
         }
 
-        api::timestamp_type ts;
-        auto disposition_result = get<raft_server::timestamp_with_term>(disposition);
-        std::tie(ts, term) = {disposition_result.timestamp, disposition_result.term};
+        ts_with_term = &get<raft_server::timestamp_with_term>(disposition);
 
         // Nothing between begin_mutate() above and add_entry() below may
         // suspend this coroutine, not even a co_await on a ready future
@@ -367,16 +385,16 @@ future<value_or_redirect<>> coordinator::mutate(schema_ptr schema,
         // still wins on the cells they share. Such a history is not
         // linearizable.
         const raft_command command {
-            .mutation{mutation_gen(ts)}
+            .mutation{mutation_gen(ts_with_term->timestamp)}
         };
         raft::command raft_cmd;
         ser::serialize(raft_cmd, command);
 
-        logger.debug("mutate(): add_entry({}), term {}",
-            command.mutation.pretty_printer(schema), term);
+        logger.debug("mutate(): add_entry({}), {}",
+            command.mutation.pretty_printer(schema), state_fmt);
 
         future<> add_entry_result = co_await coroutine::as_future(
-            op.raft_server.server().add_entry(std::move(raft_cmd),
+            op->raft_server.server().add_entry(std::move(raft_cmd),
                 raft::wait_type::committed,
                 &aoe.abort_source()));
 
@@ -386,8 +404,8 @@ future<value_or_redirect<>> coordinator::mutate(schema_ptr schema,
 
         auto ex = std::move(add_entry_result).get_exception();
         if (try_catch<raft::not_a_leader>(ex) || try_catch<raft::dropped_entry>(ex)) {
-            logger.debug("mutate(): add_entry, got retriable error {}, table {}.{}, tablet {}, term {}",
-                ex, schema->ks_name(), schema->cf_name(), op.tablet_id, term);
+            logger.debug("mutate(): add_entry, got retriable error {}, table {}.{}, {}",
+                ex, schema->ks_name(), schema->cf_name(), state_fmt);
 
             continue;
         }

--- a/test/cluster/test_strong_consistency.py
+++ b/test/cluster/test_strong_consistency.py
@@ -950,8 +950,7 @@ async def test_timed_out_queries(manager: ScyllaClusterManager):
             # Case 2: Writes.
             write_error_injections = [
                 "sc_coordinator_wait_before_acquire_server",
-                "sc_coordinator_wait_before_begin_mutate",
-                "sc_coordinator_wait_before_add_entry"
+                "sc_coordinator_wait_before_begin_mutate"
             ]
             for error_injection_name in write_error_injections:
                 await try_write(error_injection_name)
@@ -986,7 +985,7 @@ async def test_queries_while_dropping_table(manager: ScyllaClusterManager):
 
     Setup: 2 nodes, RF=2, 1 tablet (raft quorum = 2).
 
-    We pause a read (before read_barrier) and a write (before add_entry)
+    We pause a read (before read_barrier) and a write (before begin_mutate)
     on the leader, then drop the table. The follower destroys its raft group
     immediately (no in-flight ops). On the leader, the raft server is aborted
     as part of group deletion (SCYLLADB-2080 fix), causing the paused
@@ -1029,7 +1028,7 @@ async def test_queries_while_dropping_table(manager: ScyllaClusterManager):
             manager.api.enable_injection(leader_server.ip_addr,
                 "sc_coordinator_wait_before_query_read_barrier", one_shot=True),
             manager.api.enable_injection(leader_server.ip_addr,
-                "sc_coordinator_wait_before_add_entry", one_shot=True))
+                "sc_coordinator_wait_before_begin_mutate", one_shot=True))
 
         read_fut = asyncio.ensure_future(
             cql.run_async(f"SELECT * FROM {table} WHERE pk = 0", host=leader_host))
@@ -1040,7 +1039,7 @@ async def test_queries_while_dropping_table(manager: ScyllaClusterManager):
         await asyncio.gather(
             leader_log.wait_for("sc_coordinator_wait_before_query_read_barrier: waiting",
                 from_mark=mark_leader, timeout=30),
-            leader_log.wait_for("sc_coordinator_wait_before_add_entry: waiting",
+            leader_log.wait_for("sc_coordinator_wait_before_begin_mutate: waiting",
                 from_mark=mark_leader, timeout=30))
 
         mark_leader = await leader_log.mark()
@@ -1064,7 +1063,7 @@ async def test_queries_while_dropping_table(manager: ScyllaClusterManager):
             manager.api.message_injection(leader_server.ip_addr,
                 "sc_coordinator_wait_before_query_read_barrier"),
             manager.api.message_injection(leader_server.ip_addr,
-                "sc_coordinator_wait_before_add_entry"))
+                "sc_coordinator_wait_before_begin_mutate"))
 
         # Both should fail with "no such column family" / "unconfigured table".
         # The raft server is aborted as part of group deletion, causing

--- a/utils/abstract_formatter.hh
+++ b/utils/abstract_formatter.hh
@@ -10,32 +10,53 @@
 
 #include <fmt/format.h>
 #include <functional>
+#include <type_traits>
 
-/// Type-erased formatter.
-/// Allows passing formattable objects without exposing their types.
-class abstract_formatter {
-    std::function<void(fmt::format_context&)> _formatter;
+/// Makes a callable usable as a "{}" argument of fmt::format and friends.
+/// The callable receives the enclosing format context and writes into it,
+/// so nothing is rendered unless the message is actually formatted (e.g.
+/// when a log line is disabled), and no intermediate string is built.
+///
+/// The callable is stored by value without type erasure, so wrapping a
+/// lambda that captures a few references costs nothing on the hot path:
+///
+///     const auto state = lambda_formatter([&] (fmt::format_context& ctx) {
+///         fmt::format_to(ctx.out(), "x={}", x);
+///     });
+///     logger.debug("state: {}", state);
+///
+/// If Func is contextually convertible to bool (e.g. std::function), an
+/// empty callable formats as nothing instead of being invoked.
+template <typename Func>
+requires std::is_invocable_v<const Func&, fmt::format_context&>
+class lambda_formatter {
+    Func _func;
 public:
-    abstract_formatter() = default;
-
-    template<typename Func>
-    requires std::is_invocable_v<Func, fmt::format_context&>
-    explicit abstract_formatter(Func&& f) : _formatter(std::forward<Func>(f)) {}
+    lambda_formatter() = default;
+    explicit lambda_formatter(Func func) : _func(std::move(func)) {}
 
     fmt::format_context::iterator format_to(fmt::format_context& ctx) const {
-        if (_formatter) {
-            _formatter(ctx);
+        if constexpr (requires { static_cast<bool>(_func); }) {
+            if (!_func) {
+                return ctx.out();
+            }
         }
+        _func(ctx);
         return ctx.out();
     }
-
-    explicit operator bool() const noexcept { return bool(_formatter); }
 };
 
-template <> struct fmt::formatter<abstract_formatter> {
+template <typename Func>
+struct fmt::formatter<lambda_formatter<Func>> {
     constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
 
-    auto format(const abstract_formatter& formatter, fmt::format_context& ctx) const {
+    auto format(const lambda_formatter<Func>& formatter, fmt::format_context& ctx) const {
         return formatter.format_to(ctx);
     }
 };
+
+/// Type-erased formatter.
+/// Allows passing formattable objects without exposing their types.
+/// Unlike a lambda_formatter over a concrete lambda, constructing it may
+/// allocate, so prefer lambda_formatter where the type needn't be erased.
+using abstract_formatter = lambda_formatter<std::function<void(fmt::format_context&)>>;


### PR DESCRIPTION
`coordinator::mutate()` takes a timestamp from `begin_mutate()` and then appends the mutation with `raft::server::add_entry()`. `begin_mutate()` hands out timestamps in call order and raft appends entries in `add_entry()` call order ([via _add_entry_admission](https://github.com/scylladb/scylladb/pull/31445)), so the raft log order and the timestamp order agree only if nothing can suspend the coroutine in between.

The `sc_coordinator_wait_before_add_entry` injection sat exactly there. In release builds inject() returns a ready future, but the `co_await` stays, and Seastar suspends a coroutine on a ready future whenever the task quota is exhausted. Another write could then take a larger timestamp and be appended first.

With mutations touching several cells this is observable. For the log `[(X=1, ts=2), (X=2 Y=1, ts=1)]`, a linearizable read after the first entry returns `{X=1, Y=null}` and a read after the second returns `{X=1, Y=1}`. No sequential order of the two writes explains both reads, so the history is not linearizable.

The first commit removes the injection and documents the invariant. The two tests that used it only needed a write parked on the leader, which the existing `sc_coordinator_wait_before_begin_mutate` injection provides. `test_queries_while_dropping_table` still gets the expected failure: the dropped table aborts the raft server, `fsm::stop()` demotes the leader, and the resumed write fails in `wait_for_leader()` with `stopped_error`.

The second commit cleans up the logging state in mutate(). The tablet id logged on `commit_status_unknown` was never assigned (always -1), and term and timestamp were loose variables printed by only some messages. They are replaced by two pointers set as the request advances, and a single helper prints the state in every message.

backport: no need -- Strong Consistency is experimental