### PR TITLE
raft: translate seastar abort error to raft abort error in add_entry

### DIFF
--- a/raft/server.cc
+++ b/raft/server.cc
@@ -801,9 +801,19 @@ future<> server_impl::add_entry(command command, wait_type type, seastar::abort_
         {
             // Taken before the first await which can reorder callers, released before
             // waiting for the entry. See _add_entry_admission.
-            auto admission = as
-                    ? co_await get_units(_add_entry_admission, 1, *as)
-                    : co_await get_units(_add_entry_admission, 1);
+            auto f_admission = co_await coroutine::as_future(as
+                    ? get_units(_add_entry_admission, 1, *as)
+                    : get_units(_add_entry_admission, 1));
+            if (f_admission.failed()) {
+                auto eptr = f_admission.get_exception();
+                if (try_catch<seastar::abort_requested_exception>(eptr) != nullptr) {
+                    co_await coroutine::return_exception(raft::request_aborted(format(
+                            "Aborted while waiting for add_entry admission on server {}, last committed entry: {}",
+                            _id, _fsm->commit_idx())));
+                } else {
+                    co_await coroutine::return_exception_ptr(eptr);
+                }
+            }
             eid = co_await add_entry_on_leader(std::move(command), as);
         }
         co_await utils::get_local_injector().inject("block_raft_add_entry_before_wait_for_entry",

--- a/raft/server.hh
+++ b/raft/server.hh
@@ -117,6 +117,13 @@ public:
     // state machine implementations shouldn't care whether an entry was applied via
     // `state_machine::apply` or via a snapshot load.
     //
+    // When forwarding is disabled, `add_entry` guarantees that entries will be appended
+    // to the log in the same order in which the `add_entry` calls were issued.
+    // More precisely, if `add_entry(A)` is called before `add_entry(B)` - without
+    // waiting for A's future before starting the call for B - the command A
+    // will be placed in the log before B (assuming that both are successfully
+    // appended).
+    //
     // Exceptions:
     // raft::commit_status_unknown
     //     Thrown if the leader has changed and the log entry has either


### PR DESCRIPTION
The raft library takes care to only throw raft-branded exceptions on failures defined in the function's docstring. In the recently merged scylladb/scylladb#31445 a path has been introduced which waits on a semaphore with an optional abort_source, and an untranslated `seastar::abort_requested_exception` manages to escape confinement.

Add an explicit catch on that exception and translate it into `raft::request_aborted` before returning it from the function.

As a bonus, document the ordering guarantee in raft/server.hh.

Fixes: SCYLLADB-4250

Backport is not needed, the related commit is only present on `master`.