### PR TITLE
cql3: Do not reject QUERY requests when TABLETS_ROUTING_V2 enabled

### DIFF
--- a/cql3/statements/modification_statement.cc
+++ b/cql3/statements/modification_statement.cc
@@ -332,19 +332,14 @@ modification_statement::do_execute(query_processor& qp, service::query_state& qs
     if (keys_size_one && _may_use_token_aware_routing && table.uses_tablets()) {
         auto erm = table.get_effective_replication_map();
         if (qs.get_client_state().is_protocol_extension_set(cql_transport::cql_protocol_extension::TABLETS_ROUTING_V2_EXPERIMENTAL)) {
-            if (!options.get_tablet_version_block().has_value()) {
-                // V2 is negotiated but no block was parsed. process_execute_internal()
-                // reads the block unconditionally whenever the V2 extension is set and
-                // rejects the request with a protocol_exception if the byte is missing,
-                // so the block is guaranteed present here. Reaching this point is a
-                // server-side invariant violation, not a client error, hence on_internal_error.
-                utils::on_internal_error(
-                    "The protocol extension tablets-routing-v2 requires that every EXECUTE request "
-                    "carry a tablet_version_block");
-            }
-            auto tablet_info_v2 = erm->check_tablet_version(token, *options.get_tablet_version_block());
-            if (tablet_info_v2) {
-                result->add_tablet_info_v2(std::move(*tablet_info_v2));
+            // We only return routing information for EXECUTE requests.
+            // They will carry a tablet version block; QUERY reqeuests
+            // will not.
+            if (options.get_tablet_version_block().has_value()) {
+                auto tablet_info_v2 = erm->check_tablet_version(token, *options.get_tablet_version_block());
+                if (tablet_info_v2) {
+                    result->add_tablet_info_v2(std::move(*tablet_info_v2));
+                }
             }
         } else if (qs.get_client_state().is_protocol_extension_set(cql_transport::cql_protocol_extension::TABLETS_ROUTING_V1)) {
             auto tablet_info = erm->check_locality(token, qs.get_client_state().get_original_shard());

--- a/cql3/statements/select_statement.cc
+++ b/cql3/statements/select_statement.cc
@@ -500,17 +500,12 @@ select_statement::do_execute(query_processor& qp,
         auto erm = table.get_effective_replication_map();
 
         if (state.get_client_state().is_protocol_extension_set(cql_transport::cql_protocol_extension::TABLETS_ROUTING_V2_EXPERIMENTAL)) {
-            if (!options.get_tablet_version_block().has_value()) {
-                // V2 is negotiated but no block was parsed. process_execute_internal()
-                // reads the block unconditionally whenever the V2 extension is set and
-                // rejects the request with a protocol_exception if the byte is missing,
-                // so the block is guaranteed present here. Reaching this point is a
-                // server-side invariant violation, not a client error, hence on_internal_error.
-                utils::on_internal_error(
-                    "The protocol extension tablets-routing-v2 requires that every EXECUTE request "
-                    "carry a tablet_version_block");
+            // We only return routing information for EXECUTE requests.
+            // They will carry a tablet version block; QUERY reqeuests
+            // will not.
+            if (options.get_tablet_version_block().has_value()) {
+                tablet_info_v2 = erm->check_tablet_version(token, *options.get_tablet_version_block());
             }
-            tablet_info_v2 = erm->check_tablet_version(token, *options.get_tablet_version_block());
         } else if (state.get_client_state().is_protocol_extension_set(cql_transport::cql_protocol_extension::TABLETS_ROUTING_V1)) {
             tablet_info = erm->check_locality(token, state.get_client_state().get_original_shard());
         }

--- a/cql3/statements/strong_consistency/modification_statement.cc
+++ b/cql3/statements/strong_consistency/modification_statement.cc
@@ -90,23 +90,18 @@ future<shared_ptr<result_message>> modification_statement::execute_without_check
     auto result = seastar::make_shared<result_message::void_message>();
 
     if (qs.get_client_state().is_protocol_extension_set(cql_transport::cql_protocol_extension::TABLETS_ROUTING_V2_EXPERIMENTAL)) {
-        if (!options.get_tablet_version_block().has_value()) {
-            // V2 is negotiated but no block was parsed. process_execute_internal()
-            // reads the block unconditionally whenever the V2 extension is set and
-            // rejects the request with a protocol_exception if the byte is missing,
-            // so the block is guaranteed present here. Reaching this point is a
-            // server-side invariant violation, not a client error, hence on_internal_error.
-            utils::on_internal_error(
-                "The protocol extension tablets-routing-v2 requires that every EXECUTE request "
-                "carry a tablet_version_block");
-        }
+        // Only EXECUTE requests carry a tablet version block. However,
+        // QUERY requests may still target a single partition and will
+        // not be rejected. We don't send any routing information for
+        // them, though.
+        if (options.get_tablet_version_block().has_value()) {
+            const auto& groups_manager = coordinator.get().get_groups_manager();
+            const auto& table = _statement->s->table();
 
-        const auto& groups_manager = coordinator.get().get_groups_manager();
-        const auto& table = _statement->s->table();
-
-        auto maybe_routing_info_v2 = groups_manager.check_tablet_version(table, token, *options.get_tablet_version_block());
-        if (maybe_routing_info_v2) {
-            result->add_tablet_info_v2(std::move(*maybe_routing_info_v2));
+            auto maybe_routing_info_v2 = groups_manager.check_tablet_version(table, token, *options.get_tablet_version_block());
+            if (maybe_routing_info_v2) {
+                result->add_tablet_info_v2(std::move(*maybe_routing_info_v2));
+            }
         }
     }
 

--- a/cql3/statements/strong_consistency/select_statement.cc
+++ b/cql3/statements/strong_consistency/select_statement.cc
@@ -72,24 +72,19 @@ future<::shared_ptr<result_message>> select_statement::do_execute(query_processo
         read_command, options, now);
 
     if (state.get_client_state().is_protocol_extension_set(cql_transport::cql_protocol_extension::TABLETS_ROUTING_V2_EXPERIMENTAL)) {
-        if (!options.get_tablet_version_block().has_value()) {
-            // V2 is negotiated but no block was parsed. process_execute_internal()
-            // reads the block unconditionally whenever the V2 extension is set and
-            // rejects the request with a protocol_exception if the byte is missing,
-            // so the block is guaranteed present here. Reaching this point is a
-            // server-side invariant violation, not a client error, hence on_internal_error.
-            utils::on_internal_error(
-                "The protocol extension tablets-routing-v2 requires that every EXECUTE request "
-                "carry a tablet_version_block");
-        }
+        // Only EXECUTE requests carry a tablet version block. However,
+        // QUERY requests may still target a single partition and will
+        // not be rejected. We don't send any routing information for
+        // them, though.
+        if (options.get_tablet_version_block().has_value()) {
+            const auto& groups_manager = coordinator.get().get_groups_manager();
+            const auto& table = _query_schema->table();
+            const auto& token = key_ranges[0].start()->value().token();
 
-        const auto& groups_manager = coordinator.get().get_groups_manager();
-        const auto& table = _query_schema->table();
-        const auto& token = key_ranges[0].start()->value().token();
-
-        auto maybe_routing_info_v2 = groups_manager.check_tablet_version(table, token, *options.get_tablet_version_block());
-        if (maybe_routing_info_v2) {
-            result->add_tablet_info_v2(std::move(*maybe_routing_info_v2));
+            auto maybe_routing_info_v2 = groups_manager.check_tablet_version(table, token, *options.get_tablet_version_block());
+            if (maybe_routing_info_v2) {
+                result->add_tablet_info_v2(std::move(*maybe_routing_info_v2));
+            }
         }
     }
 


### PR DESCRIPTION
TABLETS_ROUTING_V2_EXPERIMENTAL protocol extension specifies that only
EXECUTE requests carry a tablet version block. However, QUERY requests
may still target a single partition and they're indistinguishable from
EXECUTE requests in the cql3 code. As a result, the existing asserts
will be triggered for them.

Get rid of them. Note that in the branches we modify, we cannot evaluate
both predicates at the same time: V2 being enabled and the tablet
version block being present. Otherwise, a V2 QUERY request could execute
the V1 branch that would violate the protocol.

Fixes: https://scylladb.atlassian.net/browse/SCYLLADB-4351

Backport: let's backport this change to 2026.3 (the only version with the code)
to avoid problems in drivers' CI.