### PR TITLE
types: render a null collection element instead of dereferencing it

### DIFF
--- a/test/boost/types_test.cc
+++ b/test/boost/types_test.cc
@@ -1014,6 +1014,24 @@ BOOST_AUTO_TEST_CASE(test_list_to_string) {
     BOOST_REQUIRE_EQUAL(m->to_string(v.serialize_nonnull()), "41, 42");
 }
 
+// A null value rendered on its own - SCYLLADB-3883.
+BOOST_AUTO_TEST_CASE(test_null_value_to_string_impl_is_empty) {
+    BOOST_REQUIRE_EQUAL(int32_type->to_string_impl(data_value::make_null(int32_type)), "");
+}
+
+// A deserialized null element keeps the element type - SCYLLADB-3883.
+BOOST_AUTO_TEST_CASE(test_deserialized_null_list_element_keeps_element_type) {
+    auto m = list_type_impl::get_instance(int32_type, true);
+    using native_type = std::vector<data_value>;
+    native_type native{data_value::make_null(int32_type)};
+    auto v = data_value::make(m, std::make_unique<native_type>(std::move(native)));
+    auto serialized = v.serialize_nonnull();
+    auto deserialized = m->deserialize(serialized);
+    const auto& elements = value_cast<list_type_impl::native_type>(deserialized);
+    BOOST_REQUIRE(elements[0].is_null());
+    BOOST_REQUIRE(elements[0].type() == int32_type);
+}
+
 BOOST_AUTO_TEST_CASE(test_collection_type_compatibility) {
     auto m__bi = map_type_impl::get_instance(bytes_type, int32_type, true);
     auto mf_bi = map_type_impl::get_instance(bytes_type, int32_type, false);

--- a/test/cqlpy/test_null.py
+++ b/test/cqlpy/test_null.py
@@ -335,3 +335,16 @@ def test_null_int_in_collection(scylla_driver_only, cql, test_keyspace, cassandr
         stmt = cql.prepare(f"INSERT INTO {table} (p,v) VALUES ({p}, ?)")
         with pytest.raises(InvalidRequest, match='null|NULL'):
             cql.execute(stmt, [[2,None]])
+
+def test_traced_null_int_in_collection(scylla_driver_only, cql, test_keyspace, cassandra_bug):
+    '''Tracing formats a request's bound values, so a null element in a bound
+    collection must render as "null" - not crash the node, and not render as
+    nothing, which an empty element also does. Reproduces SCYLLADB-3883.'''
+    schema = 'p int primary key, v list<int>'
+    with new_test_table(cql, test_keyspace, schema) as table:
+        p = unique_key_int()
+        stmt = cql.prepare(f"INSERT INTO {table} (p,v) VALUES ({p}, ?)")
+        fut = cql.execute_async(stmt, [[41, None, 42]], trace=True)
+        with pytest.raises(InvalidRequest, match='null|NULL'):
+            fut.result()
+        assert '41, null, 42' in fut.get_query_trace(max_wait=60).parameters.values()

--- a/types/types.cc
+++ b/types/types.cc
@@ -1281,12 +1281,7 @@ static sstring map_to_string(const std::vector<std::pair<data_value, data_value>
     }
 
     fmt::print(out, "{}", fmt::join(v | std::views::transform([] (const std::pair<data_value, data_value>& p) {
-        std::ostringstream out;
-        const auto& k = p.first;
-        const auto& v = p.second;
-        out << "{" << k.type()->to_string_impl(k) << " : ";
-        out << v.type()->to_string_impl(v) << "}";
-        return std::move(out).str();
+        return fmt::format("{{{} : {}}}", p.first, p.second);
     }), ", "));
 
     if (include_frozen_type) {
@@ -1587,17 +1582,16 @@ list_type_impl::deserialize(View in) const {
             auto e = _elements->deserialize(*serialized_value_opt);
             s.push_back(std::move(e));
         } else {
-            s.push_back(data_value::make_null(data_type(shared_from_this())));
+            s.push_back(data_value::make_null(_elements));
         }
     }
     return make_value(std::move(s));
 }
 template data_value list_type_impl::deserialize<>(ser::buffer_view<bytes_ostream::fragment_iterator>) const;
 
+// Elements can be null on the wire; data_value's formatter renders those as "null".
 static sstring vector_to_string(const std::vector<data_value>& v, std::string_view sep) {
-    return fmt::to_string(fmt::join(
-            v | std::views::transform([] (const data_value& e) { return e.type()->to_string_impl(e); }),
-            sep));
+    return fmt::to_string(fmt::join(v, sep));
 }
 
 template <typename F>
@@ -3242,7 +3236,8 @@ static sstring tuple_to_string(const tuple_type_impl &t, const tuple_type_impl::
 template <typename N, typename A, typename F>
 static sstring format_if_not_empty(
         const concrete_type<N, A>& type, const typename concrete_type<N, A>::native_type* b, F&& f) {
-    if (b->empty()) {
+    // b is null for a null value, which every concrete type can be handed.
+    if (!b || b->empty()) {
         return {};
     }
     return f(static_cast<const N&>(*b));


### PR DESCRIPTION
A write that binds a collection holding a null element brings the node
down when tracing is on. The write itself is rejected, but tracing
formats the bound values once the request finishes, and formatting a
null element dereferenced it. Render such an element as "null", the way
JSON output already does, so it cannot be mistaken for a genuinely empty
one, and null-check the value formatter as a backstop.

Fixes: SCYLLADB-3883
Backport: better backport it to all versions as it can cause a crash in a rare corner case.
