### PR TITLE
view_building_worker: resolve staging sstables from the table's live sstable set

### DIFF
--- a/db/view/view_building_worker.cc
+++ b/db/view/view_building_worker.cc
@@ -186,13 +186,12 @@ void view_building_worker::on_drop_view(const sstring& ks_name, const sstring& v
 
 future<> view_building_worker::register_staging_sstable_tasks(std::vector<sstables::shared_sstable> ssts, table_id table_id) {
     auto& tablet_map = _db.get_token_metadata().tablets().get_tablet_map(table_id);
-    auto staging_task_infos = ssts | std::views::as_rvalue | std::views::transform([&] (sstables::shared_sstable sst) {
+    auto staging_task_infos = ssts | std::views::transform([&] (const sstables::shared_sstable& sst) {
         auto tid = get_sstable_tablet_id(tablet_map, *sst);
         return staging_sstable_task_info {
             .table_id = table_id,
             .shard = get_sstable_shard_id(*sst),
             .last_token = tablet_map.get_last_token(tid),
-            .sst_foreign_ptr = make_foreign(std::move(sst))
         };
     }) | std::ranges::to<std::vector>();
 
@@ -252,43 +251,13 @@ future<> view_building_worker::run_staging_sstables_registrator() {
     }
 }
 
-future<std::vector<foreign_ptr<semaphore_units<>>>> view_building_worker::lock_staging_mutex_on_multiple_shards(std::flat_set<shard_id> shards) {
-    SCYLLA_ASSERT(this_shard_id() == 0);
-    // Collect `_staging_sstables_mutex` locks from multiple shards,
-    // so other shards won't interact with their `_staging_sstables` map
-    // until the caller releases them.
-    std::vector<foreign_ptr<semaphore_units<>>> locks;
-    locks.resize(this_smp_shard_count());
-    // Locks are acquired from multiple shards in parallel.
-    // This is the only place where multiple-shard locks are acquired at once
-    // and the method is called only once at a time (from `create_staging_sstable_tasks()`
-    // on shard 0), so no deadlock may occur.
-    co_await coroutine::parallel_for_each(shards, [&locks, &sharded_vbw = container()] (auto shard_id) -> future<> {
-        auto lock_ptr = co_await smp::submit_to(shard_id, [&sharded_vbw] () -> future<foreign_ptr<semaphore_units<>>> {
-            auto& vbw = sharded_vbw.local();
-            auto lock = co_await get_units(vbw._staging_sstables_mutex, 1, vbw._as);
-            co_return make_foreign(std::move(lock));
-        });
-        locks[shard_id] = std::move(lock_ptr);
-    });
-    co_return std::move(locks);
-}
-
 future<> view_building_worker::create_staging_sstable_tasks() {
-    // Explicitly lock shard0 beforehand to prevent other shards from modifying `_sstables_to_register` from `register_staging_sstable_tasks()`
+    // Lock shard0 to prevent other shards from modifying `_sstables_to_register` from `register_staging_sstable_tasks()`
     auto lock0 = co_await get_units(_staging_sstables_mutex, 1, _as);
 
     if (_sstables_to_register.empty()) {
         co_return;
     }
-
-    auto shards = _sstables_to_register 
-        | std::views::values 
-        | std::views::join 
-        | std::views::transform([] (const auto& sst_info) { return sst_info.shard; }) 
-        | std::ranges::to<std::flat_set<shard_id>>();
-    shards.erase(0); // We're already holding shard0 lock
-    auto locks = co_await lock_staging_mutex_on_multiple_shards(std::move(shards));
 
     auto guard = co_await _group0.client().start_operation(_as);
     auto uuid_gen = _vb_state_machine.building_state.make_task_uuid_generator(guard.write_timestamp());
@@ -351,29 +320,6 @@ future<> view_building_worker::create_staging_sstable_tasks() {
     cmuts.emplace_back(builder.build());
     auto cmd = _group0.client().prepare_command(service::write_mutations{std::move(cmuts)}, guard, "create view building tasks");
     co_await _group0.client().add_entry(std::move(cmd), std::move(guard), _as);
-
-    // Move staging sstables from `_sstables_to_register` (on shard0) to `_staging_sstables` on corresponding shards.
-    // Firstly reorgenize `_sstables_to_register` for easier movement.
-    // This is done in separate loop after committing the group0 command, because we need to move values from `_sstables_to_register`
-    // (`staging_sstable_task_info` is non-copyable because of `foreign_ptr` field).
-    std::unordered_map<shard_id, std::unordered_map<table_id, std::vector<foreign_ptr<sstables::shared_sstable>>>> new_sstables_per_shard;
-    for (auto& [table_id, sst_infos]: _sstables_to_register) {
-        for (auto& sst_info: sst_infos) {
-            new_sstables_per_shard[sst_info.shard][table_id].push_back(std::move(sst_info.sst_foreign_ptr));
-        }
-    }
-
-    for (auto& [shard, sstables_per_table]: new_sstables_per_shard) {
-        co_await container().invoke_on(shard, [sstables_for_this_shard = std::move(sstables_per_table)] (view_building_worker& local_vbw) mutable {
-            for (auto& [tid, ssts]: sstables_for_this_shard) {
-                auto unwrapped_ssts = ssts | std::views::as_rvalue | std::views::transform([] (auto&& fptr) {
-                    return fptr.unwrap_on_owner_shard();
-                }) | std::ranges::to<std::vector>();
-                auto& tid_ssts = local_vbw._staging_sstables[tid];
-                tid_ssts.insert(tid_ssts.end(), std::make_move_iterator(unwrapped_ssts.begin()), std::make_move_iterator(unwrapped_ssts.end()));
-            }
-        });
-    }
     _sstables_to_register.clear();
 }
 
@@ -435,9 +381,7 @@ std::unordered_map<table_id, std::vector<view_building_worker::staging_sstable_t
             if (!staging_task_exists(building_tasks, table_id, {my_host_id, shard}, last_token)) {
                 // For the future: we can check if the sstable needs to go through view building coordinator
                 //                 or maybe it can be registered to view_update_generator directly.
-                tasks_to_create[table_id].emplace_back(table_id, shard, last_token, make_foreign(std::move(sstable)));
-            } else {
-                _staging_sstables[table_id].push_back(std::move(sstable));
+                tasks_to_create[table_id].emplace_back(table_id, shard, last_token);
             }
         }
     });
@@ -843,35 +787,16 @@ future<> view_building_worker::do_process_staging(table_id table_id, dht::token 
     if (sstables_to_process.empty()) {
         co_return;
     }
-    co_await _vug.process_staging_sstables(std::move(table), sstables_to_process);
-
-    try {
-        // Remove processed sstables from `_staging_sstables` map
-        auto lock = co_await get_units(_staging_sstables_mutex, 1, _as);
-        std::unordered_set<sstables::shared_sstable> sstables_to_remove(sstables_to_process.begin(), sstables_to_process.end());
-        auto [first, last] = std::ranges::remove_if(_staging_sstables[table_id], [&] (auto& sst) {
-            return sstables_to_remove.contains(sst);
-        });
-        _staging_sstables[table_id].erase(first, last);
-    } catch (semaphore_aborted&) {
-        vbw_logger.warn("Semaphore was aborted while waiting to removed processed sstables for table {}", table_id);
-    }
-}
-
-void view_building_worker::load_sstables(table_id table_id, std::vector<sstables::shared_sstable> ssts) {
-    std::ranges::copy_if(std::move(ssts), std::back_inserter(_staging_sstables[table_id]), [] (auto& sst) {
-        return sst->state() == sstables::sstable_state::staging;
-    });
+    co_await _vug.process_staging_sstables(std::move(table), std::move(sstables_to_process));
 }
 
 future<> view_building_worker::cleanup_staging_sstables(locator::effective_replication_map_ptr erm, table_id table_id, locator::tablet_id tid) {
     auto& tablet_map = erm->get_token_metadata().tablets().get_tablet_map(table_id);
     auto tablet_range = tablet_map.get_token_range(tid);
 
-    // Remove entries from the shard-0 registration queue.
-    // Without this, a pending entry in `_sstables_to_register` would be moved into
-    // `_staging_sstables` by the registrator after cleanup deletes the tablet's storage,
-    // causing an infinite ENOENT retry loop (SCYLLADB-2312).
+    // Remove entries from the shard-0 registration queue, so the registrator doesn't
+    // create a `process_staging` task for a tablet whose storage is about to be deleted
+    // (SCYLLADB-2312).
     co_await container().invoke_on(0, [table_id, tablet_range] (view_building_worker& vbw0) -> future<> {
         auto lock = co_await get_units(vbw0._staging_sstables_mutex, 1, vbw0._as);
         auto it = vbw0._sstables_to_register.find(table_id);
@@ -887,14 +812,6 @@ future<> view_building_worker::cleanup_staging_sstables(locator::effective_repli
                 old_size - it->second.size(), table_id);
         }
     });
-
-    // Remove from local shard staging list.
-    auto lock = co_await get_units(_staging_sstables_mutex, 1, _as);
-    auto [first, last] = std::ranges::remove_if(_staging_sstables[table_id], [&] (auto& sst) {
-        auto sst_last_token = sst->get_last_decorated_key().token();
-        return tablet_range.contains(sst_last_token, dht::token_comparator());
-    });
-    _staging_sstables[table_id].erase(first, last);
 }
 
 future<view_building_state> view_building_worker::get_latest_view_building_state(raft::term_t term) {

--- a/db/view/view_building_worker.cc
+++ b/db/view/view_building_worker.cc
@@ -834,29 +834,11 @@ future<> view_building_worker::do_build_range(table_id base_id, std::vector<tabl
 
 future<> view_building_worker::do_process_staging(table_id table_id, dht::token last_token) {
     auto table = _db.get_tables_metadata().get_table(table_id).shared_from_this();
-    std::vector<sstables::shared_sstable> sstables_to_process;
+    auto tablet_range = get_tablet_token_range(table_id, last_token);
 
-    try {
-        // Acquire `_staging_sstables_mutex` to prevent `create_staging_sstable_tasks()` from
-        // concurrently modifying `_staging_sstables` (moving entries from `_sstables_to_register`)
-        // while we read them.
-        auto lock = co_await get_units(_staging_sstables_mutex, 1, _as);
-        auto& tablet_map = table->get_effective_replication_map()->get_token_metadata().tablets().get_tablet_map(table_id);
-        auto tid = tablet_map.get_tablet_id(last_token);
-        auto tablet_range = tablet_map.get_token_range(tid);
-
-        // Select sstables belonging to the tablet (identified by `last_token`)
-        for (auto& sst: _staging_sstables[table_id]) {
-            auto sst_last_token = sst->get_last_decorated_key().token();
-            if (tablet_range.contains(sst_last_token, dht::token_comparator())) {
-                sstables_to_process.push_back(sst);
-            }
-        }
-        lock.return_all();
-    } catch (semaphore_aborted&) {
-        vbw_logger.warn("Semaphore was aborted while waiting to removed processed sstables for table {}", table_id);
-        co_return;
-    }
+    auto sstables_to_process = *table->get_sstables() | std::views::filter([&] (const sstables::shared_sstable& sst) {
+        return sst->requires_view_building() && tablet_range.contains(sst->get_last_decorated_key().token(), dht::token_comparator());
+    }) | std::ranges::to<std::vector>();
 
     if (sstables_to_process.empty()) {
         co_return;

--- a/db/view/view_building_worker.hh
+++ b/db/view/view_building_worker.hh
@@ -14,7 +14,6 @@
 #include <seastar/core/shared_future.hh>
 #include <unordered_map>
 #include <unordered_set>
-#include <flat_set>
 #include "locator/abstract_replication_strategy.hh"
 #include "locator/tablets.hh"
 #include "raft/raft.hh"
@@ -116,7 +115,6 @@ class view_building_worker : public seastar::peering_sharded_service<view_buildi
         table_id table_id;
         shard_id shard;
         dht::token last_token;
-        foreign_ptr<sstables::shared_sstable> sst_foreign_ptr;
     };
 
     class consumer;
@@ -139,7 +137,6 @@ private:
     condition_variable _sstables_to_register_event;
     semaphore _staging_sstables_mutex = semaphore(1);
     std::unordered_map<table_id, std::vector<staging_sstable_task_info>> _sstables_to_register;
-    std::unordered_map<table_id, std::vector<sstables::shared_sstable>> _staging_sstables;
     semaphore _started_staging_tasks_mutex = semaphore(1);
     std::unordered_map<locator::tablet_replica, std::set<std::pair<table_id, utils::UUID>>> _started_staging_tasks;
     future<> _staging_sstables_registrator = make_ready_future<>();
@@ -159,8 +156,6 @@ public:
     virtual void on_update_view(const sstring& ks_name, const sstring& view_name, bool columns_changed) override {};
     virtual void on_drop_view(const sstring& ks_name, const sstring& view_name) override;
 
-    // Used ONLY to load staging sstables migrated during intra-node tablet migration.
-    void load_sstables(table_id table_id, std::vector<sstables::shared_sstable> ssts);
     // Used in cleanup/cleanup-target tablet transition stage
     future<> cleanup_staging_sstables(locator::effective_replication_map_ptr erm, table_id table_id, locator::tablet_id tid);
 
@@ -177,15 +172,10 @@ private:
     future<> do_process_staging(table_id base_id, dht::token last_token);
 
     future<> run_staging_sstables_registrator();
-    // Acquires `_staging_sstables_mutex` on all shards internally,
-    // so callers must not hold `_staging_sstables_mutex` when invoking it.
+    // Acquires `_staging_sstables_mutex` internally, so callers must not hold it when invoking it.
     future<> create_staging_sstable_tasks();
     future<> discover_existing_staging_sstables();
     std::unordered_map<table_id, std::vector<staging_sstable_task_info>> discover_local_staging_sstables(building_tasks building_tasks);
-    // Acquire `_staging_sstables_mutex` on multiple shards in parallel.
-    // Must be called only from shard 0.
-    // Must be called ONLY by `create_staging_sstable_tasks()` and only once at a time to avoid deadlock.
-    future<std::vector<foreign_ptr<semaphore_units<>>>> lock_staging_mutex_on_multiple_shards(std::flat_set<shard_id> shards);
 
     void init_messaging_service();
     future<> uninit_messaging_service();

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -5329,11 +5329,42 @@ table::make_mutation_reader_excluding_staging(schema_ptr s,
     return make_combined_reader(s, std::move(permit), std::move(readers), fwd, fwd_mr);
 }
 
+// Returns the sstable the table currently holds for the data of `sst`: `sst` itself if it is
+// still in the sstable set, the sstable it was cloned into by a component rewrite (incremental
+// repair marking, tablet merge) if that one is, or nullptr if the data is gone from the table
+// (tablet cleanup, already moved out of staging, or rewritten more than once since the caller
+// took its reference).
+static sstables::shared_sstable current_generation_of(const sstable_list& all, const sstables::shared_sstable& sst) {
+    if (all.contains(sst)) {
+        return sst;
+    }
+    const auto& clone = sst->cloned_to_sstable_filename();
+    if (!clone) {
+        return nullptr;
+    }
+    auto it = std::ranges::find_if(all, [&] (const sstables::shared_sstable& s) {
+        return s->component_basename(sstables::component_type::Data) == *clone;
+    });
+    return it != all.end() ? *it : nullptr;
+}
+
 future<> table::move_sstables_from_staging(std::vector<sstables::shared_sstable> sstables) {
     auto permit = co_await get_sstable_list_permit();
+    auto all = get_sstables();
     sstables::delayed_commit_changes delay_commit;
     std::unordered_set<compaction_group*> compaction_groups_to_notify;
-    for (auto sst : sstables) {
+    for (auto& registered : sstables) {
+        auto sst = current_generation_of(*all, registered);
+        if (!sst) {
+            tlogger.warn("Not moving sstable {} from staging: it is no longer part of the table", registered->get_filename());
+            continue;
+        }
+        if (sst != registered) {
+            tlogger.info("Sstable {} was rewritten into {} while in staging, moving the latter", registered->get_filename(), sst->get_filename());
+        }
+        if (!sst->requires_view_building()) {
+            continue;
+        }
         try {
             // Off-strategy can happen in parallel to view building, so the SSTable may be deleted already if the former
             // completed first.

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -5459,8 +5459,7 @@ future<> storage_service::clone_locally_tablet_storage(locator::global_tablet_id
             }
             co_return;
         };
-        auto loaded_ssts = co_await table.add_new_sstables_and_update_cache(std::vector(ssts.begin(), ssts.end()), on_add);
-        _view_building_worker.local().load_sstables(tablet.table, loaded_ssts);
+        co_await table.add_new_sstables_and_update_cache(std::vector(ssts.begin(), ssts.end()), on_add);
     });
     rtlogger.debug("Successfully loaded storage of tablet {} into pending replica {}", tablet, pending);
 }

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -1197,6 +1197,13 @@ public:
         return _sstable_identifier;
     }
 
+    // Set on the source of a component rewrite (see link_with_rewritten_component()):
+    // the basename of the Data component of the sstable it was cloned into. Lets holders
+    // of a reference to the replaced sstable find its current generation in the table.
+    const std::optional<sstring>& cloned_to_sstable_filename() const noexcept {
+        return _cloned_to_sstable_filename;
+    }
+
     // Drops all evictable in-memory caches of on-disk content.
     future<> drop_caches();
 

--- a/test/cluster/test_view_building_coordinator.py
+++ b/test/cluster/test_view_building_coordinator.py
@@ -1296,3 +1296,111 @@ async def test_staging_registration_race_with_tablet_migration(manager: ScyllaCl
         await assert_row_count_on_host(cql, s1_hosts[0], ks, "mv", rows)
         await manager.server_start(node3.server_id)
         await wait_for_cql_and_get_hosts(cql, [node3], time.time() + 30)
+
+# Incremental repair marks the sstables it wrote as repaired by rewriting their Statistics
+# component (table::perform_component_rewrite), which replaces the sstable object with a new
+# generation and unlinks the old files. Whoever registered the staging sstable for view building
+# still holds the old object. Variants:
+# - rewrite_before_processing: the view is under construction, so the staging sstable is managed by
+#   the view building worker. Its process_staging task cannot start before the repair finishes (the
+#   coordinator doesn't start tasks on a tablet under repair), so the worker used to pick up a
+#   reference to a no longer existing sstable and loop on ENOENT forever, never building the view.
+# - rewrite_during_processing: like above, but the worker is already processing the sstable when
+#   an incremental repair rewrites it (a non-incremental repair wrote it first, without marking).
+# - view_already_built: the staging sstable is registered directly with view_update_generator,
+#   which used to fail moving it out of staging and leave the rewritten one there until restart.
+# In every case the rewritten sstable has to leave staging and the view has to be complete.
+# Reproduces SCYLLADB-3372
+@pytest.mark.parametrize("scenario", ["rewrite_before_processing", "rewrite_during_processing", "view_already_built"])
+@pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
+async def test_incremental_repair_rewrites_staging_sstable(manager: ScyllaClusterManager, scenario: str):
+    node_count = 2
+    smp = 2
+    servers = await manager.servers_add(node_count, cmdline=cmdline_loggers + [f'--smp={smp}'], property_file=[
+        {"dc": "dc1", "rack": "r1"},
+        {"dc": "dc1", "rack": "r2"},
+    ])
+    cql, hosts = await manager.get_ready_cql(servers)
+    await manager.disable_tablet_balancing()
+    view_built = scenario == "view_already_built"
+
+    async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 2} AND tablets = {'initial': 1}") as ks:
+        await cql.run_async(f"CREATE TABLE {ks}.tab (key int, c int, v int, PRIMARY KEY (key))")
+        create_view = f"CREATE MATERIALIZED VIEW {ks}.mv AS SELECT * FROM {ks}.tab WHERE key IS NOT NULL AND c IS NOT NULL PRIMARY KEY (c, key)"
+
+        rows = 100
+        for i in range(rows):
+            await cql.run_async(f"INSERT INTO {ks}.tab (key, c, v) VALUES ({i}, {i}, 1)")
+        if view_built:
+            await cql.run_async(create_view)
+            await wait_for_view(cql, 'mv', node_count)
+
+        # Make node0 miss all the data, so the repair below has to write it there.
+        for table in ["tab", "mv"] if view_built else ["tab"]:
+            await manager.api.keyspace_flush(servers[0].ip_addr, ks, table)
+            await delete_table_sstables(manager, servers[0], ks, table)
+        await manager.server_stop_gracefully(servers[0].server_id)
+        await manager.server_start(servers[0].server_id)
+        await wait_for_cql_and_get_hosts(cql, servers, time.time() + 60)
+
+        s0_log = await manager.server_open_log(servers[0].server_id)
+        s0_mark = await s0_log.mark()
+
+        if not view_built:
+            # Hold the build_range tasks, so the view stays in STARTED state and the repair output
+            # goes to staging managed by the view building worker.
+            await pause_view_building_tasks(manager)
+            await cql.run_async(create_view)
+            await s0_log.wait_for("do_build_range: paused, waiting for message", from_mark=s0_mark, timeout=60)
+
+        vug_pause = "view_update_generator_pause_before_processing"
+        if scenario == "rewrite_before_processing":
+            await manager.api.tablet_repair(servers[0].ip_addr, ks, "tab", "all", incremental_mode='incremental')
+            await unpause_view_building_tasks(manager)
+        elif scenario == "rewrite_during_processing":
+            # The non-incremental repair writes the staging sstable without marking it. Then let the
+            # worker start processing it and hold it right before it generates view updates.
+            await manager.api.repair(servers[0].ip_addr, ks, "tab")
+            await s0_log.wait_for("Creating process staging task", from_mark=s0_mark, timeout=60)
+            await manager.api.enable_injection(servers[0].ip_addr, vug_pause, one_shot=True)
+            await unpause_view_building_tasks(manager)
+            await s0_log.wait_for(f"{vug_pause}: waiting for message", from_mark=s0_mark, timeout=120)
+            await manager.api.tablet_repair(servers[0].ip_addr, ks, "tab", "all", incremental_mode='incremental')
+            await manager.api.message_injection(servers[0].ip_addr, vug_pause)
+        else:
+            # Hold the generator right before it reads the sstable the repair is about to write.
+            await manager.api.enable_injection(servers[0].ip_addr, vug_pause, one_shot=True)
+            await manager.api.tablet_repair(servers[0].ip_addr, ks, "tab", "all", incremental_mode='incremental')
+            await s0_log.wait_for(f"{vug_pause}: waiting for message", from_mark=s0_mark, timeout=60)
+            await manager.api.message_injection(servers[0].ip_addr, vug_pause)
+        marked = await s0_log.grep(r"Marking sstable=.*/staging/.* for incremental repair", from_mark=s0_mark)
+        assert len(marked) > 0, "expected the repair to mark a staging sstable as repaired"
+
+        if view_built:
+            await s0_log.wait_for(f"Processed {ks}.tab", from_mark=s0_mark, timeout=60)
+        else:
+            await wait_for_view(cql, 'mv', node_count, timeout=180)
+
+        # The rewritten sstable has to leave staging, and without a retry.
+        staging_dir = os.path.join(await get_table_dir(manager, servers[0], ks, "tab"), "staging")
+        async def staging_empty():
+            return (not os.path.isdir(staging_dir) or not os.listdir(staging_dir)) or None
+        await wait_for(staging_empty, deadline=time.time() + 60)
+        failures = await s0_log.grep("Failed to move sstable|Moving some sstable from staging failed", from_mark=s0_mark)
+        assert len(failures) == 0, f"moving the staging sstable failed: {failures}"
+
+        # View updates generated from staging sstables are not awaited, so wait until the view update
+        # backlog drains before checking the view content.
+        async def view_updates_drained():
+            metrics = await manager.metrics.query(servers[0].ip_addr)
+            for shard in range(smp):
+                if metrics.get("scylla_database_view_update_backlog", {'shard': str(shard)}) > 0:
+                    return None
+            return True
+        await wait_for(view_updates_drained, deadline=time.time() + 60)
+
+        hosts = await wait_for_cql_and_get_hosts(cql, [servers[0]], time.time() + 60)
+        await manager.server_stop_gracefully(servers[1].server_id)
+        await assert_row_count_on_host(cql, hosts[0], ks, "tab", rows)
+        await assert_row_count_on_host(cql, hosts[0], ks, "mv", rows)
+        await manager.server_start(servers[1].server_id)


### PR DESCRIPTION
`view_building_worker` kept the `shared_sstable` references of the staging
sstables registered with it and used them when a `process_staging` task ran.
Those references go stale: incremental repair (`repair_meta::mark_sstable_as_repaired()`)
and tablet merge (`table::update_repaired_at_for_merge()`) rewrite the Statistics
component through `table::perform_component_rewrite()`, which replaces the sstable
object with a new generation and unlinks the old files. The worker then generated
the view updates from the stale object and failed in `table::move_sstables_from_staging()`
with 
```
link failed: No such file or directory [.../staging/<sst>-big-TOC.txt]
``` 
on every retry, forever. The view build never finished and the replacement sstable,
registered nowhere, sat in staging until the next restart.
 
#30886 serialized the on-disk operations of the rewrite and the move under
`_mutate_sem`. That fixed the shard abort (SCYLLADB-3263) but not the object
replacement, so SCYLLADB-3372 kept reproducing.

Fix: `do_process_staging()` resolves the tablet's staging sstables from
`table->get_sstables()` when the task runs, the same way `discover_local_staging_sstables()`
does at startup. If a rewrite lands between resolution and the move, the move fails
once and the batch retry picks up the replacement. This covers every rewrite trigger
and needs no changes in repair. The second commit removes the now unused
`_staging_sstables` bookkeeping, including the multi-shard locking in
`create_staging_sstable_tasks()` and `load_sstables()`.

Fixes SCYLLADB-3372

Backport: 2026.2 and 2026.3. Previous versions don't rewrite 
sstable's component to update repaired_at property.