### PR TITLE
test: fix flaky test_aborted_decommision_reenables_snapshot[s3]

### DIFF
--- a/test/cluster/object_store/test_backup.py
+++ b/test/cluster/object_store/test_backup.py
@@ -1888,6 +1888,19 @@ async def test_aborted_decommision_reenables_snapshot(manager: ScyllaClusterMana
 
         async def abort_decommission():
             tm = TaskManagerClient(manager.api)
+            # Task-list polling alone can observe the decommission after the coordinator
+            # already passed the leave breakpoint and finished (SCYLLADB-2055 race).
+            waiters = [asyncio.create_task(manager.api.wait_for_injection_enter(s.ip_addr, "topology_coordinator_before_leave"))
+                       for s in servers]
+            done, pending = await asyncio.wait(waiters, timeout=30, return_when=asyncio.FIRST_COMPLETED)
+            for p in pending:
+                p.cancel()
+            assert done, "no server entered topology_coordinator_before_leave within 30s"
+            # asyncio.wait() puts a task in `done` whether it succeeded or raised,
+            # so surface any exception instead of silently treating it as success.
+            for d in done:
+                d.result()
+
             while True:
                 logger.info("Listing tasks in %s", servers[1])
                 tasks = await tm.list_tasks(servers[1].ip_addr, "node_ops")


### PR DESCRIPTION
## Motivation
`test_aborted_decommision_reenables_snapshot[s3]` is flaky (SCYLLADB-2055): its `abort_decommission()` helper polls task_manager's task list and calls `abort_task` as soon as it sees the decommission task. On a fast run, the topology coordinator can finish the leave transition and reap the task before the abort request lands, so `abort_task` fails with 403 "cannot be aborted" or 500 "Don't know how to abort".

## Change
Before polling for the task, wait for whichever server is the topology coordinator to actually enter the `topology_coordinator_before_leave` injection point. That guarantees the coordinator is still blocked there when the subsequent task-list poll and `abort_task` call happen, eliminating the race instead of narrowing it. Follows the same `create_task`/`timeout`/`assert done` pattern already used elsewhere in this file for identical injection-wait idioms.

## Tests
`test/cluster/object_store/test_backup.py::test_aborted_decommision_reenables_snapshot` (no new test needed — this fixes the flake in the existing test itself).

## Results
Reviewed for correctness and style; verified the injection point fires unconditionally on the decommission/leave path and blocks the coordinator until released, and that the fix matches the file's existing conventions.

Fixes: SCYLLADB-2055