### PR TITLE
[Backport 2026.3] alternator: keep HTTP connection reusable when shedding requests

### DIFF
--- a/alternator/server.cc
+++ b/alternator/server.cc
@@ -18,6 +18,7 @@
 #include <seastar/core/coroutine.hh>
 #include <seastar/core/with_scheduling_group.hh>
 #include <seastar/coroutine/maybe_yield.hh>
+#include <seastar/coroutine/try_future.hh>
 #include <seastar/util/defer.hh>
 #include "seastarx.hh"
 #include "error.hh"
@@ -603,6 +604,27 @@ read_entire_stream(input_stream<char>& inp, size_t length_limit) {
     co_return ret;
 }
 
+// Reads and discards the body of a request we reject without processing,
+// so that the connection remains reusable. Replying while the body is
+// unread results in Seastar's HTTP server closing the connection.
+static future<> drain_request_body(input_stream<char>& inp, size_t request_size_limit) {
+    size_t drained = 0;
+    while (drained <= request_size_limit) {
+        temporary_buffer<char> buf = co_await inp.read();
+        if (buf.empty()) {
+            co_return;
+        }
+        drained += buf.size();
+    }
+    // Exceeding the limit while draining is possible only for a chunked
+    // request - a non-chunked one is bounded by its Content-Length, which
+    // was checked against the limit before the drain. Seastar's httpd will
+    // close the connection after sending the reply, as it does for any
+    // reply sent before reading the entire body (the client may rarely
+    // miss the reply - see #12166).
+    throw api_error::payload_too_large(fmt::format("Request body exceeds the request size limit of {} bytes", request_size_limit));
+}
+
 // safe_gzip_stream is an exception-safe wrapper for zlib's z_stream.
 // The "z_stream" struct is used by zlib to hold state while decompressing a
 // stream of data. It allocates memory which must be freed with inflateEnd(),
@@ -725,7 +747,12 @@ future<executor::request_return_type> server::handle_api_request(std::unique_ptr
     // (transport/server.cc).
     if (_pending_requests.get_count() >= _max_concurrent_requests) {
         _executor._stats.requests_shed++;
-        co_return api_error::request_limit_exceeded(format("too many in-flight requests (configured via max_concurrent_requests_per_shard): {}", _pending_requests.get_count()));
+        // Build the msg early, before the co_await below invalidates the request counter.
+        auto err = api_error::request_limit_exceeded(format("too many in-flight requests (configured via max_concurrent_requests_per_shard): {}", _pending_requests.get_count()));
+        // Discard the unread request body before replying, so the connection stays reusable
+        throwing_assert(req->content_stream);
+        co_await coroutine::try_future(drain_request_body(*req->content_stream, request_content_length_limit));
+        co_return std::move(err);
     }
     _pending_requests.enter();
     auto leave = defer([this] () noexcept { _pending_requests.leave(); });

--- a/test/alternator/test_manual_requests.py
+++ b/test/alternator/test_manual_requests.py
@@ -6,7 +6,10 @@
 # by boto3, in order to allow non-validated input to get through
 
 import base64
+import http.client
 import json
+import urllib.parse
+
 import pytest
 import requests
 import urllib3
@@ -15,7 +18,8 @@ from packaging.version import Version
 
 from test.pylib.skip_types import skip_env
 
-from test.alternator.util import random_bytes, random_string, get_signed_request, manual_request, ManualRequestError
+from test.alternator.util import random_bytes, random_string, get_signed_request, client_ssl_context, manual_request, ManualRequestError
+from test.cqlpy.util import config_value_context
 
 
 def gen_json(n):
@@ -643,3 +647,54 @@ def test_write_malformed_value(dynamodb, test_table_s, op):
         # will return this broken map and boto3's attempt to parse the
         # returned map will fail, causing the following call to fail.
         test_table_s.get_item(Key={'p': p}, ConsistentRead=True)
+
+# A test which verifies that a request rejected with RequestLimitExceeded
+# on a keep-alive connection does not break the connection. Until
+# SCYLLADB-3786 was solved the rejection was sent without reading the
+# request body, prompting the Seastar HTTP server to close the connection
+# right after the response was sent, despite the keep-alive header present
+# in the response. The affected HTTP client failed a later request with a
+# surprising disconnect.
+# The test uses http.client directly to hold exactly one connection with no
+# automatic reconnection or retry, and sets max_concurrent_requests_per_shard
+# to 0 (it's live-updatable) so every request is rejected.
+def test_request_limit_exceeded_connection_reuse(dynamodb, cql):
+    url = urllib.parse.urlsplit(dynamodb.meta.client._endpoint.host)
+    if url.scheme == 'https':
+        conn = http.client.HTTPSConnection(url.hostname, url.port, context=client_ssl_context(dynamodb), timeout=60)
+    else:
+        conn = http.client.HTTPConnection(url.hostname, url.port, timeout=60)
+
+    def do_request():
+        req = get_signed_request(dynamodb, 'DescribeTable', '{"TableName": "no_such_table"}')
+        conn.request('POST', '/', body=req.body, headers=req.headers)
+        response = conn.getresponse()
+        return response.status, response.read().decode('utf-8')
+
+    try:
+        # Sanity check - a normal request on this connection works (the
+        # table doesn't exist, so we expect ResourceNotFoundException):
+        status, body = do_request()
+        assert 'ResourceNotFoundException' in body, body
+        # config_value_context() returns after the new value has been applied
+        # on all shards, so the next request is already rejected.
+        # Careful: this test works only because the two servers gate on the same
+        # config item but not by the same condition - Alternator sheds on '>=',
+        # CQL on '>' (transport/server.cc). A limit of 0 thus rejects every
+        # Alternator request, while a CQL one still passes and can put the
+        # original limit back. Aligning the two would have broken this test: the
+        # CQL restore would be shed too, leaving the limit at 0 for later tests.
+        with config_value_context(cql, 'max_concurrent_requests_per_shard', '0'):
+            # The interesting part: each rejection must leave the connection
+            # usable. Before the fix the server closed it right after the
+            # first one, so the next do_request() raised an exception
+            # (http.client.RemoteDisconnected or similar).
+            for _ in range(2):
+                status, body = do_request()
+                assert status == 400 and 'RequestLimitExceeded' in body, body
+        # After the original limit is restored, the same connection must
+        # still work for normal request processing:
+        status, body = do_request()
+        assert 'ResourceNotFoundException' in body, body
+    finally:
+        conn.close()

--- a/test/alternator/util.py
+++ b/test/alternator/util.py
@@ -376,6 +376,19 @@ def scylla_config_temporary(dynamodb, name, value, nop = False):
     finally:
         scylla_config_write(dynamodb, name, original_value)
 
+# get_cert() returns the (cert_file, key_file) tuple that should be passed
+# as the "cert" parameter of requests.get()/post() to authenticate to the
+# given dynamodb connection's endpoint, or None if that connection does not
+# use a client certificate. Tests which send raw HTTP requests (i.e., not
+# through boto3) to the same endpoint as "dynamodb" - instead of through
+# get_signed_request()/manual_request() below - need to pass this "cert" too,
+# because under mTLS (--mtls) the TLS handshake itself will fail without it,
+# regardless of the request's content.
+def get_cert(dynamodb):
+    session = dynamodb.meta.client._endpoint.http_session
+    cert_file = getattr(session, '_cert_file', None)
+    return (cert_file, session._key_file) if cert_file else None
+
 # manual_request() can be used to send a DynamoDB API request without any
 # boto3 involvement in preparing the request - the operation name and
 # operation payload (a JSON string) are created by the caller. Use this

--- a/test/alternator/util.py
+++ b/test/alternator/util.py
@@ -7,6 +7,7 @@
 import string
 import random
 import collections
+import ssl
 import time
 import requests
 import json
@@ -388,6 +389,21 @@ def get_cert(dynamodb):
     session = dynamodb.meta.client._endpoint.http_session
     cert_file = getattr(session, '_cert_file', None)
     return (cert_file, session._key_file) if cert_file else None
+
+# An ssl.SSLContext for connecting to the given server as a client, for
+# tests which bypass boto3 and establish TLS connections themselves.
+def client_ssl_context(dynamodb):
+    context = ssl.create_default_context()
+    # check_hostname and verify_mode is needed when we use self-signed
+    # certificates in tests.
+    context.check_hostname = False
+    context.verify_mode = ssl.CERT_NONE
+    # Under mTLS, the server requires a client certificate at the TLS
+    # handshake level - so load it if there is one.
+    cert = get_cert(dynamodb)
+    if cert:
+        context.load_cert_chain(certfile=cert[0], keyfile=cert[1])
+    return context
 
 # manual_request() can be used to send a DynamoDB API request without any
 # boto3 involvement in preparing the request - the operation name and


### PR DESCRIPTION
### Problem

Since a86928caa1, a request shed due to `max_concurrent_requests_per_shard` is answered with `RequestLimitExceeded` **before its body is read**. Seastar's HTTP server then used to close the connection in this case, as the unread body would be misparsed as the next request. The closure however was done after the response was already sent with a `keep-alive` promise. Then, a completely innocent request reusing this connection fails with `ConnectionClosedError` / `RemoteDisconnected`.

### Fix

Read and discard the request body (new `drain_request_body()`) before responding (with `RequestLimitExceeded`), so the connection remains reusable. An HTTP error response does not require closing the connection.

New regression test `test_request_limit_exceeded_connection_reuse` holds a single `http.client` connection (no automatic reconnection/retry) and live-sets `max_concurrent_requests_per_shard=0` so every request is rejected, then asserts the connection survives repeated rejections and works normally after the limit is restored.

### Testing 

Without the fix the test fails with `BrokenPipeError`/`RemoteDisconnected` on the request following the first rejection; with the fix it passes.

### Backport

a86928caa1 which introduced this problem went in to 2026.3 and 2026.2, so let's backport there.

**This series has one extra commit which is not present in the parent PR**: `client_ssl_context()` calls `get_cert()`, which is missing on this branch. So this PR took it from from 20bcc86b93 as a separate commit.

Fixes SCYLLADB-4267

- (cherry picked from commit e93108dd165a90248e54e55cbb533002e74c26be)
- (partially cherry picked from commit 20bcc86b933bb20e7f2d760382c1e4bdaf808826)
- (cherry picked from commit ff45ba1650844ec09f44a103cb069dfdb8caab61)
- (cherry picked from commit 19b43206eadbfecddcb03a075dbcdef1cf10bb5f)

Parent PR: #31190