### PR TITLE
Fix migration status current storage mode

### DIFF
--- a/api/storage_service.cc
+++ b/api/storage_service.cc
@@ -1828,7 +1828,7 @@ rest_set_vnode_tablet_migration_node_storage_mode(http_context& ctx, sharded<ser
         throw std::runtime_error("vnodes-to-tablets migration requires all nodes to support the VNODES_TO_TABLETS_MIGRATIONS cluster feature");
     }
     auto mode_str = req->get_query_param("intended_mode");
-    auto mode = service::intended_storage_mode_from_string(mode_str);
+    auto mode = service::storage_mode_from_string(mode_str);
     co_await ss.local().run_with_no_api_lock([mode] (service::storage_service& ss) {
         return ss.set_node_intended_storage_mode(mode);
     });

--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -284,6 +284,7 @@ schema_ptr system_keyspace::topology() {
             .with_column("supported_features", set_type_impl::get_instance(utf8_type, true))
             .with_column("request_id", timeuuid_type)
             .with_column("intended_storage_mode", utf8_type)
+            .with_column("current_storage_mode", utf8_type)
             .with_column("ignore_nodes", set_type_impl::get_instance(uuid_type, true), column_kind::static_column)
             .with_column("new_cdc_generation_data_uuid", timeuuid_type, column_kind::static_column)
             .with_column("new_keyspace_rf_change_ks_name", utf8_type, column_kind::static_column) // deprecated
@@ -3228,9 +3229,14 @@ future<service::topology> system_keyspace::load_topology_state(const std::unorde
             }
         }
 
-        std::optional<service::storage_mode> storage_mode;
+        std::optional<service::storage_mode> intended_storage_mode;
         if (row.has("intended_storage_mode")) {
-            storage_mode = service::storage_mode_from_string(row.get_as<sstring>("intended_storage_mode"));
+            intended_storage_mode = service::storage_mode_from_string(row.get_as<sstring>("intended_storage_mode"));
+        }
+
+        std::optional<service::storage_mode> current_storage_mode;
+        if (row.has("current_storage_mode")) {
+            current_storage_mode = service::storage_mode_from_string(row.get_as<sstring>("current_storage_mode"));
         }
 
         std::unordered_map<raft::server_id, service::replica_state>* map = nullptr;
@@ -3257,7 +3263,8 @@ future<service::topology> system_keyspace::load_topology_state(const std::unorde
             map->emplace(host_id, service::replica_state{
                 nstate, std::move(datacenter), std::move(rack), std::move(release_version),
                 ring_slice, shard_count, ignore_msb, std::move(supported_features),
-                service::cleanup_status_from_string(cleanup_status), request_id, storage_mode});
+                service::cleanup_status_from_string(cleanup_status), request_id,
+                intended_storage_mode, current_storage_mode});
         }
     }
 

--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -3228,9 +3228,9 @@ future<service::topology> system_keyspace::load_topology_state(const std::unorde
             }
         }
 
-        std::optional<service::intended_storage_mode> storage_mode;
+        std::optional<service::storage_mode> storage_mode;
         if (row.has("intended_storage_mode")) {
-            storage_mode = service::intended_storage_mode_from_string(row.get_as<sstring>("intended_storage_mode"));
+            storage_mode = service::storage_mode_from_string(row.get_as<sstring>("intended_storage_mode"));
         }
 
         std::unordered_map<raft::server_id, service::replica_state>* map = nullptr;

--- a/docs/dev/system_keyspace.md
+++ b/docs/dev/system_keyspace.md
@@ -1617,6 +1617,7 @@ CREATE TABLE system.topology (
     key text,
     host_id uuid,
     cleanup_status text,
+    current_storage_mode text,
     datacenter text,
     ignore_msb int,
     intended_storage_mode text,
@@ -1673,6 +1674,7 @@ CREATE TABLE system.topology (
 - `shard_count`: Number of shards on the node
 - `ignore_msb`: MSB bits to ignore for token calculation
 - `intended_storage_mode`: Intended storage mode for tables under vnodes-to-tablets migration. The node switches to this mode on next restart.
+- `current_storage_mode`: Storage mode the node is currently running in, for tables under vnodes-to-tablets migration. Written by the node itself once it has restarted and resharded, and only while `intended_storage_mode` is set. Null means the node has published no mode since the migration began, so it still runs in vnodes mode: not yet switched on the forward path, nothing to undo on a rollback. Gated by the `TOPOLOGY_CURRENT_STORAGE_MODE` cluster feature.
 - `cleanup_status`: Status of cleanup operations
 - `supported_features`: Features supported by this node
 - `request_id`: ID of the current topology request for this node

--- a/docs/dev/topology-over-raft.md
+++ b/docs/dev/topology-over-raft.md
@@ -778,6 +778,7 @@ The schema of the table is:
 CREATE TABLE system.topology (
     key text,
     host_id uuid,
+    current_storage_mode text,
     datacenter text,
     ignore_msb int,
     intended_storage_mode text,
@@ -823,6 +824,7 @@ Each node has a clustering row in the table where its `host_id` is the clusterin
 - `rack`               -  a name of the rack the node belongs to
 - `ignore_msb`         -  the value of the node's `murmur3_partitioner_ignore_msb_bits` parameter
 - `intended_storage_mode` - if set, it indicates the intended storage mode for tables under vnodes-to-tablets migration
+- `current_storage_mode` - if set, it indicates the storage mode the node is currently running in for tables under vnodes-to-tablets migration; the node writes it after it restarted and resharded, and only while `intended_storage_mode` is set for it. Requires the `TOPOLOGY_CURRENT_STORAGE_MODE` cluster feature
 - `shard_count`        -  the node's `smp::count`
 - `release_version`    -  the node's `version::current()` (corresponding to a Cassandra version, used by drivers)
 - `node_state`         -  current state of the node (as described earlier)

--- a/gms/feature_service.hh
+++ b/gms/feature_service.hh
@@ -181,6 +181,8 @@ public:
     gms::feature tablets_intermediate_fallback_cleanup { *this, "TABLETS_INTERMEDIATE_FALLBACK_CLEANUP"sv };
     gms::feature batchlog_v2 { *this, "BATCHLOG_V2"sv };
     gms::feature vnodes_to_tablets_migrations { *this, "VNODES_TO_TABLETS_MIGRATIONS"sv };
+    // Gates the `current_storage_mode` column of system.topology.
+    gms::feature topology_current_storage_mode { *this, "TOPOLOGY_CURRENT_STORAGE_MODE"sv };
     gms::feature writetime_ttl_individual_element { *this, "WRITETIME_TTL_INDIVIDUAL_ELEMENT"sv };
     gms::feature arbitrary_tablet_boundaries { *this, "ARBITRARY_TABLET_BOUNDARIES"sv };
     gms::feature large_data_virtual_tables { *this, "LARGE_DATA_VIRTUAL_TABLES"sv };

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -848,6 +848,7 @@ bool database::is_in_critical_disk_utilization_mode() const {
 
 future<> database::parse_system_tables(sharded<service::storage_proxy>& proxy, sharded<db::system_keyspace>& sys_ks, std::optional<service::storage_mode> storage_mode) {
     using namespace db::schema_tables;
+    _boot_storage_mode = storage_mode;
     co_await do_parse_schema_tables(proxy, db::schema_tables::KEYSPACES, coroutine::lambda([&] (schema_result_value_type &v) -> future<> {
         auto scylla_specific_rs = co_await extract_scylla_specific_keyspace_info(proxy, v);
         auto ksm = co_await create_keyspace_metadata(v, scylla_specific_rs);

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -846,7 +846,7 @@ bool database::is_in_critical_disk_utilization_mode() const {
     return false;
 }
 
-future<> database::parse_system_tables(sharded<service::storage_proxy>& proxy, sharded<db::system_keyspace>& sys_ks, std::optional<service::intended_storage_mode> storage_mode) {
+future<> database::parse_system_tables(sharded<service::storage_proxy>& proxy, sharded<db::system_keyspace>& sys_ks, std::optional<service::storage_mode> storage_mode) {
     using namespace db::schema_tables;
     co_await do_parse_schema_tables(proxy, db::schema_tables::KEYSPACES, coroutine::lambda([&] (schema_result_value_type &v) -> future<> {
         auto scylla_specific_rs = co_await extract_scylla_specific_keyspace_info(proxy, v);
@@ -1200,7 +1200,7 @@ db::commitlog* database::commitlog_for(const schema_ptr& schema) {
         : _commitlog.get();
 }
 
-void database::add_column_family(keyspace& ks, schema_ptr schema, column_family::config cfg, is_new_cf is_new, locator::token_metadata_ptr not_commited_new_metadata, std::optional<service::intended_storage_mode> storage_mode) {
+void database::add_column_family(keyspace& ks, schema_ptr schema, column_family::config cfg, is_new_cf is_new, locator::token_metadata_ptr not_commited_new_metadata, std::optional<service::storage_mode> storage_mode) {
     schema = local_schema_registry().learn(schema);
     auto&& rs = ks.get_replication_strategy();
     locator::effective_replication_map_ptr erm;
@@ -1214,7 +1214,7 @@ void database::add_column_family(keyspace& ks, schema_ptr schema, column_family:
     } else {
         auto metadata_ptr = not_commited_new_metadata ? not_commited_new_metadata : _shared_token_metadata.get();
         auto table_is_migrating = metadata_ptr->tablets().has_tablet_map(schema->id());
-        if (table_is_migrating && storage_mode.has_value() && storage_mode.value() == service::intended_storage_mode::tablets) {
+        if (table_is_migrating && storage_mode.has_value() && storage_mode.value() == service::storage_mode::tablets) {
             // Table under vnode-to-tablet migration: the keyspace uses vnode-based
             // replication but this table already has a tablet map persisted in group0.
             // Build a tablet-aware RS with the same replication options so the table
@@ -1263,7 +1263,7 @@ future<> database::make_column_family_directory(schema_ptr schema) {
     co_await cf.init_storage();
 }
 
-future<> database::add_column_family_and_make_directory(schema_ptr schema, is_new_cf is_new, std::optional<service::intended_storage_mode> storage_mode) {
+future<> database::add_column_family_and_make_directory(schema_ptr schema, is_new_cf is_new, std::optional<service::storage_mode> storage_mode) {
     auto lock = co_await get_tables_metadata().hold_write_lock();
     auto& ks = find_keyspace(schema->ks_name());
     std::exception_ptr ex;

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -1799,6 +1799,9 @@ private:
 
     service::migration_notifier& _mnotifier;
     gms::feature_service& _feat;
+    // The mode this node applied when it built its tables at boot, i.e. the one it is
+    // actually running in. A change of intent only takes effect on the next restart.
+    std::optional<service::storage_mode> _boot_storage_mode;
     std::vector<std::any> _listeners;
     locator::shared_token_metadata& _shared_token_metadata;
     lang::manager& _lang_manager;
@@ -1904,7 +1907,7 @@ public:
 
     // Load the schema definitions kept in schema tables from disk and initialize in-memory schema data structures
     // (keyspace/table definitions, column mappings etc.)
-    future<> parse_system_tables(sharded<service::storage_proxy>&, sharded<db::system_keyspace>&, std::optional<service::storage_mode> storage_mode = std::nullopt);
+    future<> parse_system_tables(sharded<service::storage_proxy>&, sharded<db::system_keyspace>&, std::optional<service::storage_mode> storage_mode);
 
     database(const db::config&, database_config dbcfg, service::migration_notifier& mn, gms::feature_service& feat, locator::shared_token_metadata& stm,
             compaction::compaction_manager& cm, sstables::storage_manager& sstm, lang::manager& langm, sstables::directory_semaphore& sst_dir_sem, sstable_compressor_factory&,
@@ -1938,6 +1941,8 @@ public:
     const compaction::compaction_manager& get_compaction_manager() const {
         return _compaction_manager;
     }
+
+    std::optional<service::storage_mode> get_boot_storage_mode() const noexcept { return _boot_storage_mode; }
 
     locator::shared_token_metadata& get_shared_token_metadata() const { return _shared_token_metadata; }
     locator::token_metadata_ptr get_token_metadata_ptr() const { return _shared_token_metadata.get(); }

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -1904,7 +1904,7 @@ public:
 
     // Load the schema definitions kept in schema tables from disk and initialize in-memory schema data structures
     // (keyspace/table definitions, column mappings etc.)
-    future<> parse_system_tables(sharded<service::storage_proxy>&, sharded<db::system_keyspace>&, std::optional<service::intended_storage_mode> storage_mode = std::nullopt);
+    future<> parse_system_tables(sharded<service::storage_proxy>&, sharded<db::system_keyspace>&, std::optional<service::storage_mode> storage_mode = std::nullopt);
 
     database(const db::config&, database_config dbcfg, service::migration_notifier& mn, gms::feature_service& feat, locator::shared_token_metadata& stm,
             compaction::compaction_manager& cm, sstables::storage_manager& sstm, lang::manager& langm, sstables::directory_semaphore& sst_dir_sem, sstable_compressor_factory&,
@@ -1962,9 +1962,9 @@ public:
     void init_schema_commitlog();
 
     using is_new_cf = bool_class<struct is_new_cf_tag>;
-    void add_column_family(keyspace& ks, schema_ptr schema, column_family::config cfg, is_new_cf is_new, locator::token_metadata_ptr not_commited_new_metadata = nullptr, std::optional<service::intended_storage_mode> storage_mode = std::nullopt);
+    void add_column_family(keyspace& ks, schema_ptr schema, column_family::config cfg, is_new_cf is_new, locator::token_metadata_ptr not_commited_new_metadata = nullptr, std::optional<service::storage_mode> storage_mode = std::nullopt);
     future<> make_column_family_directory(schema_ptr schema);
-    future<> add_column_family_and_make_directory(schema_ptr schema, is_new_cf is_new, std::optional<service::intended_storage_mode> storage_mode = std::nullopt);
+    future<> add_column_family_and_make_directory(schema_ptr schema, is_new_cf is_new, std::optional<service::storage_mode> storage_mode = std::nullopt);
 
 
     /* throws no_such_column_family if missing */

--- a/replica/distributed_loader.cc
+++ b/replica/distributed_loader.cc
@@ -472,7 +472,7 @@ future<> table_populator::populate_subdir(sharded<sstables::sstable_directory>& 
 
 future<> distributed_loader::populate_keyspace(sharded<replica::database>& db,
         sharded<db::system_keyspace>& sys_ks, keyspace& ks, sstring ks_name,
-        std::optional<service::intended_storage_mode> storage_mode)
+        std::optional<service::storage_mode> storage_mode)
 {
     dblog.info("Populating Keyspace {}", ks_name);
 
@@ -489,7 +489,7 @@ future<> distributed_loader::populate_keyspace(sharded<replica::database>& db,
         auto direction = [&]() {
             if (ks.uses_tablets()) { return md::none; }
             if (cf.uses_tablets()) { return md::forward; }
-            if (tablet_metadata.has_tablet_map(uuid) && storage_mode == service::intended_storage_mode::vnodes) { return md::rollback; }
+            if (tablet_metadata.has_tablet_map(uuid) && storage_mode == service::storage_mode::vnodes) { return md::rollback; }
             return md::none;
         }();
         if (direction != md::none) {
@@ -590,7 +590,7 @@ future<> distributed_loader::init_non_system_keyspaces(sharded<replica::database
         auto topology = sys_ks.local().load_topology_state({}).get();
         auto host_id = db.local().get_token_metadata().get_my_id();
         auto node = topology.normal_nodes.find(raft::server_id{host_id.uuid()});
-        std::optional<service::intended_storage_mode> storage_mode = node != topology.normal_nodes.end() ? node->second.storage_mode : std::nullopt;
+        std::optional<service::storage_mode> storage_mode = node != topology.normal_nodes.end() ? node->second.intended_storage_mode : std::nullopt;
 
         db.invoke_on_all([&proxy, &sys_ks, &storage_mode] (replica::database& db) {
             return db.parse_system_tables(proxy, sys_ks, storage_mode);

--- a/replica/distributed_loader.hh
+++ b/replica/distributed_loader.hh
@@ -77,7 +77,7 @@ class distributed_loader {
             sharded<replica::database>& db, sharded<db::view::view_builder>& vb, sharded<db::view::view_building_worker>& vbw,
             db::view::sstable_destination_decision needs_view_update, sstring ks, sstring cf);
     static future<> populate_keyspace(sharded<replica::database>& db, sharded<db::system_keyspace>& sys_ks, keyspace& ks, sstring ks_name,
-            std::optional<service::intended_storage_mode> storage_mode = std::nullopt);
+            std::optional<service::storage_mode> storage_mode = std::nullopt);
     static future<std::tuple<table_id, std::vector<std::vector<sstables::shared_sstable>>>>
         get_sstables_from(sharded<replica::database>& db, sstring ks, sstring cf, sstables::sstable_open_config cfg,
         noncopyable_function<future<>(global_table_ptr&, sharded<sstables::sstable_directory>&)> start_dir,

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -4593,48 +4593,45 @@ future<storage_service::keyspace_migration_status> storage_service::get_tablets_
     result.keyspace = ks_name;
     result.status = get_tablets_migration_status(ks_name);
 
-    if (result.status != migration_status::migrating_to_tablets) {
+    // Only finalization sets this, and nothing unsets it, so a local reading of it needs
+    // no confirmation. Answering here keeps an already-migrated keyspace off group0.
+    if (result.status == migration_status::tablets) {
         co_return result;
     }
 
-    // system.tablet_sizes is a group0_virtual_table, so it requires group0 to
-    // be initialized. If this function is called via the task manager API,
-    // group0 may not be initialized yet.
+    // The other two answers can be stale, and so can the per-node modes, so they have to
+    // come from one snapshot: a barrier taken after the status was computed would let a
+    // concurrent finalization clear the modes under a status still saying migrating.
     if (!_group0 || !_group0->joined_group0()) {
-        throw std::runtime_error(::format("Cannot fetch node statuses for migrating keyspace '{}': group0 is not yet initialized on this node", ks_name));
+        throw std::runtime_error(::format("Cannot fetch migration status for keyspace '{}': group0 is not yet initialized on this node", ks_name));
     }
 
-    // Pick one table and query system.tablet_sizes to find which nodes
-    // report tablet sizes (i.e. have loaded tablet-based ERMs).
-    auto& ks = _db.local().find_keyspace(ks_name);
-    auto tables = ks.metadata()->tables();
-    auto sample_table_id = tables.front()->id();
+    // A node publishes its current mode before it finishes starting up, so a caller
+    // that just restarted a node expects the next status to show it. Take a read
+    // barrier to make that write visible here instead of waiting for this node to
+    // apply it on its own. Hold the group0 gate meanwhile, to prevent
+    // abort_and_drain() from destroying the raft server under it (SCYLLADB-2071).
+    {
+        auto group0_holder = _group0->hold_group0_gate();
+        co_await _group0->group0_server_with_timeouts().read_barrier(&_group0_as, raft_timeout{});
+    }
 
-    // FIXME: system.tablet_sizes might return stale data (load stats in the topology coordinator are cached).
-    auto rs = co_await _qp.execute_internal(
-            "SELECT replicas FROM system.tablet_sizes WHERE table_id = ?",
-            {sample_table_id.uuid()},
-            cql3::query_processor::cache_internal::no);
+    result.status = get_tablets_migration_status(ks_name);
 
-    // Collect all host_ids that appear in the replicas map across all tablets.
-    std::unordered_set<locator::host_id> nodes_reporting_tablets;
-    for (const auto& row : *rs) {
-        if (row.has("replicas")) {
-            auto replicas_map = row.get_map<utils::UUID, int64_t>("replicas");
-            for (const auto& [host_uuid, size] : replicas_map) {
-                nodes_reporting_tablets.insert(locator::host_id(host_uuid));
-            }
-        }
+    if (result.status != migration_status::migrating_to_tablets) {
+        co_return result;
     }
 
     const auto& topo = _topology_state_machine._topology;
     for (const auto& [server_id, rs] : topo.normal_nodes) {
         auto host_id = locator::host_id{server_id.uuid()};
-        bool reports_tablets = nodes_reporting_tablets.contains(host_id);
 
-        auto current_mode = reports_tablets
-            ? storage_mode::tablets
-            : storage_mode::vnodes;
+        // An unset current mode means the node has not restarted since the migration
+        // began, so it still runs in vnodes mode. The column is cleared when a
+        // migration is finalized, which is what keeps that reading true for the next
+        // one. During a rollback there is no ambiguity either: a node that has not
+        // restarted yet still holds the tablets it published on the forward pass.
+        auto current_mode = rs.current_storage_mode.value_or(storage_mode::vnodes);
         auto intended_mode = rs.intended_storage_mode.value_or(storage_mode::vnodes);
 
         result.nodes.push_back(node_migration_status{

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -4271,10 +4271,10 @@ future<> storage_service::prepare_for_tablets_migration(const sstring& ks_name) 
 
         auto topology = co_await get_system_keyspace().load_topology_state({});
         for (const auto& [server_id, replica_state]: topology.normal_nodes) {
-            if (replica_state.storage_mode) {
+            if (replica_state.intended_storage_mode) {
                 throw std::runtime_error(fmt::format("Another migration is in progress (node '{}' has intended storage mode '{}') - cannot start tablets migration."
                         " Please wait for the current migration to finish and retry.",
-                        server_id, *replica_state.storage_mode));
+                        server_id, *replica_state.intended_storage_mode));
             }
         }
 
@@ -4427,7 +4427,7 @@ future<> storage_service::prepare_for_tablets_migration(const sstring& ks_name) 
     }
 }
 
-future<> storage_service::set_node_intended_storage_mode(intended_storage_mode mode) {
+future<> storage_service::set_node_intended_storage_mode(storage_mode mode) {
     // Called via run_with_no_api_lock (forwards to shard 0).
     SCYLLA_ASSERT(this_shard_id() == 0);
 
@@ -4474,7 +4474,7 @@ future<> storage_service::set_node_intended_storage_mode(intended_storage_mode m
             throw std::runtime_error(::format("Node {} is not in the normal state (current state: {})", raft_server.id(), rs.state));
         }
 
-        if (rs.storage_mode == mode) {
+        if (rs.intended_storage_mode == mode) {
             slogger.info("Node {} already has intended storage mode set to {}, skipping", raft_server.id(), mode);
             co_return;
         }
@@ -4572,9 +4572,9 @@ future<storage_service::keyspace_migration_status> storage_service::get_tablets_
         bool reports_tablets = nodes_reporting_tablets.contains(host_id);
 
         auto current_mode = reports_tablets
-            ? intended_storage_mode::tablets
-            : intended_storage_mode::vnodes;
-        auto intended_mode = rs.storage_mode.value_or(intended_storage_mode::vnodes);
+            ? storage_mode::tablets
+            : storage_mode::vnodes;
+        auto intended_mode = rs.intended_storage_mode.value_or(storage_mode::vnodes);
 
         result.nodes.push_back(node_migration_status{
             .host_id = host_id,

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -1429,6 +1429,25 @@ future<> storage_service::update_topology_with_local_metadata(raft::server& raft
     auto local_release_version = version::release();
     auto local_supported_features = _feature_service.supported_feature_set() | std::ranges::to<std::set<sstring>>();
 
+    // Only report the mode once every node knows the column; older nodes silently drop
+    // a cell for a column their schema lacks. The flag gates the comparison below too,
+    // or the loop would keep retrying a write it is not allowed to make.
+    const bool report_storage_mode = bool(_feature_service.topology_current_storage_mode);
+    std::optional<storage_mode> local_storage_mode;
+    if (report_storage_mode) {
+        local_storage_mode = _db.local().get_boot_storage_mode();
+    }
+
+    // The boot mode comes from a read taken before this node caught up with group0, so
+    // it can be stale. Only reconcile it while the authoritative row still records an
+    // intent, or a node booting after finalization writes back a mode just cleared.
+    auto storage_mode_synchronized = [&] (const replica_state& rs) {
+        if (!report_storage_mode || !rs.intended_storage_mode) {
+            return true;
+        }
+        return rs.current_storage_mode == local_storage_mode;
+    };
+
     auto synchronized = [&] () {
         auto it = _topology_state_machine._topology.find(raft_server.id());
         if (!it) {
@@ -1440,7 +1459,8 @@ future<> storage_service::update_topology_with_local_metadata(raft::server& raft
         return replica_state.shard_count == local_shard_count
             && replica_state.ignore_msb == local_ignore_msb
             && replica_state.release_version == local_release_version
-            && replica_state.supported_features == local_supported_features;
+            && replica_state.supported_features == local_supported_features
+            && storage_mode_synchronized(replica_state);
     };
 
     // We avoid performing a read barrier if we're sure that our metadata stored in topology
@@ -1487,11 +1507,22 @@ future<> storage_service::update_topology_with_local_metadata(raft::server& raft
         co_await _sys_ks.local().set_must_synchronize_topology(true);
 
         topology_mutation_builder builder(guard.write_timestamp());
-        builder.with_node(raft_server.id())
+        auto& node_builder = builder.with_node(raft_server.id())
                .set("shard_count", local_shard_count)
                .set("ignore_msb", local_ignore_msb)
                .set("release_version", local_release_version)
                .set("supported_features", local_supported_features);
+        // Mirrors storage_mode_synchronized(); synchronized() above already established
+        // that the node is in the topology.
+        const auto& rs = _topology_state_machine._topology.find(raft_server.id())->second;
+        if (report_storage_mode && rs.intended_storage_mode) {
+            if (local_storage_mode) {
+                node_builder.set("current_storage_mode", *local_storage_mode);
+            } else {
+                // The intent postdates this boot, so the tables are still vnode-flavored.
+                node_builder.del("current_storage_mode");
+            }
+        }
 
         topology_change change{{builder.build()}};
         group0_command g0_cmd = _group0->client().prepare_command(
@@ -1727,6 +1758,23 @@ future<> storage_service::join_topology(sharded<service::storage_proxy>& proxy,
     }
 
     co_await update_topology_with_local_metadata(raft_server);
+
+    // The flag that call reads is frozen for the process, and on the upgrade that
+    // introduces the feature no node has seen it enabled yet: it cannot be enabled until
+    // every node published its supported features, which that call does. Reconcile again
+    // when it lands. An already-enabled feature fires immediately and finds nothing to do.
+    // _listeners keeps the registration alive and drops it in drain_on_shutdown().
+    _listeners.emplace_back(_feature_service.topology_current_storage_mode.when_enabled([this] {
+        // Runs from feature::enable() and must not block, so reconcile in the background.
+        (void)futurize_invoke(ensure_alive([this, h = _async_gate.hold()] () -> future<> {
+            auto group0_holder = _group0->hold_group0_gate();
+            co_await update_topology_with_local_metadata(_group0->group0_server());
+        })).handle_exception([] (std::exception_ptr e) {
+            slogger.warn("Failed to publish the current storage mode after "
+                         "TOPOLOGY_CURRENT_STORAGE_MODE was enabled: {}. It will be published "
+                         "on the next restart.", e);
+        });
+    }));
 
     // Node state is enough to know that bootstrap has completed, but to make legacy code happy
     // let it know that the bootstrap is completed as well
@@ -4254,6 +4302,12 @@ future<> storage_service::prepare_for_tablets_migration(const sstring& ks_name) 
     // Called via run_with_no_api_lock (forwards to shard 0).
     SCYLLA_ASSERT(this_shard_id() == 0);
 
+    // A node that does not know the column cannot report whether it switched, which
+    // would make the status wrong for the whole run.
+    if (!_feature_service.topology_current_storage_mode) {
+        throw std::runtime_error("Cannot start tablets migration: the TOPOLOGY_CURRENT_STORAGE_MODE cluster feature is not enabled yet");
+    }
+
     while (true) {
         auto guard = co_await _group0->client().start_operation(_group0_as);
 
@@ -4275,6 +4329,13 @@ future<> storage_service::prepare_for_tablets_migration(const sstring& ks_name) 
                 throw std::runtime_error(fmt::format("Another migration is in progress (node '{}' has intended storage mode '{}') - cannot start tablets migration."
                         " Please wait for the current migration to finish and retry.",
                         server_id, *replica_state.intended_storage_mode));
+            }
+            // A mode left behind by a previous migration would make this node look
+            // already switched from the outset.
+            if (replica_state.current_storage_mode) {
+                throw std::runtime_error(fmt::format("Node '{}' still has current storage mode '{}' recorded from an earlier migration"
+                        " - cannot start tablets migration.",
+                        server_id, *replica_state.current_storage_mode));
             }
         }
 

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -1432,7 +1432,9 @@ future<> storage_service::update_topology_with_local_metadata(raft::server& raft
     // Only report the mode once every node knows the column; older nodes silently drop
     // a cell for a column their schema lacks. The flag gates the comparison below too,
     // or the loop would keep retrying a write it is not allowed to make.
-    const bool report_storage_mode = bool(_feature_service.topology_current_storage_mode);
+    // The one-shot injection lets a test reproduce a boot before the feature landed.
+    const bool report_storage_mode = bool(_feature_service.topology_current_storage_mode)
+            && !utils::get_local_injector().enter("skip_current_storage_mode_publish");
     std::optional<storage_mode> local_storage_mode;
     if (report_storage_mode) {
         local_storage_mode = _db.local().get_boot_storage_mode();

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -322,7 +322,7 @@ public:
 
     migration_status get_tablets_migration_status(const sstring& ks_name);
     future<keyspace_migration_status> get_tablets_migration_status_with_node_details(const sstring& ks_name);
-    future<> set_node_intended_storage_mode(intended_storage_mode mode);
+    future<> set_node_intended_storage_mode(storage_mode mode);
     future<> finalize_tablets_migration(const sstring& ks_name);
 
     struct table_pow2_convergence_info {

--- a/service/topology_coordinator.cc
+++ b/service/topology_coordinator.cc
@@ -1362,7 +1362,7 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
 
                     // Verify that the actual storage mode matches the intended mode for all normal nodes.
                     // A node that has migrated a table's storage to tablets will report it in its load_stats.
-                    for (const auto& [node_id, _] : _topo_sm._topology.normal_nodes) {
+                    for (const auto& [node_id, node_rs] : _topo_sm._topology.normal_nodes) {
                         auto host_id = to_host_id(node_id);
                         auto it = _load_stats_per_node.find(host_id);
                         if (!rollback) { // forward path (vnodes to tablets)
@@ -1388,6 +1388,20 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
                                             host_id, ks_name, schema->cf_name()));
                                     }
                                 }
+                            }
+                        }
+
+                        // The load stats are the physical evidence; the status API answers
+                        // from current_storage_mode. Require the two to agree, or
+                        // finalization succeeds behind a status reporting no progress.
+                        if (_feature_service.topology_current_storage_mode) {
+                            auto reported = node_rs.current_storage_mode.value_or(storage_mode::vnodes);
+                            auto expected = rollback ? storage_mode::vnodes : storage_mode::tablets;
+                            if (reported != expected) {
+                                throw std::runtime_error(fmt::format(
+                                    "Node {} reports storage mode {} while its tablets for keyspace '{}'"
+                                    " say {}. Restart the node so that it publishes the mode it runs in.",
+                                    host_id, reported, ks_name, expected));
                             }
                         }
                     }

--- a/service/topology_coordinator.cc
+++ b/service/topology_coordinator.cc
@@ -1338,9 +1338,9 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
 
                     // Find the migration direction (tablets or rollback to vnodes).
                     // Nodes that haven't set their intended mode are treated as vnodes (the default).
-                    std::optional<intended_storage_mode> global_intended_mode;
+                    std::optional<storage_mode> global_intended_mode;
                     for (const auto& [server_id, replica_state] : _topo_sm._topology.normal_nodes) {
-                        auto replica_intended_mode = replica_state.storage_mode ? *replica_state.storage_mode : intended_storage_mode::vnodes;
+                        auto replica_intended_mode = replica_state.intended_storage_mode ? *replica_state.intended_storage_mode : storage_mode::vnodes;
                         if (!global_intended_mode) {
                             global_intended_mode = replica_intended_mode;
                         } else if (replica_intended_mode != *global_intended_mode) {
@@ -1353,7 +1353,7 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
                         on_internal_error(rtlogger, fmt::format(
                             "finalize_migration: no normal nodes found while finalizing migration for keyspace '{}'", ks_name));
                     }
-                    bool rollback = *global_intended_mode == intended_storage_mode::vnodes;
+                    bool rollback = *global_intended_mode == storage_mode::vnodes;
 
                     rtlogger.info("Finalizing migration for keyspace '{}': direction={}",
                         ks_name, rollback ? "rollback to vnodes" : "forward to tablets");

--- a/service/topology_coordinator.cc
+++ b/service/topology_coordinator.cc
@@ -1429,7 +1429,8 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
                     .drop_first_global_topology_request_id(_topo_sm._topology.global_requests_queue, req_id);
 
             if (error.empty()) {
-                // Only clear intended_storage_mode if no other keyspace is still under migration.
+                // Only clear the storage mode columns if no other keyspace is still under
+                // migration.
                 auto tmptr = get_token_metadata_ptr();
                 const auto& tmd = tmptr->tablets();
                 bool has_other_migrating_ks = false;
@@ -1451,7 +1452,13 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
                 }
                 if (!has_other_migrating_ks) {
                     for (const auto& [node_id, _] : _topo_sm._topology.normal_nodes) {
-                        tbuilder.with_node(node_id).del("intended_storage_mode");
+                        // current_storage_mode goes with it: the mode is meaningful only
+                        // while a migration is in progress, and a value left behind would
+                        // make every node look already switched in the next migration,
+                        // before any of them restarted.
+                        tbuilder.with_node(node_id)
+                                .del("intended_storage_mode")
+                                .del("current_storage_mode");
                     }
                 }
             }

--- a/service/topology_mutation.cc
+++ b/service/topology_mutation.cc
@@ -123,7 +123,7 @@ Builder& topology_mutation_builder_base<Builder>::set(const char* cell, cleanup_
 }
 
 template<typename Builder>
-Builder& topology_mutation_builder_base<Builder>::set(const char* cell, intended_storage_mode value) {
+Builder& topology_mutation_builder_base<Builder>::set(const char* cell, storage_mode value) {
     return apply_atomic(cell, sstring{::format("{}", value)});
 }
 

--- a/service/topology_mutation.hh
+++ b/service/topology_mutation.hh
@@ -51,7 +51,7 @@ protected:
     Builder& set(const char* cell, const raft::server_id& value);
     Builder& set(const char* cell, const uint32_t& value);
     Builder& set(const char* cell, cleanup_status value);
-    Builder& set(const char* cell, intended_storage_mode value);
+    Builder& set(const char* cell, storage_mode value);
     Builder& set(const char* cell, const utils::UUID& value);
     Builder& set(const char* cell, bool value);
     Builder& set(const char* cell, const char* value);

--- a/service/topology_state_machine.cc
+++ b/service/topology_state_machine.cc
@@ -240,18 +240,18 @@ cleanup_status cleanup_status_from_string(const sstring& s) {
     throw std::runtime_error(fmt::format("cannot map name {} to cleanup_status", s));
 }
 
-static std::unordered_map<intended_storage_mode, sstring> intended_storage_mode_to_name_map = {
-    {intended_storage_mode::vnodes, "vnodes"},
-    {intended_storage_mode::tablets, "tablets"},
+static std::unordered_map<storage_mode, sstring> storage_mode_to_name_map = {
+    {storage_mode::vnodes, "vnodes"},
+    {storage_mode::tablets, "tablets"},
 };
 
-intended_storage_mode intended_storage_mode_from_string(const sstring& s) {
-    for (auto&& e : intended_storage_mode_to_name_map) {
+storage_mode storage_mode_from_string(const sstring& s) {
+    for (auto&& e : storage_mode_to_name_map) {
         if (e.second == s) {
             return e.first;
         }
     }
-    throw std::runtime_error(fmt::format("cannot map name {} to intended_storage_mode", s));
+    throw std::runtime_error(fmt::format("cannot map name {} to storage_mode", s));
 }
 
 future<> topology_state_machine::await_not_busy() {
@@ -406,9 +406,9 @@ auto fmt::formatter<service::cleanup_status>::format(service::cleanup_status sta
     return fmt::format_to(ctx.out(), "{}", service::cleanup_status_to_name_map[status]);
 }
 
-auto fmt::formatter<service::intended_storage_mode>::format(service::intended_storage_mode mode,
+auto fmt::formatter<service::storage_mode>::format(service::storage_mode mode,
                                                      fmt::format_context& ctx) const -> decltype(ctx.out()) {
-    return fmt::format_to(ctx.out(), "{}", service::intended_storage_mode_to_name_map[mode]);
+    return fmt::format_to(ctx.out(), "{}", service::storage_mode_to_name_map[mode]);
 }
 
 auto fmt::formatter<service::topology::transition_state>::format(service::topology::transition_state s,

--- a/service/topology_state_machine.hh
+++ b/service/topology_state_machine.hh
@@ -98,14 +98,14 @@ struct ring_slice {
     std::unordered_set<dht::token> tokens;
 };
 
-// The intended storage mode for a node during vnodes-to-tablets migration.
+// The storage mode of a node during vnodes-to-tablets migration.
 //
 // When migrating a table from vnodes to tablets, each node needs to reshard
 // its local SSTables on vnode boundaries. Conversely, SSTables need to be
 // resharded in the opposite direction (i.e., with the static sharder) when the
-// operation is rolled back. This property is an indicator that a node needs to
-// perform resharding on restart, and it declares the resharding direction.
-enum class intended_storage_mode : uint16_t {
+// operation is rolled back. A node reshards on restart, in the direction given
+// by replica_state::intended_storage_mode.
+enum class storage_mode : uint16_t {
     vnodes,
     tablets,
 };
@@ -121,7 +121,7 @@ struct replica_state {
     std::set<sstring> supported_features;
     cleanup_status cleanup;
     utils::UUID request_id; // id of the current request for the node or the last one if no current one exists
-    std::optional<intended_storage_mode> storage_mode;
+    std::optional<storage_mode> intended_storage_mode;
 };
 
 struct topology_features {
@@ -366,7 +366,7 @@ std::optional<topology_request> try_topology_request_from_string(const sstring& 
 topology_request topology_request_from_string(const sstring& s);
 global_topology_request global_topology_request_from_string(const sstring&);
 cleanup_status cleanup_status_from_string(const sstring& s);
-intended_storage_mode intended_storage_mode_from_string(const sstring& s);
+storage_mode storage_mode_from_string(const sstring& s);
 }
 
 template <> struct fmt::formatter<service::cleanup_status> {
@@ -374,9 +374,9 @@ template <> struct fmt::formatter<service::cleanup_status> {
     auto format(service::cleanup_status status, fmt::format_context& ctx) const -> decltype(ctx.out());
 };
 
-template <> struct fmt::formatter<service::intended_storage_mode> {
+template <> struct fmt::formatter<service::storage_mode> {
     constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
-    auto format(service::intended_storage_mode mode, fmt::format_context& ctx) const -> decltype(ctx.out());
+    auto format(service::storage_mode mode, fmt::format_context& ctx) const -> decltype(ctx.out());
 };
 
 template <> struct fmt::formatter<service::fencing_token> : fmt::formatter<string_view> {

--- a/service/topology_state_machine.hh
+++ b/service/topology_state_machine.hh
@@ -121,7 +121,14 @@ struct replica_state {
     std::set<sstring> supported_features;
     cleanup_status cleanup;
     utils::UUID request_id; // id of the current request for the node or the last one if no current one exists
+    // The storage mode the node is meant to run in. Set while a vnodes-to-tablets
+    // migration is in progress; the node switches to it on the next restart.
     std::optional<storage_mode> intended_storage_mode;
+    // The storage mode the node is actually running in: the intended_storage_mode
+    // value it applied when it built its tables at boot, published only after the
+    // local resharding for that direction completed. Absent means the node has not
+    // restarted since the migration began, i.e. it still runs in vnodes mode.
+    std::optional<storage_mode> current_storage_mode;
 };
 
 struct topology_features {

--- a/test/cluster/test_vnodes_to_tablets_migration.py
+++ b/test/cluster/test_vnodes_to_tablets_migration.py
@@ -196,43 +196,32 @@ async def wait_for_pow2_convergence(manager: ScyllaClusterManager, server: Serve
 
 async def verify_migration_status(manager: ScyllaClusterManager, server: ServerInfo,
                                   ks: str, expected_status: str,
-                                  expected_node_statuses: dict[str, tuple[str, str]],
-                                  retries: int = 0, retry_interval: float = 0):
-    async def _check():
-        # Verify migration status via the migration status API
-        status = await manager.api.get_vnode_tablet_migration_status(server.ip_addr, ks)
-        actual_node_statuses = {n['host_id']: (n['current_mode'], n['intended_mode']) for n in status['nodes']}
-        assert status['status'] == expected_status, f"Expected migration status '{expected_status}', got '{status['status']}'"
-        assert actual_node_statuses == expected_node_statuses, f"Expected node statuses {expected_node_statuses}, got {actual_node_statuses}"
+                                  expected_node_statuses: dict[str, tuple[str, str]]):
+    # The status API takes a group0 read barrier, so a single check is enough:
+    # anything a node published before it finished starting up is already visible.
+    status = await manager.api.get_vnode_tablet_migration_status(server.ip_addr, ks)
+    actual_node_statuses = {n['host_id']: (n['current_mode'], n['intended_mode']) for n in status['nodes']}
+    assert status['status'] == expected_status, f"Expected migration status '{expected_status}', got '{status['status']}'"
+    assert actual_node_statuses == expected_node_statuses, f"Expected node statuses {expected_node_statuses}, got {actual_node_statuses}"
 
-        # Verify migration status via the tasks API
-        tm = TaskManagerClient(manager.api)
-        tasks = await tm.list_tasks(server.ip_addr, "vnodes_to_tablets_migration")
-        ks_tasks = [t for t in tasks if t.keyspace == ks and t.type == "vnodes_to_tablets_migration"]
+    # Verify migration status via the tasks API
+    tm = TaskManagerClient(manager.api)
+    tasks = await tm.list_tasks(server.ip_addr, "vnodes_to_tablets_migration")
+    ks_tasks = [t for t in tasks if t.keyspace == ks and t.type == "vnodes_to_tablets_migration"]
 
-        if expected_status == "migrating_to_tablets":
-            assert len(ks_tasks) == 1, f"Expected 1 virtual task for keyspace '{ks}', got {len(ks_tasks)}"
-            task = ks_tasks[0]
-            assert task.state == "running", f"Expected task state 'running', got '{task.state}'"
-            assert task.type == "vnodes_to_tablets_migration", f"Expected task type 'vnodes_to_tablets_migration', got '{task.type}'"
+    if expected_status == "migrating_to_tablets":
+        assert len(ks_tasks) == 1, f"Expected 1 virtual task for keyspace '{ks}', got {len(ks_tasks)}"
+        task = ks_tasks[0]
+        assert task.state == "running", f"Expected task state 'running', got '{task.state}'"
+        assert task.type == "vnodes_to_tablets_migration", f"Expected task type 'vnodes_to_tablets_migration', got '{task.type}'"
 
-            task_status = await tm.get_task_status(server.ip_addr, task.task_id)
-            expected_total = len(expected_node_statuses)
-            expected_completed = sum(1 for cm, _ in expected_node_statuses.values() if cm == 'tablets')
-            assert task_status.progress_total == expected_total, f"Expected progress_total {expected_total}, got {task_status.progress_total}"
-            assert task_status.progress_completed == expected_completed, f"Expected progress_completed {expected_completed}, got {task_status.progress_completed}"
-        else:
-            assert len(ks_tasks) == 0, f"Expected no virtual tasks for keyspace '{ks}' when status is '{expected_status}', got {len(ks_tasks)}"
-
-    for attempt in range(retries + 1):
-        try:
-            await _check()
-            return
-        except AssertionError:
-            if attempt < retries and retry_interval > 0:
-                await asyncio.sleep(retry_interval)
-            else:
-                raise
+        task_status = await tm.get_task_status(server.ip_addr, task.task_id)
+        expected_total = len(expected_node_statuses)
+        expected_completed = sum(1 for cm, _ in expected_node_statuses.values() if cm == 'tablets')
+        assert task_status.progress_total == expected_total, f"Expected progress_total {expected_total}, got {task_status.progress_total}"
+        assert task_status.progress_completed == expected_completed, f"Expected progress_completed {expected_completed}, got {task_status.progress_completed}"
+    else:
+        assert len(ks_tasks) == 0, f"Expected no virtual tasks for keyspace '{ks}' when status is '{expected_status}', got {len(ks_tasks)}"
 
 
 async def test_migration(manager: ScyllaClusterManager):
@@ -603,8 +592,7 @@ async def test_migration_multinode(manager: ScyllaClusterManager):
         logger.info("Verifying migration status after rolling restarts")
         await verify_migration_status(manager, servers[0], ks,
             expected_status='migrating_to_tablets',
-            expected_node_statuses={host_id: ('tablets', 'tablets') for host_id in host_ids},
-            retries=1, retry_interval=1) # the status is derived from the topology coordinator's load stats which are refreshed every second; give it one retry after 1 second
+            expected_node_statuses={host_id: ('tablets', 'tablets') for host_id in host_ids})
 
         logger.info("Finalizing tablets migration")
         await manager.api.finalize_vnode_tablet_migration(servers[0].ip_addr, ks)
@@ -760,8 +748,7 @@ async def test_migration_multidc(manager: ScyllaClusterManager):
         logger.info("Verifying migration status after rolling restarts")
         await verify_migration_status(manager, servers[0], ks,
             expected_status='migrating_to_tablets',
-            expected_node_statuses={host_id: ('tablets', 'tablets') for host_id in host_ids},
-            retries=1, retry_interval=1)
+            expected_node_statuses={host_id: ('tablets', 'tablets') for host_id in host_ids})
 
         logger.info("Finalizing tablets migration")
         await manager.api.finalize_vnode_tablet_migration(servers[0].ip_addr, ks)
@@ -1016,12 +1003,10 @@ async def test_migration_multiple_keyspaces(manager: ScyllaClusterManager):
             logger.info("Verifying both keyspaces show as migrating")
             await verify_migration_status(manager, server, ks1,
                 expected_status='migrating_to_tablets',
-                expected_node_statuses={host_id: ('tablets', 'tablets')},
-                retries=1, retry_interval=1)
+                expected_node_statuses={host_id: ('tablets', 'tablets')})
             await verify_migration_status(manager, server, ks2,
                 expected_status='migrating_to_tablets',
-                expected_node_statuses={host_id: ('tablets', 'tablets')},
-                retries=1, retry_interval=1)
+                expected_node_statuses={host_id: ('tablets', 'tablets')})
 
             logger.info("Finalizing migration for ks1")
             await manager.api.finalize_vnode_tablet_migration(server.ip_addr, ks1)

--- a/test/cluster/test_vnodes_to_tablets_migration.py
+++ b/test/cluster/test_vnodes_to_tablets_migration.py
@@ -1579,3 +1579,105 @@ async def test_migration_status_api_with_rf_zero_dc(manager: ScyllaClusterManage
 
         logger.info("Verifying data integrity after finalization")
         await verify_data_integrity(cql, ks, "test", num_keys, cl=ConsistencyLevel.ONE)
+
+
+async def test_migration_status_reset_between_migrations(manager: ScyllaClusterManager):
+    """Verify that a node's recorded storage mode does not leak into the next migration.
+
+    The mode a node runs in is recorded per node, not per keyspace, and it is cleared
+    when a migration is finalized. Without that clearing, a node that migrated one
+    keyspace would look as if it had already switched for the next keyspace as well -
+    before it restarted, and therefore before its tables for that keyspace got their
+    tablet flavor.
+
+    Steps:
+    1. Start a single node and create two vnode keyspaces.
+    2. Migrate and finalize the first keyspace, so the node ends up running in tablets mode.
+    3. Start a migration for the second keyspace and verify the node reports vnodes.
+    4. Mark and restart it, verify it reports tablets, then finalize.
+    """
+    num_keys = 100
+
+    logger.info("Starting a single node")
+    cfg = {'tablet_load_stats_refresh_interval_in_seconds': 1, 'num_tokens': 16}
+    servers = await manager.servers_add(1, cmdline=['--smp', '2'], config=cfg)
+    server = servers[0]
+    host_id = await manager.get_host_id(server.server_id)
+
+    cql, _ = await manager.get_ready_cql(servers)
+
+    ks_opts = "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'enabled': false}"
+    async with new_test_keyspace(manager, ks_opts) as ks1:
+        async with new_test_keyspace(manager, ks_opts) as ks2:
+            for ks in (ks1, ks2):
+                await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int)")
+                stmt = cql.prepare(f"INSERT INTO {ks}.test (pk, c) VALUES (?, ?)")
+                await asyncio.gather(*(cql.run_async(stmt, [k, k]) for k in range(num_keys)))
+
+            logger.info(f"Migrating {ks1}")
+            await manager.api.create_vnode_tablet_migration(server.ip_addr, ks1)
+            await manager.api.upgrade_node_to_tablets(server.ip_addr)
+            await manager.server_restart(server.server_id)
+            await reconnect_driver(manager)
+            cql, _ = await manager.get_ready_cql(servers)
+
+            await verify_migration_status(manager, server, ks1,
+                expected_status='migrating_to_tablets',
+                expected_node_statuses={host_id: ('tablets', 'tablets')})
+
+            logger.info(f"Finalizing the migration of {ks1}")
+            await manager.api.finalize_vnode_tablet_migration(server.ip_addr, ks1)
+            await read_barrier(manager.api, server.ip_addr)
+
+            # Let the post-finalization tablet merge settle, so the restarts below do
+            # not land mid-merge.
+            logger.info(f"Waiting for pow2 convergence of {ks1}")
+            await wait_for_pow2_convergence(manager, server, ks1, 'test')
+
+            logger.info("Verifying both storage mode columns are cleared after finalization")
+            rows = await cql.run_async("SELECT intended_storage_mode, current_storage_mode FROM system.topology WHERE key = 'topology'")
+            assert len(rows) == 1, f"Expected 1 row, got {len(rows)}"
+            assert rows[0].intended_storage_mode is None and rows[0].current_storage_mode is None, \
+                f"Expected both storage modes cleared, got intended='{rows[0].intended_storage_mode}' " \
+                f"current='{rows[0].current_storage_mode}'"
+
+            # A node only publishes the mode while an intent is recorded for it, so a
+            # restart outside a migration must not put the column back.
+            logger.info("Restarting the node outside a migration and rechecking the columns")
+            await manager.server_restart(server.server_id)
+            await reconnect_driver(manager)
+            cql, _ = await manager.get_ready_cql(servers)
+            await read_barrier(manager.api, server.ip_addr)
+            rows = await cql.run_async("SELECT intended_storage_mode, current_storage_mode FROM system.topology WHERE key = 'topology'")
+            assert rows[0].intended_storage_mode is None and rows[0].current_storage_mode is None, \
+                f"Restart outside a migration resurrected a storage mode: intended='{rows[0].intended_storage_mode}' " \
+                f"current='{rows[0].current_storage_mode}'"
+
+            # The node runs tablet-flavored tables for ks1 now, but its tables for ks2 were
+            # built before ks2 had a tablet map, so it has to restart again. The status must
+            # say so instead of reporting the mode left over from the previous migration.
+            logger.info(f"Starting a migration for {ks2} and verifying the node reports vnodes")
+            await manager.api.create_vnode_tablet_migration(server.ip_addr, ks2)
+            await verify_migration_status(manager, server, ks2,
+                expected_status='migrating_to_tablets',
+                expected_node_statuses={host_id: ('vnodes', 'vnodes')})
+
+            logger.info(f"Marking and restarting the node for {ks2}")
+            await manager.api.upgrade_node_to_tablets(server.ip_addr)
+            await manager.server_restart(server.server_id)
+            await reconnect_driver(manager)
+            cql, _ = await manager.get_ready_cql(servers)
+
+            await verify_migration_status(manager, server, ks2,
+                expected_status='migrating_to_tablets',
+                expected_node_statuses={host_id: ('tablets', 'tablets')})
+
+            logger.info(f"Finalizing the migration of {ks2}")
+            await manager.api.finalize_vnode_tablet_migration(server.ip_addr, ks2)
+            await read_barrier(manager.api, server.ip_addr)
+
+            logger.info("Verifying both keyspaces use tablets")
+            for ks in (ks1, ks2):
+                res = await cql.run_async(f"SELECT * FROM system_schema.scylla_keyspaces WHERE keyspace_name = '{ks}'")
+                assert len(res) == 1 and res[0].initial_tablets is not None, \
+                    f"Keyspace {ks} is still using vnodes after migration finalization"

--- a/test/cluster/test_vnodes_to_tablets_migration.py
+++ b/test/cluster/test_vnodes_to_tablets_migration.py
@@ -224,6 +224,126 @@ async def verify_migration_status(manager: ScyllaClusterManager, server: ServerI
         assert len(ks_tasks) == 0, f"Expected no virtual tasks for keyspace '{ks}' when status is '{expected_status}', got {len(ks_tasks)}"
 
 
+async def wait_for_node_storage_modes(manager: ScyllaClusterManager, server: ServerInfo,
+                                      ks: str, expected: tuple[str, str], timeout: float = 60):
+    """Wait until the status API reports `expected` (current, intended) for `server`.
+
+    Polls, unlike verify_migration_status(): a mode published by the feature listener
+    lands in a background fiber that startup does not wait for.
+    """
+    host_id = await manager.get_host_id(server.server_id)
+    deadline = time.time() + timeout
+    last = None
+    while time.time() < deadline:
+        status = await manager.api.get_vnode_tablet_migration_status(server.ip_addr, ks)
+        modes = {n['host_id']: (n['current_mode'], n['intended_mode']) for n in status['nodes']}
+        last = modes.get(host_id)
+        if last == expected:
+            return
+        await asyncio.sleep(0.5)
+    assert False, f"Node {host_id} reported {last}, expected {expected} within {timeout}s"
+
+
+@pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
+async def test_storage_mode_published_after_feature_enabled(manager: ScyllaClusterManager):
+    """Verify a node publishes its storage mode when TOPOLOGY_CURRENT_STORAGE_MODE is
+    enabled after it booted, without waiting for another restart.
+
+    The skip_current_storage_mode_publish one-shot injection stands in for the upgrade
+    that introduces the feature, where no node can see it enabled on that boot: it
+    suppresses the publish on the boot pass, leaving the listener to reconcile.
+    """
+    cfg = {'tablet_load_stats_refresh_interval_in_seconds': 1, 'num_tokens': 16}
+    servers = await manager.servers_add(1, cmdline=['--smp', '2'], config=cfg)
+    server = servers[0]
+    host_id = await manager.get_host_id(server.server_id)
+    cql, _ = await manager.get_ready_cql(servers)
+
+    ks_opts = "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'enabled': false}"
+    async with new_test_keyspace(manager, ks_opts) as ks:
+        await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int)")
+        stmt = cql.prepare(f"INSERT INTO {ks}.test (pk, c) VALUES (?, ?)")
+        await asyncio.gather(*(cql.run_async(stmt, [k, k]) for k in range(100)))
+
+        logger.info(f"Migrating {ks} and marking the node")
+        await manager.api.create_vnode_tablet_migration(server.ip_addr, ks)
+        await manager.api.upgrade_node_to_tablets(server.ip_addr)
+
+        await verify_migration_status(manager, server, ks,
+            expected_status='migrating_to_tablets',
+            expected_node_statuses={host_id: ('vnodes', 'tablets')})
+
+        logger.info("Restarting the node with the boot-time publish suppressed")
+        await manager.server_stop_gracefully(server.server_id)
+        await manager.server_update_config(server.server_id, 'error_injections_at_startup',
+            [{'name': 'skip_current_storage_mode_publish', 'one_shot': True}])
+        await manager.server_start(server.server_id)
+        await reconnect_driver(manager)
+        cql, _ = await manager.get_ready_cql(servers)
+
+        # The boot pass skipped the column, so this only passes because the feature
+        # listener reconciled it afterwards.
+        logger.info("Verifying the listener published the mode the boot pass skipped")
+        await wait_for_node_storage_modes(manager, server, ks, ('tablets', 'tablets'))
+
+        logger.info(f"Finalizing the migration of {ks}")
+        await manager.api.finalize_vnode_tablet_migration(server.ip_addr, ks)
+        await read_barrier(manager.api, server.ip_addr)
+
+        await verify_migration_status(manager, server, ks,
+            expected_status='tablets', expected_node_statuses={})
+
+
+@pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
+async def test_migration_refused_before_feature_enabled(manager: ScyllaClusterManager):
+    """Verify a migration cannot start until TOPOLOGY_CURRENT_STORAGE_MODE is enabled.
+
+    suppress_features stands in for a node that still runs older code.
+    """
+    cfg = {
+        'tablet_load_stats_refresh_interval_in_seconds': 1,
+        'num_tokens': 16,
+        'error_injections_at_startup': [
+            {'name': 'suppress_features', 'value': 'TOPOLOGY_CURRENT_STORAGE_MODE'}],
+    }
+    servers = await manager.servers_add(1, cmdline=['--smp', '2'], config=cfg)
+    server = servers[0]
+    cql, _ = await manager.get_ready_cql(servers)
+
+    ks_opts = "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'enabled': false}"
+    async with new_test_keyspace(manager, ks_opts) as ks:
+        await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int)")
+
+        with pytest.raises(HTTPError, match="TOPOLOGY_CURRENT_STORAGE_MODE cluster feature is not enabled"):
+            await manager.api.create_vnode_tablet_migration(server.ip_addr, ks)
+
+        logger.info("Restarting the node without the suppression so the feature is enabled")
+        await manager.server_stop_gracefully(server.server_id)
+        await manager.server_remove_config_option(server.server_id, 'error_injections_at_startup')
+        await manager.server_start(server.server_id)
+        await reconnect_driver(manager)
+        cql, _ = await manager.get_ready_cql(servers)
+
+        # The coordinator enables the feature once every node supports it. Retry only
+        # that refusal; anything else is a real error and must not be swallowed.
+        not_enabled = "TOPOLOGY_CURRENT_STORAGE_MODE cluster feature is not enabled"
+        deadline = time.time() + 60
+        while True:
+            try:
+                await manager.api.create_vnode_tablet_migration(server.ip_addr, ks)
+                break
+            except HTTPError as e:
+                if not_enabled not in e.message:
+                    raise
+                assert time.time() < deadline, f"Migration still refused after the feature should be enabled: {e}"
+                await asyncio.sleep(0.5)
+
+        host_id = await manager.get_host_id(server.server_id)
+        await verify_migration_status(manager, server, ks,
+            expected_status='migrating_to_tablets',
+            expected_node_statuses={host_id: ('vnodes', 'vnodes')})
+
+
 async def test_migration(manager: ScyllaClusterManager):
     """Verify vnodes-to-tablets migration for a single table on a single-node cluster.
 

--- a/test/cluster/test_vnodes_to_tablets_migration.py
+++ b/test/cluster/test_vnodes_to_tablets_migration.py
@@ -1354,19 +1354,20 @@ async def test_migration_with_zero_token_node(manager: ScyllaClusterManager):
     zero-token nodes because collect_tablet_load_stats only queried token-owning nodes, but
     the finalization check iterated all normal nodes.
 
-    The migration status API is deliberately not used to check progress here. It derives
-    current_mode from system.tablet_sizes, which is keyed by tablet replica, so a zero-token
-    node never appears in it and is always reported as using vnodes no matter what it has
-    actually done. That is a separate bug with a separate fix, so this test only checks that
-    finalization itself no longer fails.
+    Also reproduces SCYLLADB-3849 for the zero-token node: the status API used to derive
+    current_mode from system.tablet_sizes, which is keyed by tablet replica, so a node
+    holding no replicas of the keyspace was reported as using vnodes however far it had
+    actually got. Each node now records the mode it runs in, so the status is checked at
+    every step of the migration here, one node at a time.
 
     Steps:
     1. Start a 2-node cluster: one token-owning node in dc1 and one zero-token node in dc2 (arbiter DC).
     2. Create a vnode keyspace with RF={'dc1': 1, 'dc2': 0}.
-    3. Start the migration.
-    4. Mark both nodes for upgrade and restart them.
-    5. Finalize the migration — this should succeed (previously it would fail).
-    6. Verify the keyspace now uses tablets and the data is intact.
+    3. Start the migration — both nodes report vnodes.
+    4. Mark both nodes for upgrade — both still report vnodes, having not restarted yet.
+    5. Restart the nodes one at a time, verifying that only the restarted one reports tablets.
+    6. Finalize the migration — this should succeed (previously it would fail).
+    7. Verify the keyspace now uses tablets and the data is intact.
     """
     num_keys = 100
     tokens_per_node = 16
@@ -1386,6 +1387,9 @@ async def test_migration_with_zero_token_node(manager: ScyllaClusterManager):
     token_owning_servers = [server_dc1]
     cql, _ = await manager.get_ready_cql(token_owning_servers)
 
+    host_id_dc1 = await manager.get_host_id(server_dc1.server_id)
+    host_id_dc2 = await manager.get_host_id(server_dc2.server_id)
+
     logger.info("Creating keyspace with RF={'dc1': 1, 'dc2': 0}")
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'dc1': 1, 'dc2': 0} AND tablets = {'enabled': false}") as ks:
         await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int)")
@@ -1397,19 +1401,47 @@ async def test_migration_with_zero_token_node(manager: ScyllaClusterManager):
         logger.info("Starting vnodes-to-tablets migration")
         await manager.api.create_vnode_tablet_migration(server_dc1.ip_addr, ks)
 
+        logger.info("Verifying migration status after creating tablet map")
+        await verify_migration_status(manager, server_dc1, ks,
+            expected_status='migrating_to_tablets',
+            expected_node_statuses={host_id_dc1: ('vnodes', 'vnodes'),
+                                    host_id_dc2: ('vnodes', 'vnodes')})
+
         logger.info("Marking both nodes for tablets migration")
         await manager.api.upgrade_node_to_tablets(server_dc1.ip_addr)
         await manager.api.upgrade_node_to_tablets(server_dc2.ip_addr)
+
+        # Marking a node only states an intent. Neither node has restarted, so neither
+        # switched its storage mode - the zero-token node included.
+        logger.info("Verifying that marking the nodes did not change the mode they run in")
+        await verify_migration_status(manager, server_dc1, ks,
+            expected_status='migrating_to_tablets',
+            expected_node_statuses={host_id_dc1: ('vnodes', 'tablets'),
+                                    host_id_dc2: ('vnodes', 'tablets')})
 
         logger.info("Restarting token-owning node to trigger resharding")
         await manager.server_restart(server_dc1.server_id)
         await reconnect_driver(manager)
         cql, _ = await manager.get_ready_cql(token_owning_servers)
 
+        # No retries: a node publishes its mode before it finishes starting up, and the
+        # status API takes a read barrier, so the switch is visible right away.
+        logger.info("Verifying that only the restarted node reports tablets")
+        await verify_migration_status(manager, server_dc1, ks,
+            expected_status='migrating_to_tablets',
+            expected_node_statuses={host_id_dc1: ('tablets', 'tablets'),
+                                    host_id_dc2: ('vnodes', 'tablets')})
+
         logger.info("Restarting zero-token node to trigger its migration")
         await manager.server_restart(server_dc2.server_id)
         await reconnect_driver(manager)
         cql, _ = await manager.get_ready_cql(token_owning_servers)
+
+        logger.info("Verifying that the zero-token node reports tablets after its restart")
+        await verify_migration_status(manager, server_dc1, ks,
+            expected_status='migrating_to_tablets',
+            expected_node_statuses={host_id_dc1: ('tablets', 'tablets'),
+                                    host_id_dc2: ('tablets', 'tablets')})
 
         logger.info("Finalizing tablets migration (should succeed with zero-token node present)")
         await manager.api.finalize_vnode_tablet_migration(server_dc1.ip_addr, ks)
@@ -1425,5 +1457,125 @@ async def test_migration_with_zero_token_node(manager: ScyllaClusterManager):
         assert len(res) == 1 and res[0].initial_tablets is not None, \
             "Keyspace is still using vnodes after migration finalization"
 
+        logger.info("Verifying both storage mode columns are cleared after finalization")
+        rows = await cql.run_async("SELECT host_id, intended_storage_mode, current_storage_mode FROM system.topology WHERE key = 'topology'", host=host_dc1)
+        assert len(rows) == 2, f"Expected 2 rows, got {len(rows)}"
+        for row in rows:
+            assert row.intended_storage_mode is None and row.current_storage_mode is None, \
+                f"Expected both storage modes cleared for node {row.host_id}, got " \
+                f"intended='{row.intended_storage_mode}' current='{row.current_storage_mode}'"
+
         logger.info("Verifying data integrity after finalization")
         await verify_data_integrity(cql, ks, "test", num_keys)
+
+
+async def test_migration_status_api_with_rf_zero_dc(manager: ScyllaClusterManager):
+    """Verify the migration status API for a token-owning node in a DC where the keyspace has RF=0.
+
+    Reproduces SCYLLADB-3849: the API used to derive current_mode from
+    system.tablet_sizes, whose replicas map is built from each tablet's replica set.
+    A node that holds no replica of the migrating keyspace could never appear there,
+    so it was reported as using vnodes for the whole migration. Unlike a zero-token
+    node, the node here owns tokens - it just replicates nothing for this keyspace,
+    because the keyspace gives its DC RF=0.
+
+    Such a node still has to be upgraded: its tables have nothing to reshard, but
+    their storage_group_manager and sstable_set are flavor-dependent and built once
+    at startup, so they would stay vnode-flavored if the user later raised the RF.
+
+    The RF=0 node is restarted first, so that the run fails at the first status check
+    after that restart if the mode is derived from tablet replicas again.
+
+    Steps:
+    1. Start two token-owning nodes, one in dc1 and one in dc2.
+    2. Create a vnode keyspace with RF={'dc1': 1, 'dc2': 0}, so the dc2 node has no replicas.
+    3. Start the migration and mark both nodes — both still report vnodes.
+    4. Restart the dc2 node — only it reports tablets.
+    5. Restart the dc1 node — both report tablets.
+    6. Finalize and verify the keyspace uses tablets and the data is intact.
+    """
+    num_keys = 100
+    tokens_per_node = 16
+
+    logger.info("Starting one token-owning node in each of dc1 and dc2")
+    cfg = {'tablet_load_stats_refresh_interval_in_seconds': 1, 'num_tokens': tokens_per_node}
+    server_dc1 = await manager.server_add(cmdline=['--smp', '2'], config=cfg, property_file={"dc": "dc1", "rack": "rack1"})
+    server_dc2 = await manager.server_add(cmdline=['--smp', '2'], config=cfg, property_file={"dc": "dc2", "rack": "rack1"})
+    servers = [server_dc1, server_dc2]
+
+    cql, _ = await manager.get_ready_cql(servers)
+
+    host_id_dc1 = await manager.get_host_id(server_dc1.server_id)
+    host_id_dc2 = await manager.get_host_id(server_dc2.server_id)
+
+    logger.info("Creating keyspace with RF={'dc1': 1, 'dc2': 0}")
+    async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'dc1': 1, 'dc2': 0} AND tablets = {'enabled': false}") as ks:
+        await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int)")
+
+        logger.info(f"Populating table with {num_keys} rows")
+        # CL=ONE rather than the driver's default: the round-robin policy may pick the
+        # dc2 node as coordinator, and a LOCAL_* level cannot be met in a DC with RF=0.
+        stmt = cql.prepare(f"INSERT INTO {ks}.test (pk, c) VALUES (?, ?)")
+        stmt.consistency_level = ConsistencyLevel.ONE
+        await asyncio.gather(*(cql.run_async(stmt, [k, k]) for k in range(num_keys)))
+
+        logger.info("Starting vnodes-to-tablets migration")
+        await manager.api.create_vnode_tablet_migration(server_dc1.ip_addr, ks)
+
+        logger.info("Verifying that the tablet map has no replicas in dc2")
+        tablet_replicas = await get_all_tablet_replicas(manager, server_dc1, ks, 'test')
+        replica_hosts = {r[0] for tr in tablet_replicas for r in tr.replicas}
+        assert replica_hosts == {host_id_dc1}, \
+            f"Expected all tablet replicas on the dc1 node, got {replica_hosts}"
+
+        logger.info("Verifying migration status after creating tablet map")
+        await verify_migration_status(manager, server_dc1, ks,
+            expected_status='migrating_to_tablets',
+            expected_node_statuses={host_id_dc1: ('vnodes', 'vnodes'),
+                                    host_id_dc2: ('vnodes', 'vnodes')})
+
+        logger.info("Marking both nodes for tablets migration")
+        await manager.api.upgrade_node_to_tablets(server_dc1.ip_addr)
+        await manager.api.upgrade_node_to_tablets(server_dc2.ip_addr)
+
+        logger.info("Verifying that marking the nodes did not change the mode they run in")
+        await verify_migration_status(manager, server_dc1, ks,
+            expected_status='migrating_to_tablets',
+            expected_node_statuses={host_id_dc1: ('vnodes', 'tablets'),
+                                    host_id_dc2: ('vnodes', 'tablets')})
+
+        logger.info("Restarting the dc2 node, which holds no replicas of the keyspace")
+        await manager.server_restart(server_dc2.server_id)
+        await reconnect_driver(manager)
+        cql, _ = await manager.get_ready_cql(servers)
+
+        logger.info("Verifying that the node with no replicas reports tablets after its restart")
+        await verify_migration_status(manager, server_dc1, ks,
+            expected_status='migrating_to_tablets',
+            expected_node_statuses={host_id_dc1: ('vnodes', 'tablets'),
+                                    host_id_dc2: ('tablets', 'tablets')})
+
+        logger.info("Restarting the dc1 node to trigger resharding")
+        await manager.server_restart(server_dc1.server_id)
+        await reconnect_driver(manager)
+        cql, _ = await manager.get_ready_cql(servers)
+
+        logger.info("Verifying that both nodes report tablets")
+        await verify_migration_status(manager, server_dc1, ks,
+            expected_status='migrating_to_tablets',
+            expected_node_statuses={host_id_dc1: ('tablets', 'tablets'),
+                                    host_id_dc2: ('tablets', 'tablets')})
+
+        logger.info("Finalizing tablets migration")
+        await manager.api.finalize_vnode_tablet_migration(server_dc1.ip_addr, ks)
+
+        await read_barrier(manager.api, server_dc2.ip_addr)
+        host_dc2 = cql.cluster.metadata.get_host(server_dc2.ip_addr)
+
+        logger.info("Verifying that the keyspace schema has tablets enabled")
+        res = await cql.run_async(f"SELECT * FROM system_schema.scylla_keyspaces WHERE keyspace_name = '{ks}'", host=host_dc2)
+        assert len(res) == 1 and res[0].initial_tablets is not None, \
+            "Keyspace is still using vnodes after migration finalization"
+
+        logger.info("Verifying data integrity after finalization")
+        await verify_data_integrity(cql, ks, "test", num_keys, cl=ConsistencyLevel.ONE)


### PR DESCRIPTION
 ## Problem

  `get_tablets_migration_status_with_node_details()` derived each node's `current_mode`
  from `system.tablet_sizes`, whose replicas map is built from each tablet's replica set,
  so only replica holders can ever appear in it. The API iterates
  `topology.normal_nodes`, which also holds nodes that replicate nothing, so the lookup
  always missed for:

  - zero-token nodes, e.g. in an arbiter DC
  - token owners in a DC where the keyspace has RF=0

  Such a node reported `current_mode=vnodes` for the whole migration however far it had
  actually got. The task manager derives its progress from the same field, so progress
  never reached the node count either.

  Fixes https://scylladb.atlassian.net/browse/SCYLLADB-3849

  ## Fix

  The mode a node runs in is a per-node property, so no reading of a replica-keyed table
  can answer the question. Add a `current_storage_mode` column to `system.topology`, next
  to `intended_storage_mode`, and have each node publish the mode it actually built its
  tables with.

  - **Written** by the node itself during `join_topology()`, and only while its topology
    row records an `intended_storage_mode`. It publishes the value applied at boot, not a
    fresh read of the intent, so a published mode means the local switch is complete,
    resharding included.
  - **Cleared** by the topology coordinator at finalization, atomically with the keyspace
    alter (forward) or the tablet-map drop (rollback), so the column is only ever set
    while a migration is in flight.
  - **Read** by the status API in place of the `tablet_sizes` query.

Backport is not required, it fixes the bug, however this limitation is mentioned in doc