### PR TITLE
test/cluster/lwt: shrink CAS/resize pacing sleeps

### DIFF
--- a/test/cluster/lwt/lwt_common.py
+++ b/test/cluster/lwt/lwt_common.py
@@ -203,7 +203,7 @@ class Worker:
                     self.counter_deltas[pk] += delta
                     await self._inc_counter(pk, delta)
 
-                await asyncio.sleep(self.scale_timeout(0.5))
+                await asyncio.sleep(self.scale_timeout(0.1))
 
             except Exception:
                 self.stop()

--- a/test/cluster/lwt/test_lwt_during_tablets_resize.py
+++ b/test/cluster/lwt/test_lwt_during_tablets_resize.py
@@ -51,7 +51,7 @@ async def run_random_resizes(
     ks: str,
     table: str,
     target_steps: int = TARGET_RESIZE_COUNT,
-    pause_range=(0.5, 2.0)
+    pause_range=(0.05, 0.2)
 ):
     """
     Perform randomized tablet count changes (splits/merges) until target resize count is reached

--- a/test/cluster/lwt/test_lwt_with_counters_during_tablets_resize_and_migrations.py
+++ b/test/cluster/lwt/test_lwt_with_counters_during_tablets_resize_and_migrations.py
@@ -86,7 +86,7 @@ async def tablet_migration_ops(
     tester: BaseLWTTester,
     table: str,
     num_ops: int,
-    pause_range=(0.5, 2.0),
+    pause_range=(0.05, 0.2),
     *,
     server_properties,
 ) -> None:
@@ -192,7 +192,7 @@ async def run_random_resizes(
     table: str,
     counter_table: str,
     target_steps: int = TARGET_RESIZE_COUNT,
-    pause_range=(0.5, 2.0),
+    pause_range=(0.05, 0.2),
 ):
     """
     Perform randomized tablet count changes (splits/merges) on the main LWT table
@@ -369,7 +369,7 @@ async def test_multi_column_lwt_migrate_and_random_resizes(manager: ScyllaCluste
                     stop_event_,
                     manager, servers, tester,
                     num_ops=NUM_MIGRATIONS,
-                    pause_range=(0.3, 1.0),
+                    pause_range=(0.03, 0.1),
                     server_properties=properties,
                     table=table,
                 )
@@ -379,7 +379,7 @@ async def test_multi_column_lwt_migrate_and_random_resizes(manager: ScyllaCluste
                     stop_event_,
                     manager, servers, tester,
                     num_ops=NUM_MIGRATIONS,
-                    pause_range=(0.3, 1.0),
+                    pause_range=(0.03, 0.1),
                     server_properties=properties,
                     table=cnt_table
                 )


### PR DESCRIPTION
These sleeps only pace how fast workers hammer the cluster with CAS attempts / tablet resizes; they don't gate correctness. Iteration/target counts (`TARGET_RESIZE_COUNT`, `NUM_MIGRATIONS`) are untouched, so coverage is unchanged — only wall-clock pacing shrinks.

- `Worker.__call__` per-attempt sleep: 0.5s -> 0.1s
- `run_random_resizes` `pause_range`: (0.5, 2.0) -> (0.05, 0.2)
- `tablet_migration_ops` `pause_range`: (0.5, 2.0) -> (0.05, 0.2)
- `test_multi_column_lwt_migrate_and_random_resizes` `pause_range`: (0.3, 1.0) -> (0.03, 0.1)

Verified: `test_multi_column_lwt_during_split_merge` 169.8s -> 116.6s (dev mode).

Refs: SCYLLADB-2243