### PR TITLE
test: forward PATH/PYTHONPATH to the kmip_wrapper.py subprocess

### DIFF
--- a/test/boost/encryption_at_rest_test.cc
+++ b/test/boost/encryption_at_rest_test.cc
@@ -769,7 +769,13 @@ database_path=:memory:
                 "-v", "DEBUG",
             },
             { // env
-                fmt::format("TMPDIR={}", tmp.path().string())
+                fmt::format("TMPDIR={}", tmp.path().string()),
+                // kmip_wrapper.py's dependencies (pykmip, sqlalchemy, ...) may not live
+                // in the interpreter's default site-packages, so PATH and PYTHONPATH
+                // must be forwarded from the parent process for it to find them and
+                // for the "python" interpreter itself to be locatable.
+                fmt::format("PATH={}", tests::getenv_or_default("PATH")),
+                fmt::format("PYTHONPATH={}", tests::getenv_or_default("PYTHONPATH")),
             },
             // stdout handler
             [port_promise = std::move(port_promise), b = false](std::string_view line) mutable -> future<consumption_result<char>> {


### PR DESCRIPTION
test_kmip_provider* in encryption_at_rest_test.cc spawns
test/pylib/kmip_wrapper.py as a bare posix_spawn() with an
explicit, minimal environment containing only TMPDIR -- no PATH,
no PYTHONPATH, nothing inherited from the parent process.

This has always been technically fragile, but it was harmless as
long as kmip_wrapper.py's dependencies (pykmip, sqlalchemy, etc.)
lived in the interpreter's default site-packages, where they are
found regardless of PYTHONPATH.

This latent bug is about to surface as a real test failure: an
upcoming change decouples test.py's Python dependencies from the
frozen toolchain image, installing them into a private directory
that is only discoverable via PYTHONPATH. Once that lands, this
subprocess's stripped-down environment will no longer be able to
find sqlalchemy, and every test_kmip_provider* test will fail with
ModuleNotFoundError.

Fix it now, ahead of that change, by forwarding PATH and PYTHONPATH
from the parent process into the spawned python's environment.

Backport: not needed - this only guards against a failure mode introduced by an as-yet-unmerged, master-only change (decoupling test.py's Python dependencies from the frozen toolchain image), which no maintained release branch has. No currently released branch depends on PYTHONPATH for kmip_wrapper.py's dependencies to be found, so the previous, non-forwarding environment remains correct there.