### PR TITLE
docs: fix CAP theorem link

### DIFF
--- a/docs/kb/consistency.rst
+++ b/docs/kb/consistency.rst
@@ -39,7 +39,7 @@ In contrast to SQL’s ACID guarantees, NoSQL databases provide BASE guarantees:
 * **Soft State**: Replicas are not consistent all the time.
 * **Eventual Consistency**: Data will become consistent at some point in time, with no guarantee when.
 
-This is also related to the `CAP theorem <https://groups.google.com/d/forum/scylladb-users>`_, which states that in a distributed data system, 
+This is also related to the `CAP theorem <https://en.wikipedia.org/wiki/CAP_theorem>`_, which states that in a distributed data system,
 only two out of the following three guarantees can be satisfied:
 
 * **(Atomic) Consistency**: The same response is given to all identical requests.


### PR DESCRIPTION
Replace the incorrect ScyllaDB users group URL with the CAP theorem article. 
Fixes SCYLLADB-4228

Backport reason: This a bug (an incorrect link) that affects users of all previous versions. For this reason, it should be backported to all currently supported versions. 