### PR TITLE
test/cluster/util: use default poll period in wait_for_no_pending_topology_transition

### DIFF
--- a/test/cluster/util.py
+++ b/test/cluster/util.py
@@ -294,7 +294,7 @@ async def wait_for_no_pending_topology_transition(manager: ScyllaClusterManager,
             return None
         return True
 
-    await wait_for(no_transition, deadline, period=.5)
+    await wait_for(no_transition, deadline)
 
 
 async def wait_for_no_running_compactions(manager: ScyllaClusterManager,


### PR DESCRIPTION
The explicit `period=.5` override in `wait_for_no_pending_topology_transition` has no documented rationale — it's been present since the function's introduction, unrelated to what that commit actually fixed — and it needlessly slows every tablet test that waits on topology quiescence. This drops it, falling back to `wait_for()`'s default backoff (`period=0.1`, backing off to `max_period=1.0`), already used by every other `wait_for` caller in this file.

Verified: `test_replace` 113.6s -> 89.4s (dev mode).

Refs: SCYLLADB-2243