### PR TITLE
scylla-ci-route: skip dtest and unit tests for docs and repo-metadata changes

### DIFF
--- a/.github/workflows/scylla-ci-route.yaml
+++ b/.github/workflows/scylla-ci-route.yaml
@@ -415,21 +415,26 @@ jobs:
             fi
           done <<< "$ALL_FILES"
 
-          # dtest: required if any file does NOT match test*, dist/docker/*, dist/common/scripts/*
+          # Files that cannot affect dtest or unit-test results (RELENG-872):
+          # docs/, .github/, *.md at any depth, root repo-metadata dotfiles,
+          # licenses/, NOTICE.txt and ORIGIN.
+          NON_CODE='docs/|\.github/|(.*/)?[^/]+\.md$|\.(clang-format|coderabbit\.yaml|dockerignore|gitattributes|gitignore|gitorderfile|mailmap)$|licenses/|NOTICE\.txt$|ORIGIN$'
+
+          # dtest: required if any file does NOT match test*, dist/docker/*, dist/common/scripts/*, NON_CODE
           DTEST_REQUIRED=false
           while IFS= read -r FILE; do
             [ -z "$FILE" ] && continue
-            if ! echo "$FILE" | grep -qE '^(test(\.py|/)|dist/docker/|dist/common/scripts/)'; then
+            if ! echo "$FILE" | grep -qE "^(test(\.py|/)|dist/docker/|dist/common/scripts/|$NON_CODE)"; then
               DTEST_REQUIRED=true
               break
             fi
           done <<< "$ALL_FILES"
 
-          # unittest: required if any file does NOT match dist/docker/*, dist/common/scripts*
+          # unittest: required if any file does NOT match dist/docker/*, dist/common/scripts*, NON_CODE
           UNITTEST_REQUIRED=false
           while IFS= read -r FILE; do
             [ -z "$FILE" ] && continue
-            if ! echo "$FILE" | grep -qE '^(dist/docker/|dist/common/scripts)'; then
+            if ! echo "$FILE" | grep -qE "^(dist/docker/|dist/common/scripts|$NON_CODE)"; then
               UNITTEST_REQUIRED=true
               break
             fi


### PR DESCRIPTION
The "Check required CI types" step decides whether scylla-ci runs dtest and unit tests by checking every changed file of a PR against a small denylist. Docs-only PRs are already skipped by the docs-only check, but a PR that mixes docs/ with already-denylisted paths such as test/ still runs the full matrix, and files that cannot affect test results (.github/, *.md, root dotfiles, licenses/, NOTICE.txt, ORIGIN) are not on the denylist at all.

Add a shared NON_CODE alternation to the dtest and unittest patterns covering docs/, .github/, *.md at any depth, root repo-metadata dotfiles, licenses/, NOTICE.txt and ORIGIN. Semantics are unchanged: a single file outside the denylist still triggers the full run. build, artifacts, scylla_gdb and the docs-only check are untouched.

Fixes: RELENG-872

Backport to all active branches because all of them already use scylla-ci-route.yaml for CI jobs.