### PR TITLE
logstor: fix a queued write losing its write target

### DIFF
--- a/replica/logstor/write_buffer.cc
+++ b/replica/logstor/write_buffer.cc
@@ -548,7 +548,10 @@ bool buffered_writer::maybe_advance_head() noexcept {
     return true;
 }
 
-std::optional<future<log_location_with_holder>> buffered_writer::append_to_head_buffer(log_record_writer& writer, write_target target) {
+// The target is taken by reference and moved from only once the record is in a buffer: a caller
+// whose append does not happen goes on to queue the record, and the write target it queues has to
+// be the one it came with, holders and all.
+std::optional<future<log_location_with_holder>> buffered_writer::append_to_head_buffer(log_record_writer& writer, write_target& target) {
     if (!head_buf().can_fit(writer) && !maybe_advance_head()) {
         return std::nullopt;
     }
@@ -634,7 +637,7 @@ future<bool> buffered_writer::drain_queued_writes() {
         on_queued_write_removed(request);
         removed_queued_writes = true;
         try {
-            auto persisted = append_to_head_buffer(request.writer, std::move(request.target)).value();
+            auto persisted = append_to_head_buffer(request.writer, request.target).value();
             request.accepted_pr.set_value(buffered_write_result{request.persisted_pr.get_future()});
             std::move(persisted).forward_to(std::move(request.persisted_pr));
         } catch (...) {
@@ -748,7 +751,7 @@ future<buffered_write_result> buffered_writer::write_to_buffer(log_record_writer
     // fast path - if there are no queued writes and there is space in the current head buffer or the next, advance the
     // head buffer if needed and write to it.
     if (_queued_writes.empty()) {
-        if (auto persisted = append_to_head_buffer(writer, std::move(target))) {
+        if (auto persisted = append_to_head_buffer(writer, target)) {
             co_return buffered_write_result{std::move(*persisted)};
         }
     }

--- a/replica/logstor/write_buffer.hh
+++ b/replica/logstor/write_buffer.hh
@@ -613,7 +613,7 @@ class buffered_writer {
     bool should_rotate_head_for_flush() const noexcept;
     bool maybe_advance_head() noexcept;
 
-    std::optional<future<log_location_with_holder>> append_to_head_buffer(log_record_writer&, write_target);
+    std::optional<future<log_location_with_holder>> append_to_head_buffer(log_record_writer&, write_target&);
 
     bool try_dispatch_next_buffer();
     future<> run_dispatched_write(size_t idx);

--- a/test/boost/logstor_test.cc
+++ b/test/boost/logstor_test.cc
@@ -1662,6 +1662,75 @@ SEASTAR_THREAD_TEST_CASE(test_logstor_buffered_writer_paused_flush_fills_ring_th
     assert_records_in_order(schema, flush_ctl.all_records(), expected);
 }
 
+// A record that finds no room in the ring is queued, and it has to keep the write target it came
+// with: the holders of that target are what keep its compaction group from being reported empty to
+// a tablet split and from finishing its stop() while the write is still to come.
+SEASTAR_THREAD_TEST_CASE(test_logstor_buffered_writer_queued_write_keeps_its_write_target) {
+    auto schema = make_kv_schema();
+    constexpr size_t buffer_size = 4 * 1024;
+    const auto large_value = make_single_buffer_value(schema, buffer_size);
+
+    // Outlive the writer, so that the holders of the queued write are released before the gates
+    // they were taken from are destroyed.
+    seastar::gate non_empty_gate;
+    seastar::gate alive_gate;
+
+    test_flush_controller flush_ctl{.pause_flushes = true};
+    buffered_writer writer(make_buffered_writer_config(buffer_size, 2), [&flush_ctl] (write_buffer& wb) {
+        return flush_ctl(wb);
+    });
+
+    writer.start().get();
+    auto stop = defer([&writer] noexcept {
+        writer.stop().get();
+    });
+
+    std::vector<log_record> expected;
+    for (size_t i = 0; i < 3; ++i) {
+        expected.push_back(make_buffered_writer_record(schema, i, large_value, api::timestamp_type(300 + i)));
+    }
+
+    // Fill the ring: the first record is being flushed and the second holds the only other buffer.
+    auto accepted0 = writer.write_to_buffer(log_record_writer(expected[0]), test_timeout()).get();
+    auto persisted0 = std::move(accepted0.persisted);
+    flush_ctl.wait_for_flush_starts(1);
+    auto accepted1 = writer.write_to_buffer(log_record_writer(expected[1]), test_timeout()).get();
+    auto persisted1 = std::move(accepted1.persisted);
+
+    // The third record has nowhere to go, so it is queued rather than appended.
+    auto queued = writer.write_to_buffer(log_record_writer(expected[2]), test_timeout(), write_target{
+            .cg = nullptr,
+            .non_empty_holder = non_empty_gate.hold(),
+            .alive_holder = alive_gate.hold(),
+    });
+    BOOST_REQUIRE(!queued.available());
+    BOOST_REQUIRE_EQUAL(writer.queued_write_count(), 1u);
+
+    // The write is in flight, so its group is still held by both of the target's holders. Checked
+    // rather than required, so that a failure here still drains the writer below: a queued write
+    // left behind would hang the stop() of this test rather than fail it.
+    BOOST_CHECK_EQUAL(non_empty_gate.get_count(), 1u);
+    BOOST_CHECK_EQUAL(alive_gate.get_count(), 1u);
+
+    // Let the queued record through and drain everything, which releases the holders.
+    flush_ctl.release_one_flush();
+    wait_for_persisted(persisted0);
+    flush_ctl.wait_for_flush_starts(2);
+
+    auto accepted2 = queued.get();
+    auto persisted2 = std::move(accepted2.persisted);
+    BOOST_REQUIRE_EQUAL(writer.queued_write_count(), 0u);
+
+    flush_ctl.release_one_flush();
+    wait_for_persisted(persisted1);
+    flush_ctl.wait_for_flush_starts(3);
+
+    flush_ctl.release_one_flush();
+    wait_for_persisted(persisted2);
+
+    assert_records_in_order(schema, flush_ctl.all_records(), expected);
+}
+
 // Checks that queued writes are accepted and persisted in FIFO order once capacity becomes available.
 SEASTAR_THREAD_TEST_CASE(test_logstor_buffered_writer_queued_writes_preserve_fifo_order) {
     auto schema = make_kv_schema();


### PR DESCRIPTION
buffered_writer::append_to_head_buffer() took the write target by value, and write_to_buffer() handed it over with a std::move() before knowing whether the append would happen. When it did not - the ring is full and the head buffer cannot fit the record - the moved-into parameter was destroyed on the way out, releasing both of the target's gate holders, and the record went on to be queued with a target that held nothing.

Those two holders are what ties a record to its compaction group while the write is still to come (see write_target). One keeps the group from being reported as empty, so that a tablet split cannot ACK a pre-split group a queued record is still headed for. The other keeps the group from finishing its stop(), so that the separator flush which follows cannot run ahead of the record and leave it to be discarded when the group's separator is closed, with the segments it came from unreclaimed. Losing them for exactly as long as a write sits queued - which is under write pressure - is what this fixes.

Take the target by reference and move from it only once the record is in a buffer, the way the record writer beside it is already handled. drain_queued_writes() appends a record it has already made room for, so it is unaffected.

The new test fills the ring, queues a record with a target whose holders it can count, and checks both are still held. Before the fix both counts are 0.

no backport - logstor is experimental