### PR TITLE
db,streaming: make non-precompiled-header compilation work again

### DIFF
--- a/db/read_repair_decision.hh
+++ b/db/read_repair_decision.hh
@@ -10,7 +10,7 @@
 
 #pragma once
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <string_view>
 
 namespace db {

--- a/streaming/stream_session_state.cc
+++ b/streaming/stream_session_state.cc
@@ -8,6 +8,7 @@
  */
 
 #include "streaming/stream_session_state.hh"
+#include <string_view>
 #include <map>
 #include "seastarx.hh"
 


### PR DESCRIPTION
Fix two issues that manifest in non-precompiled-header mode:

- `streaming/stream_session_state.cc` uses `std::string_view`, but does not include it and none of the current includes (transitive or not) pulls the `<string_view>` header in.
- Due to the switch `{fmt}` v11 to v12 in scylladb/scylladb#31246, the header `fmt/core.h` changed its meaning: previously, it used to include `fmt/format.h`, now it includes only `fmt/base.h`. Because of this, including `fmt/core.h` no longer provides a specialization of the `std::string_view` formatter. This actually caused a problem in `gms/versioned_value.hh` where the specialization was needed but a compilation error was returned which looked as if the instantiation was not defined (even though appropriate headers were included in that file).

This PR provides fixes for both issues.

Backport is not needed, the compilation problem only occurs on master.