### PR TITLE
Make tracing service dependencies explicit

### DIFF
--- a/main.cc
+++ b/main.cc
@@ -1513,13 +1513,6 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
                 lifecycle_notifier.stop().get();
             });
 
-            checkpoint(stop_signal, "creating tracing");
-            sharded<tracing::tracing>& tracing = tracing::tracing::tracing_instance();
-            tracing.start(sstring("trace_keyspace_helper")).get();
-            auto destroy_tracing = defer_verbose_shutdown("tracing instance", [&tracing] {
-                tracing.stop().get();
-            });
-
             stop_signal.check();
             ctx.http_server.server().invoke_on_all([] (auto& server) { server.set_content_streaming(true); }).get();
             with_scheduling_group(dbcfg.streaming_scheduling_group, [&] {
@@ -1886,6 +1879,13 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
 
             utils::get_local_injector().inject("stop_after_starting_migration_manager",
                 [] { std::raise(SIGSTOP); });
+
+            checkpoint(stop_signal, "creating tracing");
+            sharded<tracing::tracing>& tracing = tracing::tracing::tracing_instance();
+            tracing.start(sstring("trace_keyspace_helper")).get();
+            auto destroy_tracing = defer_verbose_shutdown("tracing instance", [&tracing] {
+                tracing.stop().get();
+            });
 
             checkpoint(stop_signal, "starting mapreduce service");
             mapreduce_service.start(std::ref(messaging), std::ref(proxy), std::ref(db), std::ref(stop_signal.as_sharded_abort_source())).get();

--- a/main.cc
+++ b/main.cc
@@ -1877,6 +1877,16 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
                 tablet_allocator.stop().get();
             });
 
+            checkpoint(stop_signal, "starting migration manager");
+            debug::the_migration_manager = &mm;
+            mm.start(std::ref(mm_notifier), std::ref(feature_service), std::ref(messaging), std::ref(proxy), std::ref(gossiper), std::ref(group0_client), std::ref(sys_ks)).get();
+            auto stop_migration_manager = defer_verbose_shutdown("migration manager", [&mm] {
+                mm.stop().get();
+            });
+
+            utils::get_local_injector().inject("stop_after_starting_migration_manager",
+                [] { std::raise(SIGSTOP); });
+
             checkpoint(stop_signal, "starting mapreduce service");
             mapreduce_service.start(std::ref(messaging), std::ref(proxy), std::ref(db), std::ref(stop_signal.as_sharded_abort_source())).get();
             auto stop_mapreduce_service_handlers = defer_verbose_shutdown("mapreduce service", [&mapreduce_service] {
@@ -1900,16 +1910,6 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
                 }
             };
             auto the_sstable_dict_deleter = sstable_dict_deleter(mm_notifier.local(), feature_service.local());
-
-            checkpoint(stop_signal, "starting migration manager");
-            debug::the_migration_manager = &mm;
-            mm.start(std::ref(mm_notifier), std::ref(feature_service), std::ref(messaging), std::ref(proxy), std::ref(gossiper), std::ref(group0_client), std::ref(sys_ks)).get();
-            auto stop_migration_manager = defer_verbose_shutdown("migration manager", [&mm] {
-                mm.stop().get();
-            });
-
-            utils::get_local_injector().inject("stop_after_starting_migration_manager",
-                [] { std::raise(SIGSTOP); });
 
             // Audit must be constructed before the maintenance socket so
             // that on shutdown (reverse destruction order) the audit service

--- a/main.cc
+++ b/main.cc
@@ -1882,7 +1882,7 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
 
             checkpoint(stop_signal, "creating tracing");
             sharded<tracing::tracing>& tracing = tracing::tracing::tracing_instance();
-            tracing.start(std::ref(qp), sstring("trace_keyspace_helper")).get();
+            tracing.start(std::ref(qp), std::ref(mm), sstring("trace_keyspace_helper")).get();
             auto destroy_tracing = defer_verbose_shutdown("tracing instance", [&tracing] {
                 tracing.stop().get();
             });
@@ -2605,7 +2605,7 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
             });
 
             checkpoint(stop_signal, "starting tracing");
-            tracing.invoke_on_all(&tracing::tracing::start, std::ref(mm)).get();
+            tracing.invoke_on_all(&tracing::tracing::start).get();
             auto stop_tracing = defer_verbose_shutdown("tracing", [&tracing] {
                 tracing.invoke_on_all(&tracing::tracing::shutdown).get();
             });

--- a/main.cc
+++ b/main.cc
@@ -1882,7 +1882,7 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
 
             checkpoint(stop_signal, "creating tracing");
             sharded<tracing::tracing>& tracing = tracing::tracing::tracing_instance();
-            tracing.start(sstring("trace_keyspace_helper")).get();
+            tracing.start(std::ref(qp), sstring("trace_keyspace_helper")).get();
             auto destroy_tracing = defer_verbose_shutdown("tracing instance", [&tracing] {
                 tracing.stop().get();
             });
@@ -2605,7 +2605,7 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
             });
 
             checkpoint(stop_signal, "starting tracing");
-            tracing.invoke_on_all(&tracing::tracing::start, std::ref(qp), std::ref(mm)).get();
+            tracing.invoke_on_all(&tracing::tracing::start, std::ref(mm)).get();
             auto stop_tracing = defer_verbose_shutdown("tracing", [&tracing] {
                 tracing.invoke_on_all(&tracing::tracing::shutdown).get();
             });

--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -825,6 +825,7 @@ private:
         auto src_shard = cinfo.retrieve_auxiliary<uint32_t>("src_cpu_id");
 
         if (cmd1.trace_info) {
+            co_await utils::get_local_injector().inject("storage_proxy_pause_traced_read", utils::wait_for_message(5min));
             trace_state_ptr = tracing::tracing::get_local_tracing_instance().create_session(*cmd1.trace_info);
             tracing::begin(trace_state_ptr);
             tracing::trace(trace_state_ptr, "{}: message received from /{}", verb, src_addr);

--- a/test/boost/tracing_test.cc
+++ b/test/boost/tracing_test.cc
@@ -19,9 +19,9 @@ BOOST_AUTO_TEST_SUITE(tracing_test)
 future<> do_with_tracing_env(std::function<future<>(cql_test_env&)> func, cql_test_config cfg_in = {}) {
     return do_with_cql_env_thread([func](auto &env) {
         sharded<tracing::tracing>& tracing = tracing::tracing::tracing_instance();
-        tracing.start(std::ref(env.qp()), sstring("trace_keyspace_helper")).get();
+        tracing.start(std::ref(env.qp()), std::ref(env.migration_manager()), sstring("trace_keyspace_helper")).get();
         auto stop = defer([&tracing] noexcept { tracing.stop().get(); });
-        tracing.invoke_on_all(&tracing::tracing::start, std::ref(env.migration_manager())).get();
+        tracing.invoke_on_all(&tracing::tracing::start).get();
         func(env).get();
     }, std::move(cfg_in));
 }

--- a/test/boost/tracing_test.cc
+++ b/test/boost/tracing_test.cc
@@ -19,9 +19,9 @@ BOOST_AUTO_TEST_SUITE(tracing_test)
 future<> do_with_tracing_env(std::function<future<>(cql_test_env&)> func, cql_test_config cfg_in = {}) {
     return do_with_cql_env_thread([func](auto &env) {
         sharded<tracing::tracing>& tracing = tracing::tracing::tracing_instance();
-        tracing.start(sstring("trace_keyspace_helper")).get();
+        tracing.start(std::ref(env.qp()), sstring("trace_keyspace_helper")).get();
         auto stop = defer([&tracing] noexcept { tracing.stop().get(); });
-        tracing.invoke_on_all(&tracing::tracing::start, std::ref(env.qp()), std::ref(env.migration_manager())).get();
+        tracing.invoke_on_all(&tracing::tracing::start, std::ref(env.migration_manager())).get();
         func(env).get();
     }, std::move(cfg_in));
 }

--- a/test/cluster/test_tracing_drain.py
+++ b/test/cluster/test_tracing_drain.py
@@ -1,0 +1,88 @@
+#
+# Copyright (C) 2026-present ScyllaDB
+#
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
+#
+
+import asyncio
+import logging
+import time
+
+import pytest
+from cassandra import ConsistencyLevel  # type: ignore
+from cassandra.query import SimpleStatement  # type: ignore
+
+from test.pylib.scylla_cluster_manager import ScyllaClusterManager
+from test.pylib.rest_client import inject_error
+from test.pylib.util import wait_for_cql_and_get_hosts
+from test.cluster.util import new_test_keyspace, new_test_table, reconnect_driver
+
+logger = logging.getLogger(__name__)
+
+
+@pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
+async def test_traced_read_racing_with_drain(manager: ScyllaClusterManager) -> None:
+    """
+    Reproduce the interleaving where a traced read lands on a replica that is
+    being drained. The replica-side read verb handler is paused by error
+    injection right before it clones the tracing session from the received
+    trace_info, then drain is started on the replica, and only then the
+    handler is released. The replica must not crash and the drain must run to
+    completion: messaging service shutdown waits for the in-flight verb
+    handler and tracing is shut down only after that, so the session is
+    cloned on a still-running tracing service.
+    """
+    coord, replica = await manager.servers_add(2, auto_rack_dc="dc1")
+    cql = manager.get_cql()
+    hosts = await wait_for_cql_and_get_hosts(cql, [coord, replica], time.time() + 30)
+    [coord_host] = [h for h in hosts if h.address == coord.ip_addr]
+
+    async with new_test_keyspace(manager, "WITH REPLICATION = {'class': 'NetworkTopologyStrategy', 'replication_factor': 2}") as ks:
+        async with new_test_table(manager, ks, "pk int PRIMARY KEY, v int") as t:
+            await cql.run_async(f"INSERT INTO {t} (pk, v) VALUES (1, 1)")
+
+            replica_log = await manager.server_open_log(replica.server_id)
+            replica_mark = await replica_log.mark()
+
+            async with inject_error(manager.api, replica.ip_addr, "storage_proxy_pause_traced_read"):
+                async def do_traced_read():
+                    # CL=ALL makes the coordinator read from the replica too.
+                    # The read is allowed to fail and its outcome doesn't
+                    # matter: once the replica-side handler is paused, it
+                    # stays paused regardless of the coordinator timing out,
+                    # so the timeout is short not to delay the test. The
+                    # point is that the replica survives the whole exercise.
+                    stmt = SimpleStatement(f"SELECT * FROM {t} WHERE pk = 1 USING TIMEOUT 10s",
+                                           consistency_level=ConsistencyLevel.ALL)
+                    try:
+                        await cql.run_async(stmt, host=coord_host, trace=True, timeout=60)
+                        logger.info("Traced read completed")
+                    except Exception as e:
+                        logger.info(f"Traced read failed (which is allowed): {e}")
+
+                async def drain_replica():
+                    # Wait for the replica-side read handler to pause right
+                    # before creating the tracing session.
+                    await manager.api.wait_for_injection_enter(replica.ip_addr, "storage_proxy_pause_traced_read")
+                    # Drain the replica. The drain will block shutting down
+                    # the messaging service until the paused handler is done.
+                    drain = asyncio.create_task(manager.api.drain(replica.ip_addr))
+                    await replica_log.wait_for("Stop transport: starts", from_mark=replica_mark, timeout=60)
+                    # Release the handler -- it creates the tracing session
+                    # on the draining node now.
+                    await manager.api.message_injection(replica.ip_addr, "storage_proxy_pause_traced_read")
+                    await drain
+
+                async with asyncio.TaskGroup() as tg:
+                    tg.create_task(do_traced_read())
+                    tg.create_task(drain_replica())
+
+            # The drain must have gone all the way through tracing shutdown
+            await replica_log.wait_for("Tracing is down", from_mark=replica_mark, timeout=60)
+
+            # Bring the replica back so that the cluster is fully functional
+            # and the keyspace can be dropped (DDL needs group0 majority)
+            await manager.server_stop_gracefully(replica.server_id)
+            await manager.server_start(replica.server_id)
+            cql = await reconnect_driver(manager)
+            await wait_for_cql_and_get_hosts(cql, [coord, replica], time.time() + 30)

--- a/tracing/trace_keyspace_helper.cc
+++ b/tracing/trace_keyspace_helper.cc
@@ -211,7 +211,6 @@ trace_keyspace_helper::trace_keyspace_helper(tracing& tr)
 }
 
 future<> trace_keyspace_helper::start(cql3::query_processor& qp, service::migration_manager& mm) {
-    _mm_anchor = &mm;
     return table_helper::setup_keyspace(qp, mm, KEYSPACE_NAME, "org.apache.cassandra.locator.SimpleStrategy", "2", _dummy_query_state, { &_sessions, &_sessions_time_idx, &_events, &_slow_query_log, &_slow_query_log_time_idx });
 }
 
@@ -435,11 +434,8 @@ future<> trace_keyspace_helper::flush_one_session_mutations(lw_shared_ptr<one_se
         auto backend_state_ptr = static_cast<trace_keyspace_backend_sesssion_state*>(records->backend_state_ptr.get());
         semaphore& write_sem = backend_state_ptr->write_sem;
         return with_semaphore(write_sem, 1, [this, records, session_record_is_ready, &events_records] {
-            // This code is inside the _pending_writes gate and the mm pointer
-            // is cleared on ::stop() after the gate is closed.
-            SCYLLA_ASSERT(_mm_anchor != nullptr);
             cql3::query_processor& qp = i_tracing_backend_helper::qp();
-            service::migration_manager& mm = *_mm_anchor;
+            service::migration_manager& mm = i_tracing_backend_helper::mm();
             return apply_events_mutation(qp, mm, records, events_records).then([this, &qp, &mm, session_record_is_ready, records] {
                 if (session_record_is_ready) {
 

--- a/tracing/trace_keyspace_helper.cc
+++ b/tracing/trace_keyspace_helper.cc
@@ -210,8 +210,8 @@ trace_keyspace_helper::trace_keyspace_helper(tracing& tr)
     });
 }
 
-future<> trace_keyspace_helper::start(service::migration_manager& mm) {
-    return table_helper::setup_keyspace(qp(), mm, KEYSPACE_NAME, "org.apache.cassandra.locator.SimpleStrategy", "2", _dummy_query_state, { &_sessions, &_sessions_time_idx, &_events, &_slow_query_log, &_slow_query_log_time_idx });
+future<> trace_keyspace_helper::start() {
+    return table_helper::setup_keyspace(qp(), mm(), KEYSPACE_NAME, "org.apache.cassandra.locator.SimpleStrategy", "2", _dummy_query_state, { &_sessions, &_sessions_time_idx, &_events, &_slow_query_log, &_slow_query_log_time_idx });
 }
 
 gms::inet_address trace_keyspace_helper::my_address() const noexcept {

--- a/tracing/trace_keyspace_helper.cc
+++ b/tracing/trace_keyspace_helper.cc
@@ -211,13 +211,12 @@ trace_keyspace_helper::trace_keyspace_helper(tracing& tr)
 }
 
 future<> trace_keyspace_helper::start(cql3::query_processor& qp, service::migration_manager& mm) {
-    _qp_anchor = &qp;
     _mm_anchor = &mm;
     return table_helper::setup_keyspace(qp, mm, KEYSPACE_NAME, "org.apache.cassandra.locator.SimpleStrategy", "2", _dummy_query_state, { &_sessions, &_sessions_time_idx, &_events, &_slow_query_log, &_slow_query_log_time_idx });
 }
 
 gms::inet_address trace_keyspace_helper::my_address() const noexcept {
-    return _qp_anchor->proxy().my_address();
+    return qp().proxy().my_address();
 }
 
 void trace_keyspace_helper::write_one_session_records(lw_shared_ptr<one_session_records> records) {
@@ -436,10 +435,10 @@ future<> trace_keyspace_helper::flush_one_session_mutations(lw_shared_ptr<one_se
         auto backend_state_ptr = static_cast<trace_keyspace_backend_sesssion_state*>(records->backend_state_ptr.get());
         semaphore& write_sem = backend_state_ptr->write_sem;
         return with_semaphore(write_sem, 1, [this, records, session_record_is_ready, &events_records] {
-            // This code is inside the _pending_writes gate and the qp pointer
+            // This code is inside the _pending_writes gate and the mm pointer
             // is cleared on ::stop() after the gate is closed.
-            SCYLLA_ASSERT(_qp_anchor != nullptr && _mm_anchor != nullptr);
-            cql3::query_processor& qp = *_qp_anchor;
+            SCYLLA_ASSERT(_mm_anchor != nullptr);
+            cql3::query_processor& qp = i_tracing_backend_helper::qp();
             service::migration_manager& mm = *_mm_anchor;
             return apply_events_mutation(qp, mm, records, events_records).then([this, &qp, &mm, session_record_is_ready, records] {
                 if (session_record_is_ready) {

--- a/tracing/trace_keyspace_helper.cc
+++ b/tracing/trace_keyspace_helper.cc
@@ -210,8 +210,8 @@ trace_keyspace_helper::trace_keyspace_helper(tracing& tr)
     });
 }
 
-future<> trace_keyspace_helper::start(cql3::query_processor& qp, service::migration_manager& mm) {
-    return table_helper::setup_keyspace(qp, mm, KEYSPACE_NAME, "org.apache.cassandra.locator.SimpleStrategy", "2", _dummy_query_state, { &_sessions, &_sessions_time_idx, &_events, &_slow_query_log, &_slow_query_log_time_idx });
+future<> trace_keyspace_helper::start(service::migration_manager& mm) {
+    return table_helper::setup_keyspace(qp(), mm, KEYSPACE_NAME, "org.apache.cassandra.locator.SimpleStrategy", "2", _dummy_query_state, { &_sessions, &_sessions_time_idx, &_events, &_slow_query_log, &_slow_query_log_time_idx });
 }
 
 gms::inet_address trace_keyspace_helper::my_address() const noexcept {

--- a/tracing/trace_keyspace_helper.hh
+++ b/tracing/trace_keyspace_helper.hh
@@ -56,7 +56,7 @@ public:
     //
     // TODO: Create a stub_tracing_session object to discard the traces
     // requested during the initialization phase.
-    virtual future<> start(cql3::query_processor& qp, service::migration_manager& mm) override;
+    virtual future<> start(service::migration_manager& mm) override;
 
     virtual future<> shutdown() override {
         return _pending_writes.close();

--- a/tracing/trace_keyspace_helper.hh
+++ b/tracing/trace_keyspace_helper.hh
@@ -34,8 +34,6 @@ private:
     int64_t _slow_query_last_nanos = 0;
     service::query_state _dummy_query_state;
 
-    service::migration_manager* _mm_anchor;
-
     table_helper _sessions;
     table_helper _sessions_time_idx;
     table_helper _events;
@@ -61,9 +59,7 @@ public:
     virtual future<> start(cql3::query_processor& qp, service::migration_manager& mm) override;
 
     virtual future<> shutdown() override {
-        return _pending_writes.close().then([this] {
-            _mm_anchor = nullptr;
-        });
+        return _pending_writes.close();
     };
 
     virtual void write_records_bulk(records_bulk& bulk) override;

--- a/tracing/trace_keyspace_helper.hh
+++ b/tracing/trace_keyspace_helper.hh
@@ -34,7 +34,6 @@ private:
     int64_t _slow_query_last_nanos = 0;
     service::query_state _dummy_query_state;
 
-    cql3::query_processor* _qp_anchor;
     service::migration_manager* _mm_anchor;
 
     table_helper _sessions;
@@ -63,7 +62,6 @@ public:
 
     virtual future<> shutdown() override {
         return _pending_writes.close().then([this] {
-            _qp_anchor = nullptr;
             _mm_anchor = nullptr;
         });
     };
@@ -72,7 +70,6 @@ public:
     virtual std::unique_ptr<backend_session_state_base> allocate_session_state() const override;
 
 private:
-    // Valid only after start() sets _qp_anchor
     gms::inet_address my_address() const noexcept;
 
     /**

--- a/tracing/trace_keyspace_helper.hh
+++ b/tracing/trace_keyspace_helper.hh
@@ -56,7 +56,7 @@ public:
     //
     // TODO: Create a stub_tracing_session object to discard the traces
     // requested during the initialization phase.
-    virtual future<> start(service::migration_manager& mm) override;
+    virtual future<> start() override;
 
     virtual future<> shutdown() override {
         return _pending_writes.close();

--- a/tracing/tracing.cc
+++ b/tracing/tracing.cc
@@ -38,6 +38,13 @@ tracing::tracing(cql3::query_processor& qp, service::migration_manager& mm, sstr
         , _slow_query_record_ttl(default_slow_query_record_ttl) {
     namespace sm = seastar::metrics;
 
+    try {
+        _tracing_backend_helper_ptr = create_object<i_tracing_backend_helper>(_tracing_backend_helper_class_name, *this);
+    } catch (no_such_class& e) {
+        tracing_logger.error("Can't create tracing backend helper {}: not supported", _tracing_backend_helper_class_name);
+        throw;
+    }
+
     _metrics.add_group("tracing", {
         sm::make_counter("dropped_sessions", stats.dropped_sessions,
                         sm::description("Counts a number of dropped sessions due to too many pending sessions/records. "
@@ -132,15 +139,6 @@ trace_state_ptr tracing::create_session(const trace_info& secondary_session_info
 }
 
 future<> tracing::start() {
-    try {
-        _tracing_backend_helper_ptr = create_object<i_tracing_backend_helper>(_tracing_backend_helper_class_name, *this);
-    } catch (no_such_class& e) {
-        tracing_logger.error("Can't create tracing backend helper {}: not supported", _tracing_backend_helper_class_name);
-        throw;
-    } catch (...) {
-        throw;
-    }
-
     co_await _tracing_backend_helper_ptr->start();
     _down = false;
     _write_timer.arm(write_period);

--- a/tracing/tracing.cc
+++ b/tracing/tracing.cc
@@ -32,16 +32,15 @@ tracing::tracing(cql3::query_processor& qp, service::migration_manager& mm, sstr
         , _mm(mm)
         , _write_timer([this] { write_timer_callback(); })
         , _thread_name(seastar::format("shard {:d}", this_shard_id()))
-        , _tracing_backend_helper_class_name(std::move(tracing_backend_helper_class_name))
         , _gen(std::random_device()())
         , _slow_query_duration_threshold(default_slow_query_duraion_threshold)
         , _slow_query_record_ttl(default_slow_query_record_ttl) {
     namespace sm = seastar::metrics;
 
     try {
-        _tracing_backend_helper_ptr = create_object<i_tracing_backend_helper>(_tracing_backend_helper_class_name, *this);
+        _tracing_backend_helper_ptr = create_object<i_tracing_backend_helper>(tracing_backend_helper_class_name, *this);
     } catch (no_such_class& e) {
-        tracing_logger.error("Can't create tracing backend helper {}: not supported", _tracing_backend_helper_class_name);
+        tracing_logger.error("Can't create tracing backend helper {}: not supported", tracing_backend_helper_class_name);
         throw;
     }
 

--- a/tracing/tracing.cc
+++ b/tracing/tracing.cc
@@ -27,8 +27,9 @@ std::vector<sstring> trace_type_names = {
     "REPAIR"
 };
 
-tracing::tracing(cql3::query_processor& qp, sstring tracing_backend_helper_class_name)
+tracing::tracing(cql3::query_processor& qp, service::migration_manager& mm, sstring tracing_backend_helper_class_name)
         : _qp(qp)
+        , _mm(mm)
         , _write_timer([this] { write_timer_callback(); })
         , _thread_name(seastar::format("shard {:d}", this_shard_id()))
         , _tracing_backend_helper_class_name(std::move(tracing_backend_helper_class_name))
@@ -130,7 +131,7 @@ trace_state_ptr tracing::create_session(const trace_info& secondary_session_info
     }
 }
 
-future<> tracing::start(service::migration_manager& mm) {
+future<> tracing::start() {
     try {
         _tracing_backend_helper_ptr = create_object<i_tracing_backend_helper>(_tracing_backend_helper_class_name, *this);
     } catch (no_such_class& e) {
@@ -140,7 +141,7 @@ future<> tracing::start(service::migration_manager& mm) {
         throw;
     }
 
-    co_await _tracing_backend_helper_ptr->start(_qp, mm);
+    co_await _tracing_backend_helper_ptr->start(_qp, _mm);
     _down = false;
     _write_timer.arm(write_period);
 }

--- a/tracing/tracing.cc
+++ b/tracing/tracing.cc
@@ -141,7 +141,7 @@ future<> tracing::start() {
         throw;
     }
 
-    co_await _tracing_backend_helper_ptr->start(_qp, _mm);
+    co_await _tracing_backend_helper_ptr->start(_mm);
     _down = false;
     _write_timer.arm(write_period);
 }

--- a/tracing/tracing.cc
+++ b/tracing/tracing.cc
@@ -27,8 +27,9 @@ std::vector<sstring> trace_type_names = {
     "REPAIR"
 };
 
-tracing::tracing(sstring tracing_backend_helper_class_name)
-        : _write_timer([this] { write_timer_callback(); })
+tracing::tracing(cql3::query_processor& qp, sstring tracing_backend_helper_class_name)
+        : _qp(qp)
+        , _write_timer([this] { write_timer_callback(); })
         , _thread_name(seastar::format("shard {:d}", this_shard_id()))
         , _tracing_backend_helper_class_name(std::move(tracing_backend_helper_class_name))
         , _gen(std::random_device()())
@@ -129,7 +130,7 @@ trace_state_ptr tracing::create_session(const trace_info& secondary_session_info
     }
 }
 
-future<> tracing::start(cql3::query_processor& qp, service::migration_manager& mm) {
+future<> tracing::start(service::migration_manager& mm) {
     try {
         _tracing_backend_helper_ptr = create_object<i_tracing_backend_helper>(_tracing_backend_helper_class_name, *this);
     } catch (no_such_class& e) {
@@ -139,7 +140,7 @@ future<> tracing::start(cql3::query_processor& qp, service::migration_manager& m
         throw;
     }
 
-    co_await _tracing_backend_helper_ptr->start(qp, mm);
+    co_await _tracing_backend_helper_ptr->start(_qp, mm);
     _down = false;
     _write_timer.arm(write_period);
 }

--- a/tracing/tracing.cc
+++ b/tracing/tracing.cc
@@ -141,7 +141,7 @@ future<> tracing::start() {
         throw;
     }
 
-    co_await _tracing_backend_helper_ptr->start(_mm);
+    co_await _tracing_backend_helper_ptr->start();
     _down = false;
     _write_timer.arm(write_period);
 }

--- a/tracing/tracing.hh
+++ b/tracing/tracing.hh
@@ -315,6 +315,7 @@ public:
     } stats;
 
 private:
+    cql3::query_processor& _qp;
     // A number of currently active tracing sessions
     uint64_t _active_sessions = 0;
 
@@ -418,10 +419,10 @@ public:
         return !_down;
     }
 
-    tracing(sstring tracing_backend_helper_class_name);
+    tracing(cql3::query_processor& qp, sstring tracing_backend_helper_class_name);
 
     // Initialize a tracing backend (e.g. tracing_keyspace or logstash)
-    future<> start(cql3::query_processor& qp, service::migration_manager& mm);
+    future<> start(service::migration_manager& mm);
 
     future<> stop();
 

--- a/tracing/tracing.hh
+++ b/tracing/tracing.hh
@@ -156,7 +156,7 @@ public:
 
     i_tracing_backend_helper(tracing& tr) : _local_tracing(tr) {}
     virtual ~i_tracing_backend_helper() {}
-    virtual future<> start(service::migration_manager& mm) = 0;
+    virtual future<> start() = 0;
     virtual future<> shutdown() = 0;
 
     /**

--- a/tracing/tracing.hh
+++ b/tracing/tracing.hh
@@ -146,6 +146,8 @@ struct i_tracing_backend_helper {
 
 protected:
     tracing& _local_tracing;
+    cql3::query_processor& qp() noexcept;
+    const cql3::query_processor& qp() const noexcept;
 
 public:
     using ptr_type = std::unique_ptr<i_tracing_backend_helper>;
@@ -289,6 +291,7 @@ private:
 };
 
 class tracing : public seastar::async_sharded_service<tracing> {
+    friend struct i_tracing_backend_helper;
 public:
     static const gc_clock::duration write_period;
     // maximum number of sessions pending for write per shard
@@ -661,6 +664,15 @@ inline span_id span_id::make_span_id() {
     // make sure the value is always greater than 0
     return 1 + (tracing::get_local_tracing_instance().get_next_rand_uint64() << 1);
 }
+
+inline cql3::query_processor& i_tracing_backend_helper::qp() noexcept {
+    return _local_tracing._qp;
+}
+
+inline const cql3::query_processor& i_tracing_backend_helper::qp() const noexcept {
+    return _local_tracing._qp;
+}
+
 }
 
 template <> struct fmt::formatter<tracing::span_id> {

--- a/tracing/tracing.hh
+++ b/tracing/tracing.hh
@@ -389,7 +389,6 @@ private:
     bool _ignore_trace_events = false;
     std::unique_ptr<i_tracing_backend_helper> _tracing_backend_helper_ptr;
     sstring _thread_name;
-    sstring _tracing_backend_helper_class_name;
     seastar::metrics::metric_groups _metrics;
     double _trace_probability = 0.0; // keep this one for querying purposes
     uint64_t _normalized_trace_probability = 0;

--- a/tracing/tracing.hh
+++ b/tracing/tracing.hh
@@ -148,6 +148,8 @@ protected:
     tracing& _local_tracing;
     cql3::query_processor& qp() noexcept;
     const cql3::query_processor& qp() const noexcept;
+    service::migration_manager& mm() noexcept;
+    const service::migration_manager& mm() const noexcept;
 
 public:
     using ptr_type = std::unique_ptr<i_tracing_backend_helper>;
@@ -671,6 +673,14 @@ inline cql3::query_processor& i_tracing_backend_helper::qp() noexcept {
 
 inline const cql3::query_processor& i_tracing_backend_helper::qp() const noexcept {
     return _local_tracing._qp;
+}
+
+inline service::migration_manager& i_tracing_backend_helper::mm() noexcept {
+    return _local_tracing._mm;
+}
+
+inline const service::migration_manager& i_tracing_backend_helper::mm() const noexcept {
+    return _local_tracing._mm;
 }
 
 }

--- a/tracing/tracing.hh
+++ b/tracing/tracing.hh
@@ -316,6 +316,7 @@ public:
 
 private:
     cql3::query_processor& _qp;
+    service::migration_manager& _mm;
     // A number of currently active tracing sessions
     uint64_t _active_sessions = 0;
 
@@ -419,10 +420,10 @@ public:
         return !_down;
     }
 
-    tracing(cql3::query_processor& qp, sstring tracing_backend_helper_class_name);
+    tracing(cql3::query_processor& qp, service::migration_manager& mm, sstring tracing_backend_helper_class_name);
 
     // Initialize a tracing backend (e.g. tracing_keyspace or logstash)
-    future<> start(service::migration_manager& mm);
+    future<> start();
 
     future<> stop();
 

--- a/tracing/tracing.hh
+++ b/tracing/tracing.hh
@@ -156,7 +156,7 @@ public:
 
     i_tracing_backend_helper(tracing& tr) : _local_tracing(tr) {}
     virtual ~i_tracing_backend_helper() {}
-    virtual future<> start(cql3::query_processor& qp, service::migration_manager& mm) = 0;
+    virtual future<> start(service::migration_manager& mm) = 0;
     virtual future<> shutdown() = 0;
 
     /**


### PR DESCRIPTION
Tracing needs query processor and migration manager -- its keyspace helper commits trace records into the database with them. Today they are passed into per-shard `tracing::start()` and the helper keeps them as "anchor" pointers with hand-maintained lifetime. This PR makes both construction-time (`sharded<tracing>::start()`-time) arguments, the standard way services declare their dependencies. With that

- the keyspace helper uses the references from the main tracing instance, and the anchor pointers with their lifetime assertions go away
- per-shard `tracing::start()` needs no arguments, and the backend helper is created construction time
- tracing instance creation moves later in main.cc -- after migration manager is started and before mapreduce service registers its RPC verbs, so tracing instances outlive every verb handler that can clone a tracing session

Also adds an error-injection test for a traced read racing with node drain -- the concern raised in the #14156 review.

Supersedes #14156, whose first half (start-stop calls sanitizing that doesn't reorder anything) was merged long ago via #15611. The rest is re-implemented here from scratch on top of current master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Code dependencies cleanup (#2737), not backporting