### PR TITLE
test/cluster: don't require a TLS alert for a cert-less mTLS request

### DIFF
--- a/test/cluster/test_alternator.py
+++ b/test/cluster/test_alternator.py
@@ -1647,9 +1647,19 @@ async def test_alternator_mtls(manager: ScyllaClusterManager, tmp_path):
     # Test 2: Requests without a client certificate should be rejected.
     # With require_client_auth=true the TLS handshake fails if the client
     # doesn't present a certificate signed by the trusted CA.
+    # The server always rejects with a certificate_required TLS alert, but in
+    # TLS 1.3 the client only learns of it after it considers the handshake
+    # complete and has started writing the request, so it can hit a broken pipe
+    # before it reads the alert. Whether botocore then reports SSLError or
+    # ConnectionClosedError is a property of the client, not of the server:
+    # probing one and the same server with Python 3.14/OpenSSL 3.5 gives
+    # SSLError while Python 3.15/OpenSSL 4.0 gives ConnectionClosedError. As in
+    # tests 3 and 4 below, what matters is that the request is *rejected*.
     alternator_no_cert = get_alternator_mtls()
-    with pytest.raises(SSLError, match='certificate required'):
+    with pytest.raises((SSLError, ConnectionClosedError)) as excinfo:
         alternator_no_cert.meta.client.list_tables()
+    if isinstance(excinfo.value, SSLError):
+        assert 'certificate required' in str(excinfo.value)
 
     # Test 3: Requests with a client certificate signed by an untrusted CA
     # should also be rejected.


### PR DESCRIPTION
test_alternator_mtls's second case connects to an mTLS-enforcing Alternator port without a client certificate and expected botocore to raise SSLError('certificate required').

The server does reject the request, and it does so with a certificate_required TLS alert. But in TLS 1.3 the client only learns about it after it considers the handshake complete and has begun writing the request, so it can hit a broken pipe before it ever reads the alert - and botocore then reports ConnectionClosedError instead.

Which of the two the client ends up reporting is a property of the client, not of the server. Probing one and the same Scylla instance without a client certificate gives:

    Python 3.14 / OpenSSL 3.5.8   SSLError: ... certificate required
    Python 3.15 / OpenSSL 4.0.2   ConnectionClosedError

with identical urllib3, and the same split for a server built against either toolchain, so nothing in Alternator, seastar or GnuTLS is involved. The test was only passing because of the client's read/write ordering.

Accept either outcome, still checking for 'certificate required' when we do get an SSLError. Tests 3 and 4 in the same function already tolerate this for the untrusted-CA and expired-certificate cases; what matters here too is that the request is rejected.

Fixes: SCYLLADB-4244

Not backporting: the test does work with the current toolchain.