### PR TITLE
gossip: store the IP address of the SYN/ACK sender

### DIFF
--- a/gms/gossiper.cc
+++ b/gms/gossiper.cc
@@ -188,6 +188,11 @@ future<> gossiper::handle_syn_msg(locator::host_id from, gossip_digest_syn syn_m
         co_return;
     }
 
+    if (utils::get_local_injector().is_enabled("gossiper_ignore_incoming_syn")) {
+        logger.info("gossiper_ignore_incoming_syn: ignoring gossip syn msg from node {}", from);
+        co_return;
+    }
+
     /* If the message is from a different cluster throw it away. */
     if (syn_msg.cluster_id() != get_cluster_name()) {
         logger.warn("ClusterName mismatch from {} {}!={}", from, syn_msg.cluster_id(), get_cluster_name());

--- a/gms/gossiper.cc
+++ b/gms/gossiper.cc
@@ -524,13 +524,19 @@ future<rpc::no_wait_type> gossiper::background_msg(sstring type, noncopyable_fun
 void gossiper::init_messaging_service_handler() {
     ser::gossip_rpc_verbs::register_gossip_digest_syn(&_messaging, [this] (const rpc::client_info& cinfo, gossip_digest_syn syn_msg) {
         auto from = cinfo.retrieve_auxiliary<locator::host_id>("host_id");
-        return background_msg("GOSSIP_DIGEST_SYN", [from, syn_msg = std::move(syn_msg)] (gms::gossiper& gossiper) mutable {
+        auto from_addr = cinfo.retrieve_auxiliary<gms::inet_address>("baddr");
+        return background_msg("GOSSIP_DIGEST_SYN", [from, from_addr, syn_msg = std::move(syn_msg)] (gms::gossiper& gossiper) mutable {
+            // The address may be missing during bootstrap, after the expiring entry from CLIENT_ID is gone.
+            gossiper._address_map.opt_add_entry(from, from_addr);
             return gossiper.handle_syn_msg(from, std::move(syn_msg));
         });
     });
      ser::gossip_rpc_verbs::register_gossip_digest_ack(&_messaging, [this] (const rpc::client_info& cinfo, gossip_digest_ack msg) {
         auto from = cinfo.retrieve_auxiliary<locator::host_id>("host_id");
-        return background_msg("GOSSIP_DIGEST_ACK", [from, msg = std::move(msg)] (gms::gossiper& gossiper) mutable {
+        auto from_addr = cinfo.retrieve_auxiliary<gms::inet_address>("baddr");
+        return background_msg("GOSSIP_DIGEST_ACK", [from, from_addr, msg = std::move(msg)] (gms::gossiper& gossiper) mutable {
+            // The address may be missing during bootstrap, after the expiring entry from CLIENT_ID is gone.
+            gossiper._address_map.opt_add_entry(from, from_addr);
             return gossiper.handle_ack_msg(from, std::move(msg));
         });
     });

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -1299,14 +1299,16 @@ public:
         });
         auto result = co_await ser::join_node_rpc_verbs::send_join_node_request(
                 &_ss._messaging.local(), netw::msg_addr(g0_info.ip_addr), g0_info.id, _req);
+        if (utils::get_local_injector().is_enabled("pre_server_start_drop_expiring")) {
+            co_await utils::get_local_injector().inject("pre_server_start_drop_expiring",
+                    utils::wait_for_message(5min));
+            _ss._gossiper.get_mutable_address_map().force_drop_expiring_entries();
+        }
+
         std::visit(overloaded_functor {
             [this] (const join_node_request_result::ok&) {
                 rtlogger.info("join: request to join placed, waiting"
                              " for the response from the topology coordinator");
-
-                if (utils::get_local_injector().enter("pre_server_start_drop_expiring")) {
-                    _ss._gossiper.get_mutable_address_map().force_drop_expiring_entries();
-                }
 
                 _ss._join_node_request_done.set_value();
             },

--- a/test/cluster/test_long_join.py
+++ b/test/cluster/test_long_join.py
@@ -30,7 +30,6 @@ async def test_long_join(manager: ScyllaClusterManager) -> None:
     await asyncio.gather(task)
 
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
-@pytest.mark.xfail(reason="SCYLLADB-4095")
 async def test_long_join_drop_entries_on_bootstrapping(manager: ScyllaClusterManager) -> None:
     """The test checks that join works even if expiring entries are dropped
        on the joining node between placement of the join request and its processing"""

--- a/test/cluster/test_long_join.py
+++ b/test/cluster/test_long_join.py
@@ -58,7 +58,7 @@ async def test_long_join_drop_entries_on_bootstrapping(manager: ScyllaClusterMan
     await wait_for(gossiper_api_ready, time.time() + 60)
 
     servers.append(s)
-    await manager.servers_see_each_other(servers, interval=300)
+    await manager.servers_see_each_other(servers)
     await manager.api.enable_injection(s.ip_addr, 'join_node_response_drop_expiring', one_shot=True)
     await asyncio.gather(*(manager.api.message_injection(s.ip_addr, inj) for s in servers[:-1]))
     await asyncio.gather(task)

--- a/test/cluster/test_long_join.py
+++ b/test/cluster/test_long_join.py
@@ -30,14 +30,18 @@ async def test_long_join(manager: ScyllaClusterManager) -> None:
     await asyncio.gather(task)
 
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
+@pytest.mark.xfail(reason="SCYLLADB-4095")
 async def test_long_join_drop_entries_on_bootstrapping(manager: ScyllaClusterManager) -> None:
     """The test checks that join works even if expiring entries are dropped
        on the joining node between placement of the join request and its processing"""
     servers = await manager.servers_add(2)
     inj = 'topology_coordinator_pause_before_processing_backlog'
     await asyncio.gather(*(manager.api.enable_injection(s.ip_addr, inj, one_shot=True) for s in servers))
+    # gossiper_ignore_incoming_syn ensures the joining node doesn't make the other
+    # nodes' entries non-expiring before the test drops those entries.
     s = await manager.server_add(start=False,  config={
-        'error_injections_at_startup': ['pre_server_start_drop_expiring']
+        'error_injections_at_startup': ['pre_server_start_drop_expiring',
+                                        'gossiper_ignore_incoming_syn']
     })
     task = asyncio.create_task(manager.server_start(s.server_id))
     log = await manager.server_open_log(s.server_id)
@@ -56,6 +60,14 @@ async def test_long_join_drop_entries_on_bootstrapping(manager: ScyllaClusterMan
                 raise
 
     await wait_for(gossiper_api_ready, time.time() + 60)
+
+    # The pre-existing nodes see the joining node only once they have sent it their
+    # CLIENT_IDs, so by then it holds their addresses as expiring entries. Drop the
+    # entries at that point and let the joining node gossip again.
+    await asyncio.gather(*(manager.server_sees_other_server(e.ip_addr, s.ip_addr)
+                           for e in servers))
+    await manager.api.message_injection(s.ip_addr, 'pre_server_start_drop_expiring')
+    await manager.api.disable_injection(s.ip_addr, 'gossiper_ignore_incoming_syn')
 
     servers.append(s)
     await manager.servers_see_each_other(servers)


### PR DESCRIPTION
Bootstrap can currently hang in the following scenario:
- Joining node A starts gossiping to its only seed -- B.
- B opens a connection to A to answer its gossip. The CLIENT_ID on that
  connection gives A B's IP address, which A stores as an expiring entry
  in the address map.
- The entry expires on A before A applies B's endpoint state, which is
  what would have made the entry non-expiring. An entry is dropped after
  1h without a call to address_map_t::find(), and nothing calls it for
  B's entry: A sends its SYNs to B by IP, and it has no group 0 traffic
  while its join request is not processed. In production this needs B's
  gossip messages to stop reaching A for that long, with the connection
  kept.

A cannot recover from this state because:
- All RPCs from A addressed by B's host ID fail, as addr_for_host_id
  throws unknown_address.
- A could get B's endpoint state only in ACK2, but that requires A to
  send ACK first, which it cannot due to the above.
- B keeps using the connection it already has, so no new CLIENT_ID
  arrives either.

We fix this issue by taking the address from the connection a SYN from
node B arrives on. The messaging layer attaches the sender's broadcast
address there, next to the host ID the handler reads anyway, so it is
always available. We add it only if the address map doesn't contain an
entry for the sender, as deciding whether this address is newer than the
address in the map requires a gossip generation, which is not available
here.

We do the same for ACK. It's not necessary to fix the join hang, but it
prevents errors and can make recovery quicker.

This PR also extends test_long_join_drop_entries_on_bootstrapping to
to consistently reproduce the issue.

Fixes: SCYLLADB-4095

No backport: the bug is extremely unlikely to hit it practice and not
critical (a blocked bootstrap can be aborted and restarted), so no need
to risk backporting.