### PR TITLE
test/cluster/dtest/rebuild_test: parallelize bulk insert setup

### DIFF
--- a/test/cluster/dtest/rebuild_test.py
+++ b/test/cluster/dtest/rebuild_test.py
@@ -10,6 +10,7 @@ import string
 from concurrent.futures.thread import ThreadPoolExecutor
 
 import pytest
+from cassandra.concurrent import execute_concurrent_with_args
 
 from dtest_class import Tester
 
@@ -53,11 +54,12 @@ class TestRebuildStreamingAbortRepro(Tester):
                 "INSERT INTO keyspace1.standard1 (key, C0, C1, C2, C3, C4) VALUES (?, ?, ?, ?, ?, ?)"
             )
             key_chars = string.ascii_uppercase + string.digits
-            for _ in range(100_000):
-                session.execute(insert_query, [
-                    "".join(random.choices(key_chars, k=10)).encode(),
-                    *(random.randbytes(34) for _ in range(5)),
-                ])
+
+            # not on the race-timing path (insert precedes the rebuild/abort window) -> parallelize freely
+            execute_concurrent_with_args(session, insert_query, (
+                ["".join(random.choices(key_chars, k=10)).encode(), *(random.randbytes(34) for _ in range(5))]
+                for _ in range(100_000)
+            ))
 
             logger.debug("Changing keyspace1 replication in dc2 to 2.")
             session.execute("""\


### PR DESCRIPTION
\`test_rebuild_stream_abort_repro\` populates 100,000 rows serially before the actual rebuild/abort race being tested. This insert phase precedes the rebuild/abort window entirely (the race is on log-line-triggered node2/node3 rebuild timing, not on how fast setup data lands), so it can be dispatched via \`execute_concurrent_with_args\` instead of one row at a time.

Verified: 140.9s -> ~32-45s across repeated runs, no flakiness observed (the abort injection still reliably triggers).

Refs: SCYLLADB-2243