### PR TITLE
build: switch to C++26

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,7 +52,7 @@ endif()
 include(limit_jobs)
 
 # Configure Seastar compile options to align with Scylla
-set(CMAKE_CXX_STANDARD "23" CACHE INTERNAL "")
+set(CMAKE_CXX_STANDARD "26" CACHE INTERNAL "")
 set(CMAKE_CXX_EXTENSIONS ON CACHE INTERNAL "")
 set(CMAKE_CXX_SCAN_FOR_MODULES OFF CACHE INTERNAL "")
 set(CMAKE_VISIBILITY_INLINES_HIDDEN ON)

--- a/alternator/executor.cc
+++ b/alternator/executor.cc
@@ -4673,7 +4673,7 @@ future<executor::request_return_type> executor::describe_continuous_backups(clie
     // table doesn't exists, this operation returns a TableNoteFoundException.
     // So we can't use the usual get_table() wrapper and need a bit more code:
     std::string table_name = get_table_name(request);
-    sstring ks_name = sstring(executor::KEYSPACE_NAME_PREFIX) + table_name;
+    sstring ks_name = seastar::format("{}{}", executor::KEYSPACE_NAME_PREFIX, table_name);
     maybe_audit(audit_info, audit::statement_category::QUERY, ks_name, table_name, "DescribeContinuousBackups", request);
     schema_ptr schema;
     try {

--- a/audit/audit.cc
+++ b/audit/audit.cc
@@ -417,7 +417,7 @@ static sstring print_filtered_alternator_batch_query(const audit_info& audit_inf
                 ++it;
             }
         }
-        return operation + "|" + rjson::print(request);
+        return seastar::format("{}|{}", operation, rjson::print(request));
     } catch (...) {
         // Do not fall back to the unfiltered query: it may contain data for
         // tables that do not match this audit sink.

--- a/configure.py
+++ b/configure.py
@@ -2222,7 +2222,7 @@ def configure_seastar(build_dir, mode, mode_config, compiler_cache=None):
         '-DCMAKE_C_COMPILER={}'.format(args.cc),
         '-DCMAKE_CXX_COMPILER={}'.format(args.cxx),
         '-DCMAKE_EXPORT_NO_PACKAGE_REGISTRY=ON',
-        '-DCMAKE_CXX_STANDARD=23',
+        '-DCMAKE_CXX_STANDARD=26',
         '-DCMAKE_CXX_EXTENSIONS=ON',
         '-DSeastar_CXX_FLAGS=SHELL:{}'.format(mode_config['lib_cflags'] + extra_file_prefix_map),
         # Resolve fmt to the bundled submodule we build in configure_fmt()
@@ -2330,7 +2330,7 @@ def configure_fmt(build_dir, mode, mode_config, compiler_cache=None):
         '-DCMAKE_CXX_COMPILER={}'.format(args.cxx),
         '-DCMAKE_CXX_FLAGS_{}={}'.format(cmake_mode.upper(), cxx_flags),
         '-DCMAKE_EXPORT_COMPILE_COMMANDS=ON',
-        '-DCMAKE_CXX_STANDARD=23',
+        '-DCMAKE_CXX_STANDARD=26',
         # Static fmt gets linked into shared libseastar in some modes, so it
         # must be position-independent.
         '-DCMAKE_POSITION_INDEPENDENT_CODE=ON',
@@ -2387,7 +2387,7 @@ def configure_abseil(build_dir, mode, mode_config, compiler_cache=None):
         '-DCMAKE_CXX_COMPILER={}'.format(args.cxx),
         '-DCMAKE_CXX_FLAGS_{}={}'.format(cmake_mode.upper(), cxx_flags),
         '-DCMAKE_EXPORT_COMPILE_COMMANDS=ON',
-        '-DCMAKE_CXX_STANDARD=23',
+        '-DCMAKE_CXX_STANDARD=26',
         '-DABSL_PROPAGATE_CXX_STD=ON',
     ]
 
@@ -2604,7 +2604,7 @@ def write_build_file(f,
         configure_args = {configure_args}
         builddir = {outdir}
         cxx = {cxx}
-        cxxflags = -std=gnu++23 {user_cflags} {warnings} {defines}
+        cxxflags = -std=gnu++26 {user_cflags} {warnings} {defines}
         ldflags = {linker_flags} {user_ldflags}
         ldflags_build = {linker_flags}
         libs = {libs}

--- a/ent/encryption/azure_key_provider.cc
+++ b/ent/encryption/azure_key_provider.cc
@@ -52,7 +52,7 @@ shared_ptr<key_provider> azure_key_provider_factory::get_provider(encryption_con
     };
 
     auto host = ctxt.get_azure_host(*azure_host);
-    auto id = azure_host.value() + ":" + oov.master_key.value_or(host->options().master_key);
+    auto id = seastar::format("{}:{}", azure_host.value(), oov.master_key.value_or(host->options().master_key));
 
     auto provider = ctxt.get_cached_provider(id);
 

--- a/ent/encryption/gcp_key_provider.cc
+++ b/ent/encryption/gcp_key_provider.cc
@@ -59,11 +59,10 @@ shared_ptr<key_provider> gcp_key_provider_factory::get_provider(encryption_conte
     }
 
     auto host = ctxt.get_gcp_host(*gcp_host);
-    auto id = gcp_host.value()
-        + ":" + oov.master_key.value_or(host->options().master_key)
-        + ":" + oov.gcp_credentials_file.value_or(host->options().gcp_credentials_file)
-        + ":" + oov.gcp_impersonate_service_account.value_or(host->options().gcp_impersonate_service_account)
-        ;
+    auto id = seastar::format("{}:{}:{}:{}", gcp_host.value(),
+        oov.master_key.value_or(host->options().master_key),
+        oov.gcp_credentials_file.value_or(host->options().gcp_credentials_file),
+        oov.gcp_impersonate_service_account.value_or(host->options().gcp_impersonate_service_account));
 
     auto provider = ctxt.get_cached_provider(id);
 

--- a/ent/encryption/kmip_key_provider.cc
+++ b/ent/encryption/kmip_key_provider.cc
@@ -63,7 +63,7 @@ shared_ptr<key_provider> kmip_key_provider_factory::get_provider(encryption_cont
                     opts(KEY_NAMESPACE).value_or(""),
     };
 
-    auto cache_key = *host + ":" + boost::lexical_cast<std::string>(kopts);
+    auto cache_key = seastar::format("{}:{}", *host, boost::lexical_cast<std::string>(kopts));
     auto provider = ctxt.get_cached_provider(cache_key);
 
     if (!provider) {

--- a/ent/encryption/kms_host.cc
+++ b/ent/encryption/kms_host.cc
@@ -602,9 +602,8 @@ future<rjson::value> encryption::kms_host::impl::do_post(std::string_view target
             .host = sts_host,
             .service = "sts",
             .content_type = "application/x-www-form-urlencoded; charset=utf-8",
-            .content = "Action=AssumeRole&Version=2011-06-15&RoleArn=" 
-                + seastar::http::internal::url_encode(aws_assume_role_arn)
-                + "&RoleSessionName=" + role_session,
+            .content = seastar::format("Action=AssumeRole&Version=2011-06-15&RoleArn={}&RoleSessionName={}",
+                seastar::http::internal::url_encode(aws_assume_role_arn), role_session),
             .aws_access_key_id = aws_access_key_id,
             .aws_secret_access_key = aws_secret_access_key,
             .security_token = session,

--- a/ent/encryption/kms_key_provider.cc
+++ b/ent/encryption/kms_key_provider.cc
@@ -54,10 +54,9 @@ shared_ptr<key_provider> kms_key_provider_factory::get_provider(encryption_conte
     }
 
     auto host = ctxt.get_kms_host(*kms_host);
-    auto id = kms_host.value() 
-        + ":" + oov.master_key.value_or(host->options().master_key)
-        + ":" + oov.aws_assume_role_arn.value_or(host->options().aws_assume_role_arn)
-        ;
+    auto id = seastar::format("{}:{}:{}", kms_host.value(),
+        oov.master_key.value_or(host->options().master_key),
+        oov.aws_assume_role_arn.value_or(host->options().aws_assume_role_arn));
     auto provider = ctxt.get_cached_provider(id);
 
     if (!provider) {

--- a/ent/encryption/replicated_key_provider.cc
+++ b/ent/encryption/replicated_key_provider.cc
@@ -453,7 +453,7 @@ shared_ptr<key_provider> replicated_key_provider_factory::get_provider(encryptio
         throw std::invalid_argument("system key and local key cannot be the same");
     }
 
-    auto name = system_key->name() + ":" + local_key_file.string();
+    auto name = seastar::format("{}:{}", system_key->name(), local_key_file.string());
     auto debug = opts("DEBUG");
     if (debug) {
         name = name + ":" + *debug;

--- a/index/secondary_index_manager.cc
+++ b/index/secondary_index_manager.cc
@@ -168,7 +168,7 @@ sstring get_available_index_name(
         return !has_schema(ks_name, index_table_name) && !existing_names.contains(accepted_name);
     };
     while (!name_accepted()) {
-        accepted_name = base_name + "_" + std::to_string(++i);
+        accepted_name = seastar::format("{}_{}", base_name, ++i);
     }
     return accepted_name;
 }

--- a/node_ops/task_manager_module.cc
+++ b/node_ops/task_manager_module.cc
@@ -136,7 +136,7 @@ future<std::optional<tasks::virtual_task_hint>> node_ops_virtual_task::contains(
     if (!entry || !std::holds_alternative<service::topology_request>(entry->request_type)) {
         co_return std::nullopt;
     }
-    auto hint = std::make_optional<tasks::virtual_task_hint>({});
+    auto hint = std::make_optional(tasks::virtual_task_hint{});
     if (entry->target_host) {
         hint->node_id = locator::host_id(*entry->target_host);
     } else {

--- a/schema/schema.cc
+++ b/schema/schema.cc
@@ -1582,7 +1582,7 @@ schema_builder::default_names::default_names(const schema::raw_schema& raw)
 
 sstring schema_builder::default_names::unique_name(const sstring& base, size_t& idx, size_t off) const {
     for (;;) {
-        auto candidate = idx == 0 ? base : base + std::to_string(idx + off);
+        auto candidate = idx == 0 ? base : seastar::format("{}{}", base, idx + off);
         ++idx;
         auto i = std::find_if(_raw._columns.begin(), _raw._columns.end(), [b = to_bytes(candidate)](const column_definition& c) {
             return c.name() == b;

--- a/service/task_manager_module.cc
+++ b/service/task_manager_module.cc
@@ -401,7 +401,7 @@ future<std::optional<tasks::virtual_task_hint>> global_topology_request_virtual_
         co_return std::nullopt;
     }
 
-    auto hint = std::make_optional<tasks::virtual_task_hint>({});
+    auto hint = std::make_optional(tasks::virtual_task_hint{});
     auto entry = co_await _ss._sys_ks.local().get_topology_request_entry_opt(task_id.uuid());
     if (entry.has_value() && std::holds_alternative<service::global_topology_request>(entry->request_type) &&
             std::get<service::global_topology_request>(entry->request_type) == global_topology_request::keyspace_rf_change) {

--- a/test/boost/cdc_test.cc
+++ b/test/boost/cdc_test.cc
@@ -613,7 +613,8 @@ SEASTAR_THREAD_TEST_CASE(test_pre_post_image_logging) {
             for (auto i = 0u; i < 10; ++i) {
                 auto nv = last + 1;
                 const int64_t new_ttl = 100 * (i + 1);
-                cquery_nofail(e, "UPDATE ks.tbl" + (with_ttl ? format(" USING TTL {}", new_ttl) : "") + " SET val=" + std::to_string(nv) +" where pk=1 AND pk2=11 AND ck=111 AND ck2=1111");
+                cquery_nofail(e, seastar::format("UPDATE ks.tbl{} SET val={} where pk=1 AND pk2=11 AND ck=111 AND ck2=1111",
+                        with_ttl ? seastar::format(" USING TTL {}", new_ttl) : "", nv));
 
                 rows = select_log(e, "tbl");
 
@@ -708,7 +709,8 @@ SEASTAR_THREAD_TEST_CASE(test_pre_post_image_logging_static_row) {
             for (auto i = 0u; i < 10; ++i) {
                 auto nv = last + 1;
                 const int64_t new_ttl = 100 * (i + 1);
-                cquery_nofail(e, "UPDATE ks.tbl" + (with_ttl ? format(" USING TTL {}", new_ttl) : "") + " SET s=" + std::to_string(nv) +" where pk=1 AND pk2=11");
+                cquery_nofail(e, seastar::format("UPDATE ks.tbl{} SET s={} where pk=1 AND pk2=11",
+                        with_ttl ? seastar::format(" USING TTL {}", new_ttl) : "", nv));
 
                 rows = select_log(e, "tbl");
 

--- a/test/boost/commitlog_test.cc
+++ b/test/boost/commitlog_test.cc
@@ -1751,7 +1751,7 @@ SEASTAR_TEST_CASE(test_delete_recycled_segment_removes_size) {
     // Add a bunch of fake segments (pretending replayed). The total footprint will be much 
     // more than above limit.
     for (int i = 0; i < 20; ++i) {
-        fakes.emplace_back(cfg.commit_log_location + "/fake" + std::to_string(i) + ".log");
+        fakes.emplace_back(seastar::format("{}/fake{}.log", cfg.commit_log_location, i));
 
         auto f = co_await open_file_dma(fakes.back(), open_flags::wo|open_flags::create);
         co_await f.truncate(max_file_size_bytes);

--- a/test/boost/file_stream_test.cc
+++ b/test/boost/file_stream_test.cc
@@ -95,7 +95,7 @@ static sstring make_storage_clause(const data_dictionary::storage_options& so) {
 }
 
 static future<bool>
-do_test_file_stream(replica::database& db, netw::messaging_service& ms, std::vector<sstring> filelist, const std::string& suffix, bool inject_error, bool unsupported_file_ops = false) {
+do_test_file_stream(replica::database& db, netw::messaging_service& ms, std::vector<sstring> filelist, const sstring& suffix, bool inject_error, bool unsupported_file_ops = false) {
     bool ret = false;
     bool verb_register = false;
     auto ops_id = file_stream_id::create_random_id();
@@ -321,7 +321,7 @@ void do_test_file_stream(bool inject_error) {
     std::vector<sstring> hash_rx;
     size_t nr_files = 10;
     size_t file_size = 0;
-    static const std::string suffix = ".rx";
+    static const sstring suffix = ".rx";
 
     while (files.size() != nr_files) {
         auto name = generate_random_filename();

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -591,8 +591,8 @@ private:
             create_directories(cfg->hints_directory().c_str());
             create_directories(cfg->view_hints_directory().c_str());
             for (unsigned i = 0; i < this_smp_shard_count(); ++i) {
-                create_directories((cfg->hints_directory() + "/" + std::to_string(i)).c_str());
-                create_directories((cfg->view_hints_directory() + "/" + std::to_string(i)).c_str());
+                create_directories(seastar::format("{}/{}", cfg->hints_directory(), i).c_str());
+                create_directories(seastar::format("{}/{}", cfg->view_hints_directory(), i).c_str());
             }
 
             if (!cfg->max_memory_for_unlimited_query_soft_limit.is_set()) {

--- a/test/perf/perf_commitlog.cc
+++ b/test/perf/perf_commitlog.cc
@@ -243,7 +243,7 @@ int main(int argc, char** argv) {
 
         try {
             if (cfg.max_data_size > test_commitlog.local().log->max_record_size()) {
-                throw std::invalid_argument(sstring("Too large max data size: ") + std::to_string(cfg.max_data_size));
+                throw std::invalid_argument("Too large max data size: " + std::to_string(cfg.max_data_size));
             }
             // test "framework" expects seastar thread
             auto results = co_await seastar::async([&] {


### PR DESCRIPTION
Bump the C++ standard from 23 to 26 in both build systems: the
ninja cxxflags and the Seastar/fmt/abseil sub-configures in
configure.py, and CMAKE_CXX_STANDARD in CMakeLists.txt.

Relevant C++26 features:
 - reflection (unfortunately not yet supported in Clang)
 - std::function_ref, useful for bounded-lifetime callbacks
 - std::inplace_vector, a replacement for boost's static_vector
 - std::optional<T&>, a simplified way to write T*
 - std::views::concat, a replacement for boost join

Before the actual switch, fix two minor incompatibilties:
 - std::string gained some operator+ overloads that make concatentation ambiguous, switch to fmt::format() instead
 - let std::make_optional() deduce its template arguments, as it was intended to, since specifying the type no longer works

No backport: release branches don't get C++ version changes