### PR TITLE
tracing: Stop using the global instance getter inside the tracing module

### DIFF
--- a/tracing/trace_state.hh
+++ b/tracing/trace_state.hh
@@ -118,7 +118,7 @@ public:
     trace_state(tracing& tr, trace_type type, trace_state_props_set props)
         : _local_tracing_ptr(tr.shared_from_this())
         , _state_props(make_primary(props))
-        , _records(make_lw_shared<one_session_records>(type, ttl_by_type(type, _local_tracing_ptr->slow_query_record_ttl()), _local_tracing_ptr->slow_query_record_ttl()))
+        , _records(make_lw_shared<one_session_records>(tr, type, ttl_by_type(type, _local_tracing_ptr->slow_query_record_ttl()), _local_tracing_ptr->slow_query_record_ttl()))
         , _slow_query_threshold(_local_tracing_ptr->slow_query_threshold())
     {
     }
@@ -127,7 +127,7 @@ public:
         : _local_tracing_ptr(tr.shared_from_this())
         , _state_props(make_secondary(info.state_props))
         // inherit the slow query threshold and ttl from the coordinator
-        , _records(make_lw_shared<one_session_records>(info.type, ttl_by_type(info.type, std::chrono::seconds(info.slow_query_ttl_sec)), std::chrono::seconds(info.slow_query_ttl_sec), info.session_id, info.parent_id))
+        , _records(make_lw_shared<one_session_records>(tr, info.type, ttl_by_type(info.type, std::chrono::seconds(info.slow_query_ttl_sec)), std::chrono::seconds(info.slow_query_ttl_sec), info.session_id, info.parent_id))
         , _slow_query_threshold(info.slow_query_threshold_us)
     {
         if (info.state_props.contains<trace_state_props::log_slow_query>() && info.start_ts_us > 0u) {

--- a/tracing/trace_state.hh
+++ b/tracing/trace_state.hh
@@ -143,6 +143,12 @@ public:
         return _records->session_id;
     }
 
+    // Valid on any shard, but the returned reference is for the shard
+    // this state was created on
+    tracing& local_tracing() const noexcept {
+        return *_local_tracing_ptr;
+    }
+
     bool is_in_state(state s) const {
         return _state == s;
     }
@@ -762,11 +768,16 @@ inline void add_prepared_query_options(const trace_state_ptr& state, const cql3:
 class global_trace_state_ptr {
     unsigned _cpu_of_origin;
     trace_state_ptr _ptr;
+    // Captured on the origin shard, but points to the sharded service
+    // container which is shard-agnostic, so it's valid to use (though
+    // not to assign) on any shard. Non-null iff _ptr is non-null.
+    sharded<tracing>* _tracing;
 public:
     // Note: the trace_state_ptr must come from the current shard
     global_trace_state_ptr(trace_state_ptr t)
             : _cpu_of_origin(this_shard_id())
             , _ptr(std::move(t))
+            , _tracing(_ptr ? &_ptr->local_tracing().container() : nullptr)
     { }
 
     // May be invoked across shards.
@@ -791,7 +802,7 @@ public:
         if (_cpu_of_origin != this_shard_id()) {
             auto opt_trace_info = make_trace_info(_ptr);
             if (opt_trace_info) {
-                trace_state_ptr new_trace_state = tracing::get_local_tracing_instance().create_session(*opt_trace_info);
+                trace_state_ptr new_trace_state = _tracing->local().create_session(*opt_trace_info);
                 begin(new_trace_state);
                 return new_trace_state;
             } else {

--- a/tracing/trace_state.hh
+++ b/tracing/trace_state.hh
@@ -115,16 +115,16 @@ private:
     }
 
 public:
-    trace_state(trace_type type, trace_state_props_set props)
-        : _local_tracing_ptr(tracing::get_local_tracing_instance().shared_from_this())
+    trace_state(tracing& tr, trace_type type, trace_state_props_set props)
+        : _local_tracing_ptr(tr.shared_from_this())
         , _state_props(make_primary(props))
         , _records(make_lw_shared<one_session_records>(type, ttl_by_type(type, _local_tracing_ptr->slow_query_record_ttl()), _local_tracing_ptr->slow_query_record_ttl()))
         , _slow_query_threshold(_local_tracing_ptr->slow_query_threshold())
     {
     }
 
-    trace_state(const trace_info& info)
-        : _local_tracing_ptr(tracing::get_local_tracing_instance().shared_from_this())
+    trace_state(tracing& tr, const trace_info& info)
+        : _local_tracing_ptr(tr.shared_from_this())
         , _state_props(make_secondary(info.state_props))
         // inherit the slow query threshold and ttl from the coordinator
         , _records(make_lw_shared<one_session_records>(info.type, ttl_by_type(info.type, std::chrono::seconds(info.slow_query_ttl_sec)), std::chrono::seconds(info.slow_query_ttl_sec), info.session_id, info.parent_id))

--- a/tracing/tracing.cc
+++ b/tracing/tracing.cc
@@ -182,16 +182,16 @@ void tracing::set_trace_probability(double p) {
     tracing_logger.info("Setting tracing probability to {} (normalized {})", _trace_probability, _normalized_trace_probability);
 }
 
-one_session_records::one_session_records(trace_type type, std::chrono::seconds slow_query_ttl, std::chrono::seconds slow_query_rec_ttl,
+one_session_records::one_session_records(tracing& tr, trace_type type, std::chrono::seconds slow_query_ttl, std::chrono::seconds slow_query_rec_ttl,
             std::optional<utils::UUID> session_id_, span_id parent_id_)
-    : _local_tracing_ptr(tracing::get_local_tracing_instance().shared_from_this())
+    : _local_tracing_ptr(tr.shared_from_this())
     , session_id(session_id_ ? *session_id_ : utils::UUID_gen::get_time_UUID())
     , session_rec(type, slow_query_rec_ttl)
     , ttl(slow_query_ttl)
     , backend_state_ptr(_local_tracing_ptr->allocate_backend_session_state())
     , budget_ptr(_local_tracing_ptr->get_cached_records_ptr())
     , parent_id(parent_id_)
-    , my_span_id(span_id::make_span_id())
+    , my_span_id(span_id::make_span_id(tr))
 {
 }
 

--- a/tracing/tracing.cc
+++ b/tracing/tracing.cc
@@ -103,7 +103,7 @@ trace_state_ptr tracing::create_session(trace_type type, trace_state_props_set p
         props.set_if<trace_state_props::ignore_events>(!props.contains<trace_state_props::full_tracing>() && ignore_trace_events_enabled());
 
         ++_active_sessions;
-        return make_lw_shared<trace_state>(type, props);
+        return make_lw_shared<trace_state>(*this, type, props);
     } catch (...) {
         // return an uninitialized state in case of any error (OOM?)
         return nullptr;
@@ -122,7 +122,7 @@ trace_state_ptr tracing::create_session(const trace_info& secondary_session_info
         }
 
         ++_active_sessions;
-        return make_lw_shared<trace_state>(secondary_session_info);
+        return make_lw_shared<trace_state>(*this, secondary_session_info);
     } catch (...) {
         // return an uninitialized state in case of any error (OOM?)
         return nullptr;

--- a/tracing/tracing.hh
+++ b/tracing/tracing.hh
@@ -87,7 +87,7 @@ public:
     /**
      * @return New span_id with a random legal value
      */
-    static span_id make_span_id();
+    static span_id make_span_id(tracing& tr);
 };
 
 // !!!!IMPORTANT!!!!
@@ -242,7 +242,7 @@ public:
     span_id parent_id;
     span_id my_span_id;
 
-    one_session_records(trace_type type, std::chrono::seconds slow_query_ttl, std::chrono::seconds slow_query_rec_ttl,
+    one_session_records(tracing& tr, trace_type type, std::chrono::seconds slow_query_ttl, std::chrono::seconds slow_query_rec_ttl,
             std::optional<utils::UUID> session_id = std::nullopt, span_id parent_id = span_id::illegal_id);
 
     /**
@@ -655,9 +655,9 @@ void one_session_records::data_consumed() {
     budget_ptr = _local_tracing_ptr->get_cached_records_ptr();
 }
 
-inline span_id span_id::make_span_id() {
+inline span_id span_id::make_span_id(tracing& tr) {
     // make sure the value is always greater than 0
-    return 1 + (tracing::get_local_tracing_instance().get_next_rand_uint64() << 1);
+    return 1 + (tr.get_next_rand_uint64() << 1);
 }
 }
 

--- a/tracing/tracing.hh
+++ b/tracing/tracing.hh
@@ -288,7 +288,7 @@ private:
     bool _is_pending_for_write = false;
 };
 
-class tracing : public seastar::async_sharded_service<tracing> {
+class tracing : public seastar::async_sharded_service<tracing>, public seastar::peering_sharded_service<tracing> {
 public:
     static const gc_clock::duration write_period;
     // maximum number of sessions pending for write per shard


### PR DESCRIPTION
The tracing service is reachable via the global `tracing_instance()` getter, which goes against the sharded-services practice (#2737) and blocks turning `sharded<tracing>` into a regular main()-local service. The tracing module itself is one of the getter users: session objects grab the local instance from it on creation, and `global_trace_state_ptr` uses it to find the destination shard's instance when cloning a session across shards. Neither really needs the global -- the former are only created by the tracing instance itself, and the latter can peer through the sharded service container captured on the origin shard.

This is the first step towards removing the getter; converting its external users (storage proxy, transport, alternator, etc.) comes next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Fixing components inter-dependencies, not backporting