### PR TITLE
test.py: New max_running_shards metadata for  tests

### DIFF
--- a/docs/dev/testing.md
+++ b/docs/dev/testing.md
@@ -334,6 +334,126 @@ clean up resources, including added servers, when tests end.
 Every test gets its own cluster, created when the test starts and
 destroyed when it ends, so tests never share or reuse a cluster.
 
+## Declaring how much of the machine a test uses
+
+A cluster test can state the peak capacity it needs, in shards:
+
+```python
+@pytest.mark.max_running_shards(6)
+async def test_something(manager: ScyllaClusterManager):
+    await manager.servers_add(3)   # 3 servers x --smp 2 = 6 shards
+```
+
+Shards rather than servers, because a 1-server `--smp 8` test is not as cheap
+as a 1-server `--smp 1` one and servers cannot tell them apart. A server's
+shard count is its effective `--smp`, which is 2 unless the test passes its
+own (`manager.server_add(cmdline=['--smp', '1'])`).
+
+**The claim is an upper bound on shards running at once, not a total.** A test
+that starts two servers, stops both and starts two more peaks at 4 shards, not
+8. Everything running counts, including the servers the cluster is handed to
+the test with and any a fixture starts.
+
+**It is enforced.** The cluster refuses to start a server that would take the
+test over its claim, so the `servers_add()` that would break it raises
+`RunningShardsExceeded`, naming the marker, and the test fails there. The
+refusal comes before the server exists, so a claim that is too low costs the
+run nothing. When a test legitimately needs more of the machine, raise the
+number; when it does not, the failure is telling you the cluster grew by
+accident.
+
+Claims are not enforced when the run itself changes how big the servers are --
+`--extra-scylla-cmdline-options="--smp 4"` outranks every other source, so the
+servers are not the size the claims were measured at. The log says so once when
+that happens, rather than failing every test for a reason that has nothing to
+do with the tests.
+
+A test with no marker runs unrestricted. What a missing claim means for
+scheduling is up to whichever scheduler reads the markers -- nothing is imposed
+here.
+
+### Writing the claim for a new test
+
+You do not work the number out by hand. A new test has no marker, so nothing
+caps it -- run it, and let what it actually did write the claim:
+
+```bash
+./test.py --mode dev test/cluster/my_new_test.py
+./test/pylib/update_max_running_shards_markers.py testlog/sqlite_*.db
+```
+
+Commit the test and its marker together: `test/pylib_test` fails the build for a
+cluster test with no claim, so an unclaimed test passes locally and then stops at
+CI.
+
+The script writes a marker where there is none and raises one that has become
+too low, leaving everything else alone -- so running it twice over the same
+measurements produces no diff, and its output is an ordinary PR to review. Use
+`--headroom-shards N` for a test whose cluster varies between runs, and `--path`
+to limit it to one directory.
+
+**Re-measuring a test that already has a claim needs
+`pytest --measure-running-shards`**, because a claim caps the peak recorded
+under it: the server that would exceed it never runs, so it never counts. Every
+`cluster_metrics` row records the claim in force, and the backfill uses only
+the rows without one.
+
+Only runs that passed count: a test that failed part-way never reached its
+peak, and that under-estimate would leave the test failing on its own claim
+next time. Pass several databases at once (`testlog/sqlite_*.db`) to fold runs
+and modes together, which you need when the suite pins a test to one mode.
+
+Parametrized tests get one marker for the whole function, covering the heaviest
+parameter; `--repeat` copies of a test share its claim, which is the point --
+that is the case where too many heavy tests land on one machine at once.
+
+The measurement counts the shards the cluster manager runs, so a Scylla process
+a test launches itself -- a `scylla perf-*` or tool subprocess -- is invisible
+to it and comes out as 0. Write those claims by hand; the backfill leaves them
+alone, since it only ever raises a claim and skips measurements of 0.
+
+### Suites that declare one claim for all of their tests
+
+Only `test/cluster` leases a cluster per test. Everywhere else the shard count
+is a constant known before the run, so there is nothing to measure and no
+marker to write:
+
+- a suite whose cluster is created once per module declares
+  `pytestmark = pytest.mark.max_running_shards(n)` in its `conftest.py`, and
+  every test under it inherits that claim (a marker on the test, or on its
+  module, still wins);
+- a C++ test case's claim is derived from the `-c` on its own command line
+  (`-c2` by default, overridden per case in the suite's `custom_args`);
+- a suite that starts no Scylla at all declares nothing.
+
+None of these is enforced, and that is not an omission: nothing a test in them
+does can exceed a cluster it did not create, or a shard count Seastar fixed at
+startup from the argv we passed.
+
+Because those claims cannot be forgotten, `test/pylib_test` fails the build for
+a **cluster** test with no claim -- that being the only place one can go
+missing. Tests skipped at collection, `non_gating` and `no_parallel` are exempt:
+no scheduler places them.
+
+### Asking what the markers actually are
+
+Markers come from decorators, from `pytestmark` in a module or a conftest, from
+parametrize and from collection hooks, so the source does not tell you what a
+test ends up carrying. One collect-only pass does:
+
+```python
+from test.pylib.marker_index import build_index
+
+tests = build_index(["--mode", "dev", "test/cluster"], tmpdir)
+```
+
+The index lists every selected test with the markers it carries and their
+arguments, uninterpreted -- which is what a scheduler needs in order to weigh
+the selection before the run starts. The same module is a pytest plugin, so
+`python -m pytest --collect-only -p test.pylib.marker_index
+--marker-index=out.json ...` writes the index of any run. As a module: `-p`
+imports the plugin before any conftest puts the repo root on `sys.path`.
+
 ## Test metrics
 
 The parameter `--gather-metrics` is used to gather CPU/RAM usage during tests from the cgroup and system overall CPU/RAM
@@ -346,6 +466,10 @@ The database is created in the `testlog` directory and contains the following ta
 - `test_metrics` - contains the metrics for each test, such as memory peak usage, CPU usage, and duration
 - `system_resource_metrics` - contains system CPU and memory utilization in percents during the whole run
 - `cgroup_memory_metrics` - contains cgroup memory usage during the test run
+- `cluster_metrics` - contains the peak shard count each test's cluster ran and the `max_running_shards` claim in
+  force while it did, written for every test that leases a cluster. A row with no claim reports what the test uses
+  unrestricted; a row with one only shows that it stayed within it (see "Declaring how much of the machine a test
+  uses")
 
 ## Automation, CI, and Jenkins
 

--- a/test/alternator/conftest.py
+++ b/test/alternator/conftest.py
@@ -549,3 +549,8 @@ def cql(dynamodb):
         skip_env('Could not connect to Scylla-only CQL API')
     yield ret
     safe_driver_shutdown(cluster)
+
+# Every test here shares one cluster, created per module from
+# cluster.initial_size (which defaults to 1) at --smp 2, and no test changes
+# it -- so the claim is a constant of the suite, not something to measure.
+pytestmark = pytest.mark.max_running_shards(2)

--- a/test/cluster/auth_cluster/test_attach_service_level_to_user.py
+++ b/test/cluster/auth_cluster/test_attach_service_level_to_user.py
@@ -13,6 +13,7 @@ from test.pylib.util import unique_name, wait_for_cql_and_get_hosts
 from test.pylib.scylla_cluster_manager import ScyllaClusterManager
 from test.cluster.auth_cluster import extra_scylla_config_options as auth_config
 
+@pytest.mark.max_running_shards(6)
 async def test_attach_service_level_to_user(request, manager: ScyllaClusterManager):
     user = f"test_user_{unique_name()}"
 

--- a/test/cluster/auth_cluster/test_auth_after_reset.py
+++ b/test/cluster/auth_cluster/test_auth_after_reset.py
@@ -27,6 +27,7 @@ async def repeat_until_success(f):
 """
 Test if superuser is recreated after manual sstable delete (password reset procedure).
 """
+@pytest.mark.max_running_shards(6)
 async def test_auth_after_reset(manager: ScyllaClusterManager) -> None:
     servers = await manager.servers_add(3, config=auth_config, auto_rack_dc="dc1")
     cql, _ = await manager.get_ready_cql(servers)

--- a/test/cluster/auth_cluster/test_auth_cache_metrics.py
+++ b/test/cluster/auth_cluster/test_auth_cache_metrics.py
@@ -12,6 +12,7 @@ from cassandra.auth import PlainTextAuthProvider
 
 logger = logging.getLogger(__name__)
 
+@pytest.mark.max_running_shards(4)
 async def test_auth_cache_metrics(manager: ScyllaClusterManager):
     """
     Verify that auth cache metrics correctly track roles and permissions

--- a/test/cluster/auth_cluster/test_auth_default_superuser_replaced.py
+++ b/test/cluster/auth_cluster/test_auth_default_superuser_replaced.py
@@ -18,6 +18,7 @@ from cassandra.auth import PlainTextAuthProvider
 Checks whether the default superuser is replaced by a custom one,
 and that the default superuser is not present in the system.
 """
+@pytest.mark.max_running_shards(6)
 async def test_auth_default_superuser_replaced(manager: ScyllaClusterManager) -> None:
     servers = await manager.servers_add(3, config=auth_config, auto_rack_dc="dc1")
     cql, _ = await manager.get_ready_cql(servers)

--- a/test/cluster/auth_cluster/test_auth_no_quorum.py
+++ b/test/cluster/auth_cluster/test_auth_no_quorum.py
@@ -19,6 +19,7 @@ from test.cluster.auth_cluster import extra_scylla_config_options as auth_config
 Tests how cluster behaves when lost quorum. Ideally for operations with CL=1 live part of the
 cluster should still work but that's guaranteed only if auth data is replicated everywhere.
 """
+@pytest.mark.max_running_shards(6)
 async def test_auth_no_quorum(manager: ScyllaClusterManager) -> None:
     config = {
         **auth_config,
@@ -59,6 +60,7 @@ async def test_auth_no_quorum(manager: ScyllaClusterManager) -> None:
 """
 Tests raft snapshot transfer of auth data.
 """
+@pytest.mark.max_running_shards(4)
 async def test_auth_raft_snapshot_transfer(manager: ScyllaClusterManager) -> None:
     servers = await manager.servers_add(1, config=auth_config)
 

--- a/test/cluster/auth_cluster/test_auth_password_ensured.py
+++ b/test/cluster/auth_cluster/test_auth_password_ensured.py
@@ -28,6 +28,7 @@ async def repeat_if_host_unavailable(f):
 Test CQL is served only after superuser default password is created.
 After CQL is served, user is properily authenticated as superuser (not annonymous user)
 """
+@pytest.mark.max_running_shards(2)
 @pytest.mark.skip_mode(mode='release', reason='error injection is disabled in release mode')
 async def test_auth_password_ensured(manager: ScyllaClusterManager) -> None:
     config = {

--- a/test/cluster/auth_cluster/test_connection_stage.py
+++ b/test/cluster/auth_cluster/test_connection_stage.py
@@ -64,6 +64,7 @@ def make_server_config(auth_type: str) -> dict:
     raise ValueError(f"Unknown auth_type: {auth_type!r}")
 
 
+@pytest.mark.max_running_shards(2)
 @pytest.mark.parametrize("auth_type", [
     "allow_all",
     "password",

--- a/test/cluster/auth_cluster/test_group0_batch_barrier.py
+++ b/test/cluster/auth_cluster/test_group0_batch_barrier.py
@@ -14,6 +14,7 @@ from test.pylib.util import unique_name, wait_for
 from test.cluster.auth_cluster import extra_scylla_config_options as auth_config
 
 
+@pytest.mark.max_running_shards(6)
 @pytest.mark.skip_mode(mode='release', reason='error injection is disabled in release mode')
 async def test_create_role_visible_on_all_nodes(manager: ScyllaClusterManager) -> None:
     """After CREATE ROLE returns, the role should be immediately visible
@@ -50,6 +51,7 @@ async def test_create_role_visible_on_all_nodes(manager: ScyllaClusterManager) -
         )
 
 
+@pytest.mark.max_running_shards(6)
 async def test_create_role_mixed_cluster(manager: ScyllaClusterManager,
                                          scylla_2025_1: ScyllaVersionDescription) -> None:
     """Variant of test_create_role_visible_on_all_nodes that runs a mixed

--- a/test/cluster/auth_cluster/test_ldap_service_levels.py
+++ b/test/cluster/auth_cluster/test_ldap_service_levels.py
@@ -16,6 +16,7 @@ from test.pylib.driver_utils import safe_driver_shutdown
 from test.pylib.scylla_cluster_manager import ScyllaClusterManager
 from test.pylib.skip_types import skip_env
 from test.pylib.util import unique_name, wait_for, wait_for_cql_and_get_hosts
+import pytest
 
 logger = logging.getLogger(__name__)
 
@@ -104,6 +105,7 @@ def connect_as(manager: ScyllaClusterManager, server, username, password):
     return cluster, cluster.connect()
 
 
+@pytest.mark.max_running_shards(2)
 async def test_ldap_attach_service_level(manager: ScyllaClusterManager):
     """ATTACH, LIST and DROP SERVICE LEVEL for a user whose roles come from
     LDAP."""
@@ -149,6 +151,7 @@ async def test_ldap_attach_service_level(manager: ScyllaClusterManager):
         safe_driver_shutdown(cluster)
 
 
+@pytest.mark.max_running_shards(2)
 async def test_ldap_granted_role_service_level(manager: ScyllaClusterManager):
     """A service level attached to a group role reaches the group's members.
     jdoe is a member of role3 in the LDAP directory only. No GRANT statement

--- a/test/cluster/auth_cluster/test_maintenance_socket.py
+++ b/test/cluster/auth_cluster/test_maintenance_socket.py
@@ -95,6 +95,7 @@ async def connect_with_credentials(manager: ScyllaClusterManager, ip: str, usern
     return await wait_for(try_connect, time.time() + timeout)
 
 
+@pytest.mark.max_running_shards(2)
 async def test_maintenance_socket(manager: ScyllaClusterManager, cql_clusters: CqlClusters):
     """
     Test that when connecting to the maintenance socket, the user has superuser permissions,
@@ -150,6 +151,7 @@ async def test_maintenance_socket(manager: ScyllaClusterManager, cql_clusters: C
     maintenance_session.execute("CREATE TABLE ks1.t2 (pk int PRIMARY KEY, val int);")
 
 
+@pytest.mark.max_running_shards(2)
 async def test_no_default_superuser_exists_by_default(manager: ScyllaClusterManager, cql_clusters: CqlClusters):
     """
     Test that no 'cassandra' user exists when no default superuser is configured.
@@ -173,6 +175,7 @@ async def test_no_default_superuser_exists_by_default(manager: ScyllaClusterMana
         pass
 
 
+@pytest.mark.max_running_shards(2)
 async def test_no_default_superuser_maintenance_socket_ops(manager: ScyllaClusterManager, cql_clusters: CqlClusters):
     """
     Test that we can manage user roles via the maintenance socket.
@@ -263,6 +266,7 @@ async def test_no_default_superuser_maintenance_socket_ops(manager: ScyllaCluste
     await wait_for(check_role_dropped, time.time() + 60)
 
 
+@pytest.mark.max_running_shards(2)
 async def test_maintenance_socket_grant_revoke(manager: ScyllaClusterManager, cql_clusters: CqlClusters):
     """
     Test that GRANT, REVOKE, and REVOKE ALL via the maintenance socket work correctly.

--- a/test/cluster/auth_cluster/test_permissions_removal_restart.py
+++ b/test/cluster/auth_cluster/test_permissions_removal_restart.py
@@ -13,6 +13,7 @@ from test.cluster.auth_cluster import extra_scylla_config_options as auth_config
 logger = logging.getLogger(__name__)
 
 
+@pytest.mark.max_running_shards(2)
 async def test_permissions_removal_and_restart(manager: ScyllaClusterManager) -> None:
     """Test that a node boots successfully when role_permissions contains a
     ghost row with role and resource set but the permissions column missing.

--- a/test/cluster/auth_cluster/test_prepared_metadata_id.py
+++ b/test/cluster/auth_cluster/test_prepared_metadata_id.py
@@ -142,6 +142,7 @@ def _prepare_and_execute(host: str, query: str) -> tuple[bytes, bool, int]:
             safe_driver_shutdown(cluster)
 
 
+@pytest.mark.max_running_shards(2)
 async def test_prepared_list_metadata_ids(manager: ScyllaClusterManager) -> None:
     servers = await manager.running_servers()
     if servers:

--- a/test/cluster/auth_cluster/test_raft_service_levels.py
+++ b/test/cluster/auth_cluster/test_raft_service_levels.py
@@ -24,6 +24,7 @@ from test.cluster.auth_cluster import extra_scylla_config_options as auth_config
 logger = logging.getLogger(__name__)
 DRIVER_SL_NAME = "driver"
 
+@pytest.mark.max_running_shards(8)
 async def test_service_levels_snapshot(manager: ScyllaClusterManager):
     """
         Cluster with 3 nodes.
@@ -113,6 +114,7 @@ async def assert_connections_params(manager: ScyllaClusterManager, hosts, expect
             assert param["timeout"] == expect[role]["timeout"]
             assert param["scheduling_group"]
 
+@pytest.mark.max_running_shards(6)
 @pytest.mark.skip_mode(mode='release', reason='cql server testing REST API is not supported in release mode')
 async def test_connections_parameters_auto_update(manager: ScyllaClusterManager, build_mode):
     servers = await manager.servers_add(3, config=auth_config, auto_rack_dc="dc1")
@@ -197,6 +199,7 @@ async def test_connections_parameters_auto_update(manager: ScyllaClusterManager,
     for cluster_conn in cluster_connections:
         safe_driver_shutdown(cluster_conn)
 
+@pytest.mark.max_running_shards(2)
 async def test_service_level_cache_after_restart(manager: ScyllaClusterManager):
     servers = await manager.servers_add(1, config=auth_config, auto_rack_dc="dc1")
     cql = manager.get_cql()
@@ -223,6 +226,7 @@ async def test_service_level_cache_after_restart(manager: ScyllaClusterManager):
     result = await cql.run_async("SELECT workload_type FROM system.service_levels_v2")
     assert len(result) == 2 and result[0].workload_type == 'batch' and result[1].workload_type == 'batch'
 
+@pytest.mark.max_running_shards(2)
 @pytest.mark.skip_mode(mode='release', reason='error injection is disabled in release mode')
 async def test_shares_check(manager: ScyllaClusterManager):
     srv = await manager.server_add(config={
@@ -251,6 +255,7 @@ async def test_shares_check(manager: ScyllaClusterManager):
     await cql.run_async(f"CREATE SERVICE LEVEL {sl2} WITH shares=500")
     await cql.run_async(f"ALTER SERVICE LEVEL {sl1} WITH shares=100")
 
+@pytest.mark.max_running_shards(2)
 @pytest.mark.skip_mode(mode='release', reason='error injection is disabled in release mode')
 async def test_service_levels_over_limit(manager: ScyllaClusterManager):
     srv = await manager.server_add(config={**auth_config,
@@ -278,6 +283,7 @@ async def test_service_levels_over_limit(manager: ScyllaClusterManager):
     await log.wait_for(f"service level \"{sls[-2]}\" will be effectively dropped to make scheduling group available to \"{sl_name}\", please consider removing a service level.", timeout=10, from_mark=mark)
 
 # Reproduces issue scylla-enterprise#4912
+@pytest.mark.max_running_shards(6)
 async def test_service_level_metric_name_change(manager: ScyllaClusterManager) -> None:
     servers = await manager.servers_add(2, config=auth_config, auto_rack_dc="dc1")
     s = servers[0]
@@ -314,6 +320,7 @@ async def test_service_level_metric_name_change(manager: ScyllaClusterManager) -
     await wait_for_token_ring_and_group0_consistency(manager, time.time() + 30)
 
 # Reproduces scylladb/scylladb#24792.
+@pytest.mark.max_running_shards(2)
 @pytest.mark.skip_mode(mode='release', reason='error injection is disabled in release mode')
 async def test_reload_service_levels_after_auth_service_is_stopped(manager: ScyllaClusterManager):
     config = {**auth_config, "error_injections_at_startup": ["reload_service_level_cache_after_auth_service_is_stopped"]}
@@ -321,6 +328,7 @@ async def test_reload_service_levels_after_auth_service_is_stopped(manager: Scyl
     await manager.server_stop_gracefully(s1.server_id)
 
 # Reproduces scylladb/scylladb#26190
+@pytest.mark.max_running_shards(2)
 async def test_service_level_reuse_name(manager: ScyllaClusterManager):
     servers = await manager.servers_add(1, config=auth_config, auto_rack_dc="dc1")
     cql = manager.get_cql()
@@ -345,6 +353,7 @@ async def test_service_level_reuse_name(manager: ScyllaClusterManager):
     cql = await create_sl_and_use(cql, sl2)
     cql = await create_sl_and_use(cql, sl1)
 
+@pytest.mark.max_running_shards(6)
 async def test_driver_service_level(manager: ScyllaClusterManager) -> None:
     servers = await manager.servers_add(2, config=auth_config, auto_rack_dc="dc1")
 
@@ -376,6 +385,7 @@ async def test_driver_service_level(manager: ScyllaClusterManager) -> None:
     for host in hosts:
         assert len(await cql.run_async("LIST ALL SERVICE LEVELS", host=host)) == 0
 
+@pytest.mark.max_running_shards(4)
 async def test_driver_service_creation_failure(manager: ScyllaClusterManager) -> None:
     servers = await manager.servers_add(2, config=auth_config, auto_rack_dc="dc1")
 
@@ -449,6 +459,7 @@ async def _verify_requests_count_metrics(manager, server, used_group, unused_gro
     assert requests_processed_by_used_group - initial_requests_processed_by_used_group >= expected_number_of_requests
     assert requests_processed_by_unused_group - initial_requests_processed_by_unused_group < expected_number_of_requests
 
+@pytest.mark.max_running_shards(2)
 async def test_driver_service_level_not_used_for_user_queries(manager: ScyllaClusterManager) -> None:
     server = await manager.server_add(config=auth_config)
 
@@ -471,6 +482,7 @@ async def test_driver_service_level_not_used_for_user_queries(manager: ScyllaClu
     func = lambda: cql.execute("SELECT * from demo.events")
     await _verify_requests_count_metrics(manager, server, 'sl:test', 'sl:driver', func)
 
+@pytest.mark.max_running_shards(2)
 async def test_driver_service_level_used_for_driver_queries(manager: ScyllaClusterManager) -> None:
     server = await manager.server_add(config=auth_config)
 
@@ -504,6 +516,7 @@ async def test_driver_service_level_used_for_driver_queries(manager: ScyllaClust
 # connection permanently reclassifies it as a regular user connection, regardless
 # of whether the statement arrives as a read or write QUERY, an EXECUTE or a BATCH.
 # Reproduces SCYLLADB-2458.
+@pytest.mark.max_running_shards(2)
 async def test_control_connection_reclassified_by_user_load(manager: ScyllaClusterManager) -> None:
     server = await manager.server_add(config=auth_config)
 
@@ -553,6 +566,7 @@ async def test_control_connection_reclassified_by_user_load(manager: ScyllaClust
 # Run the queries that the ScyllaDB-supported drivers send on theirs (see
 # https://docs.scylladb.com/stable/versioning/driver-support.html) and verify the
 # connection keeps running in sl:driver - none of them must trigger a reclassification.
+@pytest.mark.max_running_shards(2)
 async def test_control_connection_not_reclassified_by_driver_queries(manager: ScyllaClusterManager) -> None:
     server = await manager.server_add(config=auth_config)
 
@@ -608,6 +622,7 @@ async def test_control_connection_not_reclassified_by_driver_queries(manager: Sc
     await _verify_requests_count_metrics(manager, server, 'sl:driver', 'sl:default', system_func)
 
 # Reproduces scylladb/scylladb#26040
+@pytest.mark.max_running_shards(2)
 async def test_anonymous_user(manager: ScyllaClusterManager) -> None:
     allow_all_config = {'authenticator':'AllowAllAuthenticator', 'authorizer':'AllowAllAuthorizer'}
     server = await manager.server_add(config=allow_all_config)
@@ -642,6 +657,7 @@ async def test_anonymous_user(manager: ScyllaClusterManager) -> None:
     # system.clients may briefly still report the old group.
     await wait_for(anonymous_connection_uses_sl_default, time.time() + 60)
 
+@pytest.mark.max_running_shards(2)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_per_service_level_cql_requests_serving(manager: ScyllaClusterManager) -> None:
     """Test that the per-service-level cql_requests_serving metric correctly
@@ -759,6 +775,7 @@ async def test_per_service_level_cql_requests_serving(manager: ScyllaClusterMana
         safe_driver_shutdown(cluster_default)
 
 
+@pytest.mark.max_running_shards(2)
 @pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_per_service_level_cql_request_latency_histogram(manager: ScyllaClusterManager) -> None:
@@ -852,6 +869,7 @@ async def test_per_service_level_cql_request_latency_histogram(manager: ScyllaCl
         safe_driver_shutdown(cluster_a)
 
 
+@pytest.mark.max_running_shards(2)
 async def test_service_level_metrics(manager: ScyllaClusterManager) -> None:
     """
     Verify service level workload type metrics

--- a/test/cluster/auth_cluster/test_service_levels_self_healing.py
+++ b/test/cluster/auth_cluster/test_service_levels_self_healing.py
@@ -47,6 +47,7 @@ async def create_system_distributed_service_levels(cql):
             shares int)""")
 
 
+@pytest.mark.max_running_shards(2)
 @pytest.mark.skip_mode(mode="release", reason="error injection is disabled in release mode")
 async def test_self_heals_service_levels_v1_after_restart(manager: ScyllaClusterManager, scale_timeout: callable):
     """Reproduces a raft-topology cluster created before service levels were initialized as v2."""
@@ -113,6 +114,7 @@ async def _validate_host_service_level_ver(hosts, cql, ver):
         assert version_rows[0].value == str(ver)
 
 
+@pytest.mark.max_running_shards(6)
 @pytest.mark.skip_mode(mode="release", reason="error injection is disabled in release mode")
 async def test_self_heal_waits_for_unavailable_replicas(manager: ScyllaClusterManager, scale_timeout: callable):
     """Verify SCYLLADB-3337: service level migration should wait for all nodes to be available"""

--- a/test/cluster/auth_cluster/test_service_levels_tolerate_invalid_role_grants_graph.py
+++ b/test/cluster/auth_cluster/test_service_levels_tolerate_invalid_role_grants_graph.py
@@ -6,8 +6,10 @@
 
 from test.cluster.auth_cluster import extra_scylla_config_options as auth_config
 from test.pylib.scylla_cluster_manager import ScyllaClusterManager
+import pytest
 
 
+@pytest.mark.max_running_shards(2)
 async def test_tolerating_cycles_in_auth(manager: ScyllaClusterManager):
     """
     Verify that the service levels logic in group0 gracefully handles cycles
@@ -44,6 +46,7 @@ async def test_tolerating_cycles_in_auth(manager: ScyllaClusterManager):
     await log.wait_for("Cycle detected in the system.role_members table: (a -> b -> a|b -> a -> b)")
 
 
+@pytest.mark.max_running_shards(2)
 async def test_invalid_graph_with_edges_to_non_existing_members(manager: ScyllaClusterManager):
     """
     Verify that the service levels logic gracefully handles invalid graphs of roles

--- a/test/cluster/auth_cluster/test_startup_response.py
+++ b/test/cluster/auth_cluster/test_startup_response.py
@@ -18,6 +18,7 @@ from test.pylib.scylla_cluster_manager import ScyllaClusterManager
 from test.pylib.driver_utils import safe_driver_shutdown
 from test.cluster.auth_cluster import extra_scylla_config_options as auth_config
 
+@pytest.mark.max_running_shards(2)
 async def test_startup_no_auth_response(manager: ScyllaClusterManager, build_mode):
     """
     Test behavior when client hangs on startup auth response.

--- a/test/cluster/auth_cluster/test_transitional_auth_malformed_sasl.py
+++ b/test/cluster/auth_cluster/test_transitional_auth_malformed_sasl.py
@@ -12,6 +12,7 @@ from cassandra.query import SimpleStatement
 
 from test.pylib.scylla_cluster_manager import ScyllaClusterManager
 from test.cluster.auth_cluster import extra_scylla_config_options as auth_config
+import pytest
 
 logger = logging.getLogger(__name__)
 
@@ -49,6 +50,7 @@ class _MalformedSaslAuthProvider(AuthProvider):
 
 
 # Reproduces SCYLLADB-4166
+@pytest.mark.max_running_shards(2)
 async def test_transitional_auth_malformed_sasl_token(manager: ScyllaClusterManager) -> None:
     server = await manager.server_add(config={**auth_config,
                                               "authenticator": TRANSITIONAL_AUTHENTICATOR,

--- a/test/cluster/conftest.py
+++ b/test/cluster/conftest.py
@@ -23,7 +23,12 @@ from test.pylib.connect_options import add_cql_connection_options, add_s3_option
 from test.pylib.encryption_provider import KeyProvider, make_key_provider_factory
 from test.pylib.object_storage import Storage, StorageFactory, StorageKind, create_gs_server, create_s3_server
 from test.pylib.random_tables import RandomTables
-from test.pylib.runner import PHASE_REPORT_KEY, make_failed_test_dir
+from test.pylib.runner import (
+    MAX_RUNNING_SHARDS,
+    MAX_RUNNING_SHARDS_CLAIM,
+    PHASE_REPORT_KEY,
+    make_failed_test_dir,
+)
 from test.pylib.scylla_cluster_manager import ScyllaClusterManager
 from test.pylib.scylla_server import ScyllaVersionDescription, get_scylla_2025_1_description, get_scylla_2026_1_description
 from test.pylib.skip_types import skip_env
@@ -204,6 +209,10 @@ async def manager(request: pytest.FixtureRequest,
             logger.debug("after_test for %s (success: %s)", test_case_name, not failed)
             cluster_status = await mgr.after_test(success=not failed)
             logger.info("Cluster after test %s (success: %s): %s", test_case_name, not failed, cluster_status)
+            # Hand what was observed to pytest_runtest_protocol, which owns this
+            # test's rows in the metrics DB.
+            request.node.stash[MAX_RUNNING_SHARDS] = cluster_status["max_running_shards"]
+            request.node.stash[MAX_RUNNING_SHARDS_CLAIM] = cluster_status["claim"]
 
         # Collect the teardown-detected failures and report them all at once,
         # so leaked tasks don't hide the found-errors report or vice versa.

--- a/test/cluster/dtest/alternator_tests.py
+++ b/test/cluster/dtest/alternator_tests.py
@@ -65,6 +65,7 @@ class TesterAlternator(BaseAlternator):
             nr_nodes += 1
         return nr_nodes
 
+    @pytest.mark.max_running_shards(6)
     def test_load_older_snapshot_and_refresh(self):
         """
         The test loading older snapshot files and checking the refresh command works
@@ -85,6 +86,7 @@ class TesterAlternator(BaseAlternator):
         diff = self.compare_table_data(table_name=table_name, expected_table_data=table_data, node=node1)
         assert not diff, f"The following items are missing:\n{pformat(diff)}"
 
+    @pytest.mark.max_running_shards(2)
     def test_create_snapshot_and_refresh(self, request):
         """
         The test checks the behavior of the `snapshot` and `refresh` commands for Alternator
@@ -114,6 +116,7 @@ class TesterAlternator(BaseAlternator):
         diff = self.compare_table_data(table_name=table_name, expected_table_data=data_before_refresh, node=node1)
         assert not diff, f"The following items are missing:\n{pformat(diff)}"
 
+    @pytest.mark.max_running_shards(8)
     def test_dynamo_gsi(self):
         self.prepare_dynamodb_cluster(num_of_nodes=4)
         node1 = self.cluster.nodelist()[0]
@@ -134,6 +137,7 @@ class TesterAlternator(BaseAlternator):
         diff_result = DeepDiff(t1=result_items, t2=expected_items, ignore_order=True)
         assert not diff_result, f"The following items differs:\n{pformat(diff_result)}"
 
+    @pytest.mark.max_running_shards(6)
     def test_drain_during_dynamo_load(self):
         """
         1. Create a load of read + update-items delete-set-elements
@@ -152,6 +156,7 @@ class TesterAlternator(BaseAlternator):
         logger.info("Drain finished")
         read_and_delete_set_elements_thread.join()
 
+    @pytest.mark.max_running_shards(6)
     def test_decommission_during_dynamo_load(self):
         self.prepare_dynamodb_cluster(num_of_nodes=3)
         node1, node2, node3 = self.cluster.nodelist()
@@ -181,6 +186,7 @@ class TesterAlternator(BaseAlternator):
         with pytest.raises(expected_exception=(EndpointConnectionError,), match="Could not connect to the endpoint URL"):
             self.get_table_items(table_name=TABLE_NAME, node=node2, num_of_items=10, consistent_read=True)
 
+    @pytest.mark.max_running_shards(6)
     def test_dynamo_reads_after_repair(self):
         self.prepare_dynamodb_cluster(num_of_nodes=3)
         node1, node2 = self.cluster.nodelist()[:2]
@@ -201,6 +207,7 @@ class TesterAlternator(BaseAlternator):
         logger.info(f"Reading Alternator queries from node {node2.name}")
         self.get_table_items(table_name=TABLE_NAME, node=node2)
 
+    @pytest.mark.max_running_shards(12)
     def test_dynamo_queries_on_multi_dc(self):
         self.prepare_dynamodb_cluster(num_of_nodes=3, is_multi_dc=True)
         dc1_node = self.cluster.nodelist()[0]
@@ -214,6 +221,7 @@ class TesterAlternator(BaseAlternator):
         logger.info(f"Reading Alternator queries from node {dc2_node.name} on data-center {dc2_node.data_center}")
         wait_for(func=lambda: not self.compare_table_data(expected_table_data=items, table_name=TABLE_NAME, node=dc2_node, consistent_read=False), timeout=5 * 60, text="Waiting until the DC2 will contain all items that insert in DC1")
 
+    @pytest.mark.max_running_shards(8)
     def test_dynamo_reads_after_new_node_repair(self):
         num_of_nodes = self._num_of_nodes_for_test(rf=3)
         self.prepare_dynamodb_cluster(num_of_nodes=num_of_nodes)
@@ -237,6 +245,7 @@ class TesterAlternator(BaseAlternator):
         logger.info(f"Reading Alternator queries from node {tested_node.name}")
         self.get_table_items(table_name=TABLE_NAME, node=tested_node, consistent_read=False)
 
+    @pytest.mark.max_running_shards(2)
     def test_batch_with_auto_snapshot_false(self):
         """Test triggers scylladb/scylladb#6995"""
 
@@ -249,6 +258,7 @@ class TesterAlternator(BaseAlternator):
                 batch.put_item({"pk": random_string(length=DEFAULT_STRING_LENGTH), "c": i, "a": load})
         self.delete_table(TABLE_NAME, node1)
 
+    @pytest.mark.max_running_shards(12)
     def test_update_condition_unused_entries_short_circuit(self):
         """
         A test for https://github.com/scylladb/scylla/issues/6572 plus a multi DC configuration
@@ -306,6 +316,7 @@ class TesterAlternator(BaseAlternator):
         item = table.get_item(Key={self._table_primary_key: new_pk_val}, ConsistentRead=True)["Item"]
         assert item == {self._table_primary_key: new_pk_val, "a": 1, "c": 3}
 
+    @pytest.mark.max_running_shards(4)
     def test_modified_tag_is_propagated_to_other_dc(self):
         self.prepare_dynamodb_cluster(num_of_nodes=1, is_multi_dc=True)
         node1 = self.cluster.nodelist()[0]
@@ -315,6 +326,7 @@ class TesterAlternator(BaseAlternator):
         set_write_isolation(table, WriteIsolation.FORBID_RMW)
         wait_for(self.is_table_schema_synced, timeout=30, step=3, text="Waiting until table schema is updated", table_name=TABLE_NAME, nodes=[node1, dc2_node])
 
+    @pytest.mark.max_running_shards(6)
     def test_read_system_tables_via_dynamodb_api(self):
         """
         make sure we could only read system tables via dynamodb api
@@ -338,6 +350,7 @@ class TesterAlternator(BaseAlternator):
             with pytest.raises(expected_exception=(ClientError,), match="ResourceNotFoundException"):
                 self.batch_write_actions(table_name=".scylla.alternator.system.peers", new_items=[dict(pk=1)], node=node)
 
+    @pytest.mark.max_running_shards(6)
     def test_table_name_with_dot_prefix(self):
         valid_dynamodb_chars = list(string.digits) + list(string.ascii_uppercase) + ["_", "-", "."]
         self.prepare_dynamodb_cluster(num_of_nodes=3)
@@ -360,6 +373,7 @@ class TesterAlternator(BaseAlternator):
         logger.info(f"Executing the following command '{cmd}'")
         node1.nodetool(cmd)
 
+    @pytest.mark.max_running_shards(2)
     @pytest.mark.parametrize("create_gsi", [False, True])
     def test_alternator_nodetool_tablestats(self, create_gsi):
         """nodetool_additional_test.py::TesterAlternator::test_cfstats_syntax
@@ -390,6 +404,7 @@ class TesterAlternator(BaseAlternator):
         ret = node1.nodetool(f"tablestats alternator_{table_name}.{table_name}")
         assert table_name in str(ret)
 
+    @pytest.mark.max_running_shards(2)
     @pytest.mark.parametrize("create_gsi", [False, True])
     def test_alternator_nodetool_info(self, create_gsi):
         """Tests that "nodetool info" works on Alternator tables.
@@ -404,6 +419,7 @@ class TesterAlternator(BaseAlternator):
         # We don't check anything specific in the output, just that
         # "nodetool info" didn't fail as it used to.
 
+    @pytest.mark.max_running_shards(4)
     def test_putitem_contention(self):  # pylint:disable=too-many-locals
         """
         This test reproduces issue #7218, where PutItem operations sometimes
@@ -475,6 +491,7 @@ class TesterAlternator(BaseAlternator):
         assert n_items == total_items
         assert n_bad_items == 0
 
+    @pytest.mark.max_running_shards(2)
     def test_tls_connection(self):
         """
         Create a HTTPS (SSL/TLS) connection, and verify the test can create a table and insert data into it.
@@ -497,6 +514,7 @@ class TesterAlternator(BaseAlternator):
             self.batch_write_actions(table_name=table_name, node=node, new_items=new_items)
         self.compare_table_data(expected_table_data=new_items, table_name=table_name, node=node1)
 
+    @pytest.mark.max_running_shards(2)
     def test_limit_concurrent_requests(self):
         """
         Test Support limiting the number of concurrent requests in alternator.
@@ -610,6 +628,7 @@ class TesterAlternator(BaseAlternator):
             if not self.is_found_in_slow_queries_log(name=table, log_result=create_table_results):
                 raise SlowQueriesLoggingError(f"Table {table} not found in slow-query-log full-scan")
 
+    @pytest.mark.max_running_shards(8)
     def test_slow_query_logging(self):
         """
         Test slow query logging for alternator queries.
@@ -648,6 +667,7 @@ class TesterAlternator(BaseAlternator):
         stress_thread.join()
         decommission_thread.join()
 
+    @pytest.mark.max_running_shards(8)
     def test_delete_elements_from_a_set(self):
         """
         Verifies https://github.com/scylladb/scylla/commit/253387ea07962d4fd8cb221eb90298b9127caf9f
@@ -678,6 +698,7 @@ class TesterAlternator(BaseAlternator):
         items = self.get_table_items(table_name=TABLE_NAME, node=node1, consistent_read=False, num_of_items=num_of_items)
         assert [item for item in items if NUM_OF_ELEMENTS_IN_SET > len(item["Item"]["hello_set"]) > 0]
 
+    @pytest.mark.max_running_shards(8)
     def test_ttl_with_load_and_decommission(self):
         """
         1. Configure a table with TTL enabled and an 'expiration' column.

--- a/test/cluster/dtest/auth_roles_test.py
+++ b/test/cluster/dtest/auth_roles_test.py
@@ -37,6 +37,7 @@ def fixture_set_cluster_settings(fixture_dtest_setup):
 @pytest.mark.single_node
 @pytest.mark.usefixtures("fixture_set_cluster_settings")
 class TestAuthRoles(Tester):
+    @pytest.mark.max_running_shards(2)
     def test_create_drop_role(self):
         self.prepare()
         cassandra = self.get_session(user="cassandra", password="cassandra")
@@ -48,6 +49,7 @@ class TestAuthRoles(Tester):
         cassandra.execute("DROP ROLE role1")
         assert_one(cassandra, "LIST ROLES", cassandra_role)
 
+    @pytest.mark.max_running_shards(2)
     def test_conditional_create_drop_role(self):
         self.prepare()
         cassandra = self.get_session(user="cassandra", password="cassandra")
@@ -61,6 +63,7 @@ class TestAuthRoles(Tester):
         cassandra.execute("DROP ROLE IF EXISTS role1")
         assert_one(cassandra, "LIST ROLES", cassandra_role)
 
+    @pytest.mark.max_running_shards(2)
     def test_create_drop_role_validation(self):
         self.prepare()
         cassandra = self.get_session(user="cassandra", password="cassandra")
@@ -76,6 +79,7 @@ class TestAuthRoles(Tester):
         cassandra.execute("DROP ROLE role1")
         assert_invalid(cassandra, "DROP ROLE role1", "role1 doesn't exist")
 
+    @pytest.mark.max_running_shards(2)
     def test_role_admin_validation(self):
         self.prepare()
         cassandra = self.get_session(user="cassandra", password="cassandra")
@@ -116,6 +120,7 @@ class TestAuthRoles(Tester):
         cassandra.execute("REVOKE administrator FROM mike")
         assert_invalid(mike, "CREATE ROLE role3 WITH LOGIN = false", "User mike has no CREATE permission on <all roles> or any of its parents", Unauthorized)
 
+    @pytest.mark.max_running_shards(2)
     def test_create_and_grant_roles_with_superuser_status(self):
         self.prepare()
         cassandra = self.get_session(user="cassandra", password="cassandra")
@@ -135,6 +140,7 @@ class TestAuthRoles(Tester):
         assert_invalid(mike, "CREATE ROLE role2 WITH SUPERUSER = true", "Only superusers can create a role with superuser status", Unauthorized)
         assert_all(cassandra, "LIST ROLES OF role1", [["another_superuser", True, False, {}], ["non_superuser", False, False, {}], ["role1", False, False, {}]])
 
+    @pytest.mark.max_running_shards(2)
     def test_drop_and_revoke_roles_with_superuser_status(self):
         self.prepare()
         cassandra = self.get_session(user="cassandra", password="cassandra")
@@ -154,6 +160,7 @@ class TestAuthRoles(Tester):
         mike.execute("DROP ROLE non_superuser")
         mike.execute("DROP ROLE role1")
 
+    @pytest.mark.max_running_shards(2)
     def test_drop_role_removes_memberships(self):
         self.prepare()
         cassandra = self.get_session(user="cassandra", password="cassandra")
@@ -176,6 +183,7 @@ class TestAuthRoles(Tester):
         assert_one(cassandra, "LIST ROLES OF mike", mike_role)
         assert_all(cassandra, "LIST ROLES", [cassandra_role, mike_role, role2_role])
 
+    @pytest.mark.max_running_shards(2)
     def test_drop_role_revokes_permissions_granted_on_it(self):
         self.prepare()
         cassandra = self.get_session(user="cassandra", password="cassandra")
@@ -191,6 +199,7 @@ class TestAuthRoles(Tester):
         cassandra.execute("DROP ROLE role2")
         assert len(list(cassandra.execute("LIST ALL PERMISSIONS OF mike"))) == 0
 
+    @pytest.mark.max_running_shards(2)
     def test_grant_revoke_roles(self):
         self.prepare()
         cassandra = self.get_session(user="cassandra", password="cassandra")
@@ -210,6 +219,7 @@ class TestAuthRoles(Tester):
         cassandra.execute("REVOKE role1 FROM role2")
         assert_one(cassandra, "LIST ROLES OF role2", role2_role)
 
+    @pytest.mark.max_running_shards(2)
     def test_grant_revoke_role_validation(self):
         self.prepare()
         cassandra = self.get_session(user="cassandra", password="cassandra")
@@ -240,6 +250,7 @@ class TestAuthRoles(Tester):
         cassandra.execute("REVOKE role1 FROM john")
         mike.execute("REVOKE role2 from john")
 
+    @pytest.mark.max_running_shards(2)
     def test_list_roles(self):
         self.prepare()
         cassandra = self.get_session(user="cassandra", password="cassandra")
@@ -270,6 +281,7 @@ class TestAuthRoles(Tester):
         cassandra.execute("GRANT DESCRIBE ON ALL ROLES TO mike")
         assert_all(mike, "LIST ROLES", [cassandra_role, mike_role, role1_role, role2_role])
 
+    @pytest.mark.max_running_shards(2)
     def test_grant_revoke_permissions(self):
         self.prepare()
         cassandra = self.get_session(user="cassandra", password="cassandra")
@@ -293,6 +305,7 @@ class TestAuthRoles(Tester):
 
         assert_invalid(mike, "INSERT INTO ks.cf (id, val) VALUES (0, 0)", re.escape("mike has no MODIFY permission on <table ks.cf> or any of its parents"), Unauthorized)
 
+    @pytest.mark.max_running_shards(2)
     def test_role_caching_authenticated_user(self):
         # This test is to show that the role caching in AuthenticatedUser
         # works correctly and revokes the roles from a logged in user
@@ -324,6 +337,7 @@ class TestAuthRoles(Tester):
 
         assert unauthorized is not None
 
+    @pytest.mark.max_running_shards(2)
     def test_prevent_circular_grants(self):
         self.prepare()
         cassandra = self.get_session(user="cassandra", password="cassandra")
@@ -335,6 +349,7 @@ class TestAuthRoles(Tester):
         assert_invalid(cassandra, "GRANT mike TO role1", "mike already includes role role1.", InvalidRequest)
         assert_invalid(cassandra, "GRANT mike TO role2", "mike already includes role role2.", InvalidRequest)
 
+    @pytest.mark.max_running_shards(2)
     def test_create_user_as_alias_for_create_role(self):
         self.prepare()
         cassandra = self.get_session(user="cassandra", password="cassandra")
@@ -344,6 +359,7 @@ class TestAuthRoles(Tester):
         cassandra.execute("CREATE USER super_user WITH PASSWORD '12345' SUPERUSER")
         assert_one(cassandra, "LIST ROLES OF super_user", ["super_user", True, True, {}])
 
+    @pytest.mark.max_running_shards(2)
     def test_role_name(self):
         """Simple test to verify the behavior of quoting when creating roles & users
         @jira_ticket CASSANDRA-10394
@@ -378,6 +394,7 @@ class TestAuthRoles(Tester):
         self.get_session(user="USER2", password="12345")
         self.assert_unauthenticated("Username and/or password are incorrect", "User2", "12345")
 
+    @pytest.mark.max_running_shards(2)
     def test_role_requires_login_privilege_to_authenticate(self):
         self.prepare()
         cassandra = self.get_session(user="cassandra", password="cassandra")
@@ -394,6 +411,7 @@ class TestAuthRoles(Tester):
         assert_one(cassandra, "LIST ROLES OF mike", ["mike", False, True, {}])
         self.get_session(user="mike", password="12345")
 
+    @pytest.mark.max_running_shards(2)
     def test_role_requires_password_to_login(self):
         self.prepare()
         cassandra = self.get_session(user="cassandra", password="cassandra")
@@ -402,6 +420,7 @@ class TestAuthRoles(Tester):
         cassandra.execute("ALTER ROLE mike WITH PASSWORD = '12345'")
         self.get_session(user="mike", password="12345")
 
+    @pytest.mark.max_running_shards(2)
     def test_superuser_status_is_inherited(self):
         self.prepare()
         cassandra = self.get_session(user="cassandra", password="cassandra")
@@ -415,6 +434,7 @@ class TestAuthRoles(Tester):
         mike.execute("CREATE ROLE another_role WITH SUPERUSER = false AND LOGIN = false")
         assert_all(mike, "LIST ROLES", [["another_role", False, False, {}], cassandra_role, ["db_admin", True, False, {}], mike_role])
 
+    @pytest.mark.max_running_shards(2)
     def test_list_users_considers_inherited_superuser_status(self):
         self.prepare()
         cassandra = self.get_session(user="cassandra", password="cassandra")
@@ -423,6 +443,7 @@ class TestAuthRoles(Tester):
         cassandra.execute("GRANT db_admin TO mike")
         assert_all(cassandra, "LIST USERS", [["cassandra", True], ["mike", True]])
 
+    @pytest.mark.max_running_shards(2)
     def test_builtin_functions_require_no_special_permissions(self):
         self.prepare()
         cassandra = self.get_session(user="cassandra", password="cassandra")
@@ -433,6 +454,7 @@ class TestAuthRoles(Tester):
         cassandra.execute("GRANT ALL PERMISSIONS ON ks.t1 TO mike")
         assert_one(mike, "SELECT * from ks.t1 WHERE k=blobasint(intasblob(1))", [1, 1])
 
+    @pytest.mark.max_running_shards(2)
     def test_disallow_grant_revoke_on_builtin_functions(self):
         self.prepare()
         cassandra = self.get_session(user="cassandra", password="cassandra")
@@ -443,6 +465,7 @@ class TestAuthRoles(Tester):
         assert_invalid(cassandra, "GRANT EXECUTE ON ALL FUNCTIONS IN KEYSPACE system TO mike", "Altering permissions on builtin functions is not supported", InvalidRequest)
         assert_invalid(cassandra, "REVOKE ALL PERMISSIONS ON ALL FUNCTIONS IN KEYSPACE system FROM mike", "Altering permissions on builtin functions is not supported", InvalidRequest)
 
+    @pytest.mark.max_running_shards(2)
     def test_disallow_grant_execute_on_non_function_resources(self):
         self.prepare()
         cassandra = self.get_session(user="cassandra", password="cassandra")
@@ -459,6 +482,7 @@ class TestAuthRoles(Tester):
         assert_invalid(cassandra, "GRANT EXECUTE ON ALL ROLES TO mike", "Resource <all roles> does not support any of the requested permissions", SyntaxException)
         assert_invalid(cassandra, "GRANT EXECUTE ON ROLE mike TO role1", "Resource <role mike> does not support any of the requested permissions", SyntaxException)
 
+    @pytest.mark.max_running_shards(2)
     def test_truncate_with_rbac(self):
         self.prepare()
         cassandra = self.get_session(user="cassandra", password="cassandra")

--- a/test/cluster/dtest/auth_test.py
+++ b/test/cluster/dtest/auth_test.py
@@ -45,6 +45,7 @@ class TestAuth(Tester):
             r"Can\'t send migration request: node.*is down",
         ]
 
+    @pytest.mark.max_running_shards(2)
     @pytest.mark.single_node
     def test_login(self):
         """
@@ -79,6 +80,7 @@ class TestAuth(Tester):
             # https://github.com/scylladb/scylla/issues/2274
             # assert 'Password must not be null' in str(list(e.errors.values())[0])
 
+    @pytest.mark.max_running_shards(2)
     @pytest.mark.single_node
     def test_anonymous(self):
         """
@@ -114,6 +116,7 @@ class TestAuth(Tester):
         self.assert_unauthorized("You have to be logged in and not anonymous to perform this request", session, "LIST USERS")
         self.assert_unauthorized("You have to be logged in and not anonymous to perform this request", session, "GRANT SELECT ON ALL KEYSPACES TO anonymous")
 
+    @pytest.mark.max_running_shards(2)
     @pytest.mark.single_node
     def test_create_user_permissions(self):
         """
@@ -130,6 +133,7 @@ class TestAuth(Tester):
         jackob = self.get_session(user="jackob", password="12345")
         self.assert_unauthorized("User jackob has no CREATE permission on <all roles> or any of its parents", jackob, "CREATE USER james WITH PASSWORD '54321' NOSUPERUSER")
 
+    @pytest.mark.max_running_shards(2)
     @pytest.mark.single_node
     def test_cant_create_existing_user(self):
         """
@@ -144,6 +148,7 @@ class TestAuth(Tester):
         session.execute("CREATE USER 'james@example.com' WITH PASSWORD '12345' NOSUPERUSER")
         assert_invalid(session, "CREATE USER 'james@example.com' WITH PASSWORD '12345' NOSUPERUSER", "james@example.com already exists")
 
+    @pytest.mark.max_running_shards(2)
     @pytest.mark.single_node
     def test_list_users(self):
         """
@@ -171,6 +176,7 @@ class TestAuth(Tester):
         assert not users["cathy"]
         assert users["dave"]
 
+    @pytest.mark.max_running_shards(2)
     @pytest.mark.single_node
     def test_user_cant_drop_themselves(self):
         """
@@ -185,6 +191,7 @@ class TestAuth(Tester):
         # handle different error messages between versions pre and post 2.2.0
         assert_invalid(session, "DROP USER cassandra", "(Users aren't allowed to DROP themselves|Cannot DROP primary role for current login)")
 
+    @pytest.mark.max_running_shards(2)
     @pytest.mark.single_node
     def test_dropping_nonexistent_user_throws_exception(self):
         """
@@ -198,6 +205,7 @@ class TestAuth(Tester):
         session = self.get_session(user="cassandra", password="cassandra")
         assert_invalid(session, "DROP USER nonexistent", "nonexistent doesn't exist")
 
+    @pytest.mark.max_running_shards(2)
     @pytest.mark.single_node
     def test_drop_user_case_sensitive(self):
         """
@@ -238,6 +246,7 @@ class TestAuth(Tester):
         assert_invalid(cassandra, "DROP USER TEST")
         assert_invalid(cassandra, "DROP USER Test")
 
+    @pytest.mark.max_running_shards(2)
     @pytest.mark.single_node
     def test_drop_user_revoke_all(self):
         """
@@ -285,6 +294,7 @@ class TestAuth(Tester):
         self.assert_unauthorized("User test has no SELECT permission on <table ks.cf> or any of its parents", session, "SELECT * FROM ks.cf")
         self.assert_unauthorized("User test has no AUTHORIZE permission on <table ks.cf> or any of its parents", session, "GRANT SELECT ON ks.cf TO test2")
 
+    @pytest.mark.max_running_shards(2)
     @pytest.mark.single_node
     def test_alter_user_case_sensitive(self):
         """
@@ -306,6 +316,7 @@ class TestAuth(Tester):
         assert_invalid(cassandra, "ALTER USER TEST WITH PASSWORD '12345'")
         cassandra.execute("ALTER USER test WITH PASSWORD '54321'")
 
+    @pytest.mark.max_running_shards(2)
     @pytest.mark.single_node
     def test_regular_users_can_alter_their_passwords_only(self):
         """
@@ -325,6 +336,7 @@ class TestAuth(Tester):
         cathy = self.get_session(user="cathy", password="54321")
         self.assert_unauthorized("User cathy has no ALTER permission on <role bob> or any of its parents", cathy, "ALTER USER bob WITH PASSWORD 'cantchangeit'")
 
+    @pytest.mark.max_running_shards(2)
     @pytest.mark.single_node
     def test_users_cant_alter_their_superuser_status(self):
         """
@@ -338,6 +350,7 @@ class TestAuth(Tester):
         session = self.get_session(user="cassandra", password="cassandra")
         self.assert_unauthorized("You aren't allowed to alter your own superuser status", session, "ALTER USER cassandra NOSUPERUSER")
 
+    @pytest.mark.max_running_shards(2)
     @pytest.mark.single_node
     def test_only_superuser_alters_superuser_status(self):
         """
@@ -356,6 +369,7 @@ class TestAuth(Tester):
 
         cassandra.execute("ALTER USER cathy SUPERUSER")
 
+    @pytest.mark.max_running_shards(2)
     @pytest.mark.single_node
     def test_altering_nonexistent_user_throws_exception(self):
         """
@@ -369,6 +383,7 @@ class TestAuth(Tester):
         session = self.get_session(user="cassandra", password="cassandra")
         assert_invalid(session, "ALTER USER nonexistent WITH PASSWORD 'doesn''tmatter'", "nonexistent doesn't exist")
 
+    @pytest.mark.max_running_shards(2)
     @pytest.mark.single_node
     def test_conditional_create_drop_user(self):
         """
@@ -395,6 +410,7 @@ class TestAuth(Tester):
         users = list(session.execute("LIST USERS"))
         assert 1 == len(users)  # cassandra
 
+    @pytest.mark.max_running_shards(2)
     @pytest.mark.single_node
     def test_create_ks_auth(self):
         """
@@ -414,6 +430,7 @@ class TestAuth(Tester):
         cassandra.execute("GRANT CREATE ON ALL KEYSPACES TO cathy")
         cathy.execute("""CREATE KEYSPACE ks WITH replication = {'class':'NetworkTopologyStrategy', 'replication_factor':1}""")
 
+    @pytest.mark.max_running_shards(2)
     @pytest.mark.single_node
     def test_create_cf_auth(self):
         """
@@ -434,6 +451,7 @@ class TestAuth(Tester):
         cassandra.execute("GRANT CREATE ON KEYSPACE ks TO cathy")
         cathy.execute("CREATE TABLE ks.cf (id int primary key)")
 
+    @pytest.mark.max_running_shards(4)
     @pytest.mark.single_node
     def test_alter_ks_auth(self):
         """
@@ -462,6 +480,7 @@ class TestAuth(Tester):
         cassandra.execute("GRANT ALTER ON KEYSPACE ks TO cathy")
         cathy.execute(f"ALTER KEYSPACE ks WITH replication = {{'class':'{replication_strategy}', '{rf_type}':2}}")
 
+    @pytest.mark.max_running_shards(2)
     @pytest.mark.single_node
     def test_alter_cf_auth(self):
         """
@@ -538,6 +557,7 @@ class TestAuth(Tester):
         cassandra.execute("GRANT ALTER ON ks.cf TO cathy")
         cathy.execute("ALTER TABLE ks.cf DROP val2")
 
+    @pytest.mark.max_running_shards(2)
     @pytest.mark.single_node
     def test_materialized_views_auth(self):
         """
@@ -578,6 +598,7 @@ class TestAuth(Tester):
         cassandra.execute("GRANT ALTER ON ks.cf TO cathy")
         cathy.execute("DROP MATERIALIZED VIEW mv1")
 
+    @pytest.mark.max_running_shards(2)
     @pytest.mark.single_node
     def test_drop_ks_auth(self):
         """
@@ -598,6 +619,7 @@ class TestAuth(Tester):
         cassandra.execute("GRANT DROP ON KEYSPACE ks TO cathy")
         cathy.execute("DROP KEYSPACE ks")
 
+    @pytest.mark.max_running_shards(2)
     @pytest.mark.single_node
     def test_drop_cf_auth(self):
         """
@@ -619,6 +641,7 @@ class TestAuth(Tester):
         cassandra.execute("GRANT DROP ON ks.cf TO cathy")
         cathy.execute("DROP TABLE ks.cf")
 
+    @pytest.mark.max_running_shards(2)
     @pytest.mark.single_node
     def test_modify_and_select_auth(self):
         """
@@ -664,6 +687,7 @@ class TestAuth(Tester):
 
         assert 0 == len(rows)
 
+    @pytest.mark.max_running_shards(2)
     @pytest.mark.single_node
     def test_grant_revoke_without_ks_specified(self):
         """
@@ -697,6 +721,7 @@ class TestAuth(Tester):
         cathy.execute("GRANT SELECT ON cf TO bob")
         bob.execute("SELECT * FROM ks.cf")
 
+    @pytest.mark.max_running_shards(2)
     @pytest.mark.single_node
     def test_grant_revoke_auth(self):
         """
@@ -725,6 +750,7 @@ class TestAuth(Tester):
         # should succeed now with both SELECT and AUTHORIZE
         cathy.execute("GRANT SELECT ON ALL KEYSPACES TO bob")
 
+    @pytest.mark.max_running_shards(2)
     @pytest.mark.single_node
     def test_grant_revoke_validation(self):
         """
@@ -747,6 +773,7 @@ class TestAuth(Tester):
 
         assert_invalid(cassandra, "REVOKE ALL ON KEYSPACE ks FROM nonexistent", "(User|Role) nonexistent doesn't exist")
 
+    @pytest.mark.max_running_shards(2)
     @pytest.mark.single_node
     def test_grant_revoke_cleanup(self):
         """
@@ -791,6 +818,7 @@ class TestAuth(Tester):
 
         self.assert_unauthorized("User cathy has no SELECT permission on <table ks.cf> or any of its parents", cathy, "SELECT * FROM ks.cf")
 
+    @pytest.mark.max_running_shards(2)
     @pytest.mark.single_node
     def test_type_auth(self):
         """
@@ -849,6 +877,7 @@ class TestAuth(Tester):
         if not (expect_rf_err or expect_auth_err or expect_invalid_req):
             logger.info("Good: session is available as expected")
 
+    @pytest.mark.max_running_shards(2)
     @pytest.mark.single_node
     def test_drop_keyspace_system_auth_1_node(self):
         """
@@ -870,6 +899,7 @@ class TestAuth(Tester):
         except Unauthorized as e:
             assert str(e) == 'Error from server: code=2100 [Unauthorized] message="Cannot DROP <keyspace system_auth>"'
 
+    @pytest.mark.max_running_shards(2)
     @pytest.mark.single_node
     def test_change_setting_to_noauth_after_system_auth_was_lost(self):
         """
@@ -889,6 +919,7 @@ class TestAuth(Tester):
             with pytest.raises(Unauthorized, match=r'Error from server: code=2100 \[Unauthorized\] message="You have to be logged in and not ' 'anonymous to perform this request"'):
                 session.execute("LIST USERS")
 
+    @pytest.mark.max_running_shards(2)
     @pytest.mark.single_node
     def test_restart_node_doesnt_lose_auth_data(self):
         """
@@ -923,6 +954,7 @@ class TestAuth(Tester):
 
         philip.execute("SELECT * FROM ks.cf")
 
+    @pytest.mark.max_running_shards(2)
     @pytest.mark.single_node
     def test_system_keyspace_sensitive(self):
         """
@@ -957,6 +989,7 @@ class TestAuth(Tester):
             except InvalidRequest as e:
                 self.assertEquals(str(e), 'Cannot DROP <keyspace %s>' % name.lower())"""
 
+    @pytest.mark.max_running_shards(2)
     @pytest.mark.single_node
     def test_all_authorization_operations(self):
         """
@@ -1034,6 +1067,7 @@ class TestAuth(Tester):
 
         self.assert_unauthorized("You are not authorized to view cathy's permissions", bob, "LIST ALL PERMISSIONS OF cathy")
 
+    @pytest.mark.max_running_shards(4)
     def test_authentication_enabled_only_in_one_node(self):
         """
         **Description:** Authentication is enabled only in one node while disabled in others -
@@ -1084,6 +1118,7 @@ class TestAuth(Tester):
         except Exception as e:  # noqa: BLE001
             assert str(e) == 'Error from server: code=2100 [Unauthorized] message="You have to be logged in and not anonymous to perform this request"'
 
+    @pytest.mark.max_running_shards(4)
     def test_transitional_auth_betweenness_from_default(self):
         """
         Start cluster with default Auth, test user permission during rolling upgrade of enable Transitional Auth.
@@ -1116,6 +1151,7 @@ class TestAuth(Tester):
         session = self.get_session(node_idx=1, user="normal", password="123456")
         self.assert_unauthorized("You have to be logged in and not anonymous to perform this request", session, "LIST USERS")
 
+    @pytest.mark.max_running_shards(4)
     def test_transitional_auth_betweenness_from_pwdauth(self):
         """
         Start cluster with strict Auth, test user permission during rolling upgrade of enable Transitional Auth.

--- a/test/cluster/dtest/batch_test.py
+++ b/test/cluster/dtest/batch_test.py
@@ -182,6 +182,7 @@ class BatchTester:
 class TestBatch(Tester):
     """Batch tests grouped by cluster topology to enable cluster reuse."""
 
+    @pytest.mark.max_running_shards(2)
     @pytest.mark.single_node
     def test_single_node_batch_group(self):
         """Group of tests that reuse a single-node cluster.
@@ -212,6 +213,7 @@ class TestBatch(Tester):
         logger.info("Running: check_unlogged_batch_gcgs_below_threshold_should_not_print_warning")
         bt.check_unlogged_batch_gcgs_below_threshold_should_not_print_warning(session)
 
+    @pytest.mark.max_running_shards(6)
     def test_multi_node_batch_group(self):
         """Group of tests that reuse a 3-node cluster."""
         bt = BatchTester(self)

--- a/test/cluster/dtest/bypass_cache_test.py
+++ b/test/cluster/dtest/bypass_cache_test.py
@@ -147,6 +147,7 @@ class TestBypassCache(Tester):
         )
         assert not errors, "Running query that is suppose to read from cache following errors found:\n" + "\n".join(errors)
 
+    @pytest.mark.max_running_shards(2)
     def test_simple_bypass_cache(self):
         session = self.prepare()
         node = self.cluster.nodelist()[0]
@@ -154,6 +155,7 @@ class TestBypassCache(Tester):
 
         self.verify_read_was_from_disk(node=node, query=query, session=session)
 
+    @pytest.mark.max_running_shards(2)
     def test_multiple_bypass_cache(self):
         session = self.prepare()
         node = self.cluster.nodelist()[0]
@@ -162,6 +164,7 @@ class TestBypassCache(Tester):
             query = "SELECT * FROM cf BYPASS CACHE"
             self.verify_read_was_from_disk(node=node, query=query, session=session)
 
+    @pytest.mark.max_running_shards(2)
     def test_read_from_cache_and_then_bypass_cache(self):
         session = self.prepare()
         node = self.cluster.nodelist()[0]
@@ -215,6 +218,7 @@ class TestBypassCache(Tester):
         )
         assert not errors, "Running range query that is suppose to read from disk following errors found:\n" + "\n".join(errors)
 
+    @pytest.mark.max_running_shards(2)
     def test_full_scan_bypass_cache(self):
         session = self.prepare()
         node = self.cluster.nodelist()[0]
@@ -239,6 +243,7 @@ class TestBypassCache(Tester):
             },
         )
 
+    @pytest.mark.max_running_shards(2)
     def test_parallelized_aggregation_range_scan_no_bypass_cache(self):
         """Verify that select_partition_range_scan_no_bypass_cache is incremented
         for parallelized aggregation queries (e.g. SELECT count(*) FROM ...) that
@@ -298,6 +303,7 @@ class TestBypassCache(Tester):
         )
         assert not errors, "Parallelized aggregation with BYPASS CACHE metric errors:\n" + "\n".join(errors)
 
+    @pytest.mark.max_running_shards(2)
     @pytest.mark.parametrize("cache_index_pages", [True, False], ids=["cache_index_pages", "no_cache_index_pages"])
     def test_create_table_caching_disabled(self, cache_index_pages: bool):
         session = self.prepare(insert_data=False, cache_index_pages=cache_index_pages)
@@ -309,6 +315,7 @@ class TestBypassCache(Tester):
         # TODO: After https://github.com/scylladb/scylla/issues/9968 is solved, remove index_cache_involved=True
         self.verify_read_was_from_disk(node=node, query=query, session=session, index_cache_involved=cache_index_pages)
 
+    @pytest.mark.max_running_shards(2)
     @pytest.mark.parametrize("cache_index_pages", [True, False], ids=["cache_index_pages", "no_cache_index_pages"])
     def test_alter_table_caching_disable(self, cache_index_pages: bool):
         session = self.prepare(insert_data=False, cache_index_pages=cache_index_pages)
@@ -323,6 +330,7 @@ class TestBypassCache(Tester):
         # TODO: After https://github.com/scylladb/scylla/issues/9968 is solved, remove index_cache_involved=True
         self.verify_read_was_from_disk(node=node, query=query, session=session, index_cache_involved=cache_index_pages)
 
+    @pytest.mark.max_running_shards(2)
     @pytest.mark.parametrize("cache_index_pages", [True, False], ids=["cache_index_pages", "no_cache_index_pages"])
     def test_alter_table_caching_enable(self, cache_index_pages: bool):
         session = self.prepare(insert_data=False, cache_index_pages=cache_index_pages)

--- a/test/cluster/dtest/cfid_test.py
+++ b/test/cluster/dtest/cfid_test.py
@@ -15,6 +15,7 @@ from dtest_class import Tester, create_cf, create_ks
 
 @pytest.mark.single_node
 class TestCFID(Tester):
+    @pytest.mark.max_running_shards(2)
     @pytest.mark.cluster_options(auto_snapshot=True)
     def test_cfid(self):
         """

--- a/test/cluster/dtest/commitlog_test.py
+++ b/test/cluster/dtest/commitlog_test.py
@@ -162,6 +162,7 @@ class TestCommitLog(Tester):
                 else:
                     raise e
 
+    @pytest.mark.max_running_shards(2)
     def test_commitlog_replay_on_startup(self):
         """Test commit log replay"""
         node1 = self.node1
@@ -219,6 +220,7 @@ class TestCommitLog(Tester):
         res = session.execute("SELECT * FROM Test. users")
         assert_lists_equal_ignoring_order(rows_to_list(res), [["gandalf", 1955, "male", "p@$$", "WA"]])
 
+    @pytest.mark.max_running_shards(2)
     def test_commitlog_replay_with_alter_table(self):
         """
         Test commit log replay with alter table
@@ -319,21 +321,25 @@ class TestCommitLog(Tester):
                 ignore_order=True,
             )
 
+    @pytest.mark.max_running_shards(2)
     def test_default_segment_size(self):
         """Test default commitlog_segment_size_in_mb (32MB)"""
 
         self._segment_size_test(32)
 
+    @pytest.mark.max_running_shards(2)
     def test_small_segment_size(self):
         """Test a small commitlog_segment_size_in_mb (5MB)"""
 
         self._segment_size_test(5)
 
+    @pytest.mark.max_running_shards(2)
     def test_default_compressed_segment_size(self):
         """Test default compressed commitlog_segment_size_in_mb (32MB)"""
         # Scylla: Unknown option commitlog_compression
         self._segment_size_test(32, compressed=True)
 
+    @pytest.mark.max_running_shards(2)
     def test_small_compressed_segment_size(self):
         """Test a small compressed commitlog_segment_size_in_mb (5MB)"""
         # Scylla: Unknown option commitlog_compression
@@ -364,6 +370,7 @@ class TestCommitLog(Tester):
         )
         return session, node1
 
+    @pytest.mark.max_running_shards(2)
     def test_periodic_commitlog(self):
         """
         Test periodic mode of commitlog flushing
@@ -519,18 +526,21 @@ class TestCommitLog(Tester):
         insert_c1c2(session, n=int(total_size * 1.5))
         assert_row_count(session=session, table_name="ks.cf", expected=int(total_size * 1.5))
 
+    @pytest.mark.max_running_shards(2)
     def test_total_space_limit_of_commitlog_with_memory_based_limit(self):
         """
         Test with auto-sized commitlog files, and total space limit (based on available memory)
         """
         self._test_total_space_limit_of_commitlog(commitlog_segment_size_in_mb=-1, commitlog_total_space_in_mb=-1)
 
+    @pytest.mark.max_running_shards(2)
     def test_total_space_limit_of_commitlog_with_small_limit(self):
         """
         Test with 5M commitlog files, total space limit is 30M
         """
         self._test_total_space_limit_of_commitlog(commitlog_segment_size_in_mb=5, commitlog_total_space_in_mb=30)
 
+    @pytest.mark.max_running_shards(2)
     def test_alter_keyspace_durable_writes_false(self):
         """
         Test 'CREATE KEYSPACE ... WITH durable_writes = false;'
@@ -570,6 +580,7 @@ class TestCommitLog(Tester):
         session = self.patient_cql_connection(node1)
         assert_all(session=session, query="SELECT * FROM dw.cf", expected=[[1], [2]], ignore_order=True)
 
+    @pytest.mark.max_running_shards(2)
     def test_alter_keyspace_durable_writes_true(self):
         """
         Test 'ALTER KEYSPACE ... WITH durable_writes = true;'
@@ -633,6 +644,7 @@ class TestCommitLog(Tester):
         session.execute(create_statement)
         self.insert_statement = session.prepare(f"INSERT INTO {self.ks}.{self.cf} ({', '.join(f'c{i:05d}' for i in range(columns))}) VALUES({', '.join('?' for i in range(columns))});")
 
+    @pytest.mark.max_running_shards(2)
     def test_one_big_mutation_replay_on_startup(self):
         """
         Test commit log replay with a single big (larger than mutation limit) commitlog mutation
@@ -659,6 +671,7 @@ class TestCommitLog(Tester):
         assert node1.grep_log(f"large_data - Writing large row {self.ks}/{self.cf}:")
         assert in_table == [self.values]
 
+    @pytest.mark.max_running_shards(2)
     def test_one_big_mutation_corrupted_on_startup(self):
         """
         Test commit log replay with a single big (larger than mutation limit) commitlog mutation
@@ -696,6 +709,7 @@ class TestCommitLog(Tester):
         assert node1.grep_log("commitlog_replayer - Corrupted file")
         assert in_table == []
 
+    @pytest.mark.max_running_shards(2)
     def test_one_big_mutation_rollback_on_startup(self):
         """
         Test commit log replay with a single big (larger than mutation limit) commitlog mutation
@@ -723,6 +737,7 @@ class TestCommitLog(Tester):
         assert not node1.grep_log(f"large_data - Writing large row {self.ks}/{self.cf}")
         assert in_table == []
 
+    @pytest.mark.max_running_shards(2)
     def test_pinned_cl_segment_doesnt_resurrect_data(self):
         """
         The tested scenario is as follows:

--- a/test/cluster/dtest/counter_test.py
+++ b/test/cluster/dtest/counter_test.py
@@ -59,6 +59,7 @@ class TestCounters(Tester):
             r"raft - apply_snapshot\[[0-9a-f-]+\] failed with std::runtime_error \(Snapshot application aborted\)",
         ]
 
+    @pytest.mark.max_running_shards(6)
     def test_simple_increment(self):
         """Simple incrementation test (Created for #3465, that wasn't a bug)"""
         cluster = self.cluster
@@ -91,6 +92,7 @@ class TestCounters(Tester):
                 assert len(res[c]) == 2, "Expecting key and counter for counter%i, got %s" % (c, str(res[c]))
                 assert res[c][1] == i + 1, "Expecting counter%i = %i, got %i" % (c, i + 1, res[c][1])
 
+    @pytest.mark.max_running_shards(4)
     def test_upgrade(self):
         """Test for bug of #4436"""
 
@@ -159,6 +161,7 @@ class TestCounters(Tester):
 
         check(3)
 
+    @pytest.mark.max_running_shards(6)
     def test_counter_consistency(self):
         """
         Do a bunch of writes with ONE, read back with ALL and check results.
@@ -258,6 +261,7 @@ class TestCounters(Tester):
             assert counter_one_actual == counter_dict[counter_id]["counter_one"]
             assert counter_two_actual == counter_dict[counter_id]["counter_two"]
 
+    @pytest.mark.max_running_shards(6)
     def test_multi_counter_update(self):
         """
         Test for singlular update statements that will affect multiple counters.
@@ -310,6 +314,7 @@ class TestCounters(Tester):
             assert count and len(count[0]), f"Expected counter_one={v} for myuuid={k}, got: {count}"
             assert v == count[0][0]
 
+    @pytest.mark.max_running_shards(2)
     @pytest.mark.single_node
     def test_validate_empty_column_name(self):
         cluster = self.cluster
@@ -344,6 +349,7 @@ class TestCounters(Tester):
 
         assert_one(session, "SELECT pk, ck, value FROM compact_counter_table", [0, "ck", 3])
 
+    @pytest.mark.max_running_shards(2)
     @pytest.mark.single_node
     def test_drop_counter_column(self):
         """Test for CASSANDRA-7831"""
@@ -368,6 +374,7 @@ class TestCounters(Tester):
 
         assert_invalid(session, "ALTER TABLE counter_bug add c counter", "Cannot re-add previously dropped counter column c")
 
+    @pytest.mark.max_running_shards(6)
     def test_increment_counters_in_threads(self):
         """
         3 nodes in test
@@ -426,6 +433,7 @@ class TestCounters(Tester):
             assert len(res[c]) == 2, "Expecting key and counter for counter%i, got %s" % (c, str(res[c]))
             assert res[c][1] == expected_counters, "Expecting counter%i = %i, got %i" % (c, expected_counters, res[c][1])
 
+    @pytest.mark.max_running_shards(6)
     def test_increment_decrement_counters_in_threads(self):
         """
         3 nodes in test
@@ -495,6 +503,7 @@ class TestCounters(Tester):
             assert len(res[c]) == 2, "Expecting key and counter for counter%i, got %s" % (c, str(res[c]))
             assert res[c][1] == expected_counters, "Expecting counter%i = %i, got %i" % (c, expected_counters, res[c][1])
 
+    @pytest.mark.max_running_shards(2)
     @pytest.mark.single_node
     def test_update_counter_with_ttl_and_timestamp_negative(self):
         """
@@ -512,6 +521,7 @@ class TestCounters(Tester):
             with pytest.raises(InvalidRequest):
                 session.execute(f"UPDATE counters USING {option} SET c = c + 1 where t = 1")
 
+    @pytest.mark.max_running_shards(2)
     @pytest.mark.single_node
     def test_prepare_statement(self):
         """
@@ -577,6 +587,7 @@ class TestCounters(Tester):
             session.execute(query)
         assert re.search(message, str(cm)), f"Expected '{message}', but got '{cm.typename}'"
 
+    @pytest.mark.max_running_shards(2)
     @pytest.mark.single_node
     def test_static_counter_column(self):
         """
@@ -624,6 +635,7 @@ class TestCounters(Tester):
             assert rows[i - 1][0] == 200
             assert rows[i - 1][1] == i + 1
 
+    @pytest.mark.max_running_shards(6)
     def test_compact_counter_cluster(self):
         """
         @jira_ticket CASSANDRA-12219
@@ -759,6 +771,7 @@ class TestCountersOnMultipleNodes(Tester):
         for node in (self.node1, self.node2):
             node.start(wait_other_notice=True)
 
+    @pytest.mark.max_running_shards(6)
     def test_counter_consistency_node_replace(self):
         """
         Cluster: 3 nodes, keyspace RF=2
@@ -774,6 +787,7 @@ class TestCountersOnMultipleNodes(Tester):
         logger.debug("Start the new node")
         node4.start(replace_node_host_id=self.node3.hostid(), wait_for_binary_proto=True)
 
+    @pytest.mark.max_running_shards(6)
     def test_counter_consistency_node_remove(self):
         """
         Cluster: 3 nodes, keyspace RF=2
@@ -788,6 +802,7 @@ class TestCountersOnMultipleNodes(Tester):
         self.node2.stop(wait_other_notice=True)
         self.node1.nodetool("removenode %s" % node2_hostid)
 
+    @pytest.mark.max_running_shards(8)
     def test_counter_consistency_node_add(self):
         """
         Cluster: 3 nodes, keyspace RF=2
@@ -801,6 +816,7 @@ class TestCountersOnMultipleNodes(Tester):
         node4 = new_node(self.cluster, bootstrap=True, data_center=self.node3.data_center, rack=self.node3.rack)
         node4.start(wait_for_binary_proto=True)
 
+    @pytest.mark.max_running_shards(6)
     def test_counter_consistency_node_decommission(self):
         """
         Cluster: 3 nodes, keyspace RF=1
@@ -814,6 +830,7 @@ class TestCountersOnMultipleNodes(Tester):
         self.node2.decommission()
         self.node2.stop()
 
+    @pytest.mark.max_running_shards(6)
     def test_counter_consistency_node_repair(self):
         """
         Cluster: 3 nodes, keyspace RF=3
@@ -843,6 +860,7 @@ class TestCountersOnMultipleNodes(Tester):
         logger.debug("Verify new data is present on node3")
         self._verify_data_repair(self._extra_row_cnt)
 
+    @pytest.mark.max_running_shards(6)
     def test_counter_consistency_node_rebuild(self):
         """
         Cluster: 3 nodes, keyspace RF=3

--- a/test/cluster/dtest/error_example_test.py
+++ b/test/cluster/dtest/error_example_test.py
@@ -5,12 +5,14 @@
 #
 
 from dtest_class import Tester, create_ks
+import pytest
 
 
 MY_NODE = 0
 
 
 class TestExample(Tester):
+    @pytest.mark.max_running_shards(6)
     def test_some(self, nodes=3, rf=3, jvm_args=None):
         cluster = self.cluster
         cluster.populate(nodes).start(wait_for_binary_proto=True)

--- a/test/cluster/dtest/limits_test.py
+++ b/test/cluster/dtest/limits_test.py
@@ -91,6 +91,7 @@ class TestLimits(Tester):
         assert len(res.current_rows) == 1
         session.execute("""DROP TABLE test1""")
 
+    @pytest.mark.max_running_shards(2)
     def test_max_key_length(self):
         cluster = self.prepare()
         cluster.populate(1).start()
@@ -150,6 +151,7 @@ class TestLimits(Tester):
         assert len(list(res)) == 1
         session.execute("""DROP TABLE test1""")
 
+    @pytest.mark.max_running_shards(2)
     def test_max_column_value_size(self):
         cluster = self.prepare()
         cluster.populate(1).start()
@@ -193,6 +195,7 @@ class TestLimits(Tester):
 
         session.execute("""DROP TABLE stuff""")
 
+    @pytest.mark.max_running_shards(2)
     def test_max_tuple(self):
         cluster = self.prepare()
         cluster.populate(1).start()
@@ -233,6 +236,7 @@ class TestLimits(Tester):
         assert len(list(res)) == rows
         session.execute("""DROP TABLE STUFF""")
 
+    @pytest.mark.max_running_shards(2)
     def test_max_batch_size(self):
         cluster = self.prepare()
         cluster.populate(1).start()
@@ -275,6 +279,7 @@ class TestLimits(Tester):
 
         session.execute("""TRUNCATE test1""")
 
+    @pytest.mark.max_running_shards(2)
     def test_max_cells(self):
         if self.cluster.scylla_mode == "debug":
             skip_env("client times out in debug mode")

--- a/test/cluster/dtest/rebuild_test.py
+++ b/test/cluster/dtest/rebuild_test.py
@@ -19,6 +19,7 @@ logger = logging.getLogger(__name__)
 
 
 class TestRebuildStreamingAbortRepro(Tester):
+    @pytest.mark.max_running_shards(6)
     @pytest.mark.cluster_options(allowed_repair_based_node_ops="")
     def test_rebuild_stream_abort_repro(self):
         """2-DC cluster parallel non-RBNO rebuild failure when expanding RF in DC2 (#27804.)

--- a/test/cluster/dtest/schema_management_test.py
+++ b/test/cluster/dtest/schema_management_test.py
@@ -43,6 +43,7 @@ class TestSchemaManagement(Tester):
         return cluster
 
 
+    @pytest.mark.max_running_shards(6)
     def test_prepared_statements_work_after_node_restart_after_altering_schema_without_changing_columns(self):
         cluster = self.prepare(racks_num=3)
 
@@ -89,6 +90,7 @@ class TestSchemaManagement(Tester):
             expected = [i, "A", "B"]
             assert list(res[i]) == expected, f"Expected {expected}, got {res[i]}"
 
+    @pytest.mark.max_running_shards(2)
     def test_dropping_keyspace_with_many_columns(self):
         """
         Exploits https://github.com/scylladb/scylla/issues/1484
@@ -108,6 +110,7 @@ class TestSchemaManagement(Tester):
             s.execute("CREATE KEYSPACE testxyz WITH replication = { 'class' : 'NetworkTopologyStrategy', 'replication_factor' : 1 }")
             s.execute("drop keyspace testxyz")
 
+    @pytest.mark.max_running_shards(6)
     def test_multiple_create_table_in_parallel(self):
         """
         Run multiple create table statements via different nodes
@@ -153,6 +156,7 @@ class TestSchemaManagement(Tester):
         rows = sessions[0].execute(SimpleStatement(f"SELECT * FROM {ks}.{step3_table}", consistency_level=ConsistencyLevel.ALL))
         assert len(rows_to_list(rows)) == 1, f"Expected 1 row but got rows:{rows} instead"
 
+    @pytest.mark.max_running_shards(6)
     @pytest.mark.parametrize("case", ("write", "read", "mixed"))
     def test_alter_table_in_parallel_to_read_and_write(self, case):
         """
@@ -250,6 +254,7 @@ class TestSchemaManagement(Tester):
         """
         raise NotImplementedError
 
+    @pytest.mark.max_running_shards(6)
     @pytest.mark.parametrize("case", ("create_table", "alter_table", "drop_table"))
     def test_update_schema_while_node_is_killed(self, case):
         """
@@ -340,6 +345,7 @@ class TestSchemaManagement(Tester):
         logger.debug("verify that commitlog has been replayed and that all data is restored")
         expected_case_result_map[case]()
 
+    @pytest.mark.max_running_shards(6)
     @pytest.mark.parametrize("is_gently_stop", [True, False])
     def test_nodes_rejoining_a_cluster_synch_on_schema(self, is_gently_stop):
         """
@@ -390,6 +396,7 @@ class TestSchemaManagement(Tester):
         for key in range(10):
             query_c1c2(session=session, key=key, consistency=ConsistencyLevel.ALL)
 
+    @pytest.mark.max_running_shards(6)
     def test_reads_schema_recreated_while_node_down(self):
         cluster = self.prepare(racks_num=3)
 
@@ -419,6 +426,7 @@ class TestSchemaManagement(Tester):
         rows = session.execute(SimpleStatement("SELECT * FROM cf", consistency_level=ConsistencyLevel.ALL))
         assert rows_to_list(rows) == [], f"Expected an empty result set, got {rows}"
 
+    @pytest.mark.max_running_shards(6)
     def test_writes_schema_recreated_while_node_down(self):
         cluster = self.prepare(racks_num=3)
 
@@ -551,6 +559,7 @@ class TestLargePartitionAlterSchema(Tester):
         logger.debug(f"Drop {column_name} column")
         session.execute(f"ALTER TABLE lp_table DROP {column_name}")
 
+    @pytest.mark.max_running_shards(2)
     def test_large_partition_with_add_column(self):
         cluster_topology = generate_cluster_topology()
         session = self.prepare(cluster_topology, rf=1)
@@ -594,6 +603,7 @@ class TestLargePartitionAlterSchema(Tester):
 
         assert_all(session, f"select pk, ck1, val1, val2, new_clmn from lp_table", data, ignore_order=True, print_result_on_failure=False)
 
+    @pytest.mark.max_running_shards(2)
     def test_large_partition_with_drop_column(self):
         cluster_topology = generate_cluster_topology()
         session = self.prepare(cluster_topology, rf=1)
@@ -732,6 +742,7 @@ class TestSchemaHistory(Tester):
         self.session = self.patient_cql_connection(self.cluster.nodelist()[0], row_factory=dict_factory)
         create_ks(self.session, "lwt_load_ks", rf)
 
+    @pytest.mark.max_running_shards(6)
     def test_schema_history_alter_table(self):
         """test schema history changes following alter table cql commands"""
         self.prepare()

--- a/test/cluster/dtest/scrub_test.py
+++ b/test/cluster/dtest/scrub_test.py
@@ -245,6 +245,7 @@ class TestScrubIndexes(TestHelper):
         assert len(ret) == 8, "Invalid number of records in table 'users'"
         return ret
 
+    @pytest.mark.max_running_shards(2)
     def test_scrub_static_table(self):
         cluster = self.cluster
         cluster.set_configuration_options(
@@ -287,6 +288,7 @@ class TestScrubIndexes(TestHelper):
         users = self.query_users(session)
         assert initial_users == users, "List of users before and after scrub are different"
 
+    @pytest.mark.max_running_shards(2)
     def test_standalone_scrub(self):
         cluster = self.cluster
         cluster.populate(1).start()
@@ -313,6 +315,7 @@ class TestScrubIndexes(TestHelper):
         users = self.query_users(session)
         assert initial_users == users, "List of users before and after scrub are different"
 
+    @pytest.mark.max_running_shards(2)
     def test_scrub_collections_table_without_indexes(self):
         cluster = self.cluster
         cluster.set_configuration_options(
@@ -383,6 +386,7 @@ class TestScrub(TestHelper):
         assert len(ret) == 5, "Amount of users is different"
         return ret
 
+    @pytest.mark.max_running_shards(2)
     def test_nodetool_scrub(self):
         cluster = self.cluster
         cluster.set_configuration_options(
@@ -425,6 +429,7 @@ class TestScrub(TestHelper):
         users = self.query_users(session)
         assert initial_users == users, "List of users before and after scrub are different"
 
+    @pytest.mark.max_running_shards(2)
     def test_standalone_scrub(self):
         cluster = self.cluster
         cluster.populate(1).start()
@@ -451,6 +456,7 @@ class TestScrub(TestHelper):
         users = self.query_users(session)
         assert initial_users == users, "List of users before and after scrub are different"
 
+    @pytest.mark.max_running_shards(2)
     def test_standalone_scrub_essential_files_only(self):
         cluster = self.cluster
         cluster.populate(1).start()
@@ -479,6 +485,7 @@ class TestScrub(TestHelper):
         users = self.query_users(session)
         assert initial_users == users, "List of users before and after scrub are different"
 
+    @pytest.mark.max_running_shards(2)
     def test_scrub_with_udt(self):
         """
         @jira_ticket CASSANDRA-7665

--- a/test/cluster/dtest/set_smp_test.py
+++ b/test/cluster/dtest/set_smp_test.py
@@ -24,6 +24,7 @@ class TestSetSmp(Tester):
         # Return the last match (most recent start)
         return int(matches[-1][1].group(1))
 
+    @pytest.mark.max_running_shards(2)
     def test_set_smp(self):
         """Verify that set_smp() takes effect on the next start."""
         cluster = self.cluster

--- a/test/cluster/lwt/test_lwt_contention.py
+++ b/test/cluster/lwt/test_lwt_contention.py
@@ -285,6 +285,7 @@ async def _run_workload(
         await tester.verify_consistency()
 
 
+@pytest.mark.max_running_shards(6)
 @pytest.mark.tier2
 async def test_lwt_contention_many_workers(manager: ScyllaClusterManager, scale_timeout, build_mode, contention_cluster):
     """
@@ -308,6 +309,7 @@ async def test_lwt_contention_many_workers(manager: ScyllaClusterManager, scale_
     )
 
 
+@pytest.mark.max_running_shards(6)
 @pytest.mark.tier2
 async def test_lwt_contention_multi_iterations(manager: ScyllaClusterManager, scale_timeout, contention_cluster):
     """

--- a/test/cluster/lwt/test_lwt_during_tablets_migration.py
+++ b/test/cluster/lwt/test_lwt_during_tablets_migration.py
@@ -96,6 +96,7 @@ async def tablet_migration_ops(stop_event: asyncio.Event,
     logger.info("Completed tablet migration ops: %d/%d", migration_count, num_ops)
 
 
+@pytest.mark.max_running_shards(8)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 @pytest.mark.skip_mode(mode='debug', reason='debug mode is too slow for this test')
 async def test_multi_column_lwt_during_migration(manager: ScyllaClusterManager, scale_timeout):

--- a/test/cluster/lwt/test_lwt_during_tablets_resize.py
+++ b/test/cluster/lwt/test_lwt_during_tablets_resize.py
@@ -131,6 +131,7 @@ async def run_random_resizes(
     }
 
 
+@pytest.mark.max_running_shards(12)
 @pytest.mark.no_parallel
 async def test_multi_column_lwt_during_split_merge(manager: ScyllaClusterManager, scale_timeout):
     """

--- a/test/cluster/lwt/test_lwt_with_counters_during_tablets_resize_and_migrations.py
+++ b/test/cluster/lwt/test_lwt_with_counters_during_tablets_resize_and_migrations.py
@@ -292,6 +292,7 @@ async def run_random_resizes(
         "seen_merge": merge_count,
     }
 
+@pytest.mark.max_running_shards(12)
 @pytest.mark.no_parallel
 async def test_multi_column_lwt_migrate_and_random_resizes(manager: ScyllaClusterManager, scale_timeout):
 

--- a/test/cluster/mv/tablets/test_mv_tablets.py
+++ b/test/cluster/mv/tablets/test_mv_tablets.py
@@ -60,6 +60,7 @@ async def assert_one_tablet(cql, keyspace_name, table_or_view_name):
     assert len(rows) == 1
 
 
+@pytest.mark.max_running_shards(2)
 async def test_tablet_mv_create(manager: ScyllaClusterManager):
     """A basic test for creating a materialized view on a table stored
        with tablets on a one-node cluster. We just create the view and
@@ -74,6 +75,7 @@ async def test_tablet_mv_create(manager: ScyllaClusterManager):
         await cql.run_async(f"CREATE MATERIALIZED VIEW {ks}.tv AS SELECT * FROM {ks}.test WHERE c IS NOT NULL AND pk IS NOT NULL PRIMARY KEY (c, pk)")
 
 
+@pytest.mark.max_running_shards(2)
 async def test_tablet_mv_simple(manager: ScyllaClusterManager):
     """A simple test for reading and writing a materialized view on a table
        stored with tablets on a one-node cluster. Because it's a one-node
@@ -92,6 +94,7 @@ async def test_tablet_mv_simple(manager: ScyllaClusterManager):
         # We used SYNCHRONOUS_UPDATES=TRUE, so the view should be updated:
         assert [(3,2)] == list(await cql.run_async(f"SELECT * FROM {ks}.tv WHERE c=3"))
 
+@pytest.mark.max_running_shards(12)
 async def test_tablet_mv_simple_6node(manager: ScyllaClusterManager):
     """A simple reproducer for a bug of forgetting that the view table has a
        different tablet mapping from the base: Using the wrong tablet mapping
@@ -116,6 +119,7 @@ async def inject_error_on(manager, error_name, servers):
     errs = [manager.api.enable_injection(s.ip_addr, error_name, False) for s in servers]
     await asyncio.gather(*errs)
 
+@pytest.mark.max_running_shards(4)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_tablet_alternator_lsi_consistency(manager: ScyllaClusterManager):
     """A reproducer for a bug where Alternator LSI was not using synchronous
@@ -193,6 +197,7 @@ async def test_tablet_alternator_lsi_consistency(manager: ScyllaClusterManager):
     )
     table.delete()
 
+@pytest.mark.max_running_shards(2)
 async def test_tablet_si_create(manager: ScyllaClusterManager):
     """A basic test for creating a secondary index on a table stored
        with tablets on a one-node cluster. We just create the index and
@@ -207,6 +212,7 @@ async def test_tablet_si_create(manager: ScyllaClusterManager):
         await cql.run_async(f"CREATE INDEX my_idx ON {ks}.test(c)")
         await cql.run_async(f"DROP INDEX {ks}.my_idx")
 
+@pytest.mark.max_running_shards(2)
 async def test_tablet_lsi_create(manager: ScyllaClusterManager):
     """A basic test for creating a *local* secondary index on a table stored
        with tablets on a one-node cluster. We just create the index and
@@ -221,6 +227,7 @@ async def test_tablet_lsi_create(manager: ScyllaClusterManager):
         await cql.run_async(f"CREATE INDEX my_idx ON {ks}.test((pk),c)")
         await cql.run_async(f"DROP INDEX {ks}.my_idx")
 
+@pytest.mark.max_running_shards(4)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_tablet_cql_lsi(manager: ScyllaClusterManager):
     """A simple reproducer for issue #16371 where CQL LSI (local secondary
@@ -271,6 +278,7 @@ async def test_tablet_cql_lsi(manager: ScyllaClusterManager):
         # immediately after the previous INSERT returned.
         assert [(7,42)] == list(await cql.run_async(f"SELECT * FROM {ks}.test WHERE pk=7 AND c=42"))
 
+@pytest.mark.max_running_shards(2)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_mv_tablet_split(manager: ScyllaClusterManager):
     """A basic test for checking that tablet split works on MV tables.

--- a/test/cluster/mv/tablets/test_mv_tablets_empty_ip.py
+++ b/test/cluster/mv/tablets/test_mv_tablets_empty_ip.py
@@ -25,6 +25,7 @@ logger = logging.getLogger(__name__)
 #
 # RF needs to be smaller than the cluster size in order ensure appearance of
 # remote view updates.
+@pytest.mark.max_running_shards(8)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 @pytest.mark.skip_mode(mode='debug', reason='node replace needs to wait for tablet rebuild, which takes a lot of time in debug mode')
 async def test_mv_tablets_empty_ip(manager: ScyllaClusterManager):

--- a/test/cluster/mv/tablets/test_mv_tablets_merge.py
+++ b/test/cluster/mv/tablets/test_mv_tablets_merge.py
@@ -15,6 +15,7 @@ from test.pylib.util import wait_for, wait_for_cql_and_get_hosts
 logger = logging.getLogger(__name__)
 
 
+@pytest.mark.max_running_shards(2)
 async def test_mv_merge_allowed(manager):
     """
     Test that tablet merge is allowed for materialized views and their base tables.

--- a/test/cluster/mv/tablets/test_mv_tablets_replace.py
+++ b/test/cluster/mv/tablets/test_mv_tablets_replace.py
@@ -64,6 +64,7 @@ def select_non_coordinator_replica_pair(base_by_rack, view_by_rack, coord_serv):
         f"base_by_rack={base_by_rack}, view_by_rack={view_by_rack}")
 
 
+@pytest.mark.max_running_shards(5)
 @pytest.mark.tier2
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_tablet_mv_replica_pairing_during_replace(manager: ScyllaClusterManager, scale_timeout: Callable[[int | float], int | float]):

--- a/test/cluster/mv/test_mv_admission_control.py
+++ b/test/cluster/mv/test_mv_admission_control.py
@@ -23,6 +23,7 @@ logger = logging.getLogger(__name__)
 # In the test, we create a table and perform a pair of writes to it. The
 # second write should fail due to admission control. We check that this
 # is indeed the error thrown.
+@pytest.mark.max_running_shards(2)
 @pytest.mark.skip_mode(mode='release', reason="error injections aren't enabled in release mode")
 async def test_mv_admission_control_exception(manager: ScyllaClusterManager) -> None:
     node_count = 2
@@ -59,6 +60,7 @@ async def test_mv_admission_control_exception(manager: ScyllaClusterManager) -> 
 # are rejected by admission control and retried until they reach all replicas, instead
 # of succeeding just on the remaining replicas, reaching a quorum, but failing the
 # write on the slow node.
+@pytest.mark.max_running_shards(8)
 @pytest.mark.skip_mode(mode='release', reason="error injections aren't enabled in release mode")
 async def test_mv_retried_writes_reach_all_replicas(manager: ScyllaClusterManager) -> None:
     node_count = 4

--- a/test/cluster/mv/test_mv_backlog.py
+++ b/test/cluster/mv/test_mv_backlog.py
@@ -21,6 +21,7 @@ logger = logging.getLogger(__name__)
 # In the test, we create a table and perform a write to it a couple of times
 # Each time, we check that a view update backlog on some shard increased
 # due to the write.
+@pytest.mark.max_running_shards(10)
 @pytest.mark.skip_mode(mode='release', reason="error injections aren't enabled in release mode")
 async def test_view_backlog_increased_after_write(manager: ScyllaClusterManager) -> None:
     node_count = 2
@@ -51,6 +52,7 @@ async def test_view_backlog_increased_after_write(manager: ScyllaClusterManager)
 # This test reproduces issues #18461 and #18783
 # In the test, we create a table and perform a write to it that fills the view update backlog.
 # After a gossip round is performed, the following write should succeed.
+@pytest.mark.max_running_shards(4)
 @pytest.mark.skip_mode(mode='release', reason="error injections aren't enabled in release mode")
 async def test_gossip_same_backlog(manager: ScyllaClusterManager) -> None:
     node_count = 2
@@ -94,6 +96,7 @@ async def test_gossip_same_backlog(manager: ScyllaClusterManager) -> None:
 # Finally, calculate ratios between the measured delays - the ratios should be
 # the same as ratios of the view_flow_control_delay_limit_in_ms parameter
 # that was set during the measurement.
+@pytest.mark.max_running_shards(2)
 @pytest.mark.skip_mode(mode='release', reason="error injections aren't enabled in release mode")
 async def test_configurable_mv_control_flow_delay(manager: ScyllaClusterManager) -> None:
     node_count = 2

--- a/test/cluster/mv/test_mv_building.py
+++ b/test/cluster/mv/test_mv_building.py
@@ -49,6 +49,7 @@ async def resume_view_builder(manager: ManagerClient, servers):
 #
 # For more context, see: https://github.com/scylladb/scylladb/issues/21232.
 # This test reproduces the issue in non-tablet mode.
+@pytest.mark.max_running_shards(2)
 @pytest.mark.skip_mode(mode='debug', reason='the test needs to do some work which takes too much time in debug mode')
 async def test_view_building_scheduling_group(manager: ScyllaClusterManager):
     # Note: The view building coordinator works in the gossiping scheduling group,
@@ -98,6 +99,7 @@ async def test_view_building_scheduling_group(manager: ScyllaClusterManager):
 
 # A sanity check test ensures that starting and shutting down Scylla when view building is
 # disabled is conducted properly and we don't run into any issues.
+@pytest.mark.max_running_shards(2)
 @pytest.mark.check_nodes_for_errors
 async def test_start_scylla_with_view_building_disabled(manager: ScyllaClusterManager):
     server = await manager.server_add(config={"view_building": "false"})
@@ -110,6 +112,7 @@ async def test_start_scylla_with_view_building_disabled(manager: ScyllaClusterMa
 # While view building is in progress, drop the index (which changes the schema
 # of the base table). The state of the view table corresponding to the index
 # may become inconsistent with the base table because they got detached.
+@pytest.mark.max_running_shards(2)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_view_building_during_drop_index(manager: ScyllaClusterManager):
     server = await manager.server_add()
@@ -140,6 +143,7 @@ async def test_view_building_during_drop_index(manager: ScyllaClusterManager):
 # We restart the node in this state and verify that when it comes up the view building
 # is completed eventually and is correct.
 # Reproduces #22989
+@pytest.mark.max_running_shards(4)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_interrupt_view_build_shard_registration(manager: ScyllaClusterManager):
     cmdline = ['--smp=4']
@@ -184,6 +188,7 @@ async def test_interrupt_view_build_shard_registration(manager: ScyllaClusterMan
 # which have different progress, we won't mistakenly decide that a view is built
 # even if a build step is empty due to resharding.
 # Reproduces https://github.com/scylladb/scylladb/issues/26523
+@pytest.mark.max_running_shards(2)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_empty_build_step_after_reshard(manager: ScyllaClusterManager):
     server = await manager.server_add(cmdline=['--smp', '1', '--logger-log-level', 'view=debug'])
@@ -226,6 +231,7 @@ async def test_empty_build_step_after_reshard(manager: ScyllaClusterManager):
 # an empty build step after reshard doesn't crash. This test verifies that a build paused
 # mid-progress (with saved progress token) resumes correctly on a differently-sharded node.
 # Migrated from dtest materialized_views_test.py::TestInterruptBuildProcess::test_interrupt_build_process_with_resharding_*_test
+@pytest.mark.max_running_shards(2)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 @pytest.mark.parametrize("smp_before,smp_after", [
     (1, 2),   # increase shards
@@ -306,6 +312,7 @@ async def test_interrupt_build_with_resharding(manager: ManagerClient, smp_befor
 # they're most likely going to fail as well. Verify that that's the case.
 #
 # Reproduces scylladb/scylladb#26686.
+@pytest.mark.max_running_shards(4)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_backoff_when_node_fails_task_rpc(manager: ScyllaClusterManager):
     """
@@ -414,6 +421,7 @@ async def test_backoff_when_node_fails_task_rpc(manager: ScyllaClusterManager):
 # Test that the view builder does not finish when some replica nodes are down,
 # and resumes correctly once they come back.
 # Migrated from dtest materialized_views_test.py::TestMaterializedViews::test_do_not_finish_view_building_with_hints
+@pytest.mark.max_running_shards(6)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_do_not_finish_view_builder_with_nodes_down(manager: ScyllaClusterManager):
     """Test that the view builder does not complete while replica nodes are down,
@@ -490,6 +498,7 @@ async def test_do_not_finish_view_builder_with_nodes_down(manager: ScyllaCluster
 
 # Migrated from dtest secondary_indexes_test.py node action tests.
 # Verifies that node operations during view building complete correctly (vnodes).
+@pytest.mark.max_running_shards(8)
 @pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 @pytest.mark.parametrize("operation", ["stop", "remove", "decommission", "add"])

--- a/test/cluster/mv/test_mv_delete_partitions.py
+++ b/test/cluster/mv/test_mv_delete_partitions.py
@@ -56,6 +56,7 @@ async def insert_with_concurrency(cql, table, value_count, concurrency):
 # The "view_update_limit" error injections will cause the test to fail due to a failed
 # replica write if the view update limit is exceeded. If, thanks to throttling, we never
 # exceed the limit, the test will pass
+@pytest.mark.max_running_shards(4)
 @pytest.mark.skip_mode(mode='release', reason="error injections aren't enabled in release mode")
 async def test_delete_partition_rows_from_table_with_mv(manager: ScyllaClusterManager) -> None:
     node_count = 2
@@ -83,6 +84,7 @@ async def test_delete_partition_rows_from_table_with_mv(manager: ScyllaClusterMa
 # a partition in this case is expected to generate one view update for deleting
 # the corresponding view partition by a partition tombstone.
 # Reproduces #8199
+@pytest.mark.max_running_shards(2)
 @pytest.mark.parametrize("permuted", [False, True])
 async def test_base_partition_deletion_with_metrics(manager: ScyllaClusterManager, permuted):
     server = await manager.server_add()
@@ -132,6 +134,7 @@ async def test_base_partition_deletion_with_metrics(manager: ScyllaClusterManage
 # Perform a deletion of a base partition in a batch with deletion of individual rows. Verify the
 # partition is deleted correctly and that a single update is generated for the view for deleting
 # the whole partition, and no view updates for each row.
+@pytest.mark.max_running_shards(2)
 async def test_base_partition_deletion_in_batch_with_delete_row_with_metrics(manager: ScyllaClusterManager):
     server = await manager.server_add()
     cql = manager.get_cql()

--- a/test/cluster/mv/test_mv_fail_building.py
+++ b/test/cluster/mv/test_mv_fail_building.py
@@ -15,6 +15,7 @@ from cassandra.query import SimpleStatement  # type: ignore
 # This test makes sure that even if the view building encounter errors, the view building is eventually finished
 # and the view is consistent with the base table.
 # Reproduces the scenario in #19261
+@pytest.mark.max_running_shards(6)
 @pytest.mark.skip_mode(mode='release', reason="error injections aren't enabled in release mode")
 async def test_mv_fail_building(manager: ScyllaClusterManager) -> None:
     node_count = 3
@@ -45,6 +46,7 @@ async def test_mv_fail_building(manager: ScyllaClusterManager) -> None:
 # Test view build operations running during node shutdown and view drain.
 # Verify the drain order is correct and the view build doesn't fail with
 # database write failures.
+@pytest.mark.max_running_shards(2)
 @pytest.mark.skip_mode(mode='release', reason="error injections aren't enabled in release mode")
 async def test_mv_build_during_shutdown(manager: ScyllaClusterManager):
     server = await manager.server_add()

--- a/test/cluster/mv/test_mv_read_concurrency.py
+++ b/test/cluster/mv/test_mv_read_concurrency.py
@@ -21,6 +21,7 @@ logger = logging.getLogger(__name__)
 # while concurrently running a small read workload on the other table.
 # The test fails if any of the reads times out.
 # Reproduces https://github.com/scylladb/scylladb/issues/8873
+@pytest.mark.max_running_shards(2)
 @pytest.mark.skip_mode(mode='release', reason="error injections aren't enabled in release mode")
 async def test_mv_read_concurrency(manager: ScyllaClusterManager) -> None:
     node_count = 1
@@ -89,6 +90,7 @@ async def test_mv_read_concurrency(manager: ScyllaClusterManager) -> None:
 # an even larger number of writes causing view updates.
 # The test fails if Scylla aborts due to using too much memory.
 # Reproduces https://github.com/scylladb/scylladb/issues/15805
+@pytest.mark.max_running_shards(2)
 @pytest.mark.skip_mode(mode='release', reason="error injections aren't enabled in release mode")
 async def test_mv_read_memory(manager: ScyllaClusterManager) -> None:
     node_count = 1

--- a/test/cluster/mv/test_mv_staging.py
+++ b/test/cluster/mv/test_mv_staging.py
@@ -44,6 +44,7 @@ async def delete_table_sstables(manager: ScyllaClusterManager, server: ServerInf
             os.remove(path)
         break # break unconditionally here to remove only files in `table_dir`
 
+@pytest.mark.max_running_shards(4)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_staging_backlog_processed_after_restart(manager: ScyllaClusterManager):
     """

--- a/test/cluster/mv/test_mv_topology_change.py
+++ b/test/cluster/mv/test_mv_topology_change.py
@@ -29,6 +29,7 @@ logger = logging.getLogger(__name__)
 # While the writes are in progress, we add then decommission a node in the cluster.
 # The test verifies that no node crashes as a result of the topology change combined
 # with the writes.
+@pytest.mark.max_running_shards(8)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_mv_topology_change(manager: ScyllaClusterManager):
     cfg = {'tablets_mode_for_new_keyspaces': 'disabled',
@@ -94,6 +95,7 @@ async def test_mv_topology_change(manager: ScyllaClusterManager):
 # 5) verify node 2 did not build view updates
 # With the parameter intranode=True it's the same except the tablet
 # is migrating between two shards on the same node.
+@pytest.mark.max_running_shards(4)
 @pytest.mark.parametrize("intranode", [True, False])
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_mv_update_on_pending_replica(manager: ScyllaClusterManager, intranode):
@@ -175,6 +177,7 @@ async def test_mv_update_on_pending_replica(manager: ScyllaClusterManager, intra
 # If the MV write handler is not completed after storing the hint, as in
 # issue #19529, it remains active until it timeouts, preventing topology changes
 # during this time.
+@pytest.mark.max_running_shards(8)
 @pytest.mark.skip_mode(mode='debug', reason='the test requires a short timeout for remove_node, but it is unpredictably slow in debug')
 async def test_mv_write_to_dead_node(manager: ScyllaClusterManager):
     servers = await manager.servers_add(4, property_file=[
@@ -201,6 +204,7 @@ async def test_mv_write_to_dead_node(manager: ScyllaClusterManager):
         # Otherwise, it is expected to complete in short time.
         await manager.remove_node(servers[0].server_id, servers[-1].server_id, timeout=180)
 
+@pytest.mark.max_running_shards(6)
 async def test_mv_pairing_during_replace(manager: ScyllaClusterManager):
     servers = await manager.servers_add(3, property_file=[
         {"dc": "dc1", "rack": "r1"},
@@ -325,6 +329,7 @@ async def test_mv_rf_change(manager: ScyllaClusterManager, delayed_replica: str,
     assert len(res) == 2
 
 # The same scenario as in the test above, but the RF change affects the first replica in a DC
+@pytest.mark.max_running_shards(2)
 @pytest.mark.parametrize("delayed_replica", ["base", "mv"])
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_mv_first_replica_in_dc(manager: ScyllaClusterManager, delayed_replica: str):
@@ -388,6 +393,7 @@ async def test_mv_first_replica_in_dc(manager: ScyllaClusterManager, delayed_rep
 # verify all expected rows appear in the MV eventually.
 # Checks for issues of view update generation during migration.
 # Reproduces #24292
+@pytest.mark.max_running_shards(8)
 @pytest.mark.parametrize("migration_type", ["tablets_internode", "tablets_intranode", "vnodes"])
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_mv_write_during_migration(manager: ScyllaClusterManager, migration_type: str):
@@ -480,6 +486,7 @@ async def test_mv_write_during_migration(manager: ScyllaClusterManager, migratio
 # on the topology coordinator, but the joining node is delayed in applying the group0 state.
 # The joining node receives base mutations from the other nodes to apply as the new replica,
 # and it also should generate view updates for them while in a joining state.
+@pytest.mark.max_running_shards(4)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_mv_write_during_node_join(manager: ScyllaClusterManager):
     cmdline = ['--logger-log-level', 'storage_service=debug', '--logger-log-level', 'raft_topology=debug']
@@ -520,6 +527,7 @@ async def test_mv_write_during_node_join(manager: ScyllaClusterManager):
 # while we're already shutting down. This code should not reference any objects destroyed
 # earlier in the shutdown sequence. The test passes if the server doesn't crash during shutdown.
 # Reproduces issue SCYLLADB-2301
+@pytest.mark.max_running_shards(4)
 @pytest.mark.skip_mode(mode='release', reason="error injections aren't enabled in release mode")
 async def test_no_crash_on_shutdown_with_pending_remote_view_update(manager: ScyllaClusterManager) -> None:
     node_count = 2
@@ -554,6 +562,7 @@ async def test_no_crash_on_shutdown_with_pending_remote_view_update(manager: Scy
         await manager.server_start(servers[0].server_id)
 
 
+@pytest.mark.max_running_shards(8)
 @pytest.mark.parametrize(
     ("tablets_enabled", "enable_repair_based_node_ops"),
     [

--- a/test/cluster/mv/test_mv_where_clause_relations.py
+++ b/test/cluster/mv/test_mv_where_clause_relations.py
@@ -8,6 +8,7 @@ import logging
 from test.cluster.util import new_materialized_view, new_test_keyspace, new_test_table
 from test.pylib.scylla_cluster_manager import ScyllaClusterManager
 from test.pylib.util import wait_for_view
+import pytest
 
 logger = logging.getLogger(__name__)
 
@@ -31,6 +32,7 @@ def prepare_insert(cql, table, key_columns):
 
 
 # Regression test for SCYLLADB-3583.
+@pytest.mark.max_running_shards(2)
 async def test_view_where_clause_above_default_relation_limit(manager: ScyllaClusterManager):
     """A view whose WHERE clause has more relations than the default limit is
     usable, no matter what the limit was when it was created. Scylla reparses
@@ -57,6 +59,7 @@ async def test_view_where_clause_above_default_relation_limit(manager: ScyllaClu
 
 
 # Regression test for SCYLLADB-3583.
+@pytest.mark.max_running_shards(2)
 async def test_rename_base_column_of_view_above_default_relation_limit(manager: ScyllaClusterManager):
     """Renaming a base column rewrites the stored WHERE clause of every view
     referring to it, which means reparsing that clause. Just like the reparse

--- a/test/cluster/mv/test_mv_with_tablets_restrictions.py
+++ b/test/cluster/mv/test_mv_with_tablets_restrictions.py
@@ -16,6 +16,7 @@ from test.pylib.scylla_cluster_manager import ScyllaClusterManager
 
 logger = logging.getLogger(__name__)
 
+@pytest.mark.max_running_shards(6)
 @pytest.mark.parametrize("rf_kind", ["numeric", "rack_list"])
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_create_mv_and_index_restrictions_in_tablet_keyspaces(manager: ScyllaClusterManager, rf_kind: str):
@@ -95,6 +96,7 @@ async def test_create_mv_and_index_restrictions_in_tablet_keyspaces(manager: Scy
         await test_create_mv_or_index_with_rf(cql, schema_kind, 2, expected_error=expected_error)
 
 
+@pytest.mark.max_running_shards(6)
 @pytest.mark.parametrize("rf_kind", ["numeric", "rack_list"])
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_alter_keyspace_rf_rack_restriction_with_mv_and_index(manager: ScyllaClusterManager, rf_kind: str):
@@ -174,6 +176,7 @@ async def test_alter_keyspace_rf_rack_restriction_with_mv_and_index(manager: Scy
         await cql.run_async(f"DROP KEYSPACE {ks}")
 
 
+@pytest.mark.max_running_shards(8)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_add_node_in_new_rack_restriction_with_mv(manager: ScyllaClusterManager):
     """
@@ -204,6 +207,7 @@ async def test_add_node_in_new_rack_restriction_with_mv(manager: ScyllaClusterMa
     await manager.server_add(config=cfg, cmdline=cmdline, property_file={"dc": "dc1", "rack": "r1"})
 
 
+@pytest.mark.max_running_shards(8)
 @pytest.mark.parametrize("op", ["remove", "decommission"])
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_remove_node_violating_rf_rack(manager: ScyllaClusterManager, op: str):

--- a/test/cluster/object_store/test_atomic_delete.py
+++ b/test/cluster/object_store/test_atomic_delete.py
@@ -55,6 +55,7 @@ async def assert_registry_clean_after_restart(manager, server, table_id):
     logger.info("Registry entries after recovery: %d", len(entries))
     return cql, entries
 
+@pytest.mark.max_running_shards(2)
 @pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_crash_after_compaction_prepare(manager: ScyllaClusterManager, object_storage):
@@ -116,6 +117,7 @@ async def test_crash_after_compaction_prepare(manager: ScyllaClusterManager, obj
         logger.info("Row count after recovery: %d", count)
         assert count == 20, f"Expected 20 rows after recovery, got {count}"
 
+@pytest.mark.max_running_shards(2)
 @pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_crash_after_compaction_unlink(manager: ScyllaClusterManager, object_storage):
@@ -148,6 +150,7 @@ async def test_crash_after_compaction_unlink(manager: ScyllaClusterManager, obje
         logger.info("Row count after recovery: %d", count)
         assert count == 20, f"Expected 20 rows after recovery, got {count}"
 
+@pytest.mark.max_running_shards(2)
 @pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_crash_during_truncate(manager: ScyllaClusterManager, object_storage):
@@ -178,6 +181,7 @@ async def test_crash_during_truncate(manager: ScyllaClusterManager, object_stora
 
         await assert_registry_clean_after_restart(manager, server, table_id)
 
+@pytest.mark.max_running_shards(2)
 @pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_crash_before_batch_mutation_commits(manager: ScyllaClusterManager, object_storage):

--- a/test/cluster/object_store/test_auto_snapshot_restore.py
+++ b/test/cluster/object_store/test_auto_snapshot_restore.py
@@ -125,6 +125,7 @@ async def add_server(manager: ScyllaClusterManager, s3_storage):
     return await manager.server_add(config=config)
 
 
+@pytest.mark.max_running_shards(2)
 @pytest.mark.parametrize("load_method", LOAD_METHODS)
 async def test_auto_snapshot_restore_table(manager: ScyllaClusterManager, s3_storage, load_method: str):
     """
@@ -155,6 +156,7 @@ async def test_auto_snapshot_restore_table(manager: ScyllaClusterManager, s3_sto
         assert rows[1].c1 == "c1-1"
 
 
+@pytest.mark.max_running_shards(2)
 @pytest.mark.parametrize("load_method", LOAD_METHODS)
 async def test_auto_snapshot_restore_table_with_dropped_column(manager: ScyllaClusterManager, s3_storage, load_method: str):
     """
@@ -198,6 +200,7 @@ async def test_auto_snapshot_restore_table_with_dropped_column(manager: ScyllaCl
             await cql.run_async(f"SELECT c2 FROM {ks}.{cf}")
 
 
+@pytest.mark.max_running_shards(2)
 @pytest.mark.parametrize("load_method", LOAD_METHODS)
 async def test_auto_snapshot_restore_table_with_dropped_and_readded_column(manager: ScyllaClusterManager, s3_storage, load_method: str):
     """

--- a/test/cluster/object_store/test_backup.py
+++ b/test/cluster/object_store/test_backup.py
@@ -58,6 +58,7 @@ async def take_snapshot_on_one_server(ks, server, manager, logger):
     return snap_name, sstables[server]
 
 
+@pytest.mark.max_running_shards(2)
 @pytest.mark.parametrize("move_files", [False, True])
 async def test_simple_backup(manager: ScyllaClusterManager, object_storage, move_files):
     '''check that backing up a snapshot for a keyspace works'''
@@ -103,6 +104,7 @@ async def test_simple_backup(manager: ScyllaClusterManager, object_storage, move
         assert len(res) == 1 and res[0][1].group(1) == 'bckp'
 
 
+@pytest.mark.max_running_shards(2)
 @pytest.mark.parametrize("ne_parameter", [ "endpoint", "bucket", "snapshot" ])
 async def test_backup_with_non_existing_parameters(manager: ScyllaClusterManager, object_storage, ne_parameter):
     '''backup should fail if either of the parameters does not exist'''
@@ -142,6 +144,7 @@ async def test_backup_with_non_existing_parameters(manager: ScyllaClusterManager
             assert status['error'] == 'std::invalid_argument: endpoint no-such-endpoint not found'
 
 
+@pytest.mark.max_running_shards(2)
 async def test_backup_endpoint_config_is_live_updateable(manager: ScyllaClusterManager, object_storage):
     '''backup should fail if the endpoint is invalid/inaccessible
        after updating the config, it should succeed'''
@@ -242,6 +245,7 @@ async def do_test_backup_abort(manager: ScyllaClusterManager, object_storage,
 
     await do_test_backup_helper(manager, object_storage, breakpoint_name, abort_and_check)
 
+@pytest.mark.max_running_shards(2)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_backup_is_abortable(manager: ScyllaClusterManager, object_storage):
     '''check that backing up a snapshot for a keyspace works'''
@@ -249,12 +253,14 @@ async def test_backup_is_abortable(manager: ScyllaClusterManager, object_storage
 
 
 
+@pytest.mark.max_running_shards(2)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_backup_is_abortable_in_s3_client(manager: ScyllaClusterManager, object_storage):
     '''check that backing up a snapshot for a keyspace works'''
     await do_test_backup_abort(manager, object_storage, breakpoint_name="backup_task_pre_upload", min_files=0, max_files=1)
 
 
+@pytest.mark.max_running_shards(2)
 @pytest.mark.parametrize("flavor", ['plain', 'abort', 'encrypt', 'view'])
 async def test_simple_backup_and_restore(manager: ScyllaClusterManager, object_storage, tmpdir, flavor):
     '''check that restoring from backed up snapshot for a keyspace:table works'''
@@ -478,6 +484,7 @@ async def do_abort_restore(manager: ScyllaClusterManager, object_storage):
             failed |= final_status['state'] == 'failed'
         assert failed, "Expected at least one restore task to fail after aborting"
 
+@pytest.mark.max_running_shards(6)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_abort_restore_with_rpc_error(manager: ScyllaClusterManager, object_storage):
     await do_abort_restore(manager, object_storage)
@@ -709,6 +716,7 @@ class SSTablesOnObjectStorage:
         await asyncio.gather(*(do_restore_server(manager, logger, ks, cf, s, sstables, scope, primary_replica_only, prefix, self.object_storage) for s, sstables in sstables_per_server.items()))
 
 
+@pytest.mark.max_running_shards(16)
 @pytest.mark.parametrize("topology", [
         topo(rf = 1, nodes = 3, racks = 1, dcs = 1),
         topo(rf = 3, nodes = 5, racks = 1, dcs = 1),
@@ -793,6 +801,7 @@ async def do_test_streaming_scopes(build_mode: str, manager: ScyllaClusterManage
 
             await cql.run_async(f"DROP TABLE {ks}.test")
 
+@pytest.mark.max_running_shards(16)
 @pytest.mark.parametrize("topology", [
         topo(rf = 1, nodes = 2, racks = 1, dcs = 1),
         topo(rf = 2, nodes = 2, racks = 2, dcs = 1),
@@ -927,6 +936,7 @@ async def do_test_restore_tablets(build_mode: str, manager: ScyllaClusterManager
                 await wait_for(view_repopulated, time.time() + 60)
 
 
+@pytest.mark.max_running_shards(4)
 @pytest.mark.xfail(reason="download_tablet_sstables()'s attach_sstable() hardcodes "
                            "sstables::sstable_state::normal for restored sstables, so neither "
                            "the view update generator nor view_building_worker is ever told "
@@ -941,6 +951,7 @@ async def test_restore_tablets_repopulates_view(build_mode: str, manager: Scylla
                                    with_views=True)
 
 
+@pytest.mark.max_running_shards(4)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_restore_tablets_parallel(build_mode: str, manager: ScyllaClusterManager, object_storage):
     '''Verify that the tablets of a single table are restored in parallel, not one by one.
@@ -1008,6 +1019,7 @@ async def test_restore_tablets_parallel(build_mode: str, manager: ScyllaClusterM
         await manager.api.quiesce_topology(servers[0].ip_addr)
         await check_mutation_replicas(cql, manager, servers, range(num_keys), topology, logger, ks, 'test')
 
+@pytest.mark.max_running_shards(4)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_restore_tablets_vs_migration(build_mode: str, manager: ScyllaClusterManager, object_storage):
     '''Check that restore handles tablets migrating around'''
@@ -1061,6 +1073,7 @@ async def test_restore_tablets_vs_migration(build_mode: str, manager: ScyllaClus
         await check_mutation_replicas(cql, manager, servers, range(num_keys), topology, logger, ks, 'test')
 
 
+@pytest.mark.max_running_shards(4)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_restore_tablets_download_failure(build_mode: str, manager: ScyllaClusterManager, object_storage):
     '''Check that failure to download an sstable propagates back to API'''
@@ -1097,6 +1110,7 @@ async def test_restore_tablets_download_failure(build_mode: str, manager: Scylla
         assert status['progress_completed'] < status['progress_total']
 
 
+@pytest.mark.max_running_shards(4)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_restore_tablets_abort(build_mode: str, manager: ScyllaClusterManager, object_storage):
     '''Verify that aborting a tablet restore task interrupts in-flight downloads
@@ -1179,6 +1193,7 @@ async def test_restore_tablets_abort(build_mode: str, manager: ScyllaClusterMana
         assert downloaded == 0, f"Expected no downloads to complete after abort, but {downloaded} of {total} sstables were downloaded"
 
 
+@pytest.mark.max_running_shards(8)
 @pytest.mark.parametrize("target", ['coordinator', 'replica', 'api'])
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_restore_tablets_node_loss_resiliency(build_mode: str, manager: ScyllaClusterManager, object_storage, target):
@@ -1234,6 +1249,7 @@ async def test_restore_tablets_node_loss_resiliency(build_mode: str, manager: Sc
             await asyncio.wait_for(manager.api.wait_task(servers[1].ip_addr, tid), timeout=60)
 
 
+@pytest.mark.max_running_shards(8)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_restore_tablets_duplicate_after_failed_api_node(build_mode: str, manager: ScyllaClusterManager, object_storage):
     '''Check that a new restore request does not hang after a previous restore failed due to API node loss,
@@ -1285,6 +1301,7 @@ async def test_restore_tablets_duplicate_after_failed_api_node(build_mode: str, 
         assert len(restored) > 0, "Restore was skipped: coordinator reused stale _tablets state and did not restore any tablet"
 
 
+@pytest.mark.max_running_shards(6)
 @pytest.mark.parametrize(("min_tablet_count_before_backup", "max_tablet_count_before_backup", "min_tablet_count_before_restore", "max_tablet_count_before_restore"), [
     (1, 1, 2, 2),
     (4, 4, 2, 2),
@@ -1336,6 +1353,7 @@ async def test_restore_tablets_with_different_tablet_hints(build_mode: str, mana
         assert f"'max_tablet_count': '{max_tablet_count_before_restore}'" in desc, f"Expected max_tablet_count={max_tablet_count_before_restore} in: {desc}"
 
 
+@pytest.mark.max_running_shards(6)
 async def test_restore_tablets_leaves_a_hintless_table_resizable(build_mode: str, manager: ScyllaClusterManager,
                                                                  object_storage):
     # Three nodes because a tablet-aware restore writes system_distributed.snapshot_sstables at
@@ -1421,6 +1439,7 @@ RESTORE_TARGETS = [
     restore_target('vnodes_to_tablets', src_ks_opts=NO_TABLETS, src_cf_opts=''),
 ]
 
+@pytest.mark.max_running_shards(2)
 @pytest.mark.parametrize("target", RESTORE_TARGETS, ids=lambda t: t.name)
 async def test_restore_into_renamed_target(manager: ScyllaClusterManager, object_storage, target):
     '''Check that a backup of one keyspace:table can be restored into another one'''
@@ -1476,6 +1495,7 @@ INCOMPATIBLE_SCHEMAS = [
     pytest.param('name text primary key', id='missing_column'),
 ]
 
+@pytest.mark.max_running_shards(2)
 @pytest.mark.parametrize("dst_schema", INCOMPATIBLE_SCHEMAS)
 async def test_restore_into_incompatible_schema(manager: ScyllaClusterManager, object_storage, dst_schema):
     '''Check that restore fails when the destination schema does not match the backed up one'''
@@ -1523,6 +1543,7 @@ TABLETS_INCOMPATIBLE_SCHEMAS = [
     pytest.param('pk text primary key', id='missing_column'),
 ]
 
+@pytest.mark.max_running_shards(4)
 @pytest.mark.parametrize("dst_schema", TABLETS_INCOMPATIBLE_SCHEMAS)
 async def test_restore_tablets_into_incompatible_schema(manager: ScyllaClusterManager, object_storage, dst_schema):
     '''Check that a tablet-aware restore into a table with a mismatching schema yields no data.
@@ -1563,6 +1584,7 @@ async def test_restore_tablets_into_incompatible_schema(manager: ScyllaClusterMa
             assert kept == expected, f'Restore into {dst_ks}.cf2 modified the source table {src_ks}.cf1: {len(kept)} rows'
 
 
+@pytest.mark.max_running_shards(4)
 async def test_restore_tablets_into_vnodes_table(manager: ScyllaClusterManager, object_storage):
     '''Check that tablet-aware restore into a vnodes-based table is rejected.
 
@@ -1596,6 +1618,7 @@ async def test_restore_tablets_into_vnodes_table(manager: ScyllaClusterManager, 
             assert kept == expected, f'Failed restore into {dst_ks}.cf2 modified the source table {src_ks}.cf1: {len(kept)} rows'
 
 
+@pytest.mark.max_running_shards(4)
 async def test_restore_tablets_vnodes_backup_into_tablets_table(manager: ScyllaClusterManager, object_storage):
     '''Check that tablet-aware restore of a vnodes-based backup is rejected.
 
@@ -1642,6 +1665,7 @@ async def test_restore_tablets_vnodes_backup_into_tablets_table(manager: ScyllaC
             assert kept == expected, f'Failed restore into {dst_ks}.cf2 modified the source table {src_ks}.cf1: {len(kept)} rows'
 
 
+@pytest.mark.max_running_shards(2)
 async def test_restore_with_non_existing_sstable(manager: ScyllaClusterManager, object_storage):
     '''Check that restore task fails well when given a non-existing sstable'''
 
@@ -1665,6 +1689,7 @@ async def test_restore_with_non_existing_sstable(manager: ScyllaClusterManager, 
         assert 'error' in status and 'Not Found' in status['error']
 
 
+@pytest.mark.max_running_shards(1)
 async def test_backup_broken_streaming(manager: ScyllaClusterManager, s3_storage):
     # Define configuration for the servers.
     objconf = s3_storage.create_endpoint_conf()
@@ -1745,6 +1770,7 @@ async def test_backup_broken_streaming(manager: ScyllaClusterManager, s3_storage
         # just make sure we had partially contained sstables as well
         await log.wait_for("partially contained SSTables", timeout=10)
 
+@pytest.mark.max_running_shards(16)
 @pytest.mark.parametrize("domain", ['rack', 'dc'])
 @pytest.mark.parametrize("scope_is_same", [True, False])
 async def test_restore_primary_replica(manager: ScyllaClusterManager, object_storage, domain, scope_is_same):
@@ -1830,6 +1856,7 @@ async def test_restore_primary_replica(manager: ScyllaClusterManager, object_sto
                 assert nodes[0] in scope_nodes, f"Primary replica should be within the scope {scope}"
 
 
+@pytest.mark.max_running_shards(4)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_decommision_waits_for_backup(manager: ScyllaClusterManager, object_storage):
     '''check that backing up a snapshot for a keyspace blocks decommission'''
@@ -1865,6 +1892,7 @@ async def test_decommision_waits_for_backup(manager: ScyllaClusterManager, objec
 
     await do_test_backup_helper(manager, object_storage, "backup_task_pre_upload", decommission_and_check, 2)
 
+@pytest.mark.max_running_shards(4)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_aborted_decommision_reenables_snapshot(manager: ScyllaClusterManager, object_storage):
     """
@@ -1928,6 +1956,7 @@ async def test_aborted_decommision_reenables_snapshot(manager: ScyllaClusterMana
         await take_snapshot_on_one_server(ks, servers[0], manager, logger)
 
 
+@pytest.mark.max_running_shards(4)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_drop_keyspace_during_tablet_restore(manager: ScyllaClusterManager, object_storage):
     """Verify that dropping a keyspace while tablet restore is downloading
@@ -1991,6 +2020,7 @@ async def test_drop_keyspace_during_tablet_restore(manager: ScyllaClusterManager
     await drop_task
 
 
+@pytest.mark.max_running_shards(2)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_drop_table_during_backup(manager: ScyllaClusterManager, object_storage):
     """Verify that dropping a table while a native backup is running does not
@@ -2044,6 +2074,7 @@ async def test_drop_table_during_backup(manager: ScyllaClusterManager, object_st
             assert f'{prefix}/{f}' in objects, f"{f} was not uploaded to the backup"
 
 
+@pytest.mark.max_running_shards(2)
 @pytest.mark.parametrize("drop", ["table", "keyspace", "table_recreated"])
 async def test_backup_after_schema_dropped(manager: ScyllaClusterManager, object_storage, drop):
     """Verify that a native backup can be started for a snapshot whose table (or
@@ -2195,6 +2226,7 @@ async def run_cluster_backup(object_storage, prefix: str, manager: ScyllaCluster
 
     return manifest
 
+@pytest.mark.max_running_shards(6)
 @pytest.mark.asyncio
 async def test_cluster_snapshot_backup(manager: ScyllaClusterManager, object_storage):
     """
@@ -2203,6 +2235,7 @@ async def test_cluster_snapshot_backup(manager: ScyllaClusterManager, object_sto
     """
     await do_test_snapshot_on_all_nodes(manager, partial(run_cluster_backup, object_storage, 'rapunzel'), object_storage)
 
+@pytest.mark.max_running_shards(6)
 @pytest.mark.asyncio
 async def test_cluster_backup_with_auto_snapshot(manager: ScyllaClusterManager, object_storage):
     """
@@ -2217,6 +2250,7 @@ async def run_double_cluster_backup(object_storage, manager: ScyllaClusterManage
     await run_cluster_backup(object_storage, 'ninja1', manager, snapshot_name, ks, cf, servers)
     await run_cluster_backup(object_storage, 'ninja2', manager, snapshot_name, ks, cf, servers)
 
+@pytest.mark.max_running_shards(6)
 @pytest.mark.asyncio
 async def test_cluster_snapshot_backup_to_new_location(manager: ScyllaClusterManager, object_storage):
     """
@@ -2238,6 +2272,7 @@ async def run_cluster_backup_and_check_redundancy(object_storage, manager: Scyll
         assert len(nodes) <= 1, f"tablet {k} not pruned"
 
 
+@pytest.mark.max_running_shards(6)
 @pytest.mark.asyncio
 async def test_cluster_snapshot_repair_set_unique(manager: ScyllaClusterManager, object_storage):
     """

--- a/test/cluster/object_store/test_basic.py
+++ b/test/cluster/object_store/test_basic.py
@@ -88,6 +88,7 @@ async def get_registry_entries(cql, table_id, node_owner, host):
     return rows
 
 
+@pytest.mark.max_running_shards(6)
 @pytest.mark.parametrize('replication_factor', [1, 3])
 @pytest.mark.parametrize('mode', ['normal', 'encrypted'])
 async def test_basic(manager: ScyllaClusterManager, object_storage, tmp_path, mode, replication_factor):
@@ -165,6 +166,7 @@ async def test_basic(manager: ScyllaClusterManager, object_storage, tmp_path, mo
         have_res = {x.name: x.value for x in res}
         assert have_res == rows, f'Unexpected table content: {have_res}'
 
+@pytest.mark.max_running_shards(2)
 async def test_garbage_collect(manager: ScyllaClusterManager, object_storage):
     '''verify ownership table is garbage-collected on boot'''
 
@@ -209,6 +211,7 @@ async def test_garbage_collect(manager: ScyllaClusterManager, object_storage):
                 assert not o.key.startswith(str(ent[2])), f'Sstable object not cleaned, found {o.key}'
 
 
+@pytest.mark.max_running_shards(2)
 async def test_populate_from_quarantine(manager: ScyllaClusterManager, object_storage):
     '''verify sstables are populated from quarantine state'''
 
@@ -246,6 +249,7 @@ async def test_populate_from_quarantine(manager: ScyllaClusterManager, object_st
         assert have_res == rows, f'Unexpected table content: {have_res}'
 
 
+@pytest.mark.max_running_shards(2)
 async def test_misconfigured_storage(manager: ScyllaClusterManager, object_storage):
     '''creating keyspace with unknown endpoint is not allowed'''
     # scylladb/scylladb#15074
@@ -267,6 +271,7 @@ async def test_misconfigured_storage(manager: ScyllaClusterManager, object_stora
                       f" REPLICATION = {replication_opts} AND STORAGE = {storage_opts};"))
 
 
+@pytest.mark.max_running_shards(2)
 async def test_storage_type_endpoint_mismatch(manager: ScyllaClusterManager, s3_storage, gs_storage):
     '''creating a keyspace whose STORAGE type doesn't match the configured type of the
     given endpoint (S3 endpoint used with type GS, or vice versa) must not be allowed,
@@ -294,6 +299,7 @@ async def test_storage_type_endpoint_mismatch(manager: ScyllaClusterManager, s3_
                       f" REPLICATION = {replication_opts} AND STORAGE = {storage_opts};"))
 
 
+@pytest.mark.max_running_shards(2)
 async def test_memtable_flush_retries(manager: ScyllaClusterManager, tmpdir, object_storage):
     '''verify that memtable flush doesn't crash in case storage access keys are incorrect'''
 
@@ -336,6 +342,7 @@ async def test_memtable_flush_retries(manager: ScyllaClusterManager, tmpdir, obj
         have_res = { x.name: x.value for x in res }
         assert have_res == dict(rows), f'Unexpected table content: {have_res}'
 
+@pytest.mark.max_running_shards(2)
 @pytest.mark.parametrize('config_with_full_url', [True, False])
 async def test_get_object_store_endpoints(manager: ScyllaClusterManager, config_with_full_url):
     if config_with_full_url:
@@ -385,6 +392,7 @@ async def get_object_storage_written_bytes(server_ip, storage_type: str) -> floa
     return written
 
 
+@pytest.mark.max_running_shards(2)
 async def test_create_keyspace_after_config_update(manager: ScyllaClusterManager, object_storage):
     print('Trying to create a keyspace with an endpoint not configured in object_storage_endpoints should trip storage_manager::is_known_endpoint()')
     server = await manager.server_add()
@@ -472,6 +480,7 @@ async def test_create_keyspace_after_config_update(manager: ScyllaClusterManager
     assert rows == {'test_key': 123, 'after_reconfig': 456, 'after_metrics': 789}, f'Unexpected table content: {rows}'
 
 
+@pytest.mark.max_running_shards(4)
 async def test_tablet_move_updates_registry(manager: ScyllaClusterManager, s3_storage):
     """
     Verify that moving a tablet from one node to another correctly
@@ -561,6 +570,7 @@ async def test_tablet_move_updates_registry(manager: ScyllaClusterManager, s3_st
         logger.info("Source registry entries cleaned up successfully")
 
 
+@pytest.mark.max_running_shards(4)
 async def test_decommission_migrates_registry(manager: ScyllaClusterManager, s3_storage):
     """
     Verify registry behavior around decommission.
@@ -642,6 +652,7 @@ async def test_decommission_migrates_registry(manager: ScyllaClusterManager, s3_
         assert len(rows) == 10, f"Expected 10 rows, got {len(rows)}"
 
 
+@pytest.mark.max_running_shards(4)
 async def test_repair_creates_registry_entries(manager: ScyllaClusterManager, s3_storage):
     """
     Verify that non-incremental (tablet) repair on an object-storage keyspace
@@ -750,6 +761,7 @@ async def test_repair_creates_registry_entries(manager: ScyllaClusterManager, s3
         assert len(rows) == 10, f"Expected 10 rows, got {len(rows)}"
 
 
+@pytest.mark.max_running_shards(4)
 @pytest.mark.parametrize('operation', ['truncate', 'drop_table', 'drop_keyspace'])
 async def test_registry_cleanup_on_all_nodes(manager: ScyllaClusterManager, object_storage, operation):
     """
@@ -791,6 +803,7 @@ async def test_registry_cleanup_on_all_nodes(manager: ScyllaClusterManager, obje
         await assert_registry_empty_on_all_nodes(cql, hosts, table_id, operation)
 
 
+@pytest.mark.max_running_shards(4)
 @pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_stream_sink_abort_on_object_storage(manager: ScyllaClusterManager, object_storage):
@@ -929,6 +942,7 @@ async def run_scylla_sstable(args, timeout=300):
     return proc.returncode, stdout.decode(), stderr.decode()
 
 
+@pytest.mark.max_running_shards(2)
 async def test_scylla_sstable_dump_scylla_metadata(manager: ScyllaClusterManager, object_storage, tmp_path):
     objconf = object_storage.create_endpoint_conf()
     cfg = {'enable_user_defined_functions': False,

--- a/test/cluster/object_store/test_scaling.py
+++ b/test/cluster/object_store/test_scaling.py
@@ -21,6 +21,7 @@ from cassandra.query import SimpleStatement, ConsistencyLevel
 
 logger = logging.getLogger(__name__)
 
+@pytest.mark.max_running_shards(12)
 async def test_scaling(manager: ScyllaClusterManager, object_storage):
     """Test cluster scaling (add/remove nodes) with tablets on object storage.
 

--- a/test/cluster/random_failures/test_random_failures.py
+++ b/test/cluster/random_failures/test_random_failures.py
@@ -86,6 +86,7 @@ async def four_nodes_cluster(manager: ScyllaClusterManager) -> None:
     await wait_for_token_ring_and_group0_consistency(manager=manager, deadline=time.time() + 30)
 
 
+@pytest.mark.max_running_shards(10)
 @pytest.mark.usefixtures("four_nodes_cluster")
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_random_failures(manager: ScyllaClusterManager,

--- a/test/cluster/storage/test_out_of_space_prevention.py
+++ b/test/cluster/storage/test_out_of_space_prevention.py
@@ -116,6 +116,7 @@ global_cmdline = ["--disk-space-monitor-normal-polling-interval-in-seconds", "1"
                   ]
 
 
+@pytest.mark.max_running_shards(6)
 async def test_user_writes_rejection(manager: ScyllaClusterManager, volumes_factory: Callable) -> None:
     async with space_limited_servers(manager, volumes_factory, ["20M"]*3, cmdline=global_cmdline) as servers:
         cql, hosts = await manager.get_ready_cql(servers)
@@ -167,6 +168,7 @@ async def test_user_writes_rejection(manager: ScyllaClusterManager, volumes_fact
                 await cql.run_async(SimpleStatement(next(wgen), consistency_level=ConsistencyLevel.ALL))
 
 
+@pytest.mark.max_running_shards(6)
 async def test_autotoggle_compaction(manager: ScyllaClusterManager, volumes_factory: Callable) -> None:
     cmdline = [*global_cmdline,
                "--logger-log-level", "compaction=debug"]
@@ -212,6 +214,7 @@ async def test_autotoggle_compaction(manager: ScyllaClusterManager, volumes_fact
                 await log.wait_for(rf"Major {ks}\.{table} .* Compacted .* sstables to .*", from_mark=mark)
 
 
+@pytest.mark.max_running_shards(4)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_critical_utilization_during_decommission(manager: ScyllaClusterManager, volumes_factory: Callable) -> None:
     """
@@ -266,6 +269,7 @@ async def test_critical_utilization_during_decommission(manager: ScyllaClusterMa
 
 
 
+@pytest.mark.max_running_shards(6)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_reject_split_compaction(manager: ScyllaClusterManager, volumes_factory: Callable) -> None:
     async with space_limited_servers(manager, volumes_factory, ["20M"]*3, cmdline=global_cmdline) as servers:
@@ -295,6 +299,7 @@ async def test_reject_split_compaction(manager: ScyllaClusterManager, volumes_fa
                     await log.wait_for(f"Split task .* for table {cf} .* stopped, reason: Compaction for {cf} was stopped due to: drain", from_mark=mark)
 
 
+@pytest.mark.max_running_shards(6)
 async def test_split_compaction_not_triggered(manager: ScyllaClusterManager, volumes_factory: Callable) -> None:
     cmd = [*global_cmdline,
            "--logger-log-level", "compaction=debug"]
@@ -328,6 +333,7 @@ async def test_split_compaction_not_triggered(manager: ScyllaClusterManager, vol
                     assert await s1_log.grep(f"compaction.*Split {cf}", from_mark=s1_mark) == []
 
 
+@pytest.mark.max_running_shards(6)
 async def test_tablet_repair(manager: ScyllaClusterManager, volumes_factory: Callable) -> None:
     async with space_limited_servers(manager, volumes_factory, ["20M"]*3, cmdline=global_cmdline) as servers:
         cql, _ = await manager.get_ready_cql(servers)
@@ -394,6 +400,7 @@ async def test_tablet_repair(manager: ScyllaClusterManager, volumes_factory: Cal
                 await manager.api.wait_task(servers[0].ip_addr, task_id)
 
 
+@pytest.mark.max_running_shards(6)
 async def test_autotoggle_reject_incoming_migrations(manager: ScyllaClusterManager, volumes_factory: Callable) -> None:
     async with space_limited_servers(manager, volumes_factory, ["20M"]*3, cmdline=global_cmdline) as servers:
         await manager.disable_tablet_balancing()
@@ -453,6 +460,7 @@ async def test_autotoggle_reject_incoming_migrations(manager: ScyllaClusterManag
                 mark, _ = await log.wait_for("Streaming for tablet migration .* successful", from_mark=mark)
 
 
+@pytest.mark.max_running_shards(6)
 async def test_node_restart_while_tablet_split(manager: ScyllaClusterManager, volumes_factory: Callable) -> None:
     cmd = [*global_cmdline,
            "--logger-log-level", "compaction=debug"]
@@ -520,6 +528,7 @@ async def test_node_restart_while_tablet_split(manager: ScyllaClusterManager, vo
                 await assert_resize_task_info(table_id, lambda response: len(response) == 2 and all(r.resize_task_info is None for r in response))
 
 # Verify that new sstable produced by repair cannot be split, if disk utilization level is critical.
+@pytest.mark.max_running_shards(6)
 @pytest.mark.skip_mode('release', 'error injections are not supported in release mode')
 async def test_repair_failure_on_split_rejection(manager: ScyllaClusterManager, volumes_factory: Callable) -> None:
     cmd = [*global_cmdline,
@@ -615,6 +624,7 @@ global_cmdline_with_disabled_monitor = [
     # "Rate-limit: suppressed N backtraces" line with no backtrace (SCYLLADB-3850).
     "--blocked-reactor-reports-per-minute", "60",
 ]
+@pytest.mark.max_running_shards(4)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_sstables_incrementally_released_during_streaming(manager: ScyllaClusterManager, volumes_factory: Callable) -> None:
     """
@@ -697,6 +707,7 @@ async def test_sstables_incrementally_released_during_streaming(manager: ScyllaC
                     await decomm_task
 
 
+@pytest.mark.max_running_shards(6)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_load_and_stream_rejected_on_critical_disk(manager: ScyllaClusterManager, volumes_factory: Callable) -> None:
     """

--- a/test/cluster/tasks/test_node_ops_tasks.py
+++ b/test/cluster/tasks/test_node_ops_tasks.py
@@ -194,6 +194,7 @@ async def check_decommission_tasks_tree(manager: ScyllaClusterManager, tm: TaskM
     vts_list = await get_new_virtual_tasks_list(tm, module_name, servers[0], previous_vts)
     return servers, previous_vts + [vts_list[0].task_id]
 
+@pytest.mark.max_running_shards(6)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_node_ops_tasks_tree(manager: ScyllaClusterManager):
     """Test node ops task manager tasks."""
@@ -220,6 +221,7 @@ async def test_node_ops_tasks_tree(manager: ScyllaClusterManager):
         # live node for DROP KEYSPACE.
         await manager.driver_connect()
 
+@pytest.mark.max_running_shards(4)
 async def test_node_ops_tasks_ttl(manager: ScyllaClusterManager):
     """Test node ops virtual tasks' ttl."""
     module_name = "node_ops"
@@ -229,6 +231,7 @@ async def test_node_ops_tasks_ttl(manager: ScyllaClusterManager):
     time.sleep(3)
     await get_new_virtual_tasks_statuses(tm, module_name, servers, [], expected_task_num=0)
 
+@pytest.mark.max_running_shards(4)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_node_ops_task_wait(manager: ScyllaClusterManager):
     """Test node ops virtual task's wait."""

--- a/test/cluster/tasks/test_tablet_tasks.py
+++ b/test/cluster/tasks/test_tablet_tasks.py
@@ -80,6 +80,7 @@ async def check_and_abort_repair_task(manager: ScyllaClusterManager, tm: TaskMan
 
     await asyncio.gather(wait_for_task(), abort_task())
 
+@pytest.mark.max_running_shards(6)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_tablet_repair_task(manager: ScyllaClusterManager):
     module_name = "tablets"
@@ -96,6 +97,7 @@ async def test_tablet_repair_task(manager: ScyllaClusterManager):
 
     await asyncio.gather(repair_task(), check_and_abort_repair_task(manager, tm, servers, module_name, ks))
 
+@pytest.mark.max_running_shards(6)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_tablet_repair_wait_with_table_drop(manager: ScyllaClusterManager):
     module_name = "tablets"
@@ -170,6 +172,7 @@ async def check_repair_task_list(tm: TaskManagerClient, servers: list[ServerInfo
 
         await tm.abort_task(servers[0].ip_addr, task0.task_id)
 
+@pytest.mark.max_running_shards(6)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_tablet_repair_task_list(manager: ScyllaClusterManager):
     module_name = "tablets"
@@ -193,6 +196,7 @@ async def test_tablet_repair_task_list(manager: ScyllaClusterManager):
 
     await asyncio.gather(run_repair(0, "test"), run_repair(1, "test2"), run_repair(2, "test3"), check_repair_task_list(tm, servers, module_name, ks))
 
+@pytest.mark.max_running_shards(6)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_tablet_repair_wait(manager: ScyllaClusterManager):
     module_name = "tablets"
@@ -231,6 +235,7 @@ async def test_tablet_repair_wait(manager: ScyllaClusterManager):
 
     await asyncio.gather(wait_for_task(), merge_tablets())
 
+@pytest.mark.max_running_shards(6)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_tablet_repair_task_children(manager: ScyllaClusterManager):
     module_name = "tablets"
@@ -287,6 +292,7 @@ async def prepare_migration_test(manager: ScyllaClusterManager):
 
     return (ks, servers, host_ids)
 
+@pytest.mark.max_running_shards(4)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_tablet_migration_task(manager: ScyllaClusterManager):
     module_name = "tablets"
@@ -321,6 +327,7 @@ async def test_tablet_migration_task(manager: ScyllaClusterManager):
     migration_dst = (host_ids[1], 0)
     await asyncio.gather(move_tablet(migration_src, migration_dst), check("migration"))
 
+@pytest.mark.max_running_shards(4)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_tablet_migration_task_list(manager: ScyllaClusterManager):
     module_name = "tablets"
@@ -367,6 +374,7 @@ async def test_tablet_migration_task_list(manager: ScyllaClusterManager):
     await enable_injection(manager, servers, injection)
     await asyncio.gather(move_tablet(servers[0], migration_src, migration_dst), check_migration_task_list("migration"))
 
+@pytest.mark.max_running_shards(4)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_tablet_migration_task_failed(manager: ScyllaClusterManager):
     module_name = "tablets"
@@ -407,6 +415,7 @@ async def test_tablet_migration_task_failed(manager: ScyllaClusterManager):
     dst = (src[0], 1 - src[1])
     await asyncio.gather(move_tablet(src, dst), check("intranode_migration", log, mark))
 
+@pytest.mark.max_running_shards(6)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_repair_task_info_is_none_when_no_running_repair(manager: ScyllaClusterManager):
     module_name = "tablets"
@@ -466,6 +475,7 @@ cmdline = ['--target-tablet-size-in-bytes', '30000', ]
 cmdline.extend(extra_scylla_cmdline_options)
 
 
+@pytest.mark.max_running_shards(2)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_tablet_resize_task(manager: ScyllaClusterManager):
     module_name = "tablets"
@@ -506,6 +516,7 @@ async def test_tablet_resize_task(manager: ScyllaClusterManager):
         await wait_and_check_status(servers[0], "split", keyspace, table2)
         await wait_and_check_status(servers[0], "merge", keyspace, table1)
 
+@pytest.mark.max_running_shards(4)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_tablet_resize_list(manager: ScyllaClusterManager):
     module_name = "tablets"
@@ -569,6 +580,7 @@ async def test_tablet_resize_list(manager: ScyllaClusterManager):
         await disable_injection(manager, servers, injection)
 
 
+@pytest.mark.max_running_shards(2)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 @pytest.mark.skip_mode(mode='debug', reason='debug mode is too time-sensitive')
 async def test_tablet_resize_revoked(manager: ScyllaClusterManager):
@@ -610,6 +622,7 @@ async def test_tablet_resize_revoked(manager: ScyllaClusterManager):
 
         await asyncio.gather(revoke_resize(log, mark), wait_for_task(task0.task_id))
 
+@pytest.mark.max_running_shards(6)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_tablet_task_sees_latest_state(manager: ScyllaClusterManager):
     servers, cql, hosts, ks, table_id = await create_table_insert_data_for_repair(manager)
@@ -630,6 +643,7 @@ async def test_tablet_task_sees_latest_state(manager: ScyllaClusterManager):
     await asyncio.gather(repair_task(), del_repair_task())
 
 
+@pytest.mark.max_running_shards(6)
 @pytest.mark.asyncio
 @pytest.mark.skip_mode(mode="release", reason="error injections are not supported in release mode")
 async def test_tablet_repair_wait_task_shutdown(manager: ScyllaClusterManager):

--- a/test/cluster/test_aggregation.py
+++ b/test/cluster/test_aggregation.py
@@ -20,6 +20,7 @@ logger = logging.getLogger(__name__)
 pytestmark = pytest.mark.prepare_3_racks_cluster
 
 
+@pytest.mark.max_running_shards(6)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_cancel_mapreduce(manager: ScyllaClusterManager, build_mode: str):
     """

--- a/test/cluster/test_alternator.py
+++ b/test/cluster/test_alternator.py
@@ -88,6 +88,7 @@ def unique_table_name():
 unique_table_name.last_ms = 0
 
 
+@pytest.mark.max_running_shards(6)
 async def test_alternator_ttl_scheduling_group(manager: ScyllaClusterManager):
     """A reproducer for issue #18719: The expiration scans and deletions
        initiated by the Alternator TTL feature are supposed to run entirely in
@@ -190,6 +191,7 @@ async def test_alternator_ttl_scheduling_group(manager: ScyllaClusterManager):
 
     table.delete()
 
+@pytest.mark.max_running_shards(6)
 @pytest.mark.parametrize("with_down_node", [False, True], ids=["all_nodes_up", "one_node_down"])
 async def test_alternator_ttl_multinode_expiration(manager: ScyllaClusterManager, with_down_node):
     """When the cluster has multiple nodes, different nodes are responsible
@@ -256,6 +258,7 @@ async def test_alternator_ttl_multinode_expiration(manager: ScyllaClusterManager
         time.sleep(0.1)
     assert items == 0
 
+@pytest.mark.max_running_shards(4)
 async def test_localnodes_broadcast_rpc_address(manager: ScyllaClusterManager):
     """Test that if the "broadcast_rpc_address" of a node is set, the
        "/localnodes" request returns not the node's internal IP address,
@@ -294,6 +297,7 @@ async def test_localnodes_broadcast_rpc_address(manager: ScyllaClusterManager):
                 break # done
             await asyncio.sleep(0.1)
 
+@pytest.mark.max_running_shards(4)
 async def test_localnodes_drained_node(manager: ScyllaClusterManager):
     """Test that if in a cluster one node is brought down with "nodetool drain"
        a "/localnodes" request should NOT return that node. This test does
@@ -335,6 +339,7 @@ async def test_localnodes_drained_node(manager: ScyllaClusterManager):
     assert await wait_for(check_localnodes_one, time.time() + 60)
 
 
+@pytest.mark.max_running_shards(4)
 async def test_localnodes_down_normal_node(manager: ScyllaClusterManager):
     """Test that if in a cluster one node reaches "normal" state and then
        brought down (so is now in "DN" state), a "/localnodes" request
@@ -377,6 +382,7 @@ async def test_localnodes_down_normal_node(manager: ScyllaClusterManager):
     assert await wait_for(check_localnodes_one, time.time() + 60)
 
 
+@pytest.mark.max_running_shards(4)
 @pytest.mark.tier2
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_localnodes_joining_nodes(manager: ScyllaClusterManager):
@@ -432,6 +438,7 @@ async def test_localnodes_joining_nodes(manager: ScyllaClusterManager):
     except Exception as e:
         assert 'Failed to add server' in str(e)
 
+@pytest.mark.max_running_shards(16)
 async def test_localnodes_multi_dc_multi_rack(manager: ScyllaClusterManager):
     """A test for /localnodes on a more general setup, with multiple DCs and
        multiple racks - an 8-node setup with two DCs, two racks in each, and
@@ -517,6 +524,7 @@ async def test_localnodes_multi_dc_multi_rack(manager: ScyllaClusterManager):
 # same one-node cluster with authentication and authorization enabled.
 # Here in this file we have the opportunity to create clusters with different
 # configurations, so we can check how these configuration settings affect RBAC.
+@pytest.mark.max_running_shards(2)
 async def test_alternator_enforce_authorization_false(manager: ScyllaClusterManager):
     """A basic test for how Alternator authentication and authorization
        work when alternator_enfore_authorization is *false* (and CQL's
@@ -538,6 +546,7 @@ async def test_alternator_enforce_authorization_false(manager: ScyllaClusterMana
     table.get_item(Key={'p': 42})
     table.delete()
 
+@pytest.mark.max_running_shards(2)
 async def test_alternator_enforce_authorization_false2(manager: ScyllaClusterManager):
     """A variant of the above test for alternator_enforce_authorization=false
        Here we check what happens when CQL's authenticator/authorizer are
@@ -592,6 +601,7 @@ async def get_secret_key(cql, user):
         deadline=time.time() + 60,
         label=f"secret key for role {user}")
 
+@pytest.mark.max_running_shards(2)
 async def test_alternator_enforce_authorization_true(manager: ScyllaClusterManager):
     """A basic test for how Alternator authentication and authorization
        work when authentication and authorization is enabled in CQL, and
@@ -641,6 +651,7 @@ async def test_alternator_enforce_authorization_true(manager: ScyllaClusterManag
     # We could further test how GRANT works, but this would be unnecessary
     # repeating of the tests in test/alternator/test_cql_rbac.py.
 
+@pytest.mark.max_running_shards(2)
 async def test_index_in_rf_rack_valid_keyspace_does_not_require_rf_rack_flag(manager: ScyllaClusterManager):
     """
     Verify that creating a table with GSI or LSI and adding GSI to an existing table works
@@ -739,6 +750,7 @@ async def test_index_in_rf_rack_valid_keyspace_does_not_require_rf_rack_flag(man
         ]
     )
 
+@pytest.mark.max_running_shards(8)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_index_requires_rf_rack_valid_keyspace(manager: ScyllaClusterManager):
     """
@@ -843,6 +855,7 @@ async def test_index_requires_rf_rack_valid_keyspace(manager: ScyllaClusterManag
             ]
         )
 
+@pytest.mark.max_running_shards(8)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_rf_rack_flag_enforces_rf_rack_validity(manager: ScyllaClusterManager):
     """
@@ -914,6 +927,7 @@ class ThreadWrapper(threading.Thread):
 # serializes its own schema modifications. This is why these tests must
 # be here, in test/cluster, and not in the single-node test/alternator.
 
+@pytest.mark.max_running_shards(6)
 async def test_concurrent_createtable(manager: ScyllaClusterManager):
     """A reproducer for issue #13152 for the CreateTable operation:
        concurrent CreateTable operations shouldn't fail "due to concurrent
@@ -980,6 +994,7 @@ async def test_concurrent_createtable(manager: ScyllaClusterManager):
                         break
                     raise
 
+@pytest.mark.max_running_shards(6)
 async def test_concurrent_deletetable(manager: ScyllaClusterManager):
     """A reproducer for issue #13152 for the DeleteTable operation:
        concurrent DeleteTable operations shouldn't fail "due to concurrent
@@ -1029,6 +1044,7 @@ async def test_concurrent_deletetable(manager: ScyllaClusterManager):
             if not 'ResourceNotFoundException' in str(e):
                 raise
 
+@pytest.mark.max_running_shards(6)
 async def test_concurrent_updatetable(manager: ScyllaClusterManager):
     """A reproducer for issue #13152 for the UpdateTable operation:
        concurrent UpdateTable operations shouldn't fail "due to concurrent
@@ -1080,6 +1096,7 @@ async def test_concurrent_updatetable(manager: ScyllaClusterManager):
             if not 'ResourceNotFoundException' in str(e):
                 raise
 
+@pytest.mark.max_running_shards(6)
 @pytest.mark.parametrize('op', ['TagResource', 'UntagResource', 'UpdateTimeToLive'])
 async def test_concurrent_modify_tags(manager: ScyllaClusterManager, op):
     """A reproducer for issue #13152 for the TagResource, UntagResource
@@ -1156,6 +1173,7 @@ async def nodes_with_data(manager, ks, cf, host):
         j = await manager.api.client.get_json('/storage_service/tokens_endpoint', host=host.ip_addr)
         return { await manager.api.get_host_id(entry['value']) for entry in j }
 
+@pytest.mark.max_running_shards(10)
 @pytest.mark.parametrize("tablets", [True, False])
 async def test_zero_token_node_load_balancer(manager, tablets):
     """Test that a zero-token node (a.k.a. coordinator-only or proxy node),
@@ -1216,6 +1234,7 @@ async def test_zero_token_node_load_balancer(manager, tablets):
     assert got == expected
     table.delete()
 
+@pytest.mark.max_running_shards(6)
 @pytest.mark.xfail(reason="#16261", strict=False)
 async def test_alternator_concurrent_rmw_same_partition_different_server(manager: ScyllaClusterManager):
     """A reproducer for issue #16261: When sending RMW (read-modify-write)
@@ -1280,6 +1299,7 @@ async def test_alternator_concurrent_rmw_same_partition_different_server(manager
         table.delete()
 
 
+@pytest.mark.max_running_shards(2)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_alternator_invalid_shard_for_lwt(manager: ScyllaClusterManager):
     """
@@ -1395,6 +1415,7 @@ async def test_alternator_invalid_shard_for_lwt(manager: ScyllaClusterManager):
     stop_event.set()
     t.join()
 
+@pytest.mark.max_running_shards(2)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_deferred_stream_enablement_on_tablets(manager: ScyllaClusterManager):
     """Test that enabling Alternator Streams on a tablet table uses deferred
@@ -1559,6 +1580,7 @@ def make_client_cert(tmp_path, name, cn=None, *, subj=None, ca='ca', extfile=Non
               f'-CA "{tmp_path}/{ca}.crt" -CAkey "{tmp_path}/{ca}.key" '
               f'-out "{tmp_path}/{name}.crt" 2>/dev/null')
 
+@pytest.mark.max_running_shards(2)
 async def test_alternator_mtls(manager: ScyllaClusterManager, tmp_path):
     """A regression test for mTLS (mutual TLS) authentication in Alternator.
     We create an Alternator instance configured with require_client_auth=true,
@@ -1684,6 +1706,7 @@ async def test_alternator_mtls(manager: ScyllaClusterManager, tmp_path):
     # exists - see https://github.com/scylladb/seastar/issues/3521.
 
 
+@pytest.mark.max_running_shards(2)
 async def test_alternator_mtls_optional(manager: ScyllaClusterManager, tmp_path):
     """Test Alternator over HTTPS with require_client_auth=optional, which allows both
        mTLS and SigV4 authentication to coexist on the same port.
@@ -1779,6 +1802,7 @@ async def test_alternator_mtls_optional(manager: ScyllaClusterManager, tmp_path)
         alternator_no_auth.meta.client.list_tables()
 
 
+@pytest.mark.max_running_shards(2)
 async def test_alternator_mtls_authorization(manager: ScyllaClusterManager, tmp_path):
     """Test that when mTLS is active, the CN of the client certificate is used
        as the CQL role name for Alternator authorization. A cert whose CN names
@@ -1843,6 +1867,7 @@ async def test_alternator_mtls_authorization(manager: ScyllaClusterManager, tmp_
         table.delete()
 
 
+@pytest.mark.max_running_shards(2)
 async def test_alternator_mtls_role_checks(manager: ScyllaClusterManager, tmp_path):
     """Test that mTLS authentication in Alternator validates the role given
     by the certificate's CN - it must be a valid CQL role with LOGIN=TRUE.
@@ -1937,6 +1962,7 @@ async def test_alternator_mtls_role_checks(manager: ScyllaClusterManager, tmp_pa
         get_alternator_mtls_and_sigv4('no_cn').meta.client.list_tables()
 
 
+@pytest.mark.max_running_shards(2)
 async def test_alternator_mtls_san(manager: ScyllaClusterManager, tmp_path):
     """Test that mTLS authentication in Alternator can extract the role name
     from a Subject Alternative Name (SAN) instead of the subject DN, using
@@ -2020,6 +2046,7 @@ async def test_alternator_mtls_san(manager: ScyllaClusterManager, tmp_path):
         get_alternator_mtls('no_san_client').meta.client.list_tables()
 
 
+@pytest.mark.max_running_shards(2)
 async def test_alternator_mtls_and_plain_http(manager: ScyllaClusterManager, tmp_path):
     """Test that require_client_auth=true, configured for the Alternator
     HTTPS port, has no effect on a separate, plain HTTP Alternator port

--- a/test/cluster/test_alternator_proxy_protocol.py
+++ b/test/cluster/test_alternator_proxy_protocol.py
@@ -204,6 +204,7 @@ async def alternator_proxy_server(manager: ScyllaClusterManager):
     yield (server, manager)
 
 
+@pytest.mark.max_running_shards(2)
 async def test_alternator_proxy_protocol_basic(alternator_proxy_server):
     """Test that connections through the Alternator proxy protocol port work."""
     server, _ = alternator_proxy_server
@@ -221,6 +222,7 @@ async def test_alternator_proxy_protocol_basic(alternator_proxy_server):
     assert 'TableNames' in response, f"Expected TableNames in response: {response}"
 
 
+@pytest.mark.max_running_shards(2)
 async def test_alternator_proxy_protocol_multiple_connections(alternator_proxy_server):
     """Test multiple connections with different source addresses."""
     server, _ = alternator_proxy_server
@@ -244,6 +246,7 @@ async def test_alternator_proxy_protocol_multiple_connections(alternator_proxy_s
         assert 'TableNames' in response, f"Expected TableNames in response for {fake_src_addr}: {response}"
 
 
+@pytest.mark.max_running_shards(2)
 async def test_alternator_proxy_protocol_ssl_basic(alternator_proxy_server):
     """Test proxy protocol with TLS encryption."""
     server, _ = alternator_proxy_server
@@ -262,6 +265,7 @@ async def test_alternator_proxy_protocol_ssl_basic(alternator_proxy_server):
     assert 'TableNames' in response, f"Expected TableNames in response: {response}"
 
 
+@pytest.mark.max_running_shards(2)
 async def test_alternator_regular_port_still_works(alternator_proxy_server):
     """Test that the regular Alternator port still works when proxy protocol ports are configured."""
     server, _ = alternator_proxy_server
@@ -277,6 +281,7 @@ async def test_alternator_regular_port_still_works(alternator_proxy_server):
     assert 'TableNames' in response, f"Expected TableNames in response: {response}"
 
 
+@pytest.mark.max_running_shards(2)
 async def test_alternator_proxy_header_to_regular_port_fails(alternator_proxy_server):
     """Test that sending a proxy protocol header to the regular port fails.
 
@@ -298,6 +303,7 @@ async def test_alternator_proxy_header_to_regular_port_fails(alternator_proxy_se
         )
 
 
+@pytest.mark.max_running_shards(2)
 async def test_alternator_no_proxy_header_to_proxy_port_fails(alternator_proxy_server):
     """Test that sending a request without proxy header to the proxy port fails.
 
@@ -318,6 +324,7 @@ async def test_alternator_no_proxy_header_to_proxy_port_fails(alternator_proxy_s
         )
 
 
+@pytest.mark.max_running_shards(2)
 @pytest.mark.parametrize("use_ssl", [False, True], ids=["http", "https"])
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_alternator_proxy_protocol_address_in_system_clients(alternator_proxy_server, use_ssl):

--- a/test/cluster/test_audit.py
+++ b/test/cluster/test_audit.py
@@ -2533,6 +2533,7 @@ verify_legacy_and_rules = pytest.mark.parametrize("rules_mode", [
 ])
 
 
+@pytest.mark.max_running_shards(2)
 @verify_legacy_and_rules
 async def test_audit_table_noauth(manager: ScyllaClusterManager, rules_mode: bool):
     """Table backend, no auth, single node — groups all tests that share this config."""
@@ -2560,6 +2561,7 @@ async def test_audit_table_noauth(manager: ScyllaClusterManager, rules_mode: boo
 
 # AuditBackendTable, auth (cassandra), rf=1
 
+@pytest.mark.max_running_shards(2)
 @verify_legacy_and_rules
 async def test_audit_table_auth(manager: ScyllaClusterManager, rules_mode: bool):
     """Table backend, auth enabled, single node."""
@@ -2578,6 +2580,7 @@ async def test_audit_table_auth(manager: ScyllaClusterManager, rules_mode: bool)
 
 # AuditBackendTable, auth (cassandra), rf=3
 
+@pytest.mark.max_running_shards(6)
 @verify_legacy_and_rules
 async def test_audit_table_auth_multinode(manager: ScyllaClusterManager, rules_mode: bool):
     """Table backend, auth enabled, multi-node (rf=3)."""
@@ -2587,48 +2590,57 @@ async def test_audit_table_auth_multinode(manager: ScyllaClusterManager, rules_m
 
 # AuditBackendTable, standalone / special config
 
+@pytest.mark.max_running_shards(2)
 async def test_audit_type_none_standalone(manager: ScyllaClusterManager):
     """audit=None — verify no auditing occurs."""
     await CQLAuditTester(manager)._test_audit_type_none()
 
 
+@pytest.mark.max_running_shards(2)
 async def test_audit_type_invalid_standalone(manager: ScyllaClusterManager):
     """audit=invalid — server should fail to start."""
     await CQLAuditTester(manager)._test_audit_type_invalid()
 
 
+@pytest.mark.max_running_shards(2)
 async def test_composite_audit_type_invalid_standalone(manager: ScyllaClusterManager):
     """audit=table,syslog,invalid — server should fail to start."""
     await CQLAuditTester(manager)._test_composite_audit_type_invalid()
 
 
+@pytest.mark.max_running_shards(2)
 async def test_audit_empty_settings_standalone(manager: ScyllaClusterManager):
     """audit=none — verify no auditing occurs."""
     await CQLAuditTester(manager)._test_audit_empty_settings()
 
 
+@pytest.mark.max_running_shards(2)
 async def test_composite_audit_empty_settings_standalone(manager: ScyllaClusterManager):
     """audit=table,syslog,none — verify no auditing occurs."""
     await CQLAuditTester(manager)._test_composite_audit_empty_settings()
 
 
+@pytest.mark.max_running_shards(2)
 async def test_audit_categories_invalid_standalone(manager: ScyllaClusterManager):
     """Invalid audit_categories — server should fail to start."""
     await CQLAuditTester(manager)._test_audit_categories_invalid()
 
 
 # No verify_legacy_and_rules, because it's a replica failure test, so it's enough to test it in one mode
+@pytest.mark.max_running_shards(14)
 async def test_insert_failure_standalone(manager: ScyllaClusterManager):
     """7-node topology, audit=table, no auth — standalone due to unique topology."""
     await CQLAuditTester(manager)._test_insert_failure_doesnt_report_success()
 
 
+@pytest.mark.max_running_shards(1)
 @verify_legacy_and_rules
 async def test_service_level_statements_standalone(manager: ScyllaClusterManager, rules_mode: bool):
     """audit=table, auth, cmdline=--smp 1 — standalone due to special cmdline."""
     await CQLAuditTester(manager, rules_mode=rules_mode)._test_service_level_statements()
 
 
+@pytest.mark.max_running_shards(2)
 @verify_legacy_and_rules
 async def test_audit_maintenance_socket_user_creation(manager: ScyllaClusterManager, rules_mode: bool):
     """Verify that creating a superuser via the maintenance socket is audited."""
@@ -2640,6 +2652,7 @@ async def test_audit_maintenance_socket_user_creation(manager: ScyllaClusterMana
 
 # AuditBackendSyslog, no auth, rf=1
 
+@pytest.mark.max_running_shards(2)
 @verify_legacy_and_rules
 async def test_audit_syslog_noauth(manager: ScyllaClusterManager, rules_mode: bool):
     """Syslog backend, no auth, single node."""
@@ -2660,6 +2673,7 @@ async def test_audit_syslog_noauth(manager: ScyllaClusterManager, rules_mode: bo
 
 # AuditBackendSyslog, auth, rf=1
 
+@pytest.mark.max_running_shards(2)
 @verify_legacy_and_rules
 async def test_audit_syslog_auth(manager: ScyllaClusterManager, rules_mode: bool):
     """Syslog backend, auth enabled, single node."""
@@ -2672,6 +2686,7 @@ async def test_audit_syslog_auth(manager: ScyllaClusterManager, rules_mode: bool
 
 # AuditBackendComposite, no auth, rf=1
 
+@pytest.mark.max_running_shards(2)
 @verify_legacy_and_rules
 async def test_audit_composite_noauth(manager: ScyllaClusterManager, rules_mode: bool):
     """Composite backend (table+syslog), no auth, single node."""
@@ -2692,6 +2707,7 @@ async def test_audit_composite_noauth(manager: ScyllaClusterManager, rules_mode:
 
 # AuditBackendComposite, auth, rf=1
 
+@pytest.mark.max_running_shards(2)
 @verify_legacy_and_rules
 async def test_audit_composite_auth(manager: ScyllaClusterManager, rules_mode: bool):
     """Composite backend (table+syslog), auth enabled, single node."""
@@ -2706,6 +2722,7 @@ _syslog = functools.partial(AuditBackendSyslog, socket_path=syslog_socket_path)
 _composite = functools.partial(AuditBackendComposite, socket_path=syslog_socket_path)
 
 
+@pytest.mark.max_running_shards(2)
 @pytest.mark.parametrize("helper_class,config_changer", [
     pytest.param(AuditBackendTable, CQLAuditTester.AuditSighupConfigChanger, id="table-sighup"),
     pytest.param(AuditBackendTable, CQLAuditTester.AuditCqlConfigChanger, id="table-cql"),
@@ -2719,6 +2736,7 @@ async def test_config_no_liveupdate(manager: ScyllaClusterManager, helper_class,
     await CQLAuditTester(manager)._test_config_no_liveupdate(helper_class, config_changer)
 
 
+@pytest.mark.max_running_shards(6)
 @pytest.mark.parametrize("helper_class,config_changer", [
     pytest.param(AuditBackendTable, CQLAuditTester.AuditSighupConfigChanger, id="table-sighup"),
     pytest.param(AuditBackendTable, CQLAuditTester.AuditCqlConfigChanger, id="table-cql"),
@@ -2732,6 +2750,7 @@ async def test_config_liveupdate(manager: ScyllaClusterManager, helper_class, co
     await CQLAuditTester(manager)._test_config_liveupdate(helper_class, config_changer)
 
 
+@pytest.mark.max_running_shards(6)
 @pytest.mark.parametrize("helper_class", [
     pytest.param(AuditBackendTable, id="table"),
     pytest.param(_syslog, id="syslog"),
@@ -2741,6 +2760,7 @@ async def test_parallel_syslog_audit(manager: ScyllaClusterManager, helper_class
     """Cluster must not fail when multiple queries are audited in parallel."""
     await CQLAuditTester(manager)._test_parallel_syslog_audit(helper_class)
 
+@pytest.mark.max_running_shards(2)
 async def test_upgrade_preserves_ddl_audit_for_tables(
         manager: ScyllaClusterManager,
         scylla_2025_1: ScyllaVersionDescription,
@@ -2800,6 +2820,7 @@ async def test_upgrade_preserves_ddl_audit_for_tables(
     )
 
 
+@pytest.mark.max_running_shards(2)
 async def test_audit_rules(manager: ScyllaClusterManager):
     """Behaviors specific to audit_rules that the legacy config cannot express."""
     await CQLAuditTester(manager)._test_audit_rules_matching()
@@ -2808,6 +2829,7 @@ async def test_audit_rules(manager: ScyllaClusterManager):
     await CQLAuditTester(manager)._test_audit_rules_sink_mismatch_warning()
 
 
+@pytest.mark.max_running_shards(4)
 async def test_audit_rules_with_auth(manager: ScyllaClusterManager):
     """audit_rules behaviors that require authentication: role filtering and cache notifications."""
     await CQLAuditTester(manager)._test_audit_rules_role_filtering()
@@ -2818,6 +2840,7 @@ async def test_audit_rules_with_auth(manager: ScyllaClusterManager):
 
 # Alternator audit regression test
 
+@pytest.mark.max_running_shards(2)
 async def test_alternator_basic_ops_audit_disabled(manager: ScyllaClusterManager):
     # Basic Alternator operations must not crash when audit is disabled.
     config = alternator_config | {'audit': 'none'}

--- a/test/cluster/test_auth_certificate_or_password.py
+++ b/test/cluster/test_auth_certificate_or_password.py
@@ -248,6 +248,7 @@ def _server_config(tmp_path, extra_config=None):
     return config
 
 
+@pytest.mark.max_running_shards(2)
 async def test_cql_optional_client_cert(manager: ScyllaClusterManager, tmp_path):
     """Test CertificateOrPasswordAuthenticator with require_client_auth=optional.
 
@@ -370,6 +371,7 @@ async def test_cql_optional_client_cert(manager: ScyllaClusterManager, tmp_path)
         safe_driver_shutdown(cluster_no_rule_cert)
 
 
+@pytest.mark.max_running_shards(2)
 async def test_cql_plain_port(manager: ScyllaClusterManager, tmp_path):
     """Test CertificateOrPasswordAuthenticator on an unencrypted CQL port.
 
@@ -475,6 +477,7 @@ def _attempt_cert_login(host, tmp_path, cert, refused):
         safe_driver_shutdown(cluster)
 
 
+@pytest.mark.max_running_shards(2)
 async def test_audit_accepted_certificate_login(manager: ScyllaClusterManager, tmp_path):
     """An accepted certificate login is audited under the role it names (SCYLLADB-3926)."""
     async with _audit_login_node(manager, tmp_path) as (host, admin):
@@ -485,6 +488,7 @@ async def test_audit_accepted_certificate_login(manager: ScyllaClusterManager, t
                             description='certuser certificate login')
 
 
+@pytest.mark.max_running_shards(2)
 async def test_audit_rejected_certificate_login(manager: ScyllaClusterManager, tmp_path):
     """A certificate the role query cannot match is audited under an empty name (SCYLLADB-3926)."""
     async with _audit_login_node(manager, tmp_path) as (host, admin):
@@ -494,6 +498,7 @@ async def test_audit_rejected_certificate_login(manager: ScyllaClusterManager, t
         _await_login_record(admin, host, '', error=True, description='rejected certificate')
 
 
+@pytest.mark.max_running_shards(2)
 async def test_audit_certificate_for_missing_role(manager: ScyllaClusterManager, tmp_path):
     """A certificate naming a role that does not exist is audited as an error (SCYLLADB-3926).
 
@@ -511,6 +516,7 @@ async def test_audit_certificate_for_missing_role(manager: ScyllaClusterManager,
             'a refused certificate login must not also produce a success record'
 
 
+@pytest.mark.max_running_shards(2)
 async def test_audit_password_login_on_tls_port(manager: ScyllaClusterManager, tmp_path):
     """A password login on the TLS port keeps producing its SASL-path record (SCYLLADB-3926)."""
     async with _audit_login_node(manager, tmp_path) as (host, admin):
@@ -574,6 +580,7 @@ def _refused_login_records(session):
     return [r for r in _login_records(session) if r.username == '' and r.error]
 
 
+@pytest.mark.max_running_shards(2)
 async def test_audit_login_without_certificate(manager: ScyllaClusterManager, tmp_path):
     """A client presenting no certificate at all must be audited (SCYLLADB-3926).
 
@@ -607,6 +614,7 @@ async def test_audit_login_without_certificate(manager: ScyllaClusterManager, tm
             assert row.table_name == ''
 
 
+@pytest.mark.max_running_shards(2)
 async def test_audit_repeated_refused_startup(manager: ScyllaClusterManager, tmp_path):
     """Every rejected STARTUP on one connection must be audited (SCYLLADB-3926).
 

--- a/test/cluster/test_automatic_cleanup.py
+++ b/test/cluster/test_automatic_cleanup.py
@@ -13,6 +13,7 @@ import asyncio
 logger = logging.getLogger(__name__)
 
 
+@pytest.mark.max_running_shards(6)
 async def test_no_cleanup_when_unnecessary(manager: ScyllaClusterManager):
     """The test runs two bootstraps and checks that there is no cleanup in between.
        Then it runs a decommission and checks that cleanup runs automatically and then
@@ -71,6 +72,7 @@ async def test_no_cleanup_when_unnecessary(manager: ScyllaClusterManager):
     assert sum(len(x) for x in matches) == 0
 
 
+@pytest.mark.max_running_shards(6)
 @pytest.mark.skip_mode(mode='debug', reason='dev is enough')
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_cleanup_waits_for_stale_writes(manager: ScyllaClusterManager):

--- a/test/cluster/test_bad_initial_token.py
+++ b/test/cluster/test_bad_initial_token.py
@@ -10,6 +10,7 @@ import logging
 logger = logging.getLogger(__name__)
 
 
+@pytest.mark.max_running_shards(4)
 async def test_bad_initial_token(manager: ScyllaClusterManager):
     # The validity of "initial_token" option is checked in the topology
     # coordinator, even if this is the first node being bootstrap, and triggers

--- a/test/cluster/test_batchlog_manager.py
+++ b/test/cluster/test_batchlog_manager.py
@@ -15,6 +15,7 @@ from test.cluster.util import new_test_keyspace, reconnect_driver, wait_for_cql_
 
 logger = logging.getLogger(__name__)
 
+@pytest.mark.max_running_shards(6)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_batchlog_replay_while_a_node_is_down(manager: ScyllaClusterManager) -> None:
     """ Test that batchlog replay handles the case when a node is down while replaying a batch.
@@ -75,6 +76,7 @@ async def test_batchlog_replay_while_a_node_is_down(manager: ScyllaClusterManage
                 return True
         await wait_for(batchlog_empty, time.time() + 60)
 
+@pytest.mark.max_running_shards(6)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_batchlog_replay_aborted_on_shutdown(manager: ScyllaClusterManager) -> None:
     """ Similar to the previous test, but also verifies that the batchlog replay is aborted on shutdown,
@@ -138,6 +140,7 @@ async def test_batchlog_replay_aborted_on_shutdown(manager: ScyllaClusterManager
                 return True
         await wait_for(batchlog_empty, time.time() + 60)
 
+@pytest.mark.max_running_shards(2)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_batchlog_replay_includes_cdc(manager: ScyllaClusterManager) -> None:
     """ Test that when a batch is replayed from the batchlog, it includes CDC mutations.
@@ -200,6 +203,7 @@ async def test_batchlog_replay_includes_cdc(manager: ScyllaClusterManager) -> No
         result2 = await cql.run_async(f"SELECT * FROM {cdc_table_name} WHERE key = 40 ALLOW FILTERING")
         assert len(result2) == 1, f"Expected 1 CDC mutation for key 40, got {len(result2)}"
 
+@pytest.mark.max_running_shards(4)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_drop_mutations_for_dropped_table(manager: ScyllaClusterManager) -> None:
     """
@@ -288,6 +292,7 @@ async def test_drop_mutations_for_dropped_table(manager: ScyllaClusterManager) -
 
         await wait_for(batchlog_empty, time.time() + 60)
 
+@pytest.mark.max_running_shards(4)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 @pytest.mark.parametrize("repair_cache", [True, False])
 async def test_batchlog_replay_failure_during_repair(manager: ScyllaClusterManager, repair_cache: bool) -> None:

--- a/test/cluster/test_boot_nodes.py
+++ b/test/cluster/test_boot_nodes.py
@@ -9,6 +9,7 @@ import time
 import logging
 logger = logging.getLogger(__name__)
 
+@pytest.mark.max_running_shards(6)
 async def test_boot(manager):
     rbno = True
     cfg = {'enable_repair_based_node_ops': rbno, 'num_tokens': 256}

--- a/test/cluster/test_bootstrap_with_quick_group0_join.py
+++ b/test/cluster/test_bootstrap_with_quick_group0_join.py
@@ -18,6 +18,7 @@ from test.pylib.util import wait_for
 logger = logging.getLogger(__name__)
 
 
+@pytest.mark.max_running_shards(4)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_bootstrap_with_quick_group0_join(manager: ScyllaClusterManager):
     """Regression test for https://scylladb.atlassian.net/browse/SCYLLADB-959.

--- a/test/cluster/test_bti_index.py
+++ b/test/cluster/test_bti_index.py
@@ -128,6 +128,7 @@ SSTABLE_FORMAT_MATRIX: list[tuple[Optional[str], bool, bool, str]] = [
     ("mt",   True,  True,  "mt"),
 ]
 
+@pytest.mark.max_running_shards(2)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_bti_index_output_format(manager: ScyllaClusterManager) -> None:
     """Checks that the sstable format written by Scylla is consistent with the
@@ -187,6 +188,7 @@ async def test_bti_index_output_format(manager: ScyllaClusterManager) -> None:
 
     manager.driver_close()
 
+@pytest.mark.max_running_shards(1)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_bti_index_read_path(manager: ScyllaClusterManager) -> None:
     """Checks that the read path uses the right index components for each sstable

--- a/test/cluster/test_cdc_generation_clearing.py
+++ b/test/cluster/test_cdc_generation_clearing.py
@@ -23,6 +23,7 @@ from typing import Optional
 logger = logging.getLogger(__name__)
 
 
+@pytest.mark.max_running_shards(8)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_cdc_generation_clearing(manager: ScyllaClusterManager):
     """Test that obsolete CDC generations are removed from CDC_GENERATIONS_V3 and TOPOLOGY.committed_cdc_generations
@@ -90,6 +91,7 @@ async def test_cdc_generation_clearing(manager: ScyllaClusterManager):
         await check_system_topology_and_cdc_generations_v3_consistency(manager, hosts)
 
 
+@pytest.mark.max_running_shards(6)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_unpublished_cdc_generations_arent_cleared(manager: ScyllaClusterManager):
     """Test that unpublished CDC generations aren't removed from CDC_GENERATIONS_V3 and

--- a/test/cluster/test_cdc_generation_data.py
+++ b/test/cluster/test_cdc_generation_data.py
@@ -12,6 +12,7 @@ logger = logging.getLogger(__name__)
 The injection forces the topology coordinator to send CDC generation data in multiple parts,
 if it didn't the command size would go over commitlog segment size limit making it impossible to commit and apply the command.
 """
+@pytest.mark.max_running_shards(4)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_send_data_in_parts(manager: ScyllaClusterManager):
     config = {
@@ -37,6 +38,7 @@ async def test_send_data_in_parts(manager: ScyllaClusterManager):
         pytest.fail("No CDC generation data sent in parts was found")
 
 
+@pytest.mark.max_running_shards(4)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_group0_apply_while_node_is_being_shutdown(manager: ScyllaClusterManager):
     # This a regression test for #24401.

--- a/test/cluster/test_cdc_generation_publishing.py
+++ b/test/cluster/test_cdc_generation_publishing.py
@@ -22,6 +22,7 @@ from typing import Optional
 logger = logging.getLogger(__name__)
 
 
+@pytest.mark.max_running_shards(6)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_cdc_generations_are_published(request, manager: ScyllaClusterManager):
     """Test that the CDC generation publisher eventually publishes committed CDC generations in the correct order."""
@@ -76,6 +77,7 @@ async def test_cdc_generations_are_published(request, manager: ScyllaClusterMana
     logger.info(f"Timestamps after check_and_repair: {gen_timestamps}")
 
 
+@pytest.mark.max_running_shards(8)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_multiple_unpublished_cdc_generations(request, manager: ScyllaClusterManager):
     """Test that the CDC generation publisher works correctly when there is more than one unpublished CDC generation."""

--- a/test/cluster/test_cdc_with_alter.py
+++ b/test/cluster/test_cdc_with_alter.py
@@ -16,6 +16,7 @@ import pytest
 
 logger = logging.getLogger(__name__)
 
+@pytest.mark.max_running_shards(6)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_add_and_drop_column_with_cdc(manager: ScyllaClusterManager):
     """ Test writing to a table with CDC enabled while adding and dropping a column.
@@ -74,6 +75,7 @@ async def test_add_and_drop_column_with_cdc(manager: ScyllaClusterManager):
         cdc_rows = await cql.run_async(f"SELECT COUNT(*) FROM {ks}.test_scylla_cdc_log")
         assert base_rows[0].count == cdc_rows[0].count, f"Base table rows: {base_rows[0].count}, CDC log rows: {cdc_rows[0].count}"
 
+@pytest.mark.max_running_shards(2)
 async def test_cdc_compatible_schema(manager: ScyllaClusterManager):
     """
     Basic test that we can write to a table with CDC enabled when the schema of
@@ -109,6 +111,7 @@ async def test_cdc_compatible_schema(manager: ScyllaClusterManager):
         matches = await log.grep("has no CDC schema set")
         assert len(matches) == 0, "Found unexpected log messages indicating missing CDC schema"
 
+@pytest.mark.max_running_shards(2)
 async def test_recreate_column_too_soon(manager: ScyllaClusterManager):
     """ Test that recreating a dropped column too soon fails with an appropriate error.
 
@@ -129,6 +132,7 @@ async def test_recreate_column_too_soon(manager: ScyllaClusterManager):
         with pytest.raises(Exception, match="a column with the same name was dropped too recently"):
             await cql.run_async(f"ALTER TABLE {ks}.test ADD dropped_col int")
 
+@pytest.mark.max_running_shards(6)
 async def test_concurrent_writes_and_drop_column_with_cdc_preimage(manager: ScyllaClusterManager):
     """ Test concurrent writes and column drop with CDC preimage enabled.
 

--- a/test/cluster/test_cdc_with_tablets.py
+++ b/test/cluster/test_cdc_with_tablets.py
@@ -32,6 +32,7 @@ class CdcStreamState(IntEnum):
 # Basic test creating a table with CDC enabled, using either CREATE or ALTER to enable CDC, and
 # verifying that CDC streams for the table are created. Then we write to the table and verify
 # the CDC log entries are created in the table's streams.
+@pytest.mark.max_running_shards(2)
 @pytest.mark.parametrize("with_alter", [pytest.param(False, id="create"), pytest.param(True, id="alter")])
 async def test_create_cdc_with_tablets(manager: ScyllaClusterManager, with_alter: bool):
     servers = await manager.servers_add(1)
@@ -70,6 +71,7 @@ async def test_create_cdc_with_tablets(manager: ScyllaClusterManager, with_alter
 
 # Create tables with CDC and verify the CDC streams are removed from the
 # system tables when the tables or keyspaces are dropped.
+@pytest.mark.max_running_shards(2)
 async def test_drop_table_and_drop_keyspace_removes_cdc_streams(manager: ScyllaClusterManager):
     servers = await manager.servers_add(1)
     cql = manager.get_cql()
@@ -103,6 +105,7 @@ async def test_drop_table_and_drop_keyspace_removes_cdc_streams(manager: ScyllaC
 
 # Create a table with CDC, then disable CDC and drop the CDC log table, and create CDC again.
 # Verify streams are created and cleaned up correctly.
+@pytest.mark.max_running_shards(2)
 async def test_drop_and_recreate_cdc(manager: ScyllaClusterManager):
     await manager.servers_add(1)
     cql = manager.get_cql()
@@ -166,6 +169,7 @@ async def validate_virtual_tables(manager, servers, cql, log_table_id, ks, table
 
 # Read CDC stream information from the virtual tables system.cdc_timestamps and system.cdc_streams
 # and verify it against the internal CDC tables.
+@pytest.mark.max_running_shards(2)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_cdc_virtual_tables(manager: ScyllaClusterManager):
     cfg = { 'tablet_load_stats_refresh_interval_in_seconds': 1 }
@@ -206,6 +210,7 @@ async def test_cdc_virtual_tables(manager: ScyllaClusterManager):
         assert [] == await cql.run_async("SELECT * FROM system.cdc_streams")
         await validate_virtual_tables(manager, servers, cql, log_table_id, ks, 'test')
 
+@pytest.mark.max_running_shards(2)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_cdc_virtual_tables_with_multiple_cdc_tables(manager: ScyllaClusterManager):
     cfg = { 'tablet_load_stats_refresh_interval_in_seconds': 1 }
@@ -244,6 +249,7 @@ async def test_cdc_virtual_tables_with_multiple_cdc_tables(manager: ScyllaCluste
 # timestamp, and by applying the differences (closed / opened) in each timestamp, and verify we
 # get the same result.
 # Then trigger tablet merge and do the same, verifying streams are merged.
+@pytest.mark.max_running_shards(2)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_cdc_stream_split_and_merge_basic(manager: ScyllaClusterManager):
     cfg = { 'tablet_load_stats_refresh_interval_in_seconds': 1 }
@@ -309,6 +315,7 @@ async def test_cdc_stream_split_and_merge_basic(manager: ScyllaClusterManager):
 # Test that base table writes and their corresponding CDC log writes are co-located on the same replica.
 # We create a 2-node cluster with RF=1, stop one node, and verify that the partitions available
 # on the alive node work correctly for both base table and CDC log.
+@pytest.mark.max_running_shards(4)
 async def test_cdc_colocation(manager: ScyllaClusterManager):
     # Create 2-node cluster to test co-location
     servers = await manager.servers_add(2)
@@ -369,6 +376,7 @@ async def test_cdc_colocation(manager: ScyllaClusterManager):
 # Create a CDC table with short TTL, then split the tablets to create a new stream set,
 # and wait until the old streams are garbage collected and we have a single stream set again.
 # Verify the remaining stream set is equal to the most recent stream set.
+@pytest.mark.max_running_shards(2)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_cdc_stream_garbage_collection(manager: ScyllaClusterManager):
     cfg = { 'tablet_load_stats_refresh_interval_in_seconds': 1, 'error_injections_at_startup': ['short_cdc_streams_gc_refresh_interval' ] }

--- a/test/cluster/test_change_ip.py
+++ b/test/cluster/test_change_ip.py
@@ -24,6 +24,7 @@ pytestmark = pytest.mark.prepare_3_racks_cluster
 
 
 
+@pytest.mark.max_running_shards(6)
 async def test_change_two(manager, random_tables, build_mode):
     """Stop two nodes, change their IPs and start, check the cluster is
     functional"""

--- a/test/cluster/test_change_replication_factor_1_to_0.py
+++ b/test/cluster/test_change_replication_factor_1_to_0.py
@@ -18,6 +18,7 @@ from test.pylib.util import wait_for
 logger = logging.getLogger(__name__)
 
 
+@pytest.mark.max_running_shards(4)
 @pytest.mark.parametrize(
     "use_tablets",
     [
@@ -70,6 +71,7 @@ async def test_change_replication_factor_1_to_0(request: pytest.FixtureRequest, 
 # Tests #22688 - we should be able to both do further alter:s of a keyspace
 # even after removing replication factor fully from a dc and decommission of said
 # dc.
+@pytest.mark.max_running_shards(4)
 @pytest.mark.parametrize(
     "use_tablets",
     [

--- a/test/cluster/test_change_rpc_address.py
+++ b/test/cluster/test_change_rpc_address.py
@@ -37,6 +37,7 @@ async def two_nodes_cluster(manager: ScyllaClusterManager) -> list[ServerNum]:
     return servers
 
 
+@pytest.mark.max_running_shards(4)
 @pytest.mark.replication_factor(N_SERVERS)
 async def test_change_rpc_address(two_nodes_cluster: list[ServerNum],
                                   manager: ScyllaClusterManager,

--- a/test/cluster/test_client_routes.py
+++ b/test/cluster/test_client_routes.py
@@ -45,6 +45,7 @@ def generate_client_routes_entry(i):
         "alternator_https_port": 8004
     }
 
+@pytest.mark.max_running_shards(6)
 async def test_client_routes(request, manager: ScyllaClusterManager):
     num_servers = 3
     cql = None
@@ -71,6 +72,7 @@ async def test_client_routes(request, manager: ScyllaClusterManager):
     await manager.api.client.delete("/v2/client-routes", host=running_server.ip_addr, json=[generate_client_routes_entry(0)])
     await wait_for_expected_client_routes_size(cql, num_servers)
 
+@pytest.mark.max_running_shards(6)
 async def test_client_routes_node_restart(request, manager: ScyllaClusterManager):
     """
     This test verifies that a node receives updates if client routes were updated
@@ -88,6 +90,7 @@ async def test_client_routes_node_restart(request, manager: ScyllaClusterManager
     cql = await manager.get_cql_exclusive(server_to_restart)
     await wait_for_expected_client_routes_size(cql, 1)
 
+@pytest.mark.max_running_shards(4)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_client_routes_upgrade(request, manager: ScyllaClusterManager):
     """
@@ -132,6 +135,7 @@ async def test_client_routes_upgrade(request, manager: ScyllaClusterManager):
     await wait_for(client_routes_ready, time.time() + 60)
 
 
+@pytest.mark.max_running_shards(6)
 async def test_client_routes_lost_quorum(request, manager: ScyllaClusterManager):
     """
     This test verifies that `/v2/client-routes` fails with a timeout if the Raft quorum cannot be reached.
@@ -191,6 +195,7 @@ async def wait_for_expected_event_num(expected_num, received_events):
         return None
     await wait_for(lambda: expected_event_num(expected_num), time.time() + 60)
 
+@pytest.mark.max_running_shards(4)
 async def test_events(request, manager: ScyllaClusterManager, monkeypatch):
     """
     This test verifies client routes change events in the following steps:
@@ -229,6 +234,7 @@ async def test_events(request, manager: ScyllaClusterManager, monkeypatch):
     assert received_events[2]["connection_ids"] == [generate_connection_id(0)]
     assert received_events[2]["host_ids"] == [generate_host_id(0)]
 
+@pytest.mark.max_running_shards(6)
 @pytest.mark.skip_mode(mode="release", reason="error injections are not supported in release mode")
 async def test_client_routes_snapshot_transfer(request, manager: ScyllaClusterManager, monkeypatch):
     """
@@ -269,6 +275,7 @@ async def test_client_routes_snapshot_transfer(request, manager: ScyllaClusterMa
     assert received_events[0]["host_ids"] == [generate_host_id(1)]
     await log.wait_for("transfer snapshot: raft snapshot includes client_routes mutation")
 
+@pytest.mark.max_running_shards(4)
 async def test_huge_event(request, manager: ScyllaClusterManager, monkeypatch):
     """
     This test verifies that an event can be sent to the driver even when it contains many host_ids and connection_ids.

--- a/test/cluster/test_cluster_config.py
+++ b/test/cluster/test_cluster_config.py
@@ -84,6 +84,7 @@ async def wait_for_schema_agreement(manager: ScyllaClusterManager, servers, dead
     return await wait_for(schema_versions_agree, deadline)
 
 
+@pytest.mark.max_running_shards(6)
 @pytest.mark.asyncio
 async def test_cluster_config_auto_repair_table_scope_persistence(manager: ScyllaClusterManager) -> None:
     servers = [
@@ -116,6 +117,7 @@ async def test_cluster_config_auto_repair_table_scope_persistence(manager: Scyll
     await wait_for_config_map_value_on_hosts(cql, hosts, CLUSTER_CONFIGS_QUERY, [], "auto_repair_enabled", None)
 
 
+@pytest.mark.max_running_shards(4)
 @pytest.mark.asyncio
 async def test_rack_name_is_not_globally_unique(manager: ScyllaClusterManager) -> None:
     """Regression guard: rack names are not required to be globally unique.
@@ -135,6 +137,7 @@ async def test_rack_name_is_not_globally_unique(manager: ScyllaClusterManager) -
     assert {server.rack for server in servers} == {"rack1"}
 
 
+@pytest.mark.max_running_shards(6)
 @pytest.mark.asyncio
 async def test_cluster_config_auto_repair_survives_restart_and_join(manager: ScyllaClusterManager) -> None:
     servers = [
@@ -166,6 +169,7 @@ async def test_cluster_config_auto_repair_survives_restart_and_join(manager: Scy
 # field-by-field in topology_coordinator::finalize_migration(). If it drops config_options,
 # make_create_keyspace_mutations() emits a collection tombstone for the empty map and every
 # keyspace-scope override is silently erased.
+@pytest.mark.max_running_shards(2)
 @pytest.mark.asyncio
 async def test_keyspace_config_survives_vnodes_to_tablets_migration(manager: ScyllaClusterManager) -> None:
     server = await manager.server_add(config={"num_tokens": 16})
@@ -239,6 +243,7 @@ async def test_mixed_version_upgrade_with_old_binary(
     await wait_for_config_map_value_on_hosts(cql, ready_hosts, CLUSTER_CONFIGS_QUERY, [], "auto_repair_enabled", None)
 
 
+@pytest.mark.max_running_shards(4)
 @pytest.mark.asyncio
 async def test_mixed_version_downgrade_with_old_binary_is_rejected_after_feature_enablement(
     manager: ScyllaClusterManager, scylla_binary: Path, scylla_2026_1: ScyllaVersionDescription,
@@ -273,6 +278,7 @@ async def test_mixed_version_downgrade_with_old_binary_is_rejected_after_feature
     )
 
 
+@pytest.mark.max_running_shards(6)
 @pytest.mark.asyncio
 async def test_old_binary_cannot_join_after_cluster_config_feature_enablement(
     manager: ScyllaClusterManager, scylla_binary: Path, scylla_2026_1: ScyllaVersionDescription,
@@ -295,6 +301,7 @@ async def test_old_binary_cannot_join_after_cluster_config_feature_enablement(
     )
 
 
+@pytest.mark.max_running_shards(6)
 @pytest.mark.asyncio
 async def test_joining_node_observes_preexisting_schema_backed_config_metadata(manager: ScyllaClusterManager) -> None:
     servers = [
@@ -323,6 +330,7 @@ async def test_joining_node_observes_preexisting_schema_backed_config_metadata(m
     await wait_for_config_map_value(cql, new_host, TABLE_CONFIGS_QUERY, ["ks_cfg_join", "tbl"], "auto_repair_enabled", "true")
 
 
+@pytest.mark.max_running_shards(6)
 @pytest.mark.asyncio
 async def test_mixed_version_schema_agreement_before_feature_enablement(
     manager: ScyllaClusterManager, scylla_binary: Path, scylla_2026_1: ScyllaVersionDescription,
@@ -422,6 +430,7 @@ async def stored_config_state(cql) -> dict:
 # wipe, replay, and require the stored configs maps to be reproduced exactly at every
 # scope. Then prove inheritance survived the trip: a broader-scope ALTER in the restored
 # cluster still propagates to the purely-inheriting table.
+@pytest.mark.max_running_shards(2)
 @pytest.mark.asyncio
 async def test_describe_schema_internals_round_trips_stored_config(manager: ScyllaClusterManager) -> None:
     server = await manager.server_add()

--- a/test/cluster/test_cluster_features.py
+++ b/test/cluster/test_cluster_features.py
@@ -62,6 +62,7 @@ async def change_support_for_test_feature_and_restart(manager: ScyllaClusterMana
     await asyncio.gather(*(manager.server_start(srv.server_id, expected_error) for srv in srvs))
 
 
+@pytest.mark.max_running_shards(6)
 async def test_rolling_upgrade_happy_path(manager: ScyllaClusterManager) -> None:
     """Simulates an upgrade of a cluster by doing a rolling restart
        and marking the test-only feature as supported on restarted nodes.
@@ -94,6 +95,7 @@ async def test_rolling_upgrade_happy_path(manager: ScyllaClusterManager) -> None
     await asyncio.gather(*(wait_for_feature(TEST_FEATURE_NAME, cql, h, time.time() + 60) for h in hosts))
 
 
+@pytest.mark.max_running_shards(6)
 async def test_downgrade_after_partial_upgrade(manager: ScyllaClusterManager) -> None:
     """Simulates a partial upgrade of a cluster by enabling the test features
        in all nodes but one, then downgrading the upgraded nodes.
@@ -121,6 +123,7 @@ async def test_downgrade_after_partial_upgrade(manager: ScyllaClusterManager) ->
         assert TEST_FEATURE_NAME not in await get_supported_features(cql, host)
 
 
+@pytest.mark.max_running_shards(8)
 async def test_joining_old_node_fails(manager: ScyllaClusterManager) -> None:
     """Upgrades the cluster to enable a new feature. Then, it first tries to
        add a new node without the feature, and then replace an existing node
@@ -154,6 +157,7 @@ async def test_joining_old_node_fails(manager: ScyllaClusterManager) -> None:
     await manager.server_start(new_server_info.server_id, expected_error="Feature check failed|received notification of being banned from the cluster from")
 
 
+@pytest.mark.max_running_shards(6)
 async def test_downgrade_after_successful_upgrade_fails(manager: ScyllaClusterManager) -> None:
     """Upgrades the cluster to enable the test feature. Then, shuts down all nodes,
        disables support for the feature, then restarts all nodes. All nodes

--- a/test/cluster/test_commitlog.py
+++ b/test/cluster/test_commitlog.py
@@ -16,6 +16,7 @@ from test.pylib.random_tables import Column, TextType
 
 logger = logging.getLogger(__name__)
 
+@pytest.mark.max_running_shards(2)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_reboot(request, manager: ScyllaClusterManager):
     # Check that commitlog provides durability in case of a node reboot.

--- a/test/cluster/test_commitlog_segment_data_resurrection.py
+++ b/test/cluster/test_commitlog_segment_data_resurrection.py
@@ -21,6 +21,7 @@ from test.pylib.util import wait_for, wait_for_cql_and_get_hosts
 logger = logging.getLogger(__name__)
 
 
+@pytest.mark.max_running_shards(2)
 async def test_pinned_cl_segment_doesnt_resurrect_data(manager: ScyllaClusterManager):
     """
         The tested scenario is as follows:
@@ -139,6 +140,7 @@ async def test_pinned_cl_segment_doesnt_resurrect_data(manager: ScyllaClusterMan
         assert len(list(cql.execute(f"SELECT * FROM {tbl2} WHERE pk = {pk1}"))) == 0
 
 
+@pytest.mark.max_running_shards(6)
 @pytest.mark.asyncio
 async def test_pinned_cl_segment_doesnt_resurrect_data_but_repair_ensures_tombstone_gc(manager: ScyllaClusterManager):
     """

--- a/test/cluster/test_compaction_backpressure.py
+++ b/test/cluster/test_compaction_backpressure.py
@@ -16,6 +16,7 @@ import logging
 logger = logging.getLogger(__name__)
 
 
+@pytest.mark.max_running_shards(1)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_intranode_migration_not_blocked_by_backpressure(manager: ScyllaClusterManager):
     """

--- a/test/cluster/test_concurrent_schema.py
+++ b/test/cluster/test_concurrent_schema.py
@@ -21,6 +21,7 @@ pytestmark = pytest.mark.prepare_3_racks_cluster
 # How this repro works:
 # - Creates 20+20 tables to alter and 20 tables to index
 # - In parallel run 20 * create table, and drop/add column and index of previous 2 tables
+@pytest.mark.max_running_shards(6)
 async def test_cassandra_issue_10250(random_tables):
     tables = random_tables
     # How many combinations of tables; original Cassandra issue repro had 20

--- a/test/cluster/test_config.py
+++ b/test/cluster/test_config.py
@@ -23,6 +23,7 @@ async def wait_for_config(manager, server, config_name, value):
         return None
     await wait_for(config_value_equal, deadline=time.time() + 60)
 
+@pytest.mark.max_running_shards(2)
 async def test_non_liveupdatable_config(manager):
 
     server = await manager.server_add()

--- a/test/cluster/test_config_live_updates.py
+++ b/test/cluster/test_config_live_updates.py
@@ -6,6 +6,7 @@ import pytest
 from test.pylib.util import wait_for
 
 
+@pytest.mark.max_running_shards(2)
 async def test_config_live_updates(manager):
     config = {
         "maintenance_socket": "ignore"  # bring back the default value

--- a/test/cluster/test_conflicting_keys_read_repair.py
+++ b/test/cluster/test_conflicting_keys_read_repair.py
@@ -18,6 +18,7 @@ from test.cluster.util import new_test_keyspace
 logger = logging.getLogger(__name__)
 
 
+@pytest.mark.max_running_shards(6)
 async def test_read_repair_with_conflicting_hash_keys(request: pytest.FixtureRequest, manager: ScyllaClusterManager) -> None:
     """
     Test that conflicting hash keys are handled correctly during read repair.

--- a/test/cluster/test_coordinator_queue_management.py
+++ b/test/cluster/test_coordinator_queue_management.py
@@ -14,6 +14,7 @@ logger = logging.getLogger(__name__)
 pytestmark = pytest.mark.prepare_3_nodes_cluster
 
 
+@pytest.mark.max_running_shards(10)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_coordinator_queue_management(manager: ScyllaClusterManager):
     """This test creates a 5 node cluster with 2 down nodes (A and B). After that it

--- a/test/cluster/test_counter_write_timeout_metric.py
+++ b/test/cluster/test_counter_write_timeout_metric.py
@@ -23,6 +23,7 @@ from .util import new_test_keyspace, new_test_table
 COORDINATOR_WRITE_TIMEOUTS_METRIC = "scylla_storage_proxy_coordinator_write_timeouts"
 
 
+@pytest.mark.max_running_shards(2)
 @pytest.mark.skip_mode(mode="release", reason="error injections are not supported in release mode")
 async def test_counter_write_timeout_updates_coordinator_metric(manager: ScyllaClusterManager):
     """

--- a/test/cluster/test_counters_with_tablets.py
+++ b/test/cluster/test_counters_with_tablets.py
@@ -17,6 +17,7 @@ import pytest
 
 logger = logging.getLogger(__name__)
 
+@pytest.mark.max_running_shards(6)
 @pytest.mark.parametrize("migration_type", ["internode", "intranode"])
 async def test_counter_updates_during_tablet_migration(manager: ScyllaClusterManager, migration_type: str):
     """
@@ -93,6 +94,7 @@ async def test_counter_updates_during_tablet_migration(manager: ScyllaClusterMan
 
         assert actual_count == total_updates, f"Counter value mismatch: expected {total_updates}, got {actual_count}"
 
+@pytest.mark.max_running_shards(3)
 async def test_counter_ids_reuse_in_single_rack(manager: ScyllaClusterManager):
     """
     Migrate a single counter tablet between 3 nodes in a single rack, performing counter updates on each node,
@@ -166,6 +168,7 @@ async def test_counter_ids_reuse_in_single_rack(manager: ScyllaClusterManager):
         assert len(counter_ids) >= 1, f"Expected at least 1 counter ID, but found none"
         assert len(counter_ids) <= 2, f"Expected at most 2 counter IDs, but found {len(counter_ids)}: {counter_ids}"
 
+@pytest.mark.max_running_shards(3)
 async def test_counter_ids_multi_rack(manager: ScyllaClusterManager):
     """
     Test counter IDs with 3 nodes in 3 different racks with RF=3.

--- a/test/cluster/test_crash_coordinator_before_streaming.py
+++ b/test/cluster/test_crash_coordinator_before_streaming.py
@@ -19,6 +19,7 @@ from test.cluster.util import (BANNED_NOTIFICATION, check_token_ring_and_group0_
 logger = logging.getLogger(__name__)
 
 
+@pytest.mark.max_running_shards(12)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_kill_coordinator_during_op(manager: ScyllaClusterManager, failure_detector_timeout: int, scale_timeout: callable) -> None:
     """ Kill coordinator with error injection while topology operation is running for cluster: decommission,

--- a/test/cluster/test_create_table_during_node_shutdown.py
+++ b/test/cluster/test_create_table_during_node_shutdown.py
@@ -9,6 +9,7 @@ from test.pylib.scylla_cluster_manager import ScyllaClusterManager
 from test.cluster.util import new_test_keyspace, reconnect_driver
 
 
+@pytest.mark.max_running_shards(2)
 @pytest.mark.skip_mode(mode='release', reason="error injections aren't enabled in release mode")
 async def test_create_table_notification_deadlock_with_shutdown(manager: ScyllaClusterManager):
     """

--- a/test/cluster/test_data_resurrection_after_cleanup.py
+++ b/test/cluster/test_data_resurrection_after_cleanup.py
@@ -15,6 +15,7 @@ import time
 
 logger = logging.getLogger(__name__)
 
+@pytest.mark.max_running_shards(2)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_data_resurrection_after_cleanup(manager: ScyllaClusterManager):
     logger.info("Bootstrapping cluster")

--- a/test/cluster/test_data_resurrection_in_memtable.py
+++ b/test/cluster/test_data_resurrection_in_memtable.py
@@ -101,30 +101,35 @@ async def run_test_cache_tombstone_gc(manager: ScyllaClusterManager, statement_p
         check_data(host3, [])
 
 
+@pytest.mark.max_running_shards(6)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_cache_tombstone_gc_partition_tombstone(manager: ScyllaClusterManager):
     await run_test_cache_tombstone_gc(manager,
                                       [("INSERT INTO {ks}.tbl (pk, ck, v) VALUES (0, 100, 999)", "DELETE FROM {ks}.tbl WHERE pk = 0")])
 
 
+@pytest.mark.max_running_shards(6)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_cache_tombstone_gc_row_tombstone(manager: ScyllaClusterManager):
     await run_test_cache_tombstone_gc(manager,
                                       [("INSERT INTO {ks}.tbl (pk, ck, v) VALUES (0, 100, 999)", "DELETE FROM {ks}.tbl WHERE pk = 0 AND ck = 100")])
 
 
+@pytest.mark.max_running_shards(6)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_cache_tombstone_gc_range_tombstone(manager: ScyllaClusterManager):
     await run_test_cache_tombstone_gc(manager,
                                       [("INSERT INTO {ks}.tbl (pk, ck, v) VALUES (0, 100, 999)", "DELETE FROM {ks}.tbl WHERE pk = 0 AND ck > 0 AND ck < 1000")])
 
 
+@pytest.mark.max_running_shards(6)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_cache_tombstone_gc_cell_tombstone(manager: ScyllaClusterManager):
     await run_test_cache_tombstone_gc(manager,
                                       [("UPDATE {ks}.tbl SET v = 999 WHERE pk = 0 AND ck = 100", "DELETE v FROM {ks}.tbl WHERE pk = 0 AND ck = 100")])
 
 
+@pytest.mark.max_running_shards(6)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_cache_tombstone_gc_cell_tombstone_and_row_tombstone(manager: ScyllaClusterManager):
     await run_test_cache_tombstone_gc(manager,

--- a/test/cluster/test_decommission.py
+++ b/test/cluster/test_decommission.py
@@ -13,6 +13,7 @@ from test.cluster.util import wait_for_token_ring_and_group0_consistency
 logger = logging.getLogger(__name__)
 
 
+@pytest.mark.max_running_shards(4)
 async def test_decommissioned_node_cant_rejoin(request, manager: ScyllaClusterManager):
     # This a regression test for #17282.
 

--- a/test/cluster/test_decommission_kill_then_replace.py
+++ b/test/cluster/test_decommission_kill_then_replace.py
@@ -22,6 +22,7 @@ from test.pylib.util import wait_for_first_completed
 logger = logging.getLogger(__name__)
 
 
+@pytest.mark.max_running_shards(6)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_decommission_kill_then_replace(manager: ScyllaClusterManager) -> None:
     """

--- a/test/cluster/test_deprecating_cluster_features.py
+++ b/test/cluster/test_deprecating_cluster_features.py
@@ -17,6 +17,7 @@ SUPPRESS_FEATURES = "suppress_features"
 ERROR_INJECTIONS_AT_STARTUP_CONFIG_KEY = "error_injections_at_startup"
 
 
+@pytest.mark.max_running_shards(2)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_feature_deprecation_works(manager: ScyllaClusterManager) -> None:
     """Simulate a very old node which, long ago, has enabled some features,
@@ -50,6 +51,7 @@ async def check_features_status(cql, features, enabled):
         assert check_feature(topology_features[0].supported_features, feature)
 
 
+@pytest.mark.max_running_shards(2)
 async def test_features_suppress_works(manager: ScyllaClusterManager, build_mode) -> None:
     """ `suppress_features` error injection allows to revoke support for
         specified cluster features. It can be used to simulate upgrade process.

--- a/test/cluster/test_describe.py
+++ b/test/cluster/test_describe.py
@@ -21,6 +21,7 @@ import os
 # to 128 * 2^10 bytes.
 #
 # Reproducer for issue scylladb/scylladb#24018.
+@pytest.mark.max_running_shards(2)
 async def test_large_create_statement(manager: ScyllaClusterManager):
     cmdline = ["--logger-log-level", "describe=trace"]
     srv = await manager.server_add(cmdline=cmdline)
@@ -52,6 +53,7 @@ async def test_large_create_statement(manager: ScyllaClusterManager):
             matches = await log.grep("oversized allocation", from_mark=marker)
             assert len(matches) == 0
 
+@pytest.mark.max_running_shards(2)
 @pytest.mark.parametrize("mode", ["normal", "maintenance"])
 async def test_describe_cluster_sanity(manager: ScyllaClusterManager, mode: str):
     """

--- a/test/cluster/test_different_group0_ids.py
+++ b/test/cluster/test_different_group0_ids.py
@@ -9,6 +9,7 @@ from test.pylib.scylla_cluster_manager import ScyllaClusterManager
 import pytest
 
 
+@pytest.mark.max_running_shards(4)
 async def test_different_group0_ids(manager: ScyllaClusterManager):
     """
     The test starts two single-node clusters (with different group0_ids). Node B (the

--- a/test/cluster/test_encryption.py
+++ b/test/cluster/test_encryption.py
@@ -45,6 +45,7 @@ def workdir():
     with tempfile.TemporaryDirectory() as tmp_dir:
         yield tmp_dir
 
+@pytest.mark.max_running_shards(2)
 async def test_file_streaming_respects_encryption(manager: ScyllaClusterManager, storage, workdir):
     # pylint: disable=missing-function-docstring
     cfg = {
@@ -218,6 +219,7 @@ supported_cipher_algorithms = {
     # "RC2": [80, 128],  # [40, 80, 128]  # 40 to 128
 }
 
+@pytest.mark.max_running_shards(2)
 async def test_supported_cipher_algorithms(manager, key_provider):
     """Checks our providers can operate the algos we claim"""
     errors = []
@@ -231,6 +233,7 @@ async def test_supported_cipher_algorithms(manager, key_provider):
                       exception_handler=handler)
     assert not errors, errors
 
+@pytest.mark.max_running_shards(2)
 async def test_wrong_cipher_algorithm(manager, key_provider):
     """Checks we reject non-valid cipher parameters/algos"""
     errors = []
@@ -271,6 +274,7 @@ async def test_wrong_cipher_algorithm(manager, key_provider):
     assert not errors, errors
     assert len(expected_errors) == len(broken_ciphers), expected_errors
 
+@pytest.mark.max_running_shards(2)
 @pytest.mark.parametrize(argnames="compression", argvalues=("LZ4", "Snappy", "Deflate"))
 async def test_encryption_table_compression(manager, tmpdir, suite_log_dir, compression, scylla_binary):
     """Test compression + ear"""
@@ -281,6 +285,7 @@ async def test_encryption_table_compression(manager, tmpdir, suite_log_dir, comp
                           compression=compression)
 
 
+@pytest.mark.max_running_shards(6)
 async def test_reboot(manager, key_provider):
     """Tests SIGKILL restart of 3-node cluster"""
     async def restart(manager: ScyllaClusterManager, servers: list[ServerInfo], table_names: list[str]):
@@ -354,6 +359,7 @@ async def validate_sstables_encryption(manager: ScyllaClusterManager, server: Se
             assert actual_data == expected_data
 
 
+@pytest.mark.max_running_shards(2)
 async def test_alter(manager, key_provider):
     """Tests altering encrypted CF:s and verify sstable data"""
     async def restart(manager: ScyllaClusterManager, servers: list[ServerInfo], table_names: list[str]):
@@ -392,6 +398,7 @@ async def test_alter(manager, key_provider):
                       ciphers={"AES/CBC/PKCS5Padding": [128]},
                       restart=restart)
 
+@pytest.mark.max_running_shards(2)
 async def test_per_table_master_key(manager: ScyllaClusterManager, tmpdir, suite_log_dir):
     """Test per table KMS master key"""
     class MultiAliasKMSProvider (KMSKeyProviderFactory):
@@ -436,6 +443,7 @@ async def test_per_table_master_key(manager: ScyllaClusterManager, tmpdir, suite
                           restart=restart)
 
 
+@pytest.mark.max_running_shards(2)
 async def test_non_existant_table_master_key(manager: ScyllaClusterManager, tmpdir, suite_log_dir):
     """Test we fail properly if using a non-existant master key"""
     class NoSuchKeyKMSProvider (KMSKeyProviderFactory):
@@ -447,6 +455,7 @@ async def test_non_existant_table_master_key(manager: ScyllaClusterManager, tmpd
         with pytest.raises(Exception):
             await _smoke_test(manager, kp, ciphers={"AES/CBC/PKCS5Padding": [128]})
 
+@pytest.mark.max_running_shards(2)
 async def test_system_auth_encryption(manager: ScyllaClusterManager, tmpdir):
     cfg = {"authenticator": "org.apache.cassandra.auth.PasswordAuthenticator", 
                "authorizer": "org.apache.cassandra.auth.CassandraAuthorizer",
@@ -541,6 +550,7 @@ async def test_system_auth_encryption(manager: ScyllaClusterManager, tmpdir):
     await verify_system_info(False) # should not see stuff now
 
 
+@pytest.mark.max_running_shards(2)
 async def test_system_encryption_reboot(manager: ScyllaClusterManager, tmpdir):
     """Tests SIGKILL restart of encrypted node"""
     async def restart(manager: ScyllaClusterManager, servers: list[ServerInfo], table_names: list[str]):

--- a/test/cluster/test_ensure_committed_by_group0.py
+++ b/test/cluster/test_ensure_committed_by_group0.py
@@ -13,6 +13,7 @@ from test.pylib.scylla_cluster_manager import ScyllaClusterManager
 logger = logging.getLogger(__name__)
 
 
+@pytest.mark.max_running_shards(2)
 @pytest.mark.asyncio
 async def test_ensure_committed_by_group0(manager: ScyllaClusterManager):
     """Tables with committed_by_group0 = null or false get fixed on restart."""

--- a/test/cluster/test_error_becoming_voter.py
+++ b/test/cluster/test_error_becoming_voter.py
@@ -17,6 +17,7 @@ from test.pylib.util import wait_for_cql_and_get_hosts
 logger = logging.getLogger(__name__)
 
 
+@pytest.mark.max_running_shards(6)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_error_while_becoming_voter(request: pytest.FixtureRequest, manager: ScyllaClusterManager) -> None:
     """

--- a/test/cluster/test_failure_after_group0_server_registration.py
+++ b/test/cluster/test_failure_after_group0_server_registration.py
@@ -12,6 +12,7 @@ from test.pylib.scylla_cluster_manager import ScyllaClusterManager
 logger = logging.getLogger(__name__)
 
 
+@pytest.mark.max_running_shards(2)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_failure_after_group0_server_registration(manager: ScyllaClusterManager) -> None:
     """Test that a node shuts down cleanly when group0 startup fails after server registration.

--- a/test/cluster/test_fencing.py
+++ b/test/cluster/test_fencing.py
@@ -57,6 +57,7 @@ def all_hints_metrics(metrics: ScyllaMetrics) -> list[str]:
     return metrics.lines_by_prefix('scylla_hints_manager_')
 
 
+@pytest.mark.max_running_shards(6)
 @pytest.mark.parametrize("tablets_enabled", [True, False])
 async def test_fence_writes(request, manager: ScyllaClusterManager, tablets_enabled: bool):
     cfg = {'tablets_mode_for_new_keyspaces' : 'enabled' if tablets_enabled else 'disabled'}
@@ -124,6 +125,7 @@ async def test_fence_writes(request, manager: ScyllaClusterManager, tablets_enab
     random_tables.drop_all()
 
 
+@pytest.mark.max_running_shards(6)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_fence_hints(request, manager: ScyllaClusterManager):
     logger.info("Bootstrapping cluster with three nodes")
@@ -214,6 +216,7 @@ async def test_fence_hints(request, manager: ScyllaClusterManager):
     random_tables.drop_all()
 
 
+@pytest.mark.max_running_shards(8)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_fence_lwt_during_bootstap(manager: ScyllaClusterManager):
     """
@@ -349,6 +352,7 @@ async def test_fence_lwt_during_bootstap(manager: ScyllaClusterManager):
         assert row.c == 2
 
 
+@pytest.mark.max_running_shards(6)
 @pytest.mark.skip_mode(mode='release', reason='dev mode is enough for this test')
 @pytest.mark.skip_mode(mode='debug', reason='dev mode is enough for this test')
 async def test_lwt_fencing_upgrade(manager: ScyllaClusterManager, scylla_2025_1: ScyllaVersionDescription, scylla_binary: Path):

--- a/test/cluster/test_global_ignore_nodes.py
+++ b/test/cluster/test_global_ignore_nodes.py
@@ -13,6 +13,7 @@ logger = logging.getLogger(__name__)
 pytestmark = pytest.mark.prepare_3_racks_cluster
 
 
+@pytest.mark.max_running_shards(10)
 async def test_global_ignored_nodes_list(manager: ScyllaClusterManager, random_tables) -> None:
     """This test creates a 5 node cluster with two nodes down (A and B). It removes A while
        specifying B in ignored nodes list. Then is downs one more node and replaces it while

--- a/test/cluster/test_gossiper.py
+++ b/test/cluster/test_gossiper.py
@@ -11,6 +11,7 @@ import pytest
 
 logger = logging.getLogger(__name__)
 
+@pytest.mark.max_running_shards(6)
 @pytest.mark.prepare_3_racks_cluster
 async def test_gossiper_endpoints(manager: ScyllaClusterManager) -> None:
     servers = await manager.running_servers()
@@ -39,6 +40,7 @@ async def test_gossiper_endpoints(manager: ScyllaClusterManager) -> None:
             assert down_server_ip in down_endpoints, "Stopped server isn't marked as dead"
 
 
+@pytest.mark.max_running_shards(6)
 @pytest.mark.asyncio
 async def test_natural_failure_detection(manager: ScyllaClusterManager, failure_detector_timeout) -> None:
     """Verify that the failure detector detects a killed node as DOWN

--- a/test/cluster/test_gossiper_apply_backlog.py
+++ b/test/cluster/test_gossiper_apply_backlog.py
@@ -52,6 +52,7 @@ BOUND = 4 * NODES
 MEASURE_SECONDS = 15
 
 
+@pytest.mark.max_running_shards(10)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 @pytest.mark.asyncio
 async def test_gossiper_apply_backlog_is_bounded(manager: ScyllaClusterManager) -> None:

--- a/test/cluster/test_gossiper_empty_self_id_on_shadow_round.py
+++ b/test/cluster/test_gossiper_empty_self_id_on_shadow_round.py
@@ -14,6 +14,7 @@ from test.cluster.util import get_coordinator_host
 from test.pylib.scylla_cluster_manager import ScyllaClusterManager
 
 
+@pytest.mark.max_running_shards(4)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_gossiper_empty_self_id_on_shadow_round(manager: ScyllaClusterManager):
     """

--- a/test/cluster/test_gossiper_orphan_remover.py
+++ b/test/cluster/test_gossiper_orphan_remover.py
@@ -16,6 +16,7 @@ from test.pylib.internal_types import ServerInfo
 logger = logging.getLogger(__name__)
 
 
+@pytest.mark.max_running_shards(8)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_crashed_node_substitution(manager: ScyllaClusterManager):
     """Test that a node which crashed after starting gossip but before joining group0

--- a/test/cluster/test_gossiper_race.py
+++ b/test/cluster/test_gossiper_race.py
@@ -12,6 +12,7 @@ from test.cluster.util import get_coordinator_host
 from test.pylib.scylla_cluster_manager import ScyllaClusterManager
 
 
+@pytest.mark.max_running_shards(6)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_gossiper_race_on_decommission(manager: ScyllaClusterManager):
     """
@@ -104,6 +105,7 @@ async def test_gossiper_race_on_decommission(manager: ScyllaClusterManager):
     assert coordinator.server_id in [s.server_id for s in running_servers]
 
 
+@pytest.mark.max_running_shards(6)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_gossiper_no_resurrection_on_decommission(manager: ScyllaClusterManager):
     """

--- a/test/cluster/test_gossiper_state_coalescing.py
+++ b/test/cluster/test_gossiper_state_coalescing.py
@@ -51,6 +51,7 @@ async def endpoint_states(manager: ScyllaClusterManager, node_ip: str) -> dict[s
     }
 
 
+@pytest.mark.max_running_shards(8)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 @pytest.mark.asyncio
 async def test_gossiper_coalescing_does_not_lose_application_states(manager: ScyllaClusterManager) -> None:

--- a/test/cluster/test_group0_recovers_after_partial_command_application.py
+++ b/test/cluster/test_group0_recovers_after_partial_command_application.py
@@ -15,6 +15,7 @@ import logging
 logger = logging.getLogger(__name__)
 
 
+@pytest.mark.max_running_shards(4)
 @pytest.mark.skip_mode(mode="release", reason="error injections are not supported in release mode")
 async def test_group0_recovers_after_partial_command_application(manager: ScyllaClusterManager):
     """

--- a/test/cluster/test_group0_snapshot_schema_race.py
+++ b/test/cluster/test_group0_snapshot_schema_race.py
@@ -13,6 +13,7 @@ from test.pylib.scylla_cluster_manager import ScyllaClusterManager
 logger = logging.getLogger(__name__)
 
 
+@pytest.mark.max_running_shards(4)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_snapshot_transfer_before_enable_sm_causes_no_such_keyspace(manager: ScyllaClusterManager) -> None:
     """Verify that a joining node handles schema correctly when transfer_snapshot()

--- a/test/cluster/test_guardrails.py
+++ b/test/cluster/test_guardrails.py
@@ -40,6 +40,7 @@ async def assert_creating_ks_fails(cql, query, ks_name):
         await cql.run_async(f"USE {ks_name}")
 
 
+@pytest.mark.max_running_shards(6)
 async def test_default_rf(manager: ScyllaClusterManager):
     """
     As of now, the only RF guardrail enabled is a soft limit checking that RF >= 3. Not complying to this soft limit
@@ -63,6 +64,7 @@ async def test_default_rf(manager: ScyllaClusterManager):
     await create_ks_and_assert_warning(cql, query, ks_name, ["warn", "min", "replication", "factor", "3", "dc1", "2"])
 
 
+@pytest.mark.max_running_shards(2)
 async def test_all_rf_limits(manager: ScyllaClusterManager):
     """
     There are 4 limits for RF: soft/hard min and soft/hard max limits. Breaking soft limits issues a warning,
@@ -101,6 +103,7 @@ async def test_all_rf_limits(manager: ScyllaClusterManager):
             await create_ks_and_assert_warning(cql, query, ks_name, [])
 
 
+@pytest.mark.max_running_shards(2)
 async def test_invalid_write_cl_guardrail_config(manager: ScyllaClusterManager):
     """A node configured with invalid values for write_consistency_levels_warned
     and write_consistency_levels_disallowed should still start and respond to
@@ -123,6 +126,7 @@ async def test_invalid_write_cl_guardrail_config(manager: ScyllaClusterManager):
     rows = await cql.run_async("SELECT * FROM system.local")
     assert len(rows) == 1
 
+@pytest.mark.max_running_shards(6)
 async def test_write_cl_default(manager: ScyllaClusterManager):
     """Test checks that the current implementation doesn't cause
     any warning nor failure for the default configuration."""

--- a/test/cluster/test_hints.py
+++ b/test/cluster/test_hints.py
@@ -168,6 +168,7 @@ async def assert_rows_present(cql, table: str, pk: str, keys, present: bool) -> 
 
 
 # Write with RF=1 and CL=ANY to a dead node should write hints and succeed
+@pytest.mark.max_running_shards(4)
 async def test_write_cl_any_to_dead_node_generates_hints(manager: ScyllaClusterManager):
     node_count = 2
     cmdline = ["--logger-log-level", "hints_manager=trace"]
@@ -207,6 +208,7 @@ async def test_write_cl_any_to_dead_node_generates_hints(manager: ScyllaClusterM
             # For dropping the keyspace
             await manager.server_start(servers[1].server_id)
 
+@pytest.mark.max_running_shards(4)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_limited_concurrency_of_writes(manager: ScyllaClusterManager):
     """
@@ -238,6 +240,7 @@ async def test_limited_concurrency_of_writes(manager: ScyllaClusterManager):
         # For dropping the keyspace
         await manager.server_start(node2.server_id)
 
+@pytest.mark.max_running_shards(6)
 async def test_sync_point(manager: ScyllaClusterManager):
     """
     We want to verify that the sync point API is compliant with its design.
@@ -291,6 +294,7 @@ async def test_sync_point(manager: ScyllaClusterManager):
         assert await await_sync_point(manager.api.client, node1.ip_addr, sync_point1, 30)
 
 
+@pytest.mark.max_running_shards(6)
 @pytest.mark.skip_mode(mode='release', reason="error injections aren't enabled in release mode")
 async def test_hints_consistency_during_decommission(manager: ScyllaClusterManager):
     """
@@ -376,6 +380,7 @@ async def test_hints_consistency_during_decommission(manager: ScyllaClusterManag
         for i in range(100):
             assert list(await cql.run_async(f"SELECT v FROM {table} WHERE pk = {i}")) == [(i + 1,)]
 
+@pytest.mark.max_running_shards(6)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_hints_consistency_during_replace(manager: ScyllaClusterManager):
     """
@@ -420,6 +425,7 @@ async def test_hints_consistency_during_replace(manager: ScyllaClusterManager):
         for i in range(100):
             assert list(await cql.run_async(f"SELECT v FROM {table} WHERE pk = {i}")) == [(i + 1,)]
 
+@pytest.mark.max_running_shards(6)
 async def test_draining_hints(manager: ScyllaClusterManager):
     """
     This test verifies that all hints are drained when a node is being decommissioned.
@@ -448,6 +454,7 @@ async def test_draining_hints(manager: ScyllaClusterManager):
         _ = tg.create_task(manager.decommission_node(s1.server_id, timeout=60))
         _ = tg.create_task(await_sync_point(manager.api.client, s1.ip_addr, sync_point, 60))
 
+@pytest.mark.max_running_shards(6)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_canceling_hint_draining(manager: ScyllaClusterManager):
     """
@@ -494,6 +501,7 @@ async def test_canceling_hint_draining(manager: ScyllaClusterManager):
     assert await await_sync_point(manager.api.client, s1.ip_addr, sync_point, 60)
     await s1_log.wait_for(f"Removed hint directory for {host_id2}")
 
+@pytest.mark.max_running_shards(4)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_hint_to_pending(manager: ScyllaClusterManager):
     """
@@ -552,6 +560,7 @@ async def test_hint_to_pending(manager: ScyllaClusterManager):
 
         assert list(await cql.run_async(f"SELECT v FROM {table} WHERE pk = 0")) == [(0,)]
 
+@pytest.mark.max_running_shards(3)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_hint_to_leaving_when_reducing_rf(manager: ScyllaClusterManager):
     '''
@@ -623,6 +632,7 @@ async def test_hint_to_leaving_when_reducing_rf(manager: ScyllaClusterManager):
         assert list(await cql.run_async(f"SELECT v FROM {table} WHERE pk = 0")) == [(0,)]
 
 
+@pytest.mark.max_running_shards(3)
 @pytest.mark.skip_mode(mode="release", reason="error injections aren't enabled in release mode")
 async def test_hints_rebalance(manager: ScyllaClusterManager):
     """
@@ -724,6 +734,7 @@ async def test_hints_rebalance(manager: ScyllaClusterManager):
     await assert_rows_present(cql, "ks.t", "pk", list(range(expected_rows)), present=True)
 
 
+@pytest.mark.max_running_shards(6)
 async def test_hints_removenode(manager: ScyllaClusterManager):
     """
     Hints addressed to a node that is removed from the cluster with removenode must be drained
@@ -762,6 +773,7 @@ async def test_hints_removenode(manager: ScyllaClusterManager):
     assert results == expected, f"Mismatch: {results} vs. {expected}"
 
 
+@pytest.mark.max_running_shards(4)
 @pytest.mark.skip_mode(mode="release", reason="error injections aren't enabled in release mode")
 async def test_hints_basic_check(manager: ScyllaClusterManager):
     """
@@ -801,6 +813,7 @@ async def test_hints_basic_check(manager: ScyllaClusterManager):
     assert rows == [(1,)], "The hint was not replayed to the node that was down"
 
 
+@pytest.mark.max_running_shards(6)
 @pytest.mark.skip_mode(mode="release", reason="error injections aren't enabled in release mode")
 async def test_hints_counter(manager: ScyllaClusterManager):
     """
@@ -873,6 +886,7 @@ async def test_hints_counter(manager: ScyllaClusterManager):
     assert result == expected
 
 
+@pytest.mark.max_running_shards(6)
 async def test_hints_decom(manager: ScyllaClusterManager):
     """
     Verify that hints are drained when a target for hints is decommissioned.
@@ -920,6 +934,7 @@ async def test_hints_decom(manager: ScyllaClusterManager):
     await wait_for_hint_dir_removed(s2_hints_dir, s3_host_id)
 
 
+@pytest.mark.max_running_shards(4)
 async def test_hints_dont_revive(manager: ScyllaClusterManager):
     """
     A hint carries the timestamp of the original write, so replaying it after the row has been
@@ -978,6 +993,7 @@ async def validate_max_hinted_handoff_concurrency(manager: ScyllaClusterManager,
         f"expected max_hinted_handoff_concurrency to be {expected_value} on {server.ip_addr}, got {value}"
 
 
+@pytest.mark.max_running_shards(4)
 @pytest.mark.parametrize("max_hinted_handoff_concurrency,cmdline", [
     (0, None),
     (64, None),
@@ -1027,6 +1043,7 @@ async def test_support_max_hh_concurrency_param(manager: ScyllaClusterManager,
     assert results[0].count == row_count
 
 
+@pytest.mark.max_running_shards(2)
 async def test_ignore_invalid_hint_directories(manager: ScyllaClusterManager):
     """
     A directory whose name is invalid must be ignored by the hint manager - both
@@ -1056,6 +1073,7 @@ async def test_ignore_invalid_hint_directories(manager: ScyllaClusterManager):
     assert list_hint_target_dirs(hints_dir) == {hint_dir_name}
 
 
+@pytest.mark.max_running_shards(9)
 async def test_hints_switch_config_in_runtime_via_http_api(manager: ScyllaClusterManager):
     """
     Enabling, disabling and DC-filtering hinted handoff through the HTTP API must take effect
@@ -1133,6 +1151,7 @@ async def test_hints_switch_config_in_runtime_via_http_api(manager: ScyllaCluste
     await assert_rows_present(cql, "ks.t", "pk", keys_dc3_only, present=True)
 
 
+@pytest.mark.max_running_shards(6)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_hintedhandoff_sync_point_api(manager: ScyllaClusterManager):
     """
@@ -1370,6 +1389,7 @@ async def test_hintedhandoff_sync_point_api(manager: ScyllaClusterManager):
     await assert_rows_present(cql, "ks.t", "pk", keys5, present=True)
 
 
+@pytest.mark.max_running_shards(4)
 async def test_hint_storage_proxy_metrics(manager: ScyllaClusterManager):
     """
     The hint metrics of the sender and of the receiver must agree: what the sender counts as
@@ -1424,6 +1444,7 @@ async def test_hint_storage_proxy_metrics(manager: ScyllaClusterManager):
     assert sent_bytes_total == received_bytes_total
 
 
+@pytest.mark.max_running_shards(2)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_hint_retransmission_keeps_column_mappings(manager: ScyllaClusterManager):
     """

--- a/test/cluster/test_in_bind_variable_name.py
+++ b/test/cluster/test_in_bind_variable_name.py
@@ -16,6 +16,7 @@ from test.cluster.util import new_test_keyspace, new_test_table
 from test.pylib.async_cql import _wrap_future
 from test.pylib.internal_types import ServerInfo
 from test.pylib.scylla_cluster_manager import ScyllaClusterManager
+import pytest
 
 logger = logging.getLogger(__name__)
 
@@ -50,6 +51,7 @@ async def assert_binding_by_name_works_across_nodes(manager: ScyllaClusterManage
         cluster.shutdown()
 
 
+@pytest.mark.max_running_shards(4)
 async def test_in_bind_variable_name_mixed_config(manager: ScyllaClusterManager):
     """
     cql_in_bind_variable_name_uses_uppercase_operator decides whether the
@@ -87,6 +89,7 @@ async def test_in_bind_variable_name_mixed_config(manager: ScyllaClusterManager)
             await assert_binding_by_name_works_across_nodes(manager, uppercase_server, lowercase_server, query, 'IN(c)', 1)
 
 
+@pytest.mark.max_running_shards(1)
 async def test_in_bind_variable_name_of_a_cached_statement(manager: ScyllaClusterManager):
     """
     The name is picked when the statement is prepared, and the item is part of

--- a/test/cluster/test_incremental_repair.py
+++ b/test/cluster/test_incremental_repair.py
@@ -250,6 +250,7 @@ async def prepare_cluster_for_incremental_repair(manager, nr_keys = 100 , cmdlin
         logs.append(await manager.server_open_log(s.server_id))
     return servers, cql, hosts, ks, table_id, logs, repaired_keys,  unrepaired_keys, current_key, token
 
+@pytest.mark.max_running_shards(6)
 async def test_tablet_repair_sstable_skipped_read_metrics(manager: ScyllaClusterManager):
     servers, cql, hosts, ks, table_id, logs, _, _, _, token = await prepare_cluster_for_incremental_repair(manager)
 
@@ -278,6 +279,7 @@ async def test_tablet_repair_sstable_skipped_read_metrics(manager: ScyllaCluster
     assert skipped_bytes3 > skipped_bytes2
     assert read_bytes3 > read_bytes2
 
+@pytest.mark.max_running_shards(6)
 async def test_tablet_incremental_repair(manager: ScyllaClusterManager):
     servers, cql, hosts, ks, table_id = await create_table_insert_data_for_repair(manager, fast_stats_refresh=False, disable_flush_cache_time=True)
     token = -1
@@ -337,6 +339,7 @@ async def test_tablet_incremental_repair(manager: ScyllaClusterManager):
         assert len(disable) == 2
         assert len(enable) == 2
 
+@pytest.mark.max_running_shards(6)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_tablet_incremental_repair_error(manager: ScyllaClusterManager):
     servers, cql, hosts, ks, table_id = await create_table_insert_data_for_repair(manager)
@@ -440,21 +443,27 @@ async def do_tablet_incremental_repair_and_ops(manager: ScyllaClusterManager, op
         assert newly_repaired, \
             f"[after second repair] server {srv_id} (first-repair replica) had no newly-repaired sstables"
 
+@pytest.mark.max_running_shards(6)
 async def test_tablet_incremental_repair_and_scrubsstables_abort(manager: ScyllaClusterManager):
     await do_tablet_incremental_repair_and_ops(manager, 'scrub_abort')
 
+@pytest.mark.max_running_shards(6)
 async def test_tablet_incremental_repair_and_scrubsstables_validate(manager: ScyllaClusterManager):
     await do_tablet_incremental_repair_and_ops(manager, 'scrub_validate')
 
+@pytest.mark.max_running_shards(6)
 async def test_tablet_incremental_repair_and_cleanup(manager: ScyllaClusterManager):
     await do_tablet_incremental_repair_and_ops(manager, 'cleanup')
 
+@pytest.mark.max_running_shards(6)
 async def test_tablet_incremental_repair_and_upgradesstables(manager: ScyllaClusterManager):
     await do_tablet_incremental_repair_and_ops(manager, 'upgradesstables')
 
+@pytest.mark.max_running_shards(6)
 async def test_tablet_incremental_repair_and_major(manager: ScyllaClusterManager):
     await do_tablet_incremental_repair_and_ops(manager, 'major')
 
+@pytest.mark.max_running_shards(6)
 async def test_tablet_incremental_repair_and_minor(manager: ScyllaClusterManager):
     nr_keys = 100
     servers, cql, hosts, ks, table_id, logs, repaired_keys, unrepaired_keys, current_key, token = await prepare_cluster_for_incremental_repair(manager, nr_keys)
@@ -559,10 +568,12 @@ async def test_tablet_incremental_repair_with_split_and_merge(manager: ScyllaClu
 async def test_tablet_incremental_repair_with_split(manager: ScyllaClusterManager):
     await do_test_tablet_incremental_repair_with_split_and_merge(manager, do_split=True, do_merge=False)
 
+@pytest.mark.max_running_shards(6)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_tablet_incremental_repair_with_merge(manager: ScyllaClusterManager):
     await do_test_tablet_incremental_repair_with_split_and_merge(manager, do_split=False, do_merge=True)
 
+@pytest.mark.max_running_shards(6)
 async def test_tablet_incremental_repair_existing_and_repair_produced_sstable(manager: ScyllaClusterManager):
     nr_keys = 100
     cmdline = ["--hinted-handoff-enabled", "0"]
@@ -586,6 +597,7 @@ async def test_tablet_incremental_repair_existing_and_repair_produced_sstable(ma
 
     await verify_repaired_and_unrepaired_keys(manager, scylla_path, servers, ks, repaired_keys, unrepaired_keys)
 
+@pytest.mark.max_running_shards(6)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_tablet_incremental_repair_merge_higher_repaired_at_number(manager):
     nr_keys = 100
@@ -623,6 +635,7 @@ async def test_tablet_incremental_repair_merge_higher_repaired_at_number(manager
 
     await verify_repaired_and_unrepaired_keys(manager, scylla_path, servers, ks, repaired_keys, unrepaired_keys)
 
+@pytest.mark.max_running_shards(6)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_tablet_incremental_repair_merge_correct_repaired_at_number_after_merge(manager):
     nr_keys = 100
@@ -694,14 +707,17 @@ async def do_test_tablet_incremental_repair_merge_error(manager, error):
 
     await verify_repaired_and_unrepaired_keys(manager, scylla_path, servers, ks, repaired_keys, unrepaired_keys)
 
+@pytest.mark.max_running_shards(6)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_tablet_incremental_repair_merge_error_in_merge_finalization(manager):
     await do_test_tablet_incremental_repair_merge_error(manager, 'handle_tablet_resize_finalization_for_merge_error')
 
+@pytest.mark.max_running_shards(6)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_tablet_incremental_repair_merge_error_in_merge_completion_fiber(manager):
     await do_test_tablet_incremental_repair_merge_error(manager, 'merge_completion_fiber_error')
 
+@pytest.mark.max_running_shards(6)
 async def test_tablet_repair_with_incremental_option(manager: ScyllaClusterManager):
     servers, cql, hosts, ks, table_id, logs, _, _, _, token = await prepare_cluster_for_incremental_repair(manager)
     token = -1
@@ -746,6 +762,7 @@ async def test_tablet_repair_with_incremental_option(manager: ScyllaClusterManag
         assert read1 < read2
     await do_repair_and_check('full', 1, rf'Starting tablet repair by API .* incremental_mode=full.*', check4)
 
+@pytest.mark.max_running_shards(6)
 async def test_incremental_repair_tablet_time_metrics(manager: ScyllaClusterManager):
     servers, _, _, ks, _, _, _, _, _, token = await prepare_cluster_for_incremental_repair(manager)
     time1 = 0
@@ -761,6 +778,7 @@ async def test_incremental_repair_tablet_time_metrics(manager: ScyllaClusterMana
     assert time2 > 0
 
 # Reproducer for https://github.com/scylladb/scylladb/issues/26346
+@pytest.mark.max_running_shards(6)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_incremental_repair_finishes_when_tablet_skips_end_repair_stage(manager):
     servers = await manager.servers_add(3, auto_rack_dc="dc1")
@@ -785,6 +803,7 @@ async def test_incremental_repair_finishes_when_tablet_skips_end_repair_stage(ma
             await manager.api.disable_injection(coord_serv.ip_addr, "delay_end_repair_update")
             await manager.api.wait_task(servers[0].ip_addr, task_id)
 
+@pytest.mark.max_running_shards(6)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_incremental_repair_rejoin_do_tablet_operation(manager):
     cmdline = ['--logger-log-level', 'raft_topology=debug']
@@ -832,6 +851,7 @@ async def test_incremental_repair_rejoin_do_tablet_operation(manager):
                 await manager.api.disable_injection(s.ip_addr, "repair_finish_wait")
             await coord_log.wait_for("Finished tablet repair")
 
+@pytest.mark.max_running_shards(6)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_incremental_retry_end_repair_stage(manager):
     config = {'tablet_load_stats_refresh_interval_in_seconds': 1}
@@ -881,6 +901,7 @@ async def test_incremental_retry_end_repair_stage(manager):
 # This test checks both tablet and vnode table. It tests the code path dealing
 # with appending sstables produced by repair to a list work correctly with
 # multishard writer when the shard count is different.
+@pytest.mark.max_running_shards(5)
 @pytest.mark.parametrize("use_tablet", [False, True])
 async def test_repair_sigsegv_with_diff_shard_count(manager: ScyllaClusterManager, use_tablet):
     cmdline0 = [ '--smp', '2']
@@ -927,6 +948,7 @@ async def test_repair_sigsegv_with_diff_shard_count(manager: ScyllaClusterManage
 
 # Reproducer for https://github.com/scylladb/scylladb/issues/27365
 # Incremental repair vs table drop
+@pytest.mark.max_running_shards(6)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_tablet_incremental_repair_table_drop_compaction_group_gone(manager: ScyllaClusterManager):
     cmdline = ['--logger-log-level', 'repair=debug']
@@ -1243,6 +1265,7 @@ async def _do_race_window_promotes_unrepaired_data(manager, servers, cql, ks, to
         f"Wrongly promoted (first 10): {sorted(wrongly_promoted)[:10]}"
     return current_key
 
+@pytest.mark.max_running_shards(6)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_incremental_repair_race_window_promotes_unrepaired_data(manager: ScyllaClusterManager):
     cmdline = ['--hinted-handoff-enabled', '0']
@@ -1353,6 +1376,7 @@ async def _assert_key_deleted(cql, ks, key, hosts, *, msg=""):
         assert not rows, f"Key {key} unexpectedly visible on host {h} — data resurrection! {msg}"
 
 
+@pytest.mark.max_running_shards(6)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_tombstone_gc_no_resurrection_basic_ordering(manager: ScyllaClusterManager):
     """Verify that the ordering guarantee prevents premature tombstone GC.
@@ -1400,6 +1424,7 @@ async def test_tombstone_gc_no_resurrection_basic_ordering(manager: ScyllaCluste
     logger.info("test_tombstone_gc_no_resurrection_basic_ordering: PASSED")
 
 
+@pytest.mark.max_running_shards(6)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_tombstone_gc_no_resurrection_hints_flush_failure(manager: ScyllaClusterManager):
     """Verify that repair_time stays at epoch when hints flush fails, so tombstones
@@ -1464,6 +1489,7 @@ async def test_tombstone_gc_no_resurrection_hints_flush_failure(manager: ScyllaC
     logger.info("test_tombstone_gc_no_resurrection_hints_flush_failure: PASSED")
 
 
+@pytest.mark.max_running_shards(6)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_tombstone_gc_no_resurrection_propagation_delay(manager: ScyllaClusterManager):
     """Verify the ordering guarantee when D arrives via hint flush just before repair.
@@ -1532,6 +1558,7 @@ async def test_tombstone_gc_no_resurrection_propagation_delay(manager: ScyllaClu
     logger.info("test_tombstone_gc_no_resurrection_propagation_delay: PASSED")
 
 
+@pytest.mark.max_running_shards(6)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_tombstone_gc_mv_optimization_safe_via_hints(manager: ScyllaClusterManager):
     """Verify the repaired-only tombstone GC optimization is safe for non-co-located MVs
@@ -1635,6 +1662,7 @@ async def test_tombstone_gc_mv_optimization_safe_via_hints(manager: ScyllaCluste
     logger.info("test_tombstone_gc_mv_optimization_safe_via_hints: PASSED")
 
 
+@pytest.mark.max_running_shards(6)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_tombstone_gc_mv_safe_staging_processor_delay(manager: ScyllaClusterManager):
     """Verify no resurrection when the view-update-generator staging processor is delayed

--- a/test/cluster/test_initial_token.py
+++ b/test/cluster/test_initial_token.py
@@ -13,6 +13,7 @@ from test.cluster.util import BANNED_NOTIFICATION
 
 logger = logging.getLogger(__name__)
 
+@pytest.mark.max_running_shards(6)
 async def test_initial_token(manager: ScyllaClusterManager) -> None:
     tokens = ["-9223372036854775808", "-4611686018427387904", "0", "4611686018427387904"]
     cfg1 = {'initial_token': f"{tokens[0]}, {tokens[1]}"}

--- a/test/cluster/test_internode_compression.py
+++ b/test/cluster/test_internode_compression.py
@@ -11,6 +11,7 @@ from test.pylib.scylla_cluster_manager import ScyllaClusterManager
 from test.pylib.internal_types import IPAddress
 from test.cluster.util import new_test_keyspace, new_test_table
 from cassandra.cluster import ConsistencyLevel
+import pytest
 
 logger = logging.getLogger(__name__)
 
@@ -172,6 +173,7 @@ async def do_test_internode_compression_between_datacenters(manager: ScyllaClust
         for addr, _, _ in proxy_addrs:
             await HostRegistry().release_host(addr)
 
+@pytest.mark.max_running_shards(6)
 async def test_internode_compression_compress_packets_between_nodes(request, manager: ScyllaClusterManager) -> None:
     def check_expected(msg_size, node1_proxy, node2_proxy, node3_proxy):
         # get the stats
@@ -184,6 +186,7 @@ async def test_internode_compression_compress_packets_between_nodes(request, man
 
     await do_test_internode_compression_between_datacenters(manager, "all", check_expected)
 
+@pytest.mark.max_running_shards(6)
 async def test_internode_compression_between_datacenters(request, manager: ScyllaClusterManager) -> None:
     def check_expected(msg_size, node1_proxy, node2_proxy, node3_proxy):
         # get the stats

--- a/test/cluster/test_ip_mappings.py
+++ b/test/cluster/test_ip_mappings.py
@@ -18,6 +18,7 @@ from cassandra.cluster import ConsistencyLevel, SimpleStatement
 
 logger = logging.getLogger(__name__)
 
+@pytest.mark.max_running_shards(4)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_broken_bootstrap(manager: ScyllaClusterManager):
     server_a = await manager.server_add()
@@ -49,6 +50,7 @@ async def test_broken_bootstrap(manager: ScyllaClusterManager):
             assert response[0].b == i
 
 
+@pytest.mark.max_running_shards(6)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 @pytest.mark.parametrize('reuse_ip', [False, True])
 async def test_full_shutdown_during_replace(manager: ScyllaClusterManager, reuse_ip: bool):

--- a/test/cluster/test_keyspace_rf.py
+++ b/test/cluster/test_keyspace_rf.py
@@ -15,6 +15,7 @@ from test.pylib.internal_types import ServerUpState
 from test.cluster.util import create_new_test_keyspace, get_replication, get_replica_count
 
 
+@pytest.mark.max_running_shards(18)
 @pytest.mark.parametrize("tablets_enabled", [True, False])
 @pytest.mark.parametrize("rf_rack_valid_keyspaces", [False, True])
 async def test_create_keyspace_with_default_replication_factor(manager: ScyllaClusterManager, tablets_enabled: bool, rf_rack_valid_keyspaces: bool, build_mode):

--- a/test/cluster/test_large_partition_guardrail.py
+++ b/test/cluster/test_large_partition_guardrail.py
@@ -29,6 +29,7 @@ async def _make_oversized_partition(cql, tbl, pk, num_rows, value_size_bytes):
         await cql.run_async(insert, [pk, ck, bytes(value_size_bytes)])
 
 
+@pytest.mark.max_running_shards(4)
 @pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_large_data_guardrails_rolling_upgrade(manager: ScyllaClusterManager):
@@ -105,6 +106,7 @@ async def test_large_data_guardrails_rolling_upgrade(manager: ScyllaClusterManag
         await cql.run_async(insert, [1, 99, b"\x00"])
 
 
+@pytest.mark.max_running_shards(4)
 @pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_read_repair_skips_large_data_guardrails(manager: ScyllaClusterManager):

--- a/test/cluster/test_left_node_notification.py
+++ b/test/cluster/test_left_node_notification.py
@@ -13,6 +13,7 @@ from test.cluster.util import check_token_ring_and_group0_consistency
 logger = logging.getLogger(__name__)
 
 
+@pytest.mark.max_running_shards(6)
 async def test_left_node_notification(manager: ScyllaClusterManager) -> None:
     """
     Create a 3-node multi-DC cluster with 2 nodes in dc1 and 1 node in dc2.

--- a/test/cluster/test_logstor.py
+++ b/test/cluster/test_logstor.py
@@ -25,6 +25,7 @@ async def count_logstor_data_files(manager: ScyllaClusterManager, server_id: int
     workdir = await manager.server_get_workdir(server_id)
     return len(list((Path(workdir) / "logstor").glob(f"ls_{shard}-*-Data.db")))
 
+@pytest.mark.max_running_shards(2)
 async def test_config_option_consistency(manager: ScyllaClusterManager):
     """
     Test that logstor storage engine requires the experimental 'logstor' feature to be enabled.
@@ -41,6 +42,7 @@ async def test_config_option_consistency(manager: ScyllaClusterManager):
         with pytest.raises(ConfigurationException, match="The experimental feature 'logstor' must be enabled"):
             await cql.run_async(f"CREATE TABLE {ks}.t_logstor (pk int PRIMARY KEY, v int) WITH storage_engine = 'logstor'")
 
+@pytest.mark.max_running_shards(2)
 async def test_parallel_writes(manager: ScyllaClusterManager):
     cmdline = ['--logger-log-level', 'logstor=debug']
     cfg = {'experimental_features': ['logstor']}
@@ -59,6 +61,7 @@ async def test_parallel_writes(manager: ScyllaClusterManager):
             assert rows[0].pk == i
             assert rows[0].v == i + 1
 
+@pytest.mark.max_running_shards(1)
 async def test_parallel_big_writes(manager: ScyllaClusterManager):
     """
     Perform multiple writes in parallel with large values and validate to test segment switching.
@@ -84,6 +87,7 @@ async def test_parallel_big_writes(manager: ScyllaClusterManager):
             assert rows[0].pk == i
             assert rows[0].v == f"{i}-{large_value}"
 
+@pytest.mark.max_running_shards(1)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_write_failure_retires_active_segment(manager: ScyllaClusterManager):
     """
@@ -151,6 +155,7 @@ async def test_write_failure_retires_active_segment(manager: ScyllaClusterManage
             assert len(rows) == 1, f"Key {pk} not found after recovery"
             assert rows[0].v == expected_v, f"Key {pk} has wrong value after recovery"
 
+@pytest.mark.max_running_shards(2)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 @pytest.mark.parametrize("fail_separator_flush", [False, True], ids=["normal", "fail_separator_flush"])
 async def test_recovery_basic(manager: ScyllaClusterManager, fail_separator_flush: bool):
@@ -237,6 +242,7 @@ async def test_recovery_basic(manager: ScyllaClusterManager, fail_separator_flus
             assert rows[0].pk == pk, f"Key {pk} has wrong pk value"
             assert rows[0].v == expected_v, f"Key {pk} has wrong value after additional writes"
 
+@pytest.mark.max_running_shards(1)
 async def test_recovery_with_segment_reuse(manager: ScyllaClusterManager):
     """
     Test recovery after segments have been compacted and reused.
@@ -305,6 +311,7 @@ async def test_recovery_with_segment_reuse(manager: ScyllaClusterManager):
             assert len(rows) == 1, f"Key {pk} not found after recovery"
             assert rows[0].v == expected_v, f"Key {pk} value mismatch after recovery"
 
+@pytest.mark.max_running_shards(1)
 async def test_grow_logstor_disk_size(manager: ScyllaClusterManager):
     """
     Test that increasing the configured logstor disk size works correctly.
@@ -350,6 +357,7 @@ async def test_grow_logstor_disk_size(manager: ScyllaClusterManager):
         assert new_free_segments >= old_free_segments + ((new_disk_size_mb - old_disk_size_mb) * 1024 * 1024) // segment_size, \
             "Free segments should increase after growing disk size"
 
+@pytest.mark.max_running_shards(1)
 async def test_shrink_logstor_disk_size_no_data(manager: ScyllaClusterManager):
     """
     Test that shrinking the configured logstor disk size works correctly when
@@ -393,6 +401,7 @@ async def test_shrink_logstor_disk_size_no_data(manager: ScyllaClusterManager):
         assert free_segments <= new_disk_size_mb * 1024 * 1024 // segment_size, "Free segments should not exceed total segments after shrinking disk size"
 
 
+@pytest.mark.max_running_shards(1)
 async def test_shrink_logstor_disk_size_dead_data(manager: ScyllaClusterManager):
     """
     Test that shrinking the configured logstor disk size can remove a file when
@@ -456,6 +465,7 @@ async def test_shrink_logstor_disk_size_dead_data(manager: ScyllaClusterManager)
             f"Expected at most one active segment after shrink with dead data, got {segments_in_use}"
 
 
+@pytest.mark.max_running_shards(1)
 async def test_shrink_logstor_disk_size_live_data(manager: ScyllaClusterManager):
     """
     Test that shrinking the configured logstor disk size preserves files that
@@ -511,6 +521,7 @@ async def test_shrink_logstor_disk_size_live_data(manager: ScyllaClusterManager)
             assert rows[0].v == value, f"Wrong value for key {i} after attempted shrink with live data"
 
 
+@pytest.mark.max_running_shards(1)
 async def test_space_accounting_metrics(manager: ScyllaClusterManager):
     """
     Verify the space accounting metrics scylla_logstor_sm_live_record_bytes and
@@ -618,6 +629,7 @@ async def test_space_accounting_metrics(manager: ScyllaClusterManager):
             f"got {final_live_record_count_after_drop}"
         )
 
+@pytest.mark.max_running_shards(1)
 async def test_compaction(manager: ScyllaClusterManager):
     """
     Test log compaction by creating dead data and verifying space reclamation.
@@ -660,6 +672,7 @@ async def test_compaction(manager: ScyllaClusterManager):
             await manager.api.logstor_compaction(servers[0].ip_addr)
         await wait_for(segments_compacted, time.time() + 60)
 
+@pytest.mark.max_running_shards(2)
 async def test_drop_table(manager: ScyllaClusterManager):
     """
     Test that DROP TABLE works properly with logstor tables.
@@ -722,6 +735,7 @@ async def test_drop_table(manager: ScyllaClusterManager):
             assert len(rows) == 1, f"Expected 1 row for key {i} in test2 after all operations, but got {len(rows)}"
             assert rows[0].v == value, f"Expected value of size {value_size} for key {i} in test2 after all operations, but got {len(rows[0].v)}"
 
+@pytest.mark.max_running_shards(1)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 @pytest.mark.parametrize("operation", ["drop", "truncate"])
 async def test_table_removal_during_logstor_compaction(manager: ScyllaClusterManager, operation: str):
@@ -791,6 +805,7 @@ async def test_table_removal_during_logstor_compaction(manager: ScyllaClusterMan
             rows = await cql.run_async(f"SELECT pk FROM {ks}.test")
             assert len(rows) == 0
 
+@pytest.mark.max_running_shards(1)
 async def test_trigger_separator_flush(manager: ScyllaClusterManager):
     """
     Write to 2 tablets, one slower than the other.
@@ -830,6 +845,7 @@ async def test_trigger_separator_flush(manager: ScyllaClusterManager):
             value = f"value_{i}_" + ('x' * (value_size - 20))
             await cql.run_async(f"INSERT INTO {ks}.test (pk, v) VALUES ({pk}, '{value}')")
 
+@pytest.mark.max_running_shards(1)
 async def test_tablet_split_trigger_by_size(manager: ScyllaClusterManager):
     """
     Test that a logstor table automatically splits tablets when the data size
@@ -881,6 +897,7 @@ async def test_tablet_split_trigger_by_size(manager: ScyllaClusterManager):
             assert len(rows) == 1, f"Key {i} not found after tablet split"
             assert rows[0].v == value, f"Wrong value for key {i} after tablet split"
 
+@pytest.mark.max_running_shards(1)
 async def test_tablet_split_and_merge(manager: ScyllaClusterManager):
     logger.info("Bootstrapping cluster")
     cmdline = [
@@ -943,6 +960,7 @@ async def test_tablet_split_and_merge(manager: ScyllaClusterManager):
 
         await check()
 
+@pytest.mark.max_running_shards(2)
 async def test_tablet_migration(manager: ScyllaClusterManager):
     """
     Test tablet migration
@@ -978,6 +996,7 @@ async def test_tablet_migration(manager: ScyllaClusterManager):
             assert len(rows) == 1, f"Expected 1 row for key {i} after tablet migration, but got {len(rows)}"
             assert rows[0].v == f"{i}_{value}", f"Expected value '{i}_{value}' for key {i} after tablet migration, but got {rows[0].v}"
 
+@pytest.mark.max_running_shards(2)
 async def test_tablet_intranode_migration(manager: ScyllaClusterManager):
     """
     Test tablet intranode migration
@@ -1012,6 +1031,7 @@ async def test_tablet_intranode_migration(manager: ScyllaClusterManager):
             assert len(rows) == 1, f"Expected 1 row for key {i} after tablet migration, but got {len(rows)}"
             assert rows[0].v == f"{i}_{value}", f"Expected value '{i}_{value}' for key {i} after tablet migration, but got {rows[0].v}"
 
+@pytest.mark.max_running_shards(2)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_tablet_migration_with_compaction(manager: ScyllaClusterManager):
     """
@@ -1104,6 +1124,7 @@ async def test_tablet_migration_with_compaction(manager: ScyllaClusterManager):
             assert len(rows) == 1, f"Key {pk} not found after migration with concurrent compaction"
             assert rows[0].v == expected_v, f"Key {pk} has wrong value after migration with concurrent compaction"
 
+@pytest.mark.max_running_shards(1)
 @pytest.mark.asyncio
 async def test_cache(manager: ScyllaClusterManager):
     """

--- a/test/cluster/test_long_join.py
+++ b/test/cluster/test_long_join.py
@@ -15,6 +15,7 @@ from test.pylib.util import wait_for
 
 logger = logging.getLogger(__name__)
 
+@pytest.mark.max_running_shards(4)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_long_join(manager: ScyllaClusterManager) -> None:
     """The test checks that join works even if expiring entries are dropped
@@ -29,6 +30,7 @@ async def test_long_join(manager: ScyllaClusterManager) -> None:
     await manager.api.message_injection(s1.ip_addr, inj)
     await asyncio.gather(task)
 
+@pytest.mark.max_running_shards(6)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_long_join_drop_entries_on_bootstrapping(manager: ScyllaClusterManager) -> None:
     """The test checks that join works even if expiring entries are dropped

--- a/test/cluster/test_long_query_timeout_erm.py
+++ b/test/cluster/test_long_query_timeout_erm.py
@@ -14,6 +14,7 @@ import logging
 import time
 
 logger = logging.getLogger(__name__)
+@pytest.mark.max_running_shards(8)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 @pytest.mark.parametrize("query_type,should_wait_for_timeout,shutdown_nodes", [
     ("SELECT", True, True),
@@ -132,6 +133,7 @@ async def test_long_query_timeout_erm(request, manager: ScyllaClusterManager, qu
             with pytest.raises(Exception, match="Operation failed for"):
                 await query_future
 
+@pytest.mark.max_running_shards(8)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 @pytest.mark.parametrize("enable_tablets", [True, False])
 async def test_long_query_timeout_without_failure_erm(request, manager: ScyllaClusterManager, enable_tablets):

--- a/test/cluster/test_lwt_semaphore.py
+++ b/test/cluster/test_lwt_semaphore.py
@@ -13,6 +13,7 @@ from cassandra.protocol import WriteTimeout
 from test.cluster.util import new_test_keyspace
 
 
+@pytest.mark.max_running_shards(1)
 @pytest.mark.skip_mode(mode='debug', reason='aarch64/debug is unpredictably slow', platform_key='aarch64')
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_cas_semaphore(manager):

--- a/test/cluster/test_maintenance_mode.py
+++ b/test/cluster/test_maintenance_mode.py
@@ -23,6 +23,7 @@ from typing import TypeAlias
 
 logger = logging.getLogger(__name__)
 
+@pytest.mark.max_running_shards(6)
 async def test_maintenance_mode(manager: ScyllaClusterManager):
     """
     The test checks that in maintenance mode server A is not available for other nodes and for clients.

--- a/test/cluster/test_major_compaction.py
+++ b/test/cluster/test_major_compaction.py
@@ -21,6 +21,7 @@ async def disable_autocompaction_across_keyspaces(manager: ScyllaClusterManager,
     for ks in (*keyspace_list, "system", "system_schema"):
         await manager.api.disable_autocompaction(server_ip_addr, ks)
 
+@pytest.mark.max_running_shards(2)
 @pytest.mark.parametrize("consider_only_existing_data", [True, False])
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_major_compaction_consider_only_existing_data(manager: ScyllaClusterManager, consider_only_existing_data):
@@ -89,6 +90,7 @@ async def test_major_compaction_consider_only_existing_data(manager: ScyllaClust
         for k in range(10):
             assert len(await cql.run_async(f"SELECT * FROM {ks}.{cf} WHERE pk = {k}")) == expected_count
 
+@pytest.mark.max_running_shards(1)
 @pytest.mark.parametrize("compaction_flush_all_tables_before_major_seconds", [0, 2, 10])
 async def test_major_compaction_flush_all_tables(manager: ScyllaClusterManager, compaction_flush_all_tables_before_major_seconds):
     """
@@ -140,6 +142,7 @@ async def test_major_compaction_flush_all_tables(manager: ScyllaClusterManager, 
         await check_all_table_flush_in_major_compaction(compaction_flush_all_tables_before_major_seconds == 2)
 
 # Testcase for https://github.com/scylladb/scylladb/issues/20197
+@pytest.mark.max_running_shards(1)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_shutdown_drain_during_compaction(manager: ScyllaClusterManager):
     """
@@ -194,6 +197,7 @@ async def test_shutdown_drain_during_compaction(manager: ScyllaClusterManager):
         await manager.server_start(server.server_id)
         await reconnect_driver(manager)
 
+@pytest.mark.max_running_shards(2)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_alter_compaction_strategy_during_compaction(manager: ScyllaClusterManager):
     """
@@ -237,6 +241,7 @@ async def test_alter_compaction_strategy_during_compaction(manager: ScyllaCluste
         await compaction_task
 
 # Testcase for https://github.com/scylladb/scylladb/issues/24501
+@pytest.mark.max_running_shards(2)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_disable_autocompaction_during_major_compaction(manager: ScyllaClusterManager):
     """

--- a/test/cluster/test_metadata_id.py
+++ b/test/cluster/test_metadata_id.py
@@ -22,6 +22,7 @@ async def create_server_and_cqls(manager, cqls_num):
 
     return tuple(create_cluster_connection() for _ in range(cqls_num))
 
+@pytest.mark.max_running_shards(2)
 async def test_changed_prepared_statement_metadata_columns(manager):
     cql1, cql2, cql3 = await create_server_and_cqls(manager, cqls_num=3)
 
@@ -41,6 +42,7 @@ async def test_changed_prepared_statement_metadata_columns(manager):
             assert len(cql1.execute(prepared).one()) == 3
             assert len(cql2.execute(prepared2).one()) == 3
 
+@pytest.mark.max_running_shards(2)
 async def test_changed_prepared_statement_metadata_types(manager):
     cql1, cql2, cql3 = await create_server_and_cqls(manager, cqls_num=3)
 
@@ -60,6 +62,7 @@ async def test_changed_prepared_statement_metadata_types(manager):
             assert len(cql1.execute(prepared).one()) == 2
             assert len(cql2.execute(prepared2).one()) == 2
 
+@pytest.mark.max_running_shards(2)
 async def test_changed_prepared_statement_metadata_udt(manager):
     cql1, cql2, cql3 = await create_server_and_cqls(manager, cqls_num=3)
 

--- a/test/cluster/test_multidc.py
+++ b/test/cluster/test_multidc.py
@@ -28,6 +28,7 @@ CONFIG = {"endpoint_snitch": "GossipingPropertyFileSnitch"}
 
 
 # Checks a cluster boot/operations in multi-dc environment with 5 nodes each in a separate DC
+@pytest.mark.max_running_shards(10)
 async def test_multidc(request: pytest.FixtureRequest, manager: ScyllaClusterManager) -> None:
     logger.info("Creating a new cluster")
     for i in range(5):
@@ -49,6 +50,7 @@ cluster_config = [
 
 
 # Simple put-get test for 2 DC with a different amount of nodes and different replication factors
+@pytest.mark.max_running_shards(8)
 @pytest.mark.parametrize("nodes_list, rf", cluster_config)
 async def test_putget_2dc_with_rf(
         request: pytest.FixtureRequest, manager: ScyllaClusterManager, nodes_list: list[int], rf: int
@@ -111,6 +113,7 @@ async def test_putget_2dc_with_rf(
             assert row[2] == f"value{i}"
 
 
+@pytest.mark.max_running_shards(4)
 async def test_read_or_write_to_dc_with_rf_0_fails(request: pytest.FixtureRequest, manager: ScyllaClusterManager):
     """
     Verifies that operations using local consistency levels (LOCAL_QUORUM, LOCAL_ONE) fail
@@ -174,6 +177,7 @@ async def test_read_or_write_to_dc_with_rf_0_fails(request: pytest.FixtureReques
         assert_operation_fails_with_rf0_error(cl,
             f"INSERT INTO {ks}.{table_name} ({columns[0].name}, {columns[1].name}) VALUES ('k_fail_{i}', 'value_fail_{i}')")
 
+@pytest.mark.max_running_shards(8)
 async def test_create_and_alter_keyspace_with_altering_rf_and_racks(manager: ScyllaClusterManager):
     """
     This test verifies that creating and altering a keyspace keeps it RF-rack-valid.
@@ -321,6 +325,7 @@ async def test_create_and_alter_keyspace_with_altering_rf_and_racks(manager: Scy
     # RF = 1 is always OK!
     await alter_fail(ks3, [1, 1], 1, 2)
 
+@pytest.mark.max_running_shards(14)
 async def test_arbiter_dc_rf_rack_valid_keyspaces(manager: ScyllaClusterManager):
     """
     This test verifies that Scylla rejects RF-rack-invalid keyspaces
@@ -398,6 +403,7 @@ async def test_arbiter_dc_rf_rack_valid_keyspaces(manager: ScyllaClusterManager)
         for task in [*valid_keyspaces, *invalid_keyspaces]:
             _ = tg.create_task(task)
 
+@pytest.mark.max_running_shards(10)
 async def test_startup_with_keyspaces_violating_rf_rack_valid_keyspaces(manager: ScyllaClusterManager):
     """
     This test verifies that starting a Scylla node fails when there's an RF-rack-invalid keyspace.
@@ -504,6 +510,7 @@ async def test_startup_with_keyspaces_violating_rf_rack_valid_keyspaces(manager:
     await manager.server_update_config(s1.server_id, "rf_rack_valid_keyspaces", "true")
     await manager.server_start(s1.server_id)
 
+@pytest.mark.max_running_shards(8)
 async def test_startup_with_keyspaces_violating_rf_rack_valid_keyspaces_but_not_enforced(manager: ScyllaClusterManager):
     """
     When the configuration option `rf_rack_valid_keyspaces` is enabled and there is an RF-rack-invalid keyspace,
@@ -546,6 +553,7 @@ async def test_startup_with_keyspaces_violating_rf_rack_valid_keyspaces_but_not_
 
     await log.wait_for(expected_pattern)
 
+@pytest.mark.max_running_shards(6)
 async def test_restart_with_prefer_local(request: pytest.FixtureRequest, manager: ScyllaClusterManager) -> None:
     logger.info("Creating a new cluster")
     for i in range(3):
@@ -558,6 +566,7 @@ async def test_restart_with_prefer_local(request: pytest.FixtureRequest, manager
     await manager.server_stop_gracefully(s_info.server_id)
     await manager.server_start(s_info.server_id)
 
+@pytest.mark.max_running_shards(10)
 async def test_warn_create_and_alter_rf_rack_invalid_ks(manager: ScyllaClusterManager):
     """
     When the configuration option `rf_rack_valid_keyspaces` is enabled, the user is not

--- a/test/cluster/test_mutation_schema_change.py
+++ b/test/cluster/test_mutation_schema_change.py
@@ -20,6 +20,7 @@ logger = logging.getLogger(__name__)
 pytestmark = pytest.mark.prepare_3_racks_cluster
 
 
+@pytest.mark.max_running_shards(6)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_mutation_schema_change(manager, random_tables):
     """
@@ -81,6 +82,7 @@ async def test_mutation_schema_change(manager, random_tables):
                                     execution_profile='whitelist')
 
 
+@pytest.mark.max_running_shards(6)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_mutation_schema_change_restart(manager, random_tables):
     """

--- a/test/cluster/test_mv.py
+++ b/test/cluster/test_mv.py
@@ -49,6 +49,7 @@ async def test_mv_tombstone_gc_setting(manager):
                 s = list(cql.execute(f"DESC {mv}"))[0].create_statement
                 assert "'mode': 'repair'" in s
 
+@pytest.mark.max_running_shards(6)
 async def test_mv_tombstone_gc_not_inherited(manager):
     """
     Test that the tombstone_gc parameter set on a base table is NOT inherited

--- a/test/cluster/test_no_dc_rack_change.py
+++ b/test/cluster/test_no_dc_rack_change.py
@@ -11,6 +11,7 @@ from test.pylib.scylla_cluster_manager import ScyllaClusterManager
 
 logger = logging.getLogger(__name__)
 
+@pytest.mark.max_running_shards(4)
 async def test_no_dc_rack_change(manager: ScyllaClusterManager) -> None:
     """
     Check that it is not possible to change node's DC or rack during restart.

--- a/test/cluster/test_no_removed_node_event_on_ip_change.py
+++ b/test/cluster/test_no_removed_node_event_on_ip_change.py
@@ -17,6 +17,7 @@ from test.pylib.util import wait_for_cql_and_get_hosts
 logger = logging.getLogger(__name__)
 
 
+@pytest.mark.max_running_shards(4)
 async def test_no_removed_node_event_on_ip_change(manager: ScyllaClusterManager, caplog: pytest.LogCaptureFixture):
     logger.info("starting the first node (leader)")
     servers = [await manager.server_add()]

--- a/test/cluster/test_node_isolation.py
+++ b/test/cluster/test_node_isolation.py
@@ -20,6 +20,7 @@ from test.cluster.util import create_new_test_keyspace
 logger = logging.getLogger(__name__)
 
 
+@pytest.mark.max_running_shards(6)
 @pytest.mark.tier2
 async def test_banned_node_notification(manager: ScyllaClusterManager, failure_detector_timeout) -> None:
     """Test that a node banned from the cluster get notification about been banned"""

--- a/test/cluster/test_node_ops_metrics.py
+++ b/test/cluster/test_node_ops_metrics.py
@@ -9,6 +9,7 @@ import logging
 
 logger = logging.getLogger(__name__)
 
+@pytest.mark.max_running_shards(6)
 async def test_bootstrap_removenode_metrics(manager):
     cfg = {'enable_repair_based_node_ops': True}
     servers = [await manager.server_add(config=cfg),

--- a/test/cluster/test_node_shutdown_waits_for_pending_requests.py
+++ b/test/cluster/test_node_shutdown_waits_for_pending_requests.py
@@ -15,6 +15,7 @@ from test.cluster.util import new_test_keyspace, reconnect_driver
 logger = logging.getLogger(__name__)
 
 
+@pytest.mark.max_running_shards(4)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_node_shutdown_waits_for_pending_requests(manager: ScyllaClusterManager) -> None:
     """Reproducer for #16382"""

--- a/test/cluster/test_nodetool.py
+++ b/test/cluster/test_nodetool.py
@@ -70,6 +70,7 @@ async def validate_status_operation(result: str, live_eps: list, down_eps: list,
     assert lines[i] == ""
 
 
+@pytest.mark.max_running_shards(10)
 async def test_zero_token_node_normal(manager: ScyllaClusterManager):
     zero_token_nodes = await manager.servers_add(servers_num=2, config={'join_ring': False})
 
@@ -114,6 +115,7 @@ async def test_zero_token_node_normal(manager: ScyllaClusterManager):
                                     host_id_map, config['num_tokens'])
 
 
+@pytest.mark.max_running_shards(8)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_zero_token_node_down_leaving(manager: ScyllaClusterManager):
     servers = await manager.running_servers()
@@ -159,6 +161,7 @@ async def test_zero_token_node_down_leaving(manager: ScyllaClusterManager):
     await task
 
 
+@pytest.mark.max_running_shards(8)
 async def test_zero_token_node_down_normal(manager: ScyllaClusterManager):
     servers = await manager.running_servers()
 
@@ -194,6 +197,7 @@ async def test_zero_token_node_down_normal(manager: ScyllaClusterManager):
                                     host_id_map, config['num_tokens'])
 
 
+@pytest.mark.max_running_shards(8)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_regular_node_joining(manager: ScyllaClusterManager):
     servers = await manager.running_servers()

--- a/test/cluster/test_not_enough_token_owners.py
+++ b/test/cluster/test_not_enough_token_owners.py
@@ -12,6 +12,7 @@ from test.pylib.util import unique_name, wait_for_cql_and_get_hosts
 from test.cluster.util import new_test_keyspace
 
 
+@pytest.mark.max_running_shards(8)
 async def test_not_enough_token_owners(manager: ScyllaClusterManager):
     """
     Test that:

--- a/test/cluster/test_prepare_race.py
+++ b/test/cluster/test_prepare_race.py
@@ -12,6 +12,7 @@ from test.pylib.scylla_cluster_manager import ScyllaClusterManager
 from test.pylib.rest_client import inject_error_one_shot
 
 
+@pytest.mark.max_running_shards(2)
 @pytest.mark.skip_mode(mode="release", reason="error injections are not supported in release mode")
 async def test_prepare_fails_if_cached_statement_is_invalidated_mid_prepare(manager: ScyllaClusterManager):
     server = await manager.server_add()

--- a/test/cluster/test_prometheus_metrics.py
+++ b/test/cluster/test_prometheus_metrics.py
@@ -13,6 +13,7 @@ from test.cluster.test_config import wait_for_config
 # Default Prometheus metrics port
 PROMETHEUS_PORT = 9180
 
+@pytest.mark.max_running_shards(6)
 @pytest.mark.asyncio
 async def test_prometheus_allow_protobuf_default(manager):
     """
@@ -36,6 +37,7 @@ async def test_prometheus_allow_protobuf_default(manager):
 # Accept header for requesting Prometheus protobuf format with native histograms
 PROMETHEUS_PROTOBUF_ACCEPT_HEADER = 'application/vnd.google.protobuf; proto=io.prometheus.client.MetricFamily; encoding=delimited'
 
+@pytest.mark.max_running_shards(4)
 @pytest.mark.asyncio
 async def test_prometheus_protobuf_native_histogram(manager):
     """

--- a/test/cluster/test_proxy_protocol.py
+++ b/test/cluster/test_proxy_protocol.py
@@ -326,6 +326,7 @@ async def proxy_server(manager: ScyllaClusterManager):
     yield (server, manager)
 
 
+@pytest.mark.max_running_shards(2)
 async def test_proxy_protocol_basic(proxy_server):
     """
     Test that connections through the proxy protocol port correctly report
@@ -353,6 +354,7 @@ async def test_proxy_protocol_basic(proxy_server):
     assert opcode == 0x08, f"Expected RESULT opcode (0x08), got {hex(opcode)}"
 
 
+@pytest.mark.max_running_shards(2)
 async def test_proxy_protocol_shard_aware(proxy_server):
     """
     Test that shard-aware proxy protocol port correctly uses the source port
@@ -415,6 +417,7 @@ async def test_proxy_protocol_shard_aware(proxy_server):
             await writer.wait_closed()
 
 
+@pytest.mark.max_running_shards(2)
 async def test_proxy_protocol_multiple_connections(proxy_server):
     """
     Test that multiple connections through the proxy protocol port
@@ -444,6 +447,7 @@ async def test_proxy_protocol_multiple_connections(proxy_server):
         assert opcode == 0x08, f"Expected RESULT opcode for {fake_src_addr}, got {hex(opcode)}"
 
 
+@pytest.mark.max_running_shards(2)
 async def test_proxy_protocol_port_preserved_in_system_clients(proxy_server):
     """
     Test that the source port from the proxy protocol header is correctly
@@ -494,6 +498,7 @@ async def test_proxy_protocol_port_preserved_in_system_clients(proxy_server):
         await writer.wait_closed()
 
 
+@pytest.mark.max_running_shards(2)
 async def test_proxy_protocol_ssl_basic(proxy_server):
     """
     Test proxy protocol with TLS encryption.
@@ -519,6 +524,7 @@ async def test_proxy_protocol_ssl_basic(proxy_server):
     assert opcode == 0x08, f"Expected RESULT opcode (0x08), got {hex(opcode)}"
 
 
+@pytest.mark.max_running_shards(2)
 async def test_proxy_protocol_ssl_shard_aware(proxy_server):
     """
     Test proxy protocol with TLS on the shard-aware port. We connect to all
@@ -618,6 +624,7 @@ async def test_proxy_protocol_ssl_shard_aware(proxy_server):
             ssl_sock.close()
 
 
+@pytest.mark.max_running_shards(2)
 async def test_proxy_protocol_ssl_port_preserved(proxy_server):
     """
     Test that the source port from the proxy protocol header is correctly

--- a/test/cluster/test_query_rebounce.py
+++ b/test/cluster/test_query_rebounce.py
@@ -18,6 +18,7 @@ from test.cluster.util import new_test_keyspace
 logger = logging.getLogger(__name__)
 
 
+@pytest.mark.max_running_shards(2)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_query_rebounce(manager: ScyllaClusterManager):
     """

--- a/test/cluster/test_quiesce_topology.py
+++ b/test/cluster/test_quiesce_topology.py
@@ -30,6 +30,7 @@ QUIESCE_DEBUG_CMDLINE = [
 ]
 
 
+@pytest.mark.max_running_shards(6)
 @pytest.mark.asyncio
 async def test_quiesce_waits_for_balancer(manager: ScyllaClusterManager):
     """
@@ -69,6 +70,7 @@ async def test_quiesce_waits_for_balancer(manager: ScyllaClusterManager):
         for host_id, count in replicas.items():
             assert 5 <= count <= 6, f"Node {host_id} has {count} tablets, expected 5 or 6"
 
+@pytest.mark.max_running_shards(4)
 @pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_quiesce_blocks_until_refresh_completes(manager: ScyllaClusterManager):
@@ -122,6 +124,7 @@ async def test_quiesce_blocks_until_refresh_completes(manager: ScyllaClusterMana
         logger.info("Quiesce completed after refresh was released")
 
 
+@pytest.mark.max_running_shards(8)
 @pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_quiesce_retries_until_balance_plan_is_empty(manager: ScyllaClusterManager):

--- a/test/cluster/test_raft_cluster_features.py
+++ b/test/cluster/test_raft_cluster_features.py
@@ -15,31 +15,37 @@ from test.cluster import test_cluster_features
 import pytest
 
 
+@pytest.mark.max_running_shards(6)
 async def test_rolling_upgrade_happy_path(manager: ScyllaClusterManager) -> None:
     await manager.servers_add(3, auto_rack_dc="dc1")
     await test_cluster_features.test_rolling_upgrade_happy_path(manager)
 
 
+@pytest.mark.max_running_shards(6)
 async def test_downgrade_after_partial_upgrade(manager: ScyllaClusterManager) -> None:
     await manager.servers_add(3, auto_rack_dc="dc1")
     await test_cluster_features.test_downgrade_after_partial_upgrade(manager)
 
 
+@pytest.mark.max_running_shards(8)
 async def test_joining_old_node_fails(manager: ScyllaClusterManager) -> None:
     await manager.servers_add(3, auto_rack_dc="dc1")
     await test_cluster_features.test_joining_old_node_fails(manager)
 
 
+@pytest.mark.max_running_shards(6)
 async def test_downgrade_after_successful_upgrade_fails(manager: ScyllaClusterManager) -> None:
     await manager.servers_add(3, auto_rack_dc="dc1")
     await test_cluster_features.test_downgrade_after_successful_upgrade_fails(manager)
 
 
+@pytest.mark.max_running_shards(6)
 async def test_partial_upgrade_can_be_finished_with_removenode(manager: ScyllaClusterManager) -> None:
     await manager.servers_add(3, auto_rack_dc="dc1")
     await test_cluster_features.test_partial_upgrade_can_be_finished_with_removenode(manager)
 
 
+@pytest.mark.max_running_shards(6)
 async def test_cannot_disable_cluster_feature_after_all_declare_support(manager: ScyllaClusterManager) -> None:
     """Upgrade all nodes to support the test cluster feature, but suppress
        the topology coordinator and prevent it from enabling the feature.

--- a/test/cluster/test_raft_ignore_nodes.py
+++ b/test/cluster/test_raft_ignore_nodes.py
@@ -60,6 +60,7 @@ async def make_servers(manager: ScyllaClusterManager, servers_num: int,
     return servers_ordered
 
 
+@pytest.mark.max_running_shards(14)
 async def test_raft_replace_ignore_nodes(manager: ScyllaClusterManager) -> None:
     """Replace 3 dead nodes.
 
@@ -108,6 +109,7 @@ async def test_raft_replace_ignore_nodes(manager: ScyllaClusterManager) -> None:
     await wait_for_token_ring_and_group0_consistency(manager, time.time() + 30)
 
 
+@pytest.mark.max_running_shards(14)
 async def test_raft_remove_ignore_nodes(manager: ScyllaClusterManager) -> None:
     """Remove 3 dead nodes.
 

--- a/test/cluster/test_raft_no_quorum.py
+++ b/test/cluster/test_raft_no_quorum.py
@@ -34,6 +34,7 @@ async def update_group0_raft_op_timeout(server_id: ServerNum, manager: ScyllaClu
         await manager.server_update_config(server_id, 'group0_raft_op_timeout_in_ms', timeout)
 
 
+@pytest.mark.max_running_shards(10)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 @pytest.mark.skip_mode(mode='debug', reason='aarch64/debug is unpredictably slow', platform_key='aarch64')
 async def test_cannot_add_new_node(manager: ScyllaClusterManager, raft_op_timeout: int) -> None:
@@ -87,6 +88,7 @@ async def test_cannot_add_new_node(manager: ScyllaClusterManager, raft_op_timeou
     logger.info("done")
 
 
+@pytest.mark.max_running_shards(8)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 @pytest.mark.skip_mode(mode='debug', reason='aarch64/debug is unpredictably slow', platform_key='aarch64')
 async def test_quorum_lost_during_node_join(manager: ScyllaClusterManager, raft_op_timeout: int) -> None:
@@ -130,6 +132,7 @@ async def test_quorum_lost_during_node_join(manager: ScyllaClusterManager, raft_
     await fourth_node_future
 
 
+@pytest.mark.max_running_shards(8)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 @pytest.mark.skip_mode(mode='debug', reason='aarch64/debug is unpredictably slow', platform_key='aarch64')
 async def test_quorum_lost_during_node_join_response_handler(manager: ScyllaClusterManager, raft_op_timeout: int) -> None:
@@ -203,6 +206,7 @@ async def test_quorum_lost_during_node_join_response_handler(manager: ScyllaClus
     await fourth_node_future
 
 
+@pytest.mark.max_running_shards(6)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 @pytest.mark.skip_mode(mode='debug', reason='aarch64/debug is unpredictably slow', platform_key='aarch64')
 async def test_cannot_run_operations(manager: ScyllaClusterManager, raft_op_timeout: int) -> None:
@@ -252,6 +256,7 @@ async def test_cannot_run_operations(manager: ScyllaClusterManager, raft_op_time
     logger.info("done")
 
 
+@pytest.mark.max_running_shards(10)
 @pytest.mark.skip_mode(mode='release', reason='dev mode is sufficient for this test')
 @pytest.mark.skip_mode(mode='debug', reason='dev mode is sufficient for this test')
 async def test_can_restart(manager: ScyllaClusterManager, raft_op_timeout: int) -> None:

--- a/test/cluster/test_raft_recovery_during_join.py
+++ b/test/cluster/test_raft_recovery_during_join.py
@@ -19,6 +19,7 @@ from test.cluster.util import check_system_topology_and_cdc_generations_v3_consi
         reconnect_driver, wait_for_cdc_generations_publishing
 
 
+@pytest.mark.max_running_shards(12)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_raft_recovery_during_join(manager: ScyllaClusterManager):
     """

--- a/test/cluster/test_raft_recovery_entry_loss.py
+++ b/test/cluster/test_raft_recovery_entry_loss.py
@@ -30,6 +30,7 @@ async def get_local_schema_version(cql: Session, h: Host) -> UUID:
     assert(rs)
     return rs[0].schema_version
 
+@pytest.mark.max_running_shards(10)
 async def test_raft_recovery_entry_loss(manager: ScyllaClusterManager):
     """
     Test that the Raft-based recovery procedure works correctly if some committed group 0 entry has been permanently

--- a/test/cluster/test_raft_recovery_user_data.py
+++ b/test/cluster/test_raft_recovery_user_data.py
@@ -22,6 +22,7 @@ from test.cluster.util import check_system_topology_and_cdc_generations_v3_consi
         reconnect_driver, start_writes, wait_for_cdc_generations_publishing
 
 
+@pytest.mark.max_running_shards(14)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 @pytest.mark.parametrize("remove_dead_nodes_with", ["remove", "replace"])
 async def test_raft_recovery_user_data(manager: ScyllaClusterManager, remove_dead_nodes_with: str):

--- a/test/cluster/test_raft_snapshot_request.py
+++ b/test/cluster/test_raft_snapshot_request.py
@@ -16,6 +16,7 @@ from test.cluster.util import reconnect_driver, trigger_snapshot, get_topology_c
 
 logger = logging.getLogger(__name__)
 
+@pytest.mark.max_running_shards(6)
 async def test_raft_snapshot_request(manager: ScyllaClusterManager):
     cmdline = [
         '--logger-log-level', 'raft=trace',

--- a/test/cluster/test_raft_snapshot_truncation.py
+++ b/test/cluster/test_raft_snapshot_truncation.py
@@ -16,6 +16,7 @@ from test.pylib.rest_client import inject_error_one_shot
 
 logger = logging.getLogger(__name__)
 
+@pytest.mark.max_running_shards(6)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_raft_snapshot_truncation(manager: ScyllaClusterManager):
     """

--- a/test/cluster/test_raft_voters.py
+++ b/test/cluster/test_raft_voters.py
@@ -31,6 +31,7 @@ async def get_number_of_voters(manager: ScyllaClusterManager, srv: ServerInfo):
 # Make sure the algorithm works with different cluster sizes.
 # (3, 1, 1) specifically checks that the largest DC doesn't get 2+ voters
 # and keep half or more of all voters, which would make losing that DC unsafe.
+@pytest.mark.max_running_shards(24)
 @pytest.mark.parametrize('dc1_nodes,dc2_nodes,dc3_nodes', [
     pytest.param(3, 1, 1),
     pytest.param(6, 3, 3,
@@ -107,6 +108,7 @@ async def test_raft_voters_multidc_kill_dc(
     await read_barrier(manager.api, dc_servers[1][0].ip_addr)
 
 
+@pytest.mark.max_running_shards(14)
 async def test_raft_limited_voters_retain_coordinator(manager: ScyllaClusterManager):
     """
     Test that the topology coordinator is retained as a voter when possible.
@@ -163,6 +165,7 @@ async def test_raft_limited_voters_retain_coordinator(manager: ScyllaClusterMana
         f"The coordinator {coordinator_id} should be a voter (but is not)"
 
 
+@pytest.mark.max_running_shards(6)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_raft_voters_stop_leader_keeps_quorum(manager: ScyllaClusterManager, build_mode: str):
     """

--- a/test/cluster/test_random_tables.py
+++ b/test/cluster/test_random_tables.py
@@ -14,6 +14,7 @@ pytestmark = pytest.mark.prepare_3_racks_cluster
 
 
 # Simple test of schema helper
+@pytest.mark.max_running_shards(6)
 async def test_new_table(manager, random_tables):
     cql = manager.cql
     assert cql is not None
@@ -41,6 +42,7 @@ async def test_new_table(manager, random_tables):
 
 
 # Simple test of schema helper with alter
+@pytest.mark.max_running_shards(6)
 async def test_alter_verify_schema(manager, random_tables):
     """Verify table schema"""
     cql = manager.cql
@@ -54,6 +56,7 @@ async def test_alter_verify_schema(manager, random_tables):
         await random_tables.verify_schema()
 
 
+@pytest.mark.max_running_shards(6)
 async def test_new_table_insert_one(manager, random_tables):
     cql = manager.cql
     assert cql is not None
@@ -68,6 +71,7 @@ async def test_new_table_insert_one(manager, random_tables):
     assert list(res[0])[:2] == vals
 
 
+@pytest.mark.max_running_shards(6)
 async def test_drop_column(manager, random_tables):
     """Drop a random column from a table"""
     cql = manager.cql
@@ -85,6 +89,7 @@ async def test_drop_column(manager, random_tables):
     await random_tables.verify_schema(table)
 
 
+@pytest.mark.max_running_shards(6)
 async def test_add_index(random_tables):
     """Add and drop an index"""
     table = await random_tables.add_table(ncolumns=5)
@@ -94,6 +99,7 @@ async def test_add_index(random_tables):
     await random_tables.verify_schema(table)
 
 
+@pytest.mark.max_running_shards(6)
 async def test_paged_result(manager, random_tables):
     """Test run_async with paged results"""
     cql = manager.cql

--- a/test/cluster/test_read_repair.py
+++ b/test/cluster/test_read_repair.py
@@ -182,6 +182,7 @@ incremental_repair_test_data = [pytest.param(row_tombstone_data, id="row-tombsto
                                 pytest.param(partition_tombstone_data, id="partition-tombstone")]
 
 
+@pytest.mark.max_running_shards(4)
 @pytest.mark.parametrize("data_class", incremental_repair_test_data)
 async def test_incremental_read_repair(data_class: DataClass, manager: ScyllaClusterManager):
     """Stress the incremental read repair logic
@@ -329,6 +330,7 @@ async def test_incremental_read_repair(data_class: DataClass, manager: ScyllaClu
         check_rows(cql, host2, all_rows)
 
 
+@pytest.mark.max_running_shards(4)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_read_repair_with_trace_logging(request, manager):
     logger.info("Creating a new cluster")

--- a/test/cluster/test_reader_concurrency_semaphore_shared_pool.py
+++ b/test/cluster/test_reader_concurrency_semaphore_shared_pool.py
@@ -15,6 +15,7 @@ from test.pylib.scylla_cluster_manager import ScyllaClusterManager
 from test.pylib.util import wait_for
 
 from .util import new_test_keyspace, new_test_table
+import pytest
 
 
 logger = logging.getLogger(__name__)
@@ -32,6 +33,7 @@ async def _pool_metric(manager: ScyllaClusterManager, ip_addr: str, name: str) -
     return int(metrics.get(name, MAIN_POOL_LABELS) or 0)
 
 
+@pytest.mark.max_running_shards(1)
 async def test_shared_pool_live_resize_under_reads(manager: ScyllaClusterManager):
     """
     Change reader_concurrency_semaphore_shared_pool_fraction live (0.2 -> 0 -> 0.5)

--- a/test/cluster/test_refresh.py
+++ b/test/cluster/test_refresh.py
@@ -93,6 +93,7 @@ class SSTablesOnLocalStorage:
     async def restore(self, manager, sstables_per_server, prefix, ks, cf, scope, primary_replica_only, logger):
         await asyncio.gather(*(self.refresh_one(manager, s, ks, cf, sstables, scope, primary_replica_only) for s, sstables in sstables_per_server.items()))
 
+@pytest.mark.max_running_shards(16)
 @pytest.mark.parametrize("topology", [
         topo(rf = 1, nodes = 3, racks = 1, dcs = 1),
         topo(rf = 3, nodes = 5, racks = 1, dcs = 1),
@@ -105,6 +106,7 @@ async def test_refresh_with_streaming_scopes(build_mode: str, manager: ScyllaClu
     await do_test_streaming_scopes(build_mode, manager, topology, SSTablesOnLocalStorage())
 
 
+@pytest.mark.max_running_shards(4)
 async def test_refresh_deletes_uploaded_sstables(manager: ScyllaClusterManager):
     '''
     Check that refreshing a cluster deletes the sstable files from the upload directory after loading
@@ -195,6 +197,7 @@ async def wait_for_row_count_on_host(cql, host, ks, table, expected, timeout=120
         pytest.fail(f"Expected {expected} rows in {ks}.{table} on {host}, got {last}")
 
 
+@pytest.mark.max_running_shards(4)
 @pytest.mark.parametrize("tablets", [False, True])
 async def test_refresh_generates_view_updates(manager: ScyllaClusterManager, tablets):
     '''
@@ -271,6 +274,7 @@ async def test_refresh_generates_view_updates(manager: ScyllaClusterManager, tab
             await wait_for_row_count_on_host(cql, host, ks, f'{idx}_index', expected_rows)
 
 
+@pytest.mark.max_running_shards(2)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_refresh_does_not_claim_sstables_created_by_another_shard(manager: ScyllaClusterManager):
     '''

--- a/test/cluster/test_remove_alive_node.py
+++ b/test/cluster/test_remove_alive_node.py
@@ -10,6 +10,7 @@ import logging
 import pytest
 
 
+@pytest.mark.max_running_shards(6)
 async def test_removing_alive_node_fails(manager: ScyllaClusterManager) -> None:
     """
     Test verifying that an attempt to remove an alive node fails as expected.

--- a/test/cluster/test_remove_rpc_client_with_pending_requests.py
+++ b/test/cluster/test_remove_rpc_client_with_pending_requests.py
@@ -17,6 +17,7 @@ from test.pylib.util import wait_for_cql_and_get_hosts
 logger = logging.getLogger(__name__)
 
 
+@pytest.mark.max_running_shards(6)
 async def test_remove_rpc_client_with_pending_requests(request, manager: ScyllaClusterManager) -> None:
     # Regression test for #17445
 

--- a/test/cluster/test_repair.py
+++ b/test/cluster/test_repair.py
@@ -38,6 +38,7 @@ async def get_injection_params(manager, node_ip, injection):
         return {}
 
 
+@pytest.mark.max_running_shards(2)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_enable_compacting_data_for_streaming_and_repair_live_update(manager):
     """
@@ -78,6 +79,7 @@ async def test_enable_compacting_data_for_streaming_and_repair_live_update(manag
     assert (await get_injection_params(manager, node1.ip_addr, "maybe_compact_for_streaming"))["compaction_enabled"] == "true"
 
 
+@pytest.mark.max_running_shards(2)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_tombstone_gc_for_streaming_and_repair(manager):
     """
@@ -153,6 +155,7 @@ async def test_tombstone_gc_for_streaming_and_repair(manager):
             "compaction_enabled": "true", "compaction_can_gc": "false"}
     check_nodes_have_data(True, True)
 
+@pytest.mark.max_running_shards(4)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_repair_succeeds_with_unitialized_bm(manager):
     servers = await manager.servers_add(2, auto_rack_dc="dc1")
@@ -211,14 +214,17 @@ async def do_batchlog_flush_in_repair(manager, cache_time_in_ms):
 
     logger.debug(f"Repair nr_repairs={nr_repairs} cache_time_in_ms={cache_time_in_ms} total_repair_duration={total_repair_duration}")
 
+@pytest.mark.max_running_shards(2)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_batchlog_flush_in_repair_with_cache(manager):
     await do_batchlog_flush_in_repair(manager, 5000);
 
+@pytest.mark.max_running_shards(2)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_batchlog_flush_in_repair_without_cache(manager):
     await do_batchlog_flush_in_repair(manager, 0);
 
+@pytest.mark.max_running_shards(4)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_keyspace_drop_during_data_sync_repair(manager):
     cfg = {
@@ -234,6 +240,7 @@ async def test_keyspace_drop_during_data_sync_repair(manager):
 
     await manager.server_add(config=cfg)
 
+@pytest.mark.max_running_shards(4)
 async def test_vnode_keyspace_describe_ring(manager: ScyllaClusterManager):
     cfg = {
         'tablets_mode_for_new_keyspaces': 'disabled',
@@ -278,6 +285,7 @@ async def test_vnode_keyspace_describe_ring(manager: ScyllaClusterManager):
             assert natural_endpoints == ring_endpoints, f"natural_endpoint mismatch describe_ring for {key=} {token=} {natural_endpoints=} {ring_endpoints=}"
 
 
+@pytest.mark.max_running_shards(2)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_repair_timtestamp_difference(manager):
     cmdline = [ "--smp", "1", "--logger-log-level", "api=trace", "--hinted-handoff-enabled", "0" ]
@@ -333,6 +341,7 @@ async def test_repair_timtestamp_difference(manager):
     logger.info("Checking timestamps after repair")
     await check({host1: update2_timestamp, host2: update2_timestamp})
 
+@pytest.mark.max_running_shards(4)
 async def test_small_table_optimization_repair(manager):
     servers = await manager.servers_add(2, auto_rack_dc="dc1")
 
@@ -347,6 +356,7 @@ async def test_small_table_optimization_repair(manager):
     assert len(rows) == 1
 
 
+@pytest.mark.max_running_shards(3)
 @pytest.mark.parametrize("reason", ["rebuild", "bootstrap", "decommission"])
 async def test_small_table_optimization_for_rbno_auto_detect_by_size(manager, reason):
     """Verify that the small table optimization is automatically enabled for a
@@ -427,6 +437,7 @@ async def test_small_table_optimization_for_rbno_auto_detect_by_size(manager, re
         from_mark=mark)
 
 
+@pytest.mark.max_running_shards(4)
 async def test_repair_rejects_equal_start_and_end_token(manager):
     """Verify that repair rejects a request where startToken == endToken.
     When start == end, the wrapping range (T, T] covers the full token ring,
@@ -539,6 +550,7 @@ async def _repair_history(cql, host, ks: str) -> list[tuple[int, int]]:
     return sorted((r.range_start, r.range_end) for r in rows if r.keyspace_name == ks)
 
 
+@pytest.mark.max_running_shards(4)
 async def test_repair_history_not_recorded_for_range_spanning_replica_sets(manager: ScyllaClusterManager):
     """Repairing a range that spans two different replica sets must not claim the
     whole range as repaired.
@@ -609,6 +621,7 @@ async def test_repair_history_not_recorded_for_range_spanning_replica_sets(manag
                 f"but it was recorded on {sorted(recorded_on)}")
 
 
+@pytest.mark.max_running_shards(4)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_data_resurrection_from_repair_range_spanning_replica_sets(manager: ScyllaClusterManager):
     """End-to-end reproducer for the customer's data resurrection.
@@ -730,6 +743,7 @@ async def test_data_resurrection_from_repair_range_spanning_replica_sets(manager
         assert rows == [], f"deleted row was resurrected: {rows}"
 
 
+@pytest.mark.max_running_shards(6)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_topology_barrier_aborts_vnode_repair_pinning_stale_versions(manager: ManagerClient):
     """Verify that a topology barrier is not blocked behind a long-running
@@ -787,6 +801,7 @@ async def test_topology_barrier_aborts_vnode_repair_pinning_stale_versions(manag
     assert status == "FAILED"
 
 
+@pytest.mark.max_running_shards(4)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_tablet_migration_barrier_does_not_abort_vnode_repair(manager: ManagerClient):
     """Verify that a tablet migration barrier does not abort a running
@@ -857,6 +872,7 @@ async def test_tablet_migration_barrier_does_not_abort_vnode_repair(manager: Man
     assert status == "SUCCESSFUL"
 
 
+@pytest.mark.max_running_shards(4)
 async def test_repair_rejects_invalid_ranges_parallelism(manager):
     """Verify that repair rejects invalid ranges_parallelism values.
 

--- a/test/cluster/test_replace.py
+++ b/test/cluster/test_replace.py
@@ -20,6 +20,7 @@ from test.pylib.random_tables import RandomTables, Column, TextType
 logger = logging.getLogger(__name__)
 
 
+@pytest.mark.max_running_shards(6)
 async def test_replace_different_ip(manager: ScyllaClusterManager) -> None:
     """Replace an existing node with new node using a different IP address"""
     servers = await manager.servers_add(3)
@@ -65,6 +66,7 @@ async def test_replace_different_ip(manager: ScyllaClusterManager) -> None:
         await wait_for(check_peers_and_gossiper, time.time() + 60)
         logger.info(f"server {s} system.peers and gossiper state is valid")
 
+@pytest.mark.max_running_shards(6)
 async def test_replace_different_ip_using_host_id(manager: ScyllaClusterManager) -> None:
     """Replace an existing node with new node reusing the replaced node host id"""
     servers = await manager.servers_add(3)
@@ -73,6 +75,7 @@ async def test_replace_different_ip_using_host_id(manager: ScyllaClusterManager)
     await manager.server_add(replace_cfg)
     await wait_for_token_ring_and_group0_consistency(manager, time.time() + 30)
 
+@pytest.mark.max_running_shards(6)
 async def test_replace_reuse_ip(request, manager: ScyllaClusterManager) -> None:
     """Replace an existing node with new node using the same IP address"""
     servers = await manager.servers_add(3, auto_rack_dc="dc1")
@@ -126,6 +129,7 @@ async def test_replace_reuse_ip(request, manager: ScyllaClusterManager) -> None:
     await manager.server_sees_other_server(servers[1].ip_addr, servers[0].ip_addr)
     await manager.server_sees_other_server(servers[2].ip_addr, servers[0].ip_addr)
 
+@pytest.mark.max_running_shards(6)
 async def test_replace_reuse_ip_using_host_id(manager: ScyllaClusterManager) -> None:
     """Replace an existing node with new node using the same IP address and same host id"""
     servers = await manager.servers_add(3)

--- a/test/cluster/test_replace_alive_node.py
+++ b/test/cluster/test_replace_alive_node.py
@@ -11,6 +11,7 @@ import pytest
 pytestmark = pytest.mark.prepare_3_racks_cluster
 
 
+@pytest.mark.max_running_shards(8)
 async def test_replacing_alive_node_fails(manager: ScyllaClusterManager) -> None:
     """Try replacing an alive node and check that it fails"""
     servers = await manager.running_servers()

--- a/test/cluster/test_replace_with_encryption.py
+++ b/test/cluster/test_replace_with_encryption.py
@@ -8,6 +8,7 @@ from test.pylib.scylla_cluster_manager import ScyllaClusterManager
 from test.pylib.scylla_cluster import ReplaceConfig
 
 
+@pytest.mark.max_running_shards(12)
 @pytest.mark.parametrize("join_ring", [True, False])
 async def test_replace_with_encryption(manager: ScyllaClusterManager, join_ring):
     """Test that a node can be replaced if inter-dc encryption is enabled.

--- a/test/cluster/test_replace_with_same_ip_twice.py
+++ b/test/cluster/test_replace_with_same_ip_twice.py
@@ -13,6 +13,7 @@ import logging
 logger = logging.getLogger(__name__)
 
 
+@pytest.mark.max_running_shards(6)
 async def test_replace_with_same_ip_twice(manager: ScyllaClusterManager, failure_detector_timeout) -> None:
     logger.info("starting a cluster with two nodes")
     servers = await manager.servers_add(3, config={'failure_detector_timeout_in_ms': failure_detector_timeout})

--- a/test/cluster/test_replica_exceptions.py
+++ b/test/cluster/test_replica_exceptions.py
@@ -81,6 +81,7 @@ async def _test_impl(
     cpp_exceptions = get_metric_count(metrics_after, CPP_EXCEPTIONS_METRIC_NAME) - get_metric_count(metrics_before, CPP_EXCEPTIONS_METRIC_NAME)
     assert cpp_exceptions <= measurement.cpp_exception_threshold
 
+@pytest.mark.max_running_shards(2)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_replica_do_apply_rate_limit_no_cpp_exceptions(manager: ScyllaClusterManager):
     measurement = (m := Measurement())._replace(
@@ -103,6 +104,7 @@ async def test_replica_do_apply_rate_limit_no_cpp_exceptions(manager: ScyllaClus
         injection=injection
     )
 
+@pytest.mark.max_running_shards(2)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_replica_query_rate_limit_no_cpp_exceptions(manager: ScyllaClusterManager):
     measurement = (m := Measurement())._replace(
@@ -125,6 +127,7 @@ async def test_replica_query_rate_limit_no_cpp_exceptions(manager: ScyllaCluster
         injection=injection
     )
 
+@pytest.mark.max_running_shards(2)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_replica_writes_apply_counter_update_timeout(manager: ScyllaClusterManager):
     measurement = (m := Measurement())._replace(
@@ -148,6 +151,7 @@ async def test_replica_writes_apply_counter_update_timeout(manager: ScyllaCluste
         injection=injection
     )
 
+@pytest.mark.max_running_shards(2)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_replica_writes_do_apply_counter_update_timeout(manager: ScyllaClusterManager):
     config = { "counter_write_request_timeout_in_ms": 50 }
@@ -173,6 +177,7 @@ async def test_replica_writes_do_apply_counter_update_timeout(manager: ScyllaClu
         injection=injection
     )
 
+@pytest.mark.max_running_shards(2)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_replica_database_apply_timeout(manager: ScyllaClusterManager):
     measurement = (m := Measurement())._replace(

--- a/test/cluster/test_rest_api_on_startup.py
+++ b/test/cluster/test_rest_api_on_startup.py
@@ -13,6 +13,7 @@ from test.pylib.rest_client import HTTPError
 
 logger = logging.getLogger(__name__)
 
+@pytest.mark.max_running_shards(2)
 async def test_rest_api_on_startup(request, manager: ScyllaClusterManager):
 
     host = None

--- a/test/cluster/test_restart_cluster.py
+++ b/test/cluster/test_restart_cluster.py
@@ -17,6 +17,7 @@ from test.pylib.util import wait_for_cql_and_get_hosts
 logger = logging.getLogger(__name__)
 
 
+@pytest.mark.max_running_shards(6)
 async def test_restart_cluster(manager: ScyllaClusterManager) -> None:
     """Test that cluster can restart fine after all nodes are stopped gracefully"""
     servers = await manager.servers_add(3)

--- a/test/cluster/test_resurrection.py
+++ b/test/cluster/test_resurrection.py
@@ -20,6 +20,7 @@ def disable_auto_compaction(ip_addr, ks_name, cf_name):
     if not ret.ok:
         raise RuntimeError(f'failed to disable autocompaction using {api_path}: {ret.text}')
 
+@pytest.mark.max_running_shards(4)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_resurrection_while_file_streaming(manager: ScyllaClusterManager):
     '''

--- a/test/cluster/test_reversed_queries_during_simulated_upgrade_process.py
+++ b/test/cluster/test_reversed_queries_during_simulated_upgrade_process.py
@@ -18,6 +18,7 @@ def verify_data(response, expected_data):
         pytest.fail("Length of response and expected data mismatch")
 
 
+@pytest.mark.max_running_shards(4)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_reversed_queries_during_upgrade(manager: ScyllaClusterManager) -> None:
     """

--- a/test/cluster/test_rpc_compression.py
+++ b/test/cluster/test_rpc_compression.py
@@ -51,6 +51,7 @@ async def with_retries(test_once: typing.Callable[[], typing.Awaitable], timeout
             else:
                 break
 
+@pytest.mark.max_running_shards(4)
 async def test_basic(manager: ScyllaClusterManager) -> None:
     """Tests basic functionality of internode compression.
     Also, tests that changing internode_compression_zstd_max_cpu_fraction from 0.0 to 1.0 enables zstd as expected.
@@ -91,6 +92,7 @@ async def test_basic(manager: ScyllaClusterManager) -> None:
 
         await with_retries(functools.partial(test_algo, "zstd", 0.25), timeout=600)
 
+@pytest.mark.max_running_shards(4)
 async def test_dict_training(manager: ScyllaClusterManager) -> None:
     """Tests population of system.dicts with dicts trained on RPC traffic."""
     training_min_bytes = 128*1024
@@ -152,6 +154,7 @@ async def test_dict_training(manager: ScyllaClusterManager) -> None:
 
         await with_retries(test_once, timeout=600)
 
+@pytest.mark.max_running_shards(4)
 async def test_external_dicts(manager: ScyllaClusterManager) -> None:
     """Tests internode compression with external dictionaries"""
     cfg = {
@@ -214,6 +217,7 @@ async def test_external_dicts(manager: ScyllaClusterManager) -> None:
         await with_retries(functools.partial(test_once, "lz4", 0.5), timeout=600)
 
 # Similar to test_external_dicts, but simpler.
+@pytest.mark.max_running_shards(4)
 async def test_external_dicts_sanity(manager: ScyllaClusterManager) -> None:
     """Tests internode compression with external dictionaries, by spamming the same UPDATE statement."""
     cfg = {

--- a/test/cluster/test_secondary_index_paging.py
+++ b/test/cluster/test_secondary_index_paging.py
@@ -47,6 +47,7 @@ async def fill(cql, table, rows):
         await cql.run_async(insert, [p, v])
 
 
+@pytest.mark.max_running_shards(4)
 async def test_resumed_page_keeps_its_plan_on_another_coordinator(manager: ScyllaClusterManager) -> None:
     servers = await manager.servers_add(2, auto_rack_dc="dc1")
     cql = manager.get_cql()
@@ -84,6 +85,7 @@ async def test_resumed_page_keeps_its_plan_on_another_coordinator(manager: Scyll
         assert expected == sorted(row.p for row in got)
 
 
+@pytest.mark.max_running_shards(4)
 async def test_resuming_a_dropped_index_is_refused_on_another_coordinator(manager: ScyllaClusterManager) -> None:
     servers = await manager.servers_add(2, auto_rack_dc="dc1")
     cql = manager.get_cql()
@@ -142,6 +144,7 @@ async def indexed_table(cql, hosts, ks):
     return table
 
 
+@pytest.mark.max_running_shards(4)
 @pytest.mark.skip_mode(mode='release', reason='dev mode is enough for this test')
 @pytest.mark.skip_mode(mode='debug', reason='dev mode is enough for this test')
 async def test_paged_read_crosses_versions(manager: ScyllaClusterManager,
@@ -170,6 +173,7 @@ async def test_paged_read_crosses_versions(manager: ScyllaClusterManager,
             assert expected == sorted(row.p for row in got)
 
 
+@pytest.mark.max_running_shards(4)
 @pytest.mark.skip_mode(mode='release', reason='dev mode is enough for this test')
 @pytest.mark.skip_mode(mode='debug', reason='dev mode is enough for this test')
 async def test_resuming_a_pre_plan_paging_state_is_not_refused(manager: ScyllaClusterManager,

--- a/test/cluster/test_select_from_mutation_fragments.py
+++ b/test/cluster/test_select_from_mutation_fragments.py
@@ -14,6 +14,7 @@ from test.cluster.util import new_test_keyspace
 from test.pylib.scylla_cluster_manager import ScyllaClusterManager
 
 
+@pytest.mark.max_running_shards(4)
 async def test_sticky_coordinator_enforced(manager: ScyllaClusterManager) -> None:
     await manager.servers_add(2, cmdline=['--logger-log-level', 'paging=trace'], auto_rack_dc="dc1")
 

--- a/test/cluster/test_session_abort_repair_meta.py
+++ b/test/cluster/test_session_abort_repair_meta.py
@@ -35,6 +35,7 @@ async def wait_for_cleanup_log(logs, marks, timeout: float = 15) -> list[tuple[s
             task.cancel()
 
 
+@pytest.mark.max_running_shards(6)
 @pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_session_abort_cleans_orphan_repair_meta(manager: ScyllaClusterManager):

--- a/test/cluster/test_shutdown_hang.py
+++ b/test/cluster/test_shutdown_hang.py
@@ -20,6 +20,7 @@ from test.cluster.util import wait_for_token_ring_and_group0_consistency, new_te
 logger = logging.getLogger(__name__)
 
 
+@pytest.mark.max_running_shards(4)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_hints_manager_shutdown_hang(manager: ScyllaClusterManager) -> None:
     """Reproducer for #8079"""

--- a/test/cluster/test_size_based_load_balancing.py
+++ b/test/cluster/test_size_based_load_balancing.py
@@ -15,6 +15,7 @@ logger = logging.getLogger(__name__)
 
 GB = 1024 * 1024 * 1024
 
+@pytest.mark.max_running_shards(4)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_balance_empty_tablets(manager: ScyllaClusterManager):
 

--- a/test/cluster/test_snapshot.py
+++ b/test/cluster/test_snapshot.py
@@ -17,6 +17,7 @@ logger = logging.getLogger(__name__)
 pytestmark = pytest.mark.prepare_3_racks_cluster
 
 
+@pytest.mark.max_running_shards(8)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_snapshot(manager, random_tables):
     """

--- a/test/cluster/test_snapshot_with_tablets.py
+++ b/test/cluster/test_snapshot_with_tablets.py
@@ -10,6 +10,7 @@ import json
 from test.pylib.scylla_cluster_manager import ScyllaClusterManager
 from test.pylib.internal_types import ServerInfo
 from test.cluster.object_store.test_backup import do_test_snapshot_on_all_nodes
+import pytest
 
 logger = logging.getLogger(__name__)
 
@@ -41,6 +42,7 @@ async def get_snapshot_manifest(manager:ScyllaClusterManager, server, keyspace:s
         return json.load(f)
 
 
+@pytest.mark.max_running_shards(6)
 async def test_snapshot_on_all_nodes(manager: ScyllaClusterManager):
     """
     Tests that a topology operation snapshot is done on all nodes,

--- a/test/cluster/test_speculative_retry_config.py
+++ b/test/cluster/test_speculative_retry_config.py
@@ -9,6 +9,7 @@ import pytest
 from test.pylib.scylla_cluster_manager import ScyllaClusterManager
 
 
+@pytest.mark.max_running_shards(2)
 @pytest.mark.parametrize('cfg_source', ['yaml', 'cmdline'])
 async def test_invalid_speculative_retry_config(manager: ScyllaClusterManager, cfg_source: str):
     """

--- a/test/cluster/test_split_after_merge_repair_race.py
+++ b/test/cluster/test_split_after_merge_repair_race.py
@@ -117,6 +117,7 @@ async def _wait_for_pattern_any(logs, marks, pattern, timeout):
     raise asyncio.TimeoutError(f"pattern {pattern!r}: lost matching server")
 
 
+@pytest.mark.max_running_shards(6)
 @pytest.mark.asyncio
 @pytest.mark.skip_mode('release', 'error injections are not supported in release mode')
 async def test_split_bypass_race_with_repair_after_merge(manager: ScyllaClusterManager):

--- a/test/cluster/test_sstable_cleanup_stop.py
+++ b/test/cluster/test_sstable_cleanup_stop.py
@@ -13,6 +13,7 @@ import asyncio
 import logging
 
 logger = logging.getLogger(__name__)
+@pytest.mark.max_running_shards(1)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_cleanup_stop(manager: ScyllaClusterManager):
     logger.info("Bootstrapping cluster")

--- a/test/cluster/test_sstable_compression_config.py
+++ b/test/cluster/test_sstable_compression_config.py
@@ -31,6 +31,7 @@ def yaml_to_cmdline(config):
     return cmdline
 
 
+@pytest.mark.max_running_shards(2)
 @pytest.mark.parametrize('cfg_source', ['yaml', 'cmdline'])
 async def test_chunk_size_negative(manager: ScyllaClusterManager, cfg_source: str):
     config = {
@@ -46,6 +47,7 @@ async def test_chunk_size_negative(manager: ScyllaClusterManager, cfg_source: st
         await manager.server_add(cmdline=yaml_to_cmdline(config), expected_error=expected_error)
 
 
+@pytest.mark.max_running_shards(2)
 @pytest.mark.parametrize('cfg_source', ['yaml', 'cmdline'])
 async def test_chunk_size_beyond_max(manager: ScyllaClusterManager, cfg_source: str):
     config = {
@@ -61,6 +63,7 @@ async def test_chunk_size_beyond_max(manager: ScyllaClusterManager, cfg_source: 
         await manager.server_add(cmdline=yaml_to_cmdline(config), expected_error=expected_error)
 
 
+@pytest.mark.max_running_shards(2)
 @pytest.mark.parametrize('cfg_source', ['yaml', 'cmdline'])
 async def test_chunk_size_not_power_of_two(manager: ScyllaClusterManager, cfg_source: str):
     config = {
@@ -77,6 +80,7 @@ async def test_chunk_size_not_power_of_two(manager: ScyllaClusterManager, cfg_so
         await manager.server_add(cmdline=yaml_to_cmdline(config), expected_error=expected_error)
 
 
+@pytest.mark.max_running_shards(2)
 @pytest.mark.parametrize('cfg_source', ['yaml', 'cmdline'])
 async def test_crc_check_chance_out_of_bounds(manager: ScyllaClusterManager, cfg_source: str):
     config = {
@@ -92,6 +96,7 @@ async def test_crc_check_chance_out_of_bounds(manager: ScyllaClusterManager, cfg
     else:
         await manager.server_add(cmdline=yaml_to_cmdline(config), expected_error=expected_error)
 
+@pytest.mark.max_running_shards(4)
 async def test_default_compression_on_upgrade(manager: ScyllaClusterManager, scylla_2025_1: ScyllaVersionDescription, scylla_binary: Path):
     """
     Check that the default SSTable compression algorithm is:
@@ -144,6 +149,7 @@ async def test_default_compression_on_upgrade(manager: ScyllaClusterManager, scy
     await create_table_and_check_compression(cql, "test_ks", "table_after_upgrade", "LZ4WithDictsCompressor", "after upgrade and feature enabled")
 
 
+@pytest.mark.max_running_shards(2)
 async def test_alternator_tables_respect_compression_config(manager: ScyllaClusterManager):
     """
     Check that the default compression settings for all Alternator tables (base
@@ -229,6 +235,7 @@ async def test_alternator_tables_respect_compression_config(manager: ScyllaClust
         table.delete()
 
 
+@pytest.mark.max_running_shards(2)
 async def test_cql_base_tables_respect_compression_config(manager: ScyllaClusterManager):
     """
     Check that the default compression settings for CQL base tables are taken
@@ -259,6 +266,7 @@ async def test_cql_base_tables_respect_compression_config(manager: ScyllaCluster
         await cql.run_async(f"DROP KEYSPACE {ks}")
 
 
+@pytest.mark.max_running_shards(2)
 async def test_cql_aux_tables_respect_compression_config(manager: ScyllaClusterManager):
     """
     Check that the default compression settings for CQL auxiliary tables

--- a/test/cluster/test_sstable_compression_dictionaries_autotrain.py
+++ b/test/cluster/test_sstable_compression_dictionaries_autotrain.py
@@ -43,6 +43,7 @@ async def with_retries(test_once: typing.Callable[[], typing.Awaitable], timeout
             else:
                 break
 
+@pytest.mark.max_running_shards(4)
 async def test_autoretrain_dict(manager: ScyllaClusterManager):
     """
     Tests that sstable compression dictionary autotraining is doing its job.

--- a/test/cluster/test_sstable_compression_dictionaries_basic.py
+++ b/test/cluster/test_sstable_compression_dictionaries_basic.py
@@ -79,6 +79,7 @@ common_debug_cli_options = [
     '--dump-memory-diagnostics-on-alloc-failure-kind=all',
 ]
 
+@pytest.mark.max_running_shards(4)
 async def test_retrain_dict(manager: ScyllaClusterManager):
     """
     Tests basic functionality of SSTable compression with shared dictionaries.
@@ -203,6 +204,7 @@ async def test_retrain_dict(manager: ScyllaClusterManager):
 
     logger.info("Test completed successfully")
 
+@pytest.mark.max_running_shards(4)
 async def test_estimate_compression_ratios(manager: ScyllaClusterManager):
     logger.info("Bootstrapping cluster")
 
@@ -295,6 +297,7 @@ async def test_estimate_compression_ratios(manager: ScyllaClusterManager):
 
     assert sorted(expected_entries.keys()) == sorted(tuple(r.items()) for r in result)
 
+@pytest.mark.max_running_shards(2)
 async def test_dict_memory_limit(manager: ScyllaClusterManager):
     # Bootstrap cluster and configure server
     logger.info("Bootstrapping cluster")
@@ -401,6 +404,7 @@ async def test_dict_memory_limit(manager: ScyllaClusterManager):
         await cql.run_async("DROP TABLE test.test")
         await assert_eventually_dict_memory_leq_than(total_threshold=0)
 
+@pytest.mark.max_running_shards(2)
 async def test_sstable_compression_dictionaries_enable_writing(manager: ScyllaClusterManager):
     """
     Tests basic functionality of the `sstable_compression_dictionaries_enable_writing` config knob.

--- a/test/cluster/test_sstable_compression_dictionaries_upgrade.py
+++ b/test/cluster/test_sstable_compression_dictionaries_upgrade.py
@@ -26,6 +26,7 @@ from cassandra.query import SimpleStatement
 logger = logging.getLogger(__name__)
 
 
+@pytest.mark.max_running_shards(4)
 async def test_upgrade_and_rollback(manager: ScyllaClusterManager, scylla_2025_1: ScyllaVersionDescription, scylla_binary: pathlib.Path):
 
     logger.info("Bootstrapping cluster")

--- a/test/cluster/test_sstable_set.py
+++ b/test/cluster/test_sstable_set.py
@@ -13,6 +13,7 @@ from test.cluster.util import create_new_test_keyspace
 
 logger = logging.getLogger(__name__)
 
+@pytest.mark.max_running_shards(1)
 @pytest.mark.parametrize("mode", ['vnode', 'tablet'])
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_partitioned_sstable_set(manager: ScyllaClusterManager, mode):

--- a/test/cluster/test_stale_rpc_connection_on_ip_change.py
+++ b/test/cluster/test_stale_rpc_connection_on_ip_change.py
@@ -57,6 +57,7 @@ class BlackholeServer:
             await srv.wait_closed()
         logger.info(f"Blackhole server on {self.ip} stopped")
 
+@pytest.mark.max_running_shards(4)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 @pytest.mark.asyncio
 async def test_stale_client_id_evicted(manager: ScyllaClusterManager):
@@ -131,6 +132,7 @@ async def test_stale_client_id_evicted(manager: ScyllaClusterManager):
     logger.info("Stale CLIENT_ID eviction of IP_A confirmed!")
 
 
+@pytest.mark.max_running_shards(4)
 @pytest.mark.asyncio
 async def test_direct_fd_recovers_after_ip_change(manager: ScyllaClusterManager):
     """Reproduces SCYLLADB-2127: when a node restarts with a new IP (e.g. K8s

--- a/test/cluster/test_stop_before_starting_compaction_manager.py
+++ b/test/cluster/test_stop_before_starting_compaction_manager.py
@@ -8,6 +8,7 @@ import pytest
 from test.pylib.scylla_cluster_manager import ScyllaClusterManager
 
 
+@pytest.mark.max_running_shards(2)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_stop_before_starting_compaction_manager(manager: ScyllaClusterManager) -> None:
     """Test that Scylla doesn't crash when stopped during boot after constructing compaction manager (and thus

--- a/test/cluster/test_streaming_deadlock.py
+++ b/test/cluster/test_streaming_deadlock.py
@@ -16,6 +16,7 @@ from test.pylib.scylla_cluster_manager import ScyllaClusterManager
 logger = logging.getLogger(__name__)
 
 
+@pytest.mark.max_running_shards(6)
 async def test_streaming_deadlock_removenode(request, manager: ScyllaClusterManager):
     # Force removenode to exercise range_streamer and not repair.
     # The bug is in the streaming, and when senders are on different nodes,

--- a/test/cluster/test_strong_consistency.py
+++ b/test/cluster/test_strong_consistency.py
@@ -118,6 +118,7 @@ async def get_table_raft_group_id(manager: ScyllaClusterManager, ks: str, table:
     rows = await manager.get_cql().run_async(f"SELECT raft_group_id FROM system.tablets where table_id = {table_id}")
     return str(rows[0].raft_group_id)
 
+@pytest.mark.max_running_shards(6)
 async def test_basic_write_read(manager: ScyllaClusterManager, build_mode: str):
 
     logger.info("Bootstrapping cluster")
@@ -330,6 +331,7 @@ async def test_basic_write_read(manager: ScyllaClusterManager, build_mode: str):
     # To check that the servers can be stopped gracefully. By default the test runner just kills them.
     await gather_safely(*[manager.server_stop_gracefully(s.server_id) for s in servers])
 
+@pytest.mark.max_running_shards(12)
 async def test_multi_shard_write_read(manager: ScyllaClusterManager):
     """
     Verify that strongly consistent tables work correctly on non-shard-0.
@@ -365,6 +367,7 @@ async def test_multi_shard_write_read(manager: ScyllaClusterManager):
 
     await gather_safely(*[manager.server_stop_gracefully(s.server_id) for s in servers])
 
+@pytest.mark.max_running_shards(4)
 async def test_sc_multishard_metadata_reads(manager: ScyllaClusterManager):
     """
     Verify that multi-shard reads of raft metadata for strongly-consistent tables work correctly.
@@ -451,6 +454,7 @@ async def test_sc_multishard_metadata_reads(manager: ScyllaClusterManager):
 
     await manager.server_stop_gracefully(server.server_id)
 
+@pytest.mark.max_running_shards(4)
 async def test_sc_persistence_restart_with_smp_increase(manager: ScyllaClusterManager):
     """
     Verify that the metadata for strongly-consistent tables
@@ -501,6 +505,7 @@ async def test_sc_persistence_restart_with_smp_increase(manager: ScyllaClusterMa
     await manager.server_stop_gracefully(server.server_id)
 
 
+@pytest.mark.max_running_shards(2)
 async def test_sc_persistence_with_compaction(manager: ScyllaClusterManager):
     """
     Verify that compaction of system.raft_groups works correctly.
@@ -546,6 +551,7 @@ async def test_sc_persistence_with_compaction(manager: ScyllaClusterManager):
     await manager.server_stop_gracefully(server.server_id)
 
 
+@pytest.mark.max_running_shards(2)
 async def test_sc_persistence_after_crash(manager: ScyllaClusterManager):
     """
     Verify that metadata for strongly-consistent tables is recovered
@@ -581,6 +587,7 @@ async def test_sc_persistence_after_crash(manager: ScyllaClusterManager):
 
     await manager.server_stop_gracefully(server.server_id)
 
+@pytest.mark.max_running_shards(6)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_no_schema_when_apply_write(manager: ScyllaClusterManager):
     servers = await manager.servers_add(2, config=DEFAULT_CONFIG, cmdline=DEFAULT_CMDLINE, auto_rack_dc='my_dc')
@@ -625,6 +632,7 @@ async def test_no_schema_when_apply_write(manager: ScyllaClusterManager):
         assert row.c == 20
         assert row.new_col == 30
 
+@pytest.mark.max_running_shards(6)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_old_schema_when_apply_write(manager: ScyllaClusterManager):
     servers = await manager.servers_add(2, config=DEFAULT_CONFIG, cmdline=DEFAULT_CMDLINE, auto_rack_dc='my_dc')
@@ -667,6 +675,7 @@ async def test_old_schema_when_apply_write(manager: ScyllaClusterManager):
         assert row.c == 20
         assert row.new_col is None
 
+@pytest.mark.max_running_shards(4)
 async def test_forward_cql_prepared_with_bound_values(manager: ScyllaClusterManager):
     """
     When we prepare an statement not on the leader, we should
@@ -709,6 +718,7 @@ async def test_forward_cql_prepared_with_bound_values(manager: ScyllaClusterMana
                 logger.info(f"Trace event: {event.description}")
                 assert "Prepared statement not found on target" not in event.description
 
+@pytest.mark.max_running_shards(4)
 async def test_forward_cql_cache_invalidation(manager: ScyllaClusterManager):
     """
     Test that cql forwarding works after invalidation of prepared statement cache on schema changes.
@@ -750,6 +760,7 @@ async def test_forward_cql_cache_invalidation(manager: ScyllaClusterManager):
             prepared_not_found_after = metrics_after.get('scylla_transport_requests_forwarded_prepared_not_found') or 0
             assert prepared_not_found_after > prepared_not_found_before
 
+@pytest.mark.max_running_shards(6)
 @pytest.mark.skip_mode('release', "error injections aren't enabled in release mode")
 async def test_forward_cql_exception_passthrough(manager: ScyllaClusterManager):
     """
@@ -817,6 +828,7 @@ async def test_forward_cql_exception_passthrough(manager: ScyllaClusterManager):
             await manager.api.message_injection(non_leader_replica_host.address, "wait_before_handling_forwarded_request")
 
 
+@pytest.mark.max_running_shards(2)
 @pytest.mark.skip_mode("release", "error injections aren't enabled in release mode")
 async def test_drop_table_during_insert(manager: ScyllaClusterManager):
     """Regression test for SCYLLADB-1450: node crashes when DROP TABLE races with
@@ -870,6 +882,7 @@ async def test_drop_table_during_insert(manager: ScyllaClusterManager):
         await manager.api.get_host_id(server.ip_addr)
 
 
+@pytest.mark.max_running_shards(2)
 @pytest.mark.skip_mode(mode="release", reason="error injections are not supported in release mode")
 async def test_timed_out_queries(manager: ScyllaClusterManager):
     """
@@ -978,6 +991,7 @@ async def test_timed_out_queries(manager: ScyllaClusterManager):
                 await cql.run_async(f"INSERT INTO {table} (pk, v) VALUES (11, 13) USING TIMEOUT 100ms")
 
 
+@pytest.mark.max_running_shards(4)
 @pytest.mark.skip_mode(mode="release", reason="error injections are not supported in release mode")
 async def test_queries_while_dropping_table(manager: ScyllaClusterManager):
     """Verify that in-flight reads and writes are promptly aborted when
@@ -1086,6 +1100,7 @@ async def test_queries_while_dropping_table(manager: ScyllaClusterManager):
             await read_fut
 
 
+@pytest.mark.max_running_shards(6)
 @pytest.mark.skip_mode(mode="release", reason="error injections are not supported in release mode")
 @pytest.mark.parametrize("target", ["leader", "follower"])
 async def test_queries_when_shutting_down(manager: ScyllaClusterManager, target: str):
@@ -1319,6 +1334,7 @@ async def test_abort_state_machine_apply_during_shutdown(manager: ScyllaClusterM
         assert len(rows) == 1
         assert rows[0].v == 13
 
+@pytest.mark.max_running_shards(8)
 async def test_leader_cache_eliminates_redirect(manager: ScyllaClusterManager):
     """
     Verify that after a non-replica node learns the leader location via a redirect,
@@ -1417,6 +1433,7 @@ async def test_leader_cache_eliminates_redirect(manager: ScyllaClusterManager):
             assert len(rows) == 1
             assert rows[0].value == 25
 
+@pytest.mark.max_running_shards(8)
 @pytest.mark.asyncio
 async def test_read_forwarding(manager: ScyllaClusterManager):
     """
@@ -1512,6 +1529,7 @@ async def test_read_forwarding(manager: ScyllaClusterManager):
                 assert rows[0].c == i * 10, f"Linearizability violation: pk={100 + i}, expected c={i * 10}, got c={rows[0].c}"
 
 
+@pytest.mark.max_running_shards(4)
 async def test_write_from_non_replica_after_leader_down(manager: ScyllaClusterManager):
     """
     Verify that if a raft group leader goes down, a non-replica node can still
@@ -1585,6 +1603,7 @@ async def test_write_from_non_replica_after_leader_down(manager: ScyllaClusterMa
             assert len(rows) == 1
             assert rows[0].c == 2
 
+@pytest.mark.max_running_shards(3)
 @pytest.mark.asyncio
 @pytest.mark.skip_mode(mode="release", reason="error injections are not supported in release mode")
 async def test_stepdown_on_graceful_shutdown(manager: ScyllaClusterManager):

--- a/test/cluster/test_strong_consistency_commitlog.py
+++ b/test/cluster/test_strong_consistency_commitlog.py
@@ -10,6 +10,7 @@ from test.cluster.util import new_test_keyspace
 import pytest
 
 
+@pytest.mark.max_running_shards(2)
 @pytest.mark.asyncio
 async def test_data_survives_crash(manager: ScyllaClusterManager):
     """Verify that SC table data survives a non-graceful crash and is recovered
@@ -58,6 +59,7 @@ async def test_data_survives_crash(manager: ScyllaClusterManager):
     await manager.server_stop_gracefully(server.server_id)
 
 
+@pytest.mark.max_running_shards(2)
 @pytest.mark.asyncio
 async def test_schema_upgrade_during_replay(manager: ScyllaClusterManager):
     """Verify that SC table data survives a crash even when the schema was altered
@@ -112,6 +114,7 @@ async def test_schema_upgrade_during_replay(manager: ScyllaClusterManager):
     await manager.server_stop_gracefully(server.server_id)
 
 
+@pytest.mark.max_running_shards(2)
 @pytest.mark.asyncio
 async def test_double_crash_recovery(manager: ScyllaClusterManager):
     """Verify that SC table data survives two consecutive crashes.
@@ -164,6 +167,7 @@ async def test_double_crash_recovery(manager: ScyllaClusterManager):
     await manager.server_stop_gracefully(server.server_id)
 
 
+@pytest.mark.max_running_shards(2)
 @pytest.mark.asyncio
 async def test_crash_with_multiple_commitlog_segments(manager: ScyllaClusterManager):
     """Verify crash recovery when data spans multiple commitlog segments.
@@ -211,6 +215,7 @@ async def test_crash_with_multiple_commitlog_segments(manager: ScyllaClusterMana
     await manager.server_stop_gracefully(server.server_id)
 
 
+@pytest.mark.max_running_shards(2)
 @pytest.mark.asyncio
 async def test_crash_recovery_multi_tablet(manager: ScyllaClusterManager):
     """Verify crash recovery with multiple tablets (independent raft groups).
@@ -254,6 +259,7 @@ async def test_crash_recovery_multi_tablet(manager: ScyllaClusterManager):
     await manager.server_stop_gracefully(server.server_id)
 
 
+@pytest.mark.max_running_shards(2)
 @pytest.mark.asyncio
 async def test_crash_recovery_after_flush(manager: ScyllaClusterManager):
     """Verify crash recovery when some data was flushed to sstables before the crash.

--- a/test/cluster/test_table_desc_read_barrier.py
+++ b/test/cluster/test_table_desc_read_barrier.py
@@ -15,6 +15,7 @@ from test.cluster.util import new_test_keyspace
 logger = logging.getLogger(__name__)
 
 
+@pytest.mark.max_running_shards(4)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_table_desc_read_barrier(manager: ScyllaClusterManager) -> None:
     """

--- a/test/cluster/test_table_drop.py
+++ b/test/cluster/test_table_drop.py
@@ -9,6 +9,7 @@ import pytest
 
 logger = logging.getLogger(__name__)
 
+@pytest.mark.max_running_shards(4)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_drop_table_during_streaming_receiver_side(manager: ScyllaClusterManager):
     servers = [await manager.server_add(config={
@@ -19,6 +20,7 @@ async def test_drop_table_during_streaming_receiver_side(manager: ScyllaClusterM
     }) for _ in range(2)]
 
 
+@pytest.mark.max_running_shards(4)
 @pytest.mark.parametrize("feature_config", feature_configs(FeatureConfigurations.EVENTUAL_CONSISTENCY,
     FeatureConfigurations.STRONG_CONSISTENCY, FeatureConfigurations.LOGSTOR_EVENTUAL_CONSISTENCY,
     FeatureConfigurations.LOGSTOR_STRONG_CONSISTENCY))
@@ -38,6 +40,7 @@ async def test_drop_table_during_flush(manager: ScyllaClusterManager, feature_co
         await manager.api.keyspace_flush(servers[0].ip_addr, ks, "test")
 
 
+@pytest.mark.max_running_shards(2)
 @pytest.mark.parametrize("feature_config", feature_configs(FeatureConfigurations.EVENTUAL_CONSISTENCY,
     FeatureConfigurations.STRONG_CONSISTENCY))
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')

--- a/test/cluster/test_tablet_repair_scheduler.py
+++ b/test/cluster/test_tablet_repair_scheduler.py
@@ -106,18 +106,22 @@ async def do_test_tablet_repair_progress_split_merge(manager: ScyllaClusterManag
     await inject_error_off(manager, "tablet_repair_skip_sched", servers)
     await wait_task_progress(nr_tablets, nr_tablets)
 
+@pytest.mark.max_running_shards(6)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_tablet_repair_progress(manager: ScyllaClusterManager):
     await do_test_tablet_repair_progress_split_merge(manager, do_split=False, do_merge=False)
 
+@pytest.mark.max_running_shards(6)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_tablet_repair_progress_split(manager: ScyllaClusterManager):
     await do_test_tablet_repair_progress_split_merge(manager, do_split=True)
 
+@pytest.mark.max_running_shards(6)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_tablet_repair_progress_merge(manager: ScyllaClusterManager):
     await do_test_tablet_repair_progress_split_merge(manager, do_merge=True)
 
+@pytest.mark.max_running_shards(6)
 async def test_tablet_manual_repair(manager: ScyllaClusterManager):
     servers, cql, hosts, ks, table_id = await create_table_insert_data_for_repair(manager, fast_stats_refresh=False, disable_flush_cache_time=True)
     token = -1
@@ -142,6 +146,7 @@ async def test_tablet_manual_repair(manager: ScyllaClusterManager):
 
     assert t2 > t1
 
+@pytest.mark.max_running_shards(6)
 async def test_tombstone_gc_insert_flush(manager: ScyllaClusterManager):
     servers, cql, hosts, ks, table_id = await create_table_insert_data_for_repair(manager, fast_stats_refresh=False, disable_flush_cache_time=True)
     token = "all"
@@ -172,6 +177,7 @@ async def test_tombstone_gc_insert_flush(manager: ScyllaClusterManager):
         else:
             assert time.time() < deadline
 
+@pytest.mark.max_running_shards(6)
 async def test_tablet_manual_repair_all_tokens(manager: ScyllaClusterManager):
     servers, cql, hosts, ks, table_id = await create_table_insert_data_for_repair(manager, fast_stats_refresh=False, disable_flush_cache_time=True)
     token = "all"
@@ -190,6 +196,7 @@ async def test_tablet_manual_repair_all_tokens(manager: ScyllaClusterManager):
         assert v != None
         assert v > now
 
+@pytest.mark.max_running_shards(6)
 async def test_tablet_manual_repair_async(manager: ScyllaClusterManager):
     servers, cql, hosts, ks, table_id = await create_table_insert_data_for_repair(manager, fast_stats_refresh=False)
     token = "-1"
@@ -201,6 +208,7 @@ async def test_tablet_manual_repair_async(manager: ScyllaClusterManager):
     logging.info(f"{res=}")
     assert len(res) == 1
 
+@pytest.mark.max_running_shards(6)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_tablet_manual_repair_reject_parallel_requests(manager: ScyllaClusterManager):
     servers, cql, hosts, ks, table_id = await create_table_insert_data_for_repair(manager, fast_stats_refresh=False)
@@ -229,6 +237,7 @@ async def test_tablet_manual_repair_reject_parallel_requests(manager: ScyllaClus
     assert state.ok == 1
     assert state.error == 2
 
+@pytest.mark.max_running_shards(6)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_tablet_repair_error_and_retry(manager: ScyllaClusterManager):
     servers, cql, hosts, ks, table_id = await create_table_insert_data_for_repair(manager)
@@ -239,6 +248,7 @@ async def test_tablet_repair_error_and_retry(manager: ScyllaClusterManager):
     await manager.api.tablet_repair(servers[0].ip_addr, ks, "test", token)
     await inject_error_off(manager, "repair_tablet_fail_on_rpc_call", servers)
 
+@pytest.mark.max_running_shards(6)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_tablet_repair_error_not_finish(manager: ScyllaClusterManager):
     servers, cql, hosts, ks, table_id = await create_table_insert_data_for_repair(manager)
@@ -253,6 +263,7 @@ async def test_tablet_repair_error_not_finish(manager: ScyllaClusterManager):
         logger.info("Repair timeout as expected")
     await inject_error_off(manager, "repair_tablet_fail_on_rpc_call", servers)
 
+@pytest.mark.max_running_shards(6)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_tablet_repair_error_delete(manager: ScyllaClusterManager):
     servers, cql, hosts, ks, table_id = await create_table_insert_data_for_repair(manager)
@@ -296,6 +307,7 @@ def check_repairs(row_num_before: list[int], row_num_after: list[int], expected_
         else:
             assert val_before == row_num_after[i]
 
+@pytest.mark.max_running_shards(6)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 @pytest.mark.parametrize("included_host_count", [2, 1, 0])
 async def test_tablet_repair_hosts_filter(manager: ScyllaClusterManager, included_host_count):
@@ -344,6 +356,7 @@ async def prepare_multi_dc_repair(manager) -> tuple[list[ServerInfo], CassandraS
     hosts = await wait_for_cql_and_get_hosts(cql, servers, time.time() + 60)
     return (servers, cql, hosts, ks, table_id)
 
+@pytest.mark.max_running_shards(6)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 @pytest.mark.parametrize("dcs_filter_and_res", [("DC1", [0, 1]), ("DC2", []), ("DC3", [])])
 async def test_tablet_repair_dcs_filter(manager: ScyllaClusterManager, dcs_filter_and_res):
@@ -373,6 +386,7 @@ async def test_tablet_repair_dcs_filter(manager: ScyllaClusterManager, dcs_filte
     row_num_after = [get_repair_row_from_disk(server) for server in servers]
     check_repairs(row_num_before, row_num_after, expected_repairs)
 
+@pytest.mark.max_running_shards(6)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_tablet_repair_hosts_and_dcs_filter(manager: ScyllaClusterManager):
     servers, cql, hosts, ks, table_id = await prepare_multi_dc_repair(manager)
@@ -402,6 +416,7 @@ async def test_tablet_repair_hosts_and_dcs_filter(manager: ScyllaClusterManager)
     row_num_after = [get_repair_row_from_disk(server) for server in servers]
     check_repairs(row_num_before, row_num_after, [0, 2])
 
+@pytest.mark.max_running_shards(6)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_tablet_repair_multiple_rows(manager: ScyllaClusterManager):
     cmdline = ["--hinted-handoff-enabled", "0"]
@@ -469,10 +484,12 @@ async def run_tablet_repair_multiple_rows_merge(manager: ScyllaClusterManager, i
     rows_query = [(r.pk, r.ck, r.data) for r in results]
     assert sorted(rows) == sorted(rows_query)
 
+@pytest.mark.max_running_shards(6)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_tablet_repair_multiple_rows_merge_fragments_nr(manager: ScyllaClusterManager):
     await run_tablet_repair_multiple_rows_merge(manager, "row_level_repair_max_fragments_nr", "10")
 
+@pytest.mark.max_running_shards(6)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_tablet_repair_multiple_rows_merge_fragments_size(manager: ScyllaClusterManager):
     await run_tablet_repair_multiple_rows_merge(manager, "row_level_repair_max_fragments_size", "1000")
@@ -489,6 +506,7 @@ async def config_auto_repair(manager, servers, ks, table, auto_repair_enabled, a
     else:
         raise NotImplementedError("Per-table auto-repair configuration is not supported yet.")
 
+@pytest.mark.max_running_shards(6)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_tablet_auto_repair(manager: ScyllaClusterManager):
     servers, cql, hosts, ks, table_id = await create_table_insert_data_for_repair(manager, fast_stats_refresh=True, disable_flush_cache_time=True)
@@ -545,6 +563,7 @@ async def check_has_repair_time(cql, hosts, table_id, timeout = 300):
         assert duration < timeout
         time.sleep(1)
 
+@pytest.mark.max_running_shards(6)
 async def test_tablet_auto_repair_cfg_enable(manager: ScyllaClusterManager):
     cmdline = ["--auto-repair-enabled-default", "1",  "--auto-repair-threshold-default-in-seconds", "1"]
     servers, cql, hosts, ks, table_id = await create_table_insert_data_for_repair(manager, cmdline=cmdline, fast_stats_refresh=True, disable_flush_cache_time=True)
@@ -623,6 +642,7 @@ def verify_sort_order(plans):
                 is_sorted = False
     return is_sorted
 
+@pytest.mark.max_running_shards(6)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_tablet_user_and_auto_repair_priority(manager: ScyllaClusterManager):
     servers, cql, hosts, ks, table_id = await create_table_insert_data_for_repair(manager, fast_stats_refresh=True, disable_flush_cache_time=True)

--- a/test/cluster/test_tablet_snapshot.py
+++ b/test/cluster/test_tablet_snapshot.py
@@ -75,6 +75,7 @@ def get_live_topology(host: str) -> topology.LiveClusterTopologySource:
     return topology.get_live_topology_source_from_args(source_args(host))
 
 
+@pytest.mark.max_running_shards(6)
 @pytest.mark.asyncio
 async def test_tablet_snapshot_matches_live_topology(manager: ScyllaClusterManager, tmp_path: Path):
     """
@@ -133,6 +134,7 @@ async def test_tablet_snapshot_matches_live_topology(manager: ScyllaClusterManag
             assert live_topo == manual_snapshot_topo
 
 
+@pytest.mark.max_running_shards(6)
 @pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 @pytest.mark.tier2

--- a/test/cluster/test_tablet_stats.py
+++ b/test/cluster/test_tablet_stats.py
@@ -14,6 +14,7 @@ from test.pylib.rest_client import read_barrier
 logger = logging.getLogger(__name__)
 
 
+@pytest.mark.max_running_shards(6)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_load_stats_on_coordinator_failover(manager: ScyllaClusterManager):
     cfg = {
@@ -84,6 +85,7 @@ async def test_load_stats_on_coordinator_failover(manager: ScyllaClusterManager)
             break
 
 
+@pytest.mark.max_running_shards(6)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_load_stats_refresh_during_shutdown(manager: ScyllaClusterManager):
     """Verify that _tablet_load_stats_refresh is properly joined during

--- a/test/cluster/test_tablets.py
+++ b/test/cluster/test_tablets.py
@@ -37,6 +37,7 @@ logger = logging.getLogger(__name__)
 # me-1-big-TOC.txt
 sstable_filename_glob = "??-*-???-*.*"
 
+@pytest.mark.max_running_shards(4)
 async def test_tablet_replication_factor_enough_nodes(manager: ScyllaClusterManager):
     cfg = {'enable_user_defined_functions': False, 'tablets_mode_for_new_keyspaces': 'enabled'}
     # This test verifies that Scylla rejects creating a table if there are too few token-owning nodes.
@@ -59,6 +60,7 @@ async def test_tablet_replication_factor_enough_nodes(manager: ScyllaClusterMana
         await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int);")
 
 
+@pytest.mark.max_running_shards(2)
 async def test_tablet_scaling_option_is_respected(manager: ScyllaClusterManager):
     # 32 is high enough to ensure we demand more tablets than the default choice.
     cfg = {'tablets_mode_for_new_keyspaces': 'enabled', 'tablets_initial_scale_factor': 32}
@@ -73,6 +75,7 @@ async def test_tablet_scaling_option_is_respected(manager: ScyllaClusterManager)
     assert len(tablets) == 64
 
 
+@pytest.mark.max_running_shards(8)
 async def test_tablet_cannot_decommision_below_replication_factor(manager: ScyllaClusterManager):
     logger.info("Bootstrapping cluster")
     cfg = {'enable_user_defined_functions': False, 'tablets_mode_for_new_keyspaces': 'enabled'}
@@ -107,6 +110,7 @@ async def test_tablet_cannot_decommision_below_replication_factor(manager: Scyll
         for r in rows:
             assert r.c == r.pk
 
+@pytest.mark.max_running_shards(1)
 async def test_reshape_with_tablets(manager: ScyllaClusterManager):
     logger.info("Bootstrapping cluster")
     cfg = {'enable_user_defined_functions': False, 'tablets_mode_for_new_keyspaces': 'enabled'}
@@ -143,6 +147,7 @@ async def test_reshape_with_tablets(manager: ScyllaClusterManager):
         assert len(sstable_info[0]['sstables']) == number_of_tablets
 
 
+@pytest.mark.max_running_shards(1)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_stop_reshape_aborts_all_compaction_groups(manager: ScyllaClusterManager):
     """Verify that stop RESHAPE aborts reshape across all tables and compaction groups.
@@ -252,6 +257,7 @@ async def test_stop_reshape_aborts_all_compaction_groups(manager: ScyllaClusterM
                 assert rows[0].count > 0
 
 
+@pytest.mark.max_running_shards(4)
 @pytest.mark.parametrize("direction", ["up", "down", "none"])
 async def test_tablet_rf_change(manager: ScyllaClusterManager, direction):
     cfg = {'enable_user_defined_functions': False, 'tablets_mode_for_new_keyspaces': 'enabled'}
@@ -321,6 +327,7 @@ async def test_tablet_rf_change(manager: ScyllaClusterManager, direction):
             assert len(fragments[k]) == rf_to, f"Found mutations for {k} key on {fragments[k]} hosts, but expected only {rf_to} of them"
 
 
+@pytest.mark.max_running_shards(6)
 async def test_tablet_mutation_fragments_unowned_partition(manager: ScyllaClusterManager):
     """Check that MUTATION_FRAGMENTS() queries handle the case when a partition
     not owned by the node is attempted to be read."""
@@ -349,6 +356,7 @@ async def test_tablet_mutation_fragments_unowned_partition(manager: ScyllaCluste
 
 # The test checks that describe_ring and range_to_address_map API return
 # information that's consistent with system.tablets contents
+@pytest.mark.max_running_shards(12)
 @pytest.mark.parametrize("endpoint", ["describe_ring", "range_to_endpoint", "tokens_endpoint"])
 async def test_tablets_api_consistency(manager: ScyllaClusterManager, endpoint):
     servers = []
@@ -405,6 +413,7 @@ async def test_tablets_api_consistency(manager: ScyllaClusterManager, endpoint):
 # That provides us with a guarantee that the old and the new QUORUM overlap.
 # In this test, we verify that in a simple scenario with one DC. We explicitly disable
 # enforcing RF-rack-valid keyspaces to be able to perform more flexible alterations.
+@pytest.mark.max_running_shards(2)
 async def test_singledc_alter_tablets_rf(manager: ScyllaClusterManager):
     await manager.server_add(config={"rf_rack_valid_keyspaces": "false", "enable_tablets": "true"}, property_file={"dc": "dc1", "rack": "r1"})
     cql = manager.get_cql()
@@ -428,6 +437,7 @@ async def test_singledc_alter_tablets_rf(manager: ScyllaClusterManager):
         with pytest.raises(InvalidRequest):
             await change_rf(0) # Trying to decrease the RF by more than 2 should fail.
 
+@pytest.mark.max_running_shards(10)
 async def test_arbitrary_multi_rf_change_fails(manager: ScyllaClusterManager):
     config = {"rf_rack_valid_keyspaces": "false", "enable_tablets": "true", "tablet_load_stats_refresh_interval_in_seconds": 1}
     cmdline = ['--logger-log-level', 'raft_topology=debug', '--logger-log-level', 'load_balancer=debug']
@@ -492,6 +502,7 @@ async def test_arbitrary_multi_rf_change_fails(manager: ScyllaClusterManager):
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'dc1': ['r1'], 'dc2': ['r4']}") as ks:
         await cql.run_async(f"ALTER KEYSPACE {ks} WITH replication = {{'class': 'NetworkTopologyStrategy', 'dc1': ['r1'], 'dc2': 0, 'dc3': ['r7']}}")
 
+@pytest.mark.max_running_shards(8)
 async def test_alter_tablets_rf_dc_drop(request: pytest.FixtureRequest, manager: ScyllaClusterManager) -> None:
     config = {"endpoint_snitch": "GossipingPropertyFileSnitch", "tablets_mode_for_new_keyspaces": "enabled"}
 
@@ -532,6 +543,7 @@ async def test_alter_tablets_rf_dc_drop(request: pytest.FixtureRequest, manager:
         await cql.run_async(f"alter keyspace {ks} with durable_writes = true")
         await check_rf(ks=ks, expected_dc1_rf=2, expected_dc2_rf=0)
 
+@pytest.mark.max_running_shards(8)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_numeric_rf_to_rack_list_conversion(request: pytest.FixtureRequest, manager: ScyllaClusterManager) -> None:
     async def get_replication_options(ks: str, host, ip_addr):
@@ -635,6 +647,7 @@ async def test_numeric_rf_to_rack_list_conversion(request: pytest.FixtureRequest
     assert len(repl['dc2']) == 1
     assert repl['dc2'][0] == 'rack2a'
 
+@pytest.mark.max_running_shards(8)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_enforce_rack_list_option(request: pytest.FixtureRequest, manager: ScyllaClusterManager) -> None:
     async def get_replication_options(ks: str, host, ip_addr):
@@ -746,6 +759,7 @@ async def check_system_schema_keyspaces(manager, keyspace, replication, next_rep
     else:
         assert res[0].next_replication is None
 
+@pytest.mark.max_running_shards(12)
 async def test_multi_rf_change_multi_dc_0_N(request: pytest.FixtureRequest, manager: ScyllaClusterManager) -> None:
     """Test RF changes where each DC transitions only between 0 and N replicas."""
     config = {"tablets_mode_for_new_keyspaces": "enabled", "rf_rack_valid_keyspaces": "false", "tablet_load_stats_refresh_interval_in_seconds": 1}
@@ -806,6 +820,7 @@ async def test_multi_rf_change_multi_dc_0_N(request: pytest.FixtureRequest, mana
         assert len(t.replicas) == 1
         assert t.replicas[0][0] in dc2_host_ids
 
+@pytest.mark.max_running_shards(12)
 async def test_multi_rf_change_colocated_tables_0_N(request: pytest.FixtureRequest, manager: ScyllaClusterManager) -> None:
     """Test RF changes with colocated tables where each DC transitions only between 0 and N replicas."""
     config = {"tablets_mode_for_new_keyspaces": "enabled", "rf_rack_valid_keyspaces": "false", "tablet_load_stats_refresh_interval_in_seconds": 1}
@@ -852,6 +867,7 @@ async def test_multi_rf_change_colocated_tables_0_N(request: pytest.FixtureReque
     await check_system_schema_keyspaces(manager, "ks1", {'dc1': ['rack1a']}, None)
     await check_replicas(1)
 
+@pytest.mark.max_running_shards(8)
 @pytest.mark.parametrize("enforce_rack_list", ['false', 'true'])
 async def test_multi_rf_change_0_N(request: pytest.FixtureRequest, manager: ScyllaClusterManager, enforce_rack_list) -> None:
     config = {"tablets_mode_for_new_keyspaces": "enabled", "rf_rack_valid_keyspaces": "false", "tablet_load_stats_refresh_interval_in_seconds": 1}
@@ -880,6 +896,7 @@ async def test_multi_rf_change_0_N(request: pytest.FixtureRequest, manager: Scyl
         for r in replicas:
             assert len(r.replicas) == 2
 
+@pytest.mark.max_running_shards(12)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_multi_rf_increase_abort_0_N(request: pytest.FixtureRequest, manager: ScyllaClusterManager) -> None:
     """Test aborting a 0->N RF increase (adding a new DC)."""
@@ -955,6 +972,7 @@ async def test_multi_rf_increase_abort_0_N(request: pytest.FixtureRequest, manag
         for rep in t.replicas:
             assert rep[0] in dc1_host_ids
 
+@pytest.mark.max_running_shards(12)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_multi_rf_decrease_abort_0_N(request: pytest.FixtureRequest, manager: ScyllaClusterManager) -> None:
     """Test aborting an N->0 RF decrease (removing a DC). Abort should not be allowed."""
@@ -1024,6 +1042,7 @@ async def test_multi_rf_decrease_abort_0_N(request: pytest.FixtureRequest, manag
         for rep in t.replicas:
             assert rep[0] in dc1_host_ids
 
+@pytest.mark.max_running_shards(16)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_multi_rf_of_many_keyspaces_0_N(request: pytest.FixtureRequest, manager: ScyllaClusterManager) -> None:
     """Test concurrent 0->N RF changes across multiple keyspaces."""
@@ -1096,6 +1115,7 @@ async def test_multi_rf_of_many_keyspaces_0_N(request: pytest.FixtureRequest, ma
             for host_id in dc2_host_ids:
                 assert host_id in [r[0] for r in t.replicas]
 
+@pytest.mark.max_running_shards(12)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_multi_rf_increase_before_decrease_0_N(request: pytest.FixtureRequest, manager: ScyllaClusterManager) -> None:
     """Test aborting an RF change that involves both 0->N increase and N->0 decrease across DCs."""
@@ -1181,6 +1201,7 @@ async def test_multi_rf_increase_before_decrease_0_N(request: pytest.FixtureRequ
             assert rep[0] in host_ids[0:3]
         assert all(host in [r[0] for r in t.replicas] for host in host_ids[0:3])
 
+@pytest.mark.max_running_shards(4)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_numeric_rf_to_rack_list_conversion_abort(request: pytest.FixtureRequest, manager: ScyllaClusterManager) -> None:
     async def get_replication_options(ks: str, host, ip_addr):
@@ -1244,6 +1265,7 @@ async def test_numeric_rf_to_rack_list_conversion_abort(request: pytest.FixtureR
     repl = await get_replication_options("ks1", host, servers[0].ip_addr)
     assert repl['dc1'] == '1'
 
+@pytest.mark.max_running_shards(6)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_failed_tablet_rebuild_is_retried(request: pytest.FixtureRequest, manager: ScyllaClusterManager) -> None:
     async def alter_keyspace(new_rf):
@@ -1293,6 +1315,7 @@ async def test_failed_tablet_rebuild_is_retried(request: pytest.FixtureRequest, 
 
     await alter_keyspace("'dc1': ['rack1a', 'rack1b', 'rack1c']")
 
+@pytest.mark.max_running_shards(6)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_failed_tablet_rebuild_is_retried_on_alter(manager: ScyllaClusterManager) -> None:
     async def alter_keyspace(new_rf):
@@ -1339,6 +1362,7 @@ async def test_failed_tablet_rebuild_is_retried_on_alter(manager: ScyllaClusterM
 # available nodes (all excluded), the ALTER KEYSPACE must fail promptly
 # instead of livelocking with the request endlessly bouncing between
 # paused and resumed states.
+@pytest.mark.max_running_shards(6)
 @pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_rack_list_colocation_livelock_no_target_nodes(request: pytest.FixtureRequest, manager: ScyllaClusterManager) -> None:
@@ -1441,6 +1465,7 @@ async def test_rack_list_colocation_livelock_no_target_nodes(request: pytest.Fix
 # Reproducer for https://github.com/scylladb/scylladb/issues/18110
 # Check that an existing cached read, will be cleaned up when the tablet it reads
 # from is migrated away.
+@pytest.mark.max_running_shards(4)
 async def test_saved_readers_tablet_migration(manager: ScyllaClusterManager, build_mode):
     cfg = {'enable_user_defined_functions': False, 'tablets_mode_for_new_keyspaces': 'enabled'}
 
@@ -1510,6 +1535,7 @@ async def test_saved_readers_tablet_migration(manager: ScyllaClusterManager, bui
 #   5) A has view, so writes to it will also result in reads (table::push_view_replica_updates())
 #   6) tablet's update_effective_replication_map() is not refreshing tablet sstable set (for new tablet migrating in)
 #   7) so read on step 5 is not being able to find sstable set for tablet migrating in
+@pytest.mark.max_running_shards(4)
 @pytest.mark.parametrize("with_cache", ['false', 'true'])
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_read_of_pending_replica_during_migration(manager: ScyllaClusterManager, with_cache):
@@ -1576,6 +1602,7 @@ async def test_read_of_pending_replica_during_migration(manager: ScyllaClusterMa
 
 # This test checks that --enable-tablets option and the TABLETS parameters of the CQL CREATE KEYSPACE
 # statement are mutually correct.
+@pytest.mark.max_running_shards(2)
 @pytest.mark.parametrize("tablets_mode_for_new_keyspaces", ["enabled", "disabled", "enforced"])
 @pytest.mark.parametrize("cql_tablets_params", ["enabled", "disabled", None])
 @pytest.mark.parametrize("replication_strategy", ["NetworkTopologyStrategy", "SimpleStrategy", "EverywhereStrategy", "LocalStrategy"])
@@ -1627,6 +1654,7 @@ async def test_keyspace_creation_cql_vs_config_sanity(manager: ScyllaClusterMana
         await cql.run_async(f"drop keyspace {ks}")
 
 
+@pytest.mark.max_running_shards(4)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_tablet_streaming_with_unbuilt_view(manager: ScyllaClusterManager):
     """
@@ -1692,6 +1720,7 @@ async def test_tablet_streaming_with_unbuilt_view(manager: ScyllaClusterManager)
         rows = await cql.run_async(f"SELECT c from {ks}.mv1")
         assert len(list(rows)) == num_of_rows
 
+@pytest.mark.max_running_shards(4)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_tablet_streaming_with_staged_sstables(manager: ScyllaClusterManager):
     """
@@ -1781,6 +1810,7 @@ async def test_tablet_streaming_with_staged_sstables(manager: ScyllaClusterManag
         rows = await cql.run_async(f"SELECT c from {ks}.mv1")
         assert len(list(rows)) == expected_num_of_rows
 
+@pytest.mark.max_running_shards(4)
 async def test_orphaned_sstables_on_startup(manager: ScyllaClusterManager):
     """
     Reproducer for https://github.com/scylladb/scylladb/issues/18038
@@ -1834,6 +1864,7 @@ async def test_orphaned_sstables_on_startup(manager: ScyllaClusterManager):
     # Error thrown is of format : "Unable to load SSTable {sstable_name} : Storage wasn't found for tablet {tablet_id} of table {ks}.test"
     await manager.server_start(servers[0].server_id, expected_error="Storage wasn't found for tablet", expected_crash=True)
 
+@pytest.mark.max_running_shards(12)
 @pytest.mark.parametrize("with_zero_token_node", [False, True])
 async def test_remove_failure_with_no_normal_token_owners_in_dc(manager: ScyllaClusterManager, with_zero_token_node: bool):
     """
@@ -1877,6 +1908,7 @@ async def test_remove_failure_with_no_normal_token_owners_in_dc(manager: ScyllaC
                                     ignore_dead_nodes=[replaced_host_id])
         await manager.server_add(replace_cfg=replace_cfg, property_file=node_to_remove.property_file())
 
+@pytest.mark.max_running_shards(8)
 async def test_excludenode(manager: ScyllaClusterManager):
     """
     Verifies recovery scenario involving marking the node as excluded using excludenode.
@@ -1915,6 +1947,7 @@ async def test_excludenode(manager: ScyllaClusterManager):
         # Check that removenode succeeds on the node which is excluded
         await manager.remove_node(live_node.server_id, server_id=node_to_remove.server_id)
 
+@pytest.mark.max_running_shards(6)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_excludenode_shrink_rf(manager: ScyllaClusterManager):
     """
@@ -1962,6 +1995,7 @@ async def test_excludenode_shrink_rf(manager: ScyllaClusterManager):
         repl = get_replication(cql, ks)
         assert 'dc2' not in repl or get_replica_count(repl.get('dc2', '0')) == 0
 
+@pytest.mark.max_running_shards(12)
 @pytest.mark.parametrize("with_zero_token_node", [False, True])
 async def test_remove_failure_then_replace(manager: ScyllaClusterManager, with_zero_token_node: bool):
     """
@@ -1996,6 +2030,7 @@ async def test_remove_failure_then_replace(manager: ScyllaClusterManager, with_z
         replace_cfg = ReplaceConfig(replaced_id=node_to_remove.server_id, reuse_ip_addr = False, use_host_id=True, wait_dead=True)
         await manager.server_add(replace_cfg=replace_cfg, property_file=node_to_remove.property_file())
 
+@pytest.mark.max_running_shards(12)
 @pytest.mark.tier2
 @pytest.mark.parametrize("with_zero_token_node", [False, True])
 async def test_replace_with_no_normal_token_owners_in_dc(manager: ScyllaClusterManager, with_zero_token_node: bool):
@@ -2054,6 +2089,7 @@ async def test_replace_with_no_normal_token_owners_in_dc(manager: ScyllaClusterM
         # For dropping the keyspace
         await asyncio.gather(*[manager.server_start(node.server_id) for node in servers['dc2']])
 
+@pytest.mark.max_running_shards(12)
 async def test_replace_after_losing_all_tablet_replicas(manager: ScyllaClusterManager):
     """
     Verify what happens when a node is replaced after all replicas of some
@@ -2217,6 +2253,7 @@ async def test_replace_after_losing_all_tablet_replicas(manager: ScyllaClusterMa
         await asyncio.gather(*[cql.run_async(stmt, [k, k]) for k in doomed_keys])
         assert {r.pk for r in await cql.run_async(query)} == set(keys)
 
+@pytest.mark.max_running_shards(2)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_drop_keyspace_while_split(manager: ScyllaClusterManager):
 
@@ -2267,6 +2304,7 @@ async def test_drop_keyspace_while_split(manager: ScyllaClusterManager):
     await manager.api.message_injection(servers[0].ip_addr, "truncate_compaction_disabled_wait")
     await drop_ks_task
 
+@pytest.mark.max_running_shards(2)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_drop_with_tablet_migration_cleanup(manager: ScyllaClusterManager):
 
@@ -2321,6 +2359,7 @@ async def test_drop_with_tablet_migration_cleanup(manager: ScyllaClusterManager)
         await drop_future
 
 
+@pytest.mark.max_running_shards(6)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_two_tablets_concurrent_repair_and_migration(manager: ScyllaClusterManager):
     injection = "repair_shard_repair_task_impl_do_repair_ranges"
@@ -2348,6 +2387,7 @@ async def test_two_tablets_concurrent_repair_and_migration(manager: ScyllaCluste
 
     await asyncio.gather(repair_task(), migration_task())
 
+@pytest.mark.max_running_shards(4)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_tablet_split_finalization_with_migrations(manager: ScyllaClusterManager):
     """
@@ -2427,6 +2467,7 @@ async def test_tablet_split_finalization_with_migrations(manager: ScyllaClusterM
     logger.info("Waiting for migrations to complete")
     await log.wait_for("Tablet load balancer did not make any plan", from_mark=migration_mark)
 
+@pytest.mark.max_running_shards(6)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_two_tablets_concurrent_repair_and_migration_repair_writer_level(manager: ScyllaClusterManager):
     injection = "repair_writer_impl_create_writer_wait"
@@ -2532,13 +2573,16 @@ async def check_tablet_rebuild_with_repair(manager: ScyllaClusterManager, fail: 
             else:
                 assert res[0].count == 0
 
+@pytest.mark.max_running_shards(6)
 async def test_tablet_rebuild(manager: ScyllaClusterManager):
     await check_tablet_rebuild_with_repair(manager, False)
 
+@pytest.mark.max_running_shards(6)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_tablet_rebuild_failure(manager: ScyllaClusterManager):
     await check_tablet_rebuild_with_repair(manager, True)
 
+@pytest.mark.max_running_shards(6)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_repair_with_invalid_session_id(manager: ScyllaClusterManager):
     injection = "handle_tablet_migration_repair_random_session"
@@ -2554,6 +2598,7 @@ async def test_repair_with_invalid_session_id(manager: ScyllaClusterManager):
     matches = [await log.grep(r"std::runtime_error: Session not found", from_mark=mark) for log, mark in zip(logs, marks)]
     assert sum(len(x) for x in matches) > 0
 
+@pytest.mark.max_running_shards(2)
 async def test_moving_replica_to_replica(manager: ScyllaClusterManager):
     """
     Verify that trying to move a tablet replica to a node that is already
@@ -2592,6 +2637,7 @@ async def test_moving_replica_to_replica(manager: ScyllaClusterManager):
             dst_shard=0,
             token=tablet_token)
 
+@pytest.mark.max_running_shards(2)
 async def test_moving_replica_within_single_rack(manager: ScyllaClusterManager):
     """
     Verify that it's possible to move a tablet from a replica node to a node
@@ -2634,6 +2680,7 @@ async def test_moving_replica_within_single_rack(manager: ScyllaClusterManager):
         dst_shard=0,
         token=tablet_token)
 
+@pytest.mark.max_running_shards(4)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_disabling_balancing_preempts_balancer(manager: ScyllaClusterManager):
     servers = await manager.servers_add(2, auto_rack_dc="dc1")
@@ -2653,6 +2700,7 @@ async def test_disabling_balancing_preempts_balancer(manager: ScyllaClusterManag
         await manager.disable_tablet_balancing()
 
 
+@pytest.mark.max_running_shards(4)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_table_creation_wakes_up_balancer(manager: ScyllaClusterManager):
     """
@@ -2686,6 +2734,7 @@ async def test_table_creation_wakes_up_balancer(manager: ScyllaClusterManager):
         await manager.api.message_injection(server.ip_addr, 'wait-before-topology-coordinator-goes-to-sleep')
         await log.wait_for('wait-after-topology-coordinator-gets-event: wait', from_mark=mark, timeout=5)
 
+@pytest.mark.max_running_shards(6)
 async def test_multi_rf_increase_auto_abort_excluded_node(request: pytest.FixtureRequest, manager: ScyllaClusterManager) -> None:
     """Test that an RF change is automatically aborted when a required rack has no available nodes.
 
@@ -2748,6 +2797,7 @@ async def test_multi_rf_increase_auto_abort_excluded_node(request: pytest.Fixtur
             assert len(t.replicas) == 1
             assert t.replicas[0][0] == dc1_host_id
 
+@pytest.mark.max_running_shards(6)
 async def test_rf_extend_abort_with_down_node(request: pytest.FixtureRequest, manager: ScyllaClusterManager) -> None:
     """Test that an RF extend is aborted when a required rack has a down (not excluded) node.
 
@@ -2801,6 +2851,7 @@ async def test_rf_extend_abort_with_down_node(request: pytest.FixtureRequest, ma
             assert t.replicas[0][0] == dc1_host_id
 
 
+@pytest.mark.max_running_shards(6)
 @pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_split_completion_with_data_in_main_cg(manager: ScyllaClusterManager):
@@ -2893,6 +2944,7 @@ async def test_split_completion_with_data_in_main_cg(manager: ScyllaClusterManag
         await manager.api.message_injection(target.ip_addr, "tablet_split_monitor_wait")
         await manager.server_update_config(target.server_id, "error_injections_at_startup", [])
 
+@pytest.mark.max_running_shards(10)
 @pytest.mark.asyncio
 async def test_rf_reduction_preserves_quorum_writes(manager: ScyllaClusterManager) -> None:
     """RF reduction must preserve QUORUM-acknowledged writes even when surviving replicas missed them.

--- a/test/cluster/test_tablets2.py
+++ b/test/cluster/test_tablets2.py
@@ -79,6 +79,7 @@ async def wait_for_valid_load_stats(cql, table_id, timeout=120):
 
         await asyncio.sleep(0.2)
 
+@pytest.mark.max_running_shards(6)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_tablet_metadata_propagates_with_schema_changes_in_snapshot_mode(manager: ScyllaClusterManager):
     """Test that you can create a table and insert and query data"""
@@ -152,6 +153,7 @@ async def test_tablet_metadata_propagates_with_schema_changes_in_snapshot_mode(m
                 conn_logger.setLevel(logging.INFO)
 
 
+@pytest.mark.max_running_shards(6)
 async def test_scans(manager: ScyllaClusterManager):
     logger.info("Bootstrapping cluster")
     servers = await manager.servers_add(3)
@@ -172,6 +174,7 @@ async def test_scans(manager: ScyllaClusterManager):
             assert r.c == r.pk
 
 
+@pytest.mark.max_running_shards(6)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_table_drop_with_auto_snapshot(manager: ScyllaClusterManager):
     logger.info("Bootstrapping cluster")
@@ -192,6 +195,7 @@ async def test_table_drop_with_auto_snapshot(manager: ScyllaClusterManager):
     await cql.run_async("DROP KEYSPACE test;")
 
 
+@pytest.mark.max_running_shards(10)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_topology_changes(manager: ScyllaClusterManager):
     logger.info("Bootstrapping cluster")
@@ -270,6 +274,7 @@ async def get_two_servers_to_move_tablet(manager: ScyllaClusterManager):
 
     return (servers, cql, s0_host_id, s1_host_id, replica, tablet_token, dst_shard, ks)
 
+@pytest.mark.max_running_shards(4)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_streaming_rx_error_no_failed_message_with_fail_stream_plan(manager: ScyllaClusterManager):
     servers, cql, s0_host_id, s1_host_id, replica, tablet_token, dst_shard, ks = await get_two_servers_to_move_tablet(manager)
@@ -310,6 +315,7 @@ async def test_streaming_rx_error_no_failed_message_with_fail_stream_plan(manage
     rows = await cql.run_async(f"SELECT pk from {ks}.test")
     assert len(list(rows)) == 0
 
+@pytest.mark.max_running_shards(4)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_streaming_rx_error_no_failed_message_no_fail_stream_plan_hang(manager: ScyllaClusterManager):
     servers, cql, s0_host_id, s1_host_id, replica, tablet_token, dst_shard, ks = await get_two_servers_to_move_tablet(manager)
@@ -334,6 +340,7 @@ async def test_streaming_rx_error_no_failed_message_no_fail_stream_plan_hang(man
     except TimeoutError:
         logger.info("Migration timeout as expected")
 
+@pytest.mark.max_running_shards(4)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_streaming_is_guarded_by_topology_guard(manager: ScyllaClusterManager):
     logger.info("Bootstrapping cluster")
@@ -408,6 +415,7 @@ async def test_streaming_is_guarded_by_topology_guard(manager: ScyllaClusterMana
         assert len(list(rows)) == 0
 
 
+@pytest.mark.max_running_shards(4)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_table_dropped_during_streaming(manager: ScyllaClusterManager):
     """
@@ -482,6 +490,7 @@ async def test_table_dropped_during_streaming(manager: ScyllaClusterManager):
         replica = await get_tablet_replica(manager, servers[0], ks, 'test2', tablet_token)
         assert replica == (s1_host_id, 0)
 
+@pytest.mark.max_running_shards(4)
 async def test_tablet_cleanup(manager: ScyllaClusterManager):
     cmdline = ['--smp=2', '--commitlog-sync=batch']
 
@@ -552,6 +561,7 @@ async def test_tablet_cleanup(manager: ScyllaClusterManager):
         # Bonus: check that commitlog_cleanups doesn't have any garbage after restart.
         assert 0 == (await cql.run_async("SELECT COUNT(*) FROM system.commitlog_cleanups", host=hosts[0]))[0].count
 
+@pytest.mark.max_running_shards(3)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_tablet_cleanup_failure(manager: ScyllaClusterManager):
     cmdline = ['--smp=1']
@@ -606,6 +616,7 @@ async def test_tablet_cleanup_failure(manager: ScyllaClusterManager):
         logger.info("Guarantee source node of migration left no sstables undeleted")
         assert len(ssts) == 0
 
+@pytest.mark.max_running_shards(3)
 async def test_tablet_resharding(manager: ScyllaClusterManager):
     cmdline = ['--smp=3']
     config = {'tablets_mode_for_new_keyspaces': 'enabled'}
@@ -627,6 +638,7 @@ async def test_tablet_resharding(manager: ScyllaClusterManager):
         server.server_id,
         expected_error="Detected a tablet with invalid replica shard, reducing shard count with tablet-enabled tables is not yet supported. Replace the node instead.")
 
+@pytest.mark.max_running_shards(4)
 @pytest.mark.parametrize("injection_error", ["foreach_compaction_group_wait", "major_compaction_wait"])
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_tablet_split(manager: ScyllaClusterManager, injection_error: str):
@@ -696,6 +708,7 @@ async def test_tablet_split(manager: ScyllaClusterManager, injection_error: str)
         await s1_log.wait_for(f"{injection_error}: released", from_mark=s1_mark)
         await compaction_task
 
+@pytest.mark.max_running_shards(4)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_correctness_of_tablet_split_finalization_after_restart(manager: ScyllaClusterManager):
     logger.info("Bootstrapping cluster")
@@ -769,6 +782,7 @@ async def test_correctness_of_tablet_split_finalization_after_restart(manager: S
 
         await check()
 
+@pytest.mark.max_running_shards(4)
 @pytest.mark.parametrize("injection_error", ["foreach_compaction_group_wait", "major_compaction_wait"])
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_concurrent_tablet_migration_and_major(manager: ScyllaClusterManager, injection_error):
@@ -825,6 +839,7 @@ async def test_concurrent_tablet_migration_and_major(manager: ScyllaClusterManag
 
         await check()
 
+@pytest.mark.max_running_shards(2)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_concurrent_table_drop_and_major(manager: ScyllaClusterManager):
     logger.info("Bootstrapping cluster")
@@ -862,6 +877,7 @@ async def test_concurrent_table_drop_and_major(manager: ScyllaClusterManager):
             logger.info("Check that major was successfully aborted on migration")
             await s1_log.wait_for(f"ongoing compactions for table {ks}.test .* due to table removal", from_mark=s1_mark)
 
+@pytest.mark.max_running_shards(4)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_tablet_leaves_cleanup_stage_during_major_compaction(manager: ScyllaClusterManager):
     """Reproducer for SCYLLADB-3758: tablet migration stuck in stage=cleanup.
@@ -985,6 +1001,7 @@ def get_shard_that_has_tablets(tablet_count_per_shard: list[int]) -> int:
             return shard_id
     return -1
 
+@pytest.mark.max_running_shards(8)
 async def test_tablet_count_metric_per_shard(manager: ScyllaClusterManager):
     # Given two running servers
     shards_count = 4
@@ -1071,6 +1088,7 @@ async def test_tablet_count_metric_per_shard(manager: ScyllaClusterManager):
         dest_expected_count_per_shard[3] += count_of_tokens_on_src_shard_to_move
         await assert_tablet_count_metric_value_for_shards(manager, dest_server, dest_expected_count_per_shard)
 
+@pytest.mark.max_running_shards(2)
 @pytest.mark.parametrize("primary_replica_only", [False, True])
 async def test_tablet_load_and_stream(manager: ScyllaClusterManager, primary_replica_only):
     logger.info("Bootstrapping cluster")
@@ -1171,6 +1189,7 @@ async def test_tablet_load_and_stream(manager: ScyllaClusterManager, primary_rep
 
     await asyncio.gather(*[cql.run_async(f"drop keyspace {i}") for i in [ks, ks2]])
 
+@pytest.mark.max_running_shards(8)
 async def test_storage_service_api_uneven_ownership_keyspace_and_table_params_used(manager: ScyllaClusterManager):
     # Given two running servers
     shards_count = 4
@@ -1205,6 +1224,7 @@ async def test_storage_service_api_uneven_ownership_keyspace_and_table_params_us
 
             already_verified.add(actual_ip)
 
+@pytest.mark.max_running_shards(4)
 async def test_tablet_storage_freeing(manager: ScyllaClusterManager):
     logger.info("Start first node")
     servers = [await manager.server_add()]
@@ -1245,6 +1265,7 @@ async def test_tablet_storage_freeing(manager: ScyllaClusterManager):
         size_after = await manager.server_get_sstables_disk_usage(servers[0].server_id, ks, "test")
         assert size_before * 0.33 < size_after < size_before * 0.66
 
+@pytest.mark.max_running_shards(4)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_schema_change_during_cleanup(manager: ScyllaClusterManager):
     logger.info("Start first node")
@@ -1286,6 +1307,7 @@ async def test_schema_change_during_cleanup(manager: ScyllaClusterManager):
         await cql.run_async(f"ALTER TABLE {ks}.test WITH gc_grace_seconds = 0;")
         await migration_task
 
+@pytest.mark.max_running_shards(2)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_tombstone_gc_correctness_during_tablet_split(manager: ScyllaClusterManager):
     logger.info("Bootstrapping cluster")
@@ -1443,6 +1465,7 @@ def verify_replicas_per_server(desc: str, expected_replicas_per_server: dict[Ser
     assert total == initial_tablets * rf
 
 
+@pytest.mark.max_running_shards(12)
 async def test_decommission_rack_basic(manager: ScyllaClusterManager):
     """
     Test decommissioning of all nodes in a rack
@@ -1484,6 +1507,7 @@ async def test_decommission_rack_basic(manager: ScyllaClusterManager):
         tablet_count = await get_tablet_count_per_shard_for_hosts(manager, live_servers.values(), tables)
         verify_replicas_per_server("After decommission", expected_replicas_per_server, tablet_count, ctx.initial_tablets, ctx.rf)
 
+@pytest.mark.max_running_shards(16)
 async def test_decommission_rack_after_adding_new_rack(manager: ScyllaClusterManager):
     """
     Test decommissioning a rack, after a rack with new nodes is added
@@ -1536,6 +1560,7 @@ async def test_decommission_rack_after_adding_new_rack(manager: ScyllaClusterMan
         tablet_count = await get_tablet_count_per_shard_for_hosts(manager, all_servers, tables)
         verify_replicas_per_server("After decommission", expected_replicas_per_server, tablet_count, ctx.initial_tablets, ctx.rf)
 
+@pytest.mark.max_running_shards(12)
 async def test_decommission_not_enough_racks(manager: ScyllaClusterManager):
     """
     Test that decommissioning a rack fails if the number of rack is
@@ -1578,6 +1603,7 @@ async def test_decommission_not_enough_racks(manager: ScyllaClusterManager):
         tablet_count = await get_tablet_count_per_shard_for_hosts(manager, all_servers.values(), tables)
         verify_replicas_per_server("After decommission", expected_replicas_per_server, tablet_count, ctx.initial_tablets, ctx.rf)
 
+@pytest.mark.max_running_shards(3)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_tablet_cleanup_vs_snapshot_race(manager: ScyllaClusterManager):
     cmdline = ['--smp=1']
@@ -1618,6 +1644,7 @@ async def test_tablet_cleanup_vs_snapshot_race(manager: ScyllaClusterManager):
 # It's achieved by migrating a tablet away that contains the highest replay position of a shard,
 # so when drop/truncate happens, the highest replay position will be greater than all the data
 # found in the table (includes data in memtable).
+@pytest.mark.max_running_shards(2)
 @pytest.mark.parametrize("operation", ['DROP TABLE', 'TRUNCATE'])
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_drop_table_and_truncate_after_migration(manager: ScyllaClusterManager, operation):
@@ -1658,6 +1685,7 @@ async def test_drop_table_and_truncate_after_migration(manager: ScyllaClusterMan
     await cql.run_async(f"{operation} {ks}.test")
 
 
+@pytest.mark.max_running_shards(4)
 @pytest.mark.parametrize("streaming_mode", ["sstables_during_snapshot", "sstables_after_snapshot", "logstor_after_snapshot"])
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_drop_table_during_streaming(manager: ScyllaClusterManager, streaming_mode: str):
@@ -1722,6 +1750,7 @@ async def test_drop_table_during_streaming(manager: ScyllaClusterManager, stream
         except HTTPError as e:
             logger.info("Tablet migration failed after drop as expected: %s", e.message)
 
+@pytest.mark.max_running_shards(8)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_truncate_during_topology_change(manager: ScyllaClusterManager):
     """Test truncate operation during topology change."""
@@ -1787,6 +1816,7 @@ async def test_truncate_during_topology_change(manager: ScyllaClusterManager):
         assert rows[0].count == 0, "Table should be empty after truncation"
 
 # Reproducer for https://github.com/scylladb/scylladb/issues/22040.
+@pytest.mark.max_running_shards(2)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_concurrent_schema_change_with_compaction_completion(manager: ScyllaClusterManager):
     cmdline = ['--smp=2']
@@ -1824,6 +1854,7 @@ async def test_concurrent_schema_change_with_compaction_completion(manager: Scyl
         await force_minor_compaction()
 
 # This is a test and reproducer for https://github.com/scylladb/scylladb/issues/24153
+@pytest.mark.max_running_shards(1)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_split_correctness_on_tablet_count_change(manager: ScyllaClusterManager):
     logger.info('Bootstrapping cluster')
@@ -1894,6 +1925,7 @@ async def test_split_correctness_on_tablet_count_change(manager: ScyllaClusterMa
         await manager.api.message_injection(server.ip_addr, "merge_completion_fiber")
 
 # Reproducer for https://github.com/scylladb/scylladb/issues/26041.
+@pytest.mark.max_running_shards(2)
 @pytest.mark.parametrize("primary_replica_only", [False, True])
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_tablet_load_and_stream_and_split_synchronization(manager: ScyllaClusterManager, primary_replica_only):
@@ -1983,6 +2015,7 @@ async def test_tablet_load_and_stream_and_split_synchronization(manager: ScyllaC
 
         await check(ks)
 
+@pytest.mark.max_running_shards(4)
 async def test_update_load_stats_after_rebuild(manager: ScyllaClusterManager):
     logger.info("Bootstrapping cluster")
     cmdline = [
@@ -2033,6 +2066,7 @@ async def test_update_load_stats_after_rebuild(manager: ScyllaClusterManager):
         assert len(replica_hosts) == 2
         assert s0_host_id in replica_hosts and s1_host_id in replica_hosts, "Tablet size was added to load_stats after rebuild"
 
+@pytest.mark.max_running_shards(4)
 async def test_update_load_stats_after_migration(manager: ScyllaClusterManager):
     logger.info("Bootstrapping cluster")
     cmdline = [
@@ -2092,6 +2126,7 @@ async def test_update_load_stats_after_migration(manager: ScyllaClusterManager):
         assert leaving_replica[0] not in replica_hosts, "Leaving replica tablet size is not in load_stats any more"
         assert pending_replica[0] in replica_hosts, "Pending replica tablet size is in load_stats"
 
+@pytest.mark.max_running_shards(4)
 @pytest.mark.skip_mode('release', 'error injections are not supported in release mode')
 async def test_crash_on_missing_table_from_load_stats(manager: ScyllaClusterManager):
     logger.info('Bootstrapping cluster')
@@ -2129,6 +2164,7 @@ async def test_crash_on_missing_table_from_load_stats(manager: ScyllaClusterMana
         await s0_log.wait_for('raft topology: Refreshed table load stats for all DC', from_mark=s0_mark)
 
 
+@pytest.mark.max_running_shards(4)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_tablets_barrier_waits_for_replica_erms(manager: ScyllaClusterManager):
     """
@@ -2210,6 +2246,7 @@ async def test_tablets_barrier_waits_for_replica_erms(manager: ScyllaClusterMana
         assert len(list(rows)) == 1
 
 # This is a test and reproducer for https://github.com/scylladb/scylladb/issues/26041
+@pytest.mark.max_running_shards(4)
 @pytest.mark.parametrize("repair_before_split", [False, True])
 @pytest.mark.skip_mode('release', 'error injections are not supported in release mode')
 async def test_split_and_incremental_repair_synchronization(manager: ScyllaClusterManager, repair_before_split: bool):
@@ -2299,6 +2336,7 @@ async def test_split_and_incremental_repair_synchronization(manager: ScyllaClust
         hosts = await wait_for_cql_and_get_hosts(cql, servers, time.time() + 60)
         await manager.servers_see_each_other(servers)
 
+@pytest.mark.max_running_shards(2)
 @pytest.mark.skip_mode('release', 'error injections are not supported in release mode')
 async def test_split_and_intranode_synchronization(manager: ScyllaClusterManager):
     logger.info('Bootstrapping cluster')
@@ -2375,6 +2413,7 @@ async def test_split_and_intranode_synchronization(manager: ScyllaClusterManager
         # Give enough time for split to happen in debug mode
         await wait_for(finished_splitting, time.time() + 120)
 
+@pytest.mark.max_running_shards(1)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_split_stopped_on_shutdown(manager: ScyllaClusterManager):
     logger.info('Bootstrapping cluster')
@@ -2447,6 +2486,7 @@ async def test_split_stopped_on_shutdown(manager: ScyllaClusterManager):
         assert tablet_count >= expected_tablet_count
 
 
+@pytest.mark.max_running_shards(2)
 @pytest.mark.asyncio
 @pytest.mark.skip_mode('release', 'error injections are not supported in release mode')
 async def test_split_vs_regular_compaction_stale_snapshot(manager: ScyllaClusterManager):

--- a/test/cluster/test_tablets_colocation.py
+++ b/test/cluster/test_tablets_colocation.py
@@ -51,6 +51,7 @@ async def wait_for_tablet_stage(manager, server, keyspace_name, table_name, toke
 # We create multiple views, some with the same partition key and some not, and
 # check that those views with the same partition key are co-located by reading
 # their tablet map from system.tablets and checking they have base_table set.
+@pytest.mark.max_running_shards(2)
 async def test_base_view_colocation(manager: ScyllaClusterManager):
     cfg = {'enable_tablets': True}
     cmdline = [
@@ -96,6 +97,7 @@ async def test_base_view_colocation(manager: ScyllaClusterManager):
 # both tablets to be co-located on the other node.  After they are moved we
 # stop the other node, remaining only with the one node that should hold the
 # base and view tablets, and verify we can read both tables from this node.
+@pytest.mark.max_running_shards(4)
 @pytest.mark.parametrize("move_table", ["base", "child"])
 async def test_move_tablet(manager: ScyllaClusterManager, move_table: str):
     cfg = {'enable_tablets': True}
@@ -164,6 +166,7 @@ async def test_move_tablet(manager: ScyllaClusterManager, move_table: str):
 # be split because it's co-located with the base table and their combined sizes are large enough.
 # We verify that the tablets of both tables are split, and the tables have the same tablet count.
 # Then delete some keys and verify the tablets of both tables are merged.
+@pytest.mark.max_running_shards(4)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 @pytest.mark.parametrize(
     "with_merge",
@@ -296,6 +299,7 @@ async def test_tablet_split_and_merge(manager: ScyllaClusterManager, with_merge:
 # While it's in some transition stage, we hold it and create a co-located view.
 # We verify we can continue read and write to both tables. Then we complete the
 # migration and verify everything continues to work as expected.
+@pytest.mark.max_running_shards(4)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 @pytest.mark.parametrize("wait_stage", [("streaming", "stream_tablet_wait"), ("cleanup", "cleanup_tablet_wait")])
 async def test_create_colocated_table_while_base_is_migrating(manager: ScyllaClusterManager, wait_stage):
@@ -432,6 +436,7 @@ async def test_repair_colocated_base_and_view(manager: ScyllaClusterManager):
 
 # Verify the default tombstone GC mode for colocated tables is 'timeout',
 # and that altering it to 'repair' is not allowed.
+@pytest.mark.max_running_shards(6)
 async def test_colocated_tables_gc_mode(manager: ScyllaClusterManager):
     servers = await manager.servers_add(3, auto_rack_dc="dc1")
     cql = manager.get_cql()

--- a/test/cluster/test_tablets_cql.py
+++ b/test/cluster/test_tablets_cql.py
@@ -17,6 +17,7 @@ from test.cluster.util import disable_schema_agreement_wait, parse_replication_o
 logger = logging.getLogger(__name__)
 
 
+@pytest.mark.max_running_shards(4)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_alter_dropped_tablets_keyspace(manager: ScyllaClusterManager) -> None:
     config = {
@@ -67,6 +68,7 @@ async def test_alter_dropped_tablets_keyspace(manager: ScyllaClusterManager) -> 
     with pytest.raises(InvalidRequest, match=f"Can't ALTER keyspace {ks}, keyspace doesn't exist|Can't find a keyspace {ks}") as e:
         await task
 
+@pytest.mark.max_running_shards(4)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_alter_tablets_keyspace_concurrent_modification(manager: ScyllaClusterManager) -> None:
     config = {

--- a/test/cluster/test_tablets_intranode.py
+++ b/test/cluster/test_tablets_intranode.py
@@ -22,6 +22,7 @@ import threading
 logger = logging.getLogger(__name__)
 
 
+@pytest.mark.max_running_shards(2)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_intranode_migration(manager: ScyllaClusterManager):
     logger.info("Bootstrapping cluster")
@@ -58,6 +59,7 @@ async def test_intranode_migration(manager: ScyllaClusterManager):
             assert r.c == r.pk
 
 
+@pytest.mark.max_running_shards(2)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_crash_during_intranode_migration(manager: ScyllaClusterManager):
     cmdline = [
@@ -109,6 +111,7 @@ async def test_crash_during_intranode_migration(manager: ScyllaClusterManager):
             assert r.c == r.pk
 
 
+@pytest.mark.max_running_shards(4)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_cross_shard_migration(manager: ScyllaClusterManager):
     """

--- a/test/cluster/test_tablets_lwt.py
+++ b/test/cluster/test_tablets_lwt.py
@@ -44,6 +44,7 @@ async def inject_error_one_shot_on(manager, error_name, servers):
     await asyncio.gather(*errs)
 
 
+@pytest.mark.max_running_shards(6)
 async def test_lwt(manager: ScyllaClusterManager):
     logger.info("Bootstrapping cluster")
     cmdline = [
@@ -105,6 +106,7 @@ async def test_lwt(manager: ScyllaClusterManager):
     await manager.get_cql().run_async(f"DROP KEYSPACE \"{ks}\"")
 
 
+@pytest.mark.max_running_shards(6)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_lwt_during_migration(manager: ScyllaClusterManager):
     # Scenario:
@@ -205,6 +207,7 @@ async def test_lwt_during_migration(manager: ScyllaClusterManager):
         assert row.c == 2
 
 
+@pytest.mark.max_running_shards(8)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_lwt_state_is_preserved_on_tablet_migration(manager: ScyllaClusterManager):
     # Scenario:
@@ -296,6 +299,7 @@ async def test_lwt_state_is_preserved_on_tablet_migration(manager: ScyllaCluster
         assert row.c2 is None
 
 
+@pytest.mark.max_running_shards(2)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_no_lwt_with_tablets_feature(manager: ScyllaClusterManager):
     config = {
@@ -326,6 +330,7 @@ async def test_no_lwt_with_tablets_feature(manager: ScyllaClusterManager):
         assert res[0].val == 0
 
 
+@pytest.mark.max_running_shards(6)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_lwt_state_is_preserved_on_tablet_rebuild(manager: ScyllaClusterManager):
     # Scenario:
@@ -410,6 +415,7 @@ async def test_lwt_state_is_preserved_on_tablet_rebuild(manager: ScyllaClusterMa
         assert row.c == 1
 
 
+@pytest.mark.max_running_shards(2)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_lwt_concurrent_base_table_recreation(manager: ScyllaClusterManager):
     # The test checks that the node doesn't crash when the base table is recreated
@@ -452,6 +458,7 @@ async def test_lwt_concurrent_base_table_recreation(manager: ScyllaClusterManage
             await lwt_task
 
 
+@pytest.mark.max_running_shards(6)
 @pytest.mark.skip_mode(mode='debug', reason='aarch64/debug is unpredictably slow', platform_key='aarch64')
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_lwt_timeout_while_creating_paxos_state_table(manager: ScyllaClusterManager, build_mode):
@@ -488,6 +495,7 @@ async def test_lwt_timeout_while_creating_paxos_state_table(manager: ScyllaClust
                              manager.server_start(servers[2].server_id))
 
 
+@pytest.mark.max_running_shards(2)
 async def test_paxos_state_table_permissions(manager: ScyllaClusterManager):
     # This test checks permission handling for paxos state tables:
     #   * Only a superuser is allowed to access a paxos state table
@@ -581,6 +589,7 @@ async def test_paxos_state_table_permissions(manager: ScyllaClusterManager):
         cql = manager.get_cql()
 
 
+@pytest.mark.max_running_shards(4)
 async def test_lwt_coordinator_shard(manager: ScyllaClusterManager):
     # The test checks that an LWT coordinator runs on a replica shard, and not on a 'default' (zero) shard.
     # Scenario:
@@ -633,6 +642,7 @@ async def test_lwt_coordinator_shard(manager: ScyllaClusterManager):
         assert "shard 1" in matches[0][0]
 
 
+@pytest.mark.max_running_shards(6)
 @pytest.mark.skip_mode(mode='debug', reason='dev is enought: the test checks non-critical functionality')
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_error_message_for_timeout_due_to_write_uncertainty(manager: ScyllaClusterManager):
@@ -693,6 +703,7 @@ async def test_error_message_for_timeout_due_to_write_uncertainty(manager: Scyll
             await lwt_task
 
 
+@pytest.mark.max_running_shards(6)
 @pytest.mark.skip_mode(mode='debug', reason='dev is enought')
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_no_uncertainty_for_reads(manager: ScyllaClusterManager):
@@ -755,6 +766,7 @@ async def test_no_uncertainty_for_reads(manager: ScyllaClusterManager):
         assert row.c == 2
 
 
+@pytest.mark.max_running_shards(2)
 async def test_lwts_for_special_tables(manager: ScyllaClusterManager):
     """
     SELECT commands with SERIAL consistency level are historically allowed for vnode-based views,
@@ -781,6 +793,7 @@ async def test_lwts_for_special_tables(manager: ScyllaClusterManager):
             await cql.run_async(SimpleStatement(f"SELECT * FROM {ks}.test_scylla_cdc_log WHERE \"cdc$stream_id\"=0xAB", consistency_level=ConsistencyLevel.SERIAL))
 
 
+@pytest.mark.max_running_shards(4)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_lwt_shutdown(manager: ScyllaClusterManager):
     """
@@ -859,6 +872,7 @@ async def test_lwt_shutdown(manager: ScyllaClusterManager):
         assert row.v == 2
 
 
+@pytest.mark.max_running_shards(2)
 @pytest.mark.skip_mode(mode='debug', reason='dev is enough')
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_tablets_merge_waits_for_lwt(manager: ScyllaClusterManager, scale_timeout):
@@ -955,6 +969,7 @@ async def test_tablets_merge_waits_for_lwt(manager: ScyllaClusterManager, scale_
         await lwt
 
 
+@pytest.mark.max_running_shards(6)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_column_mapping_migrated_with_tablet(manager: ScyllaClusterManager):
     """Reproducer for CUSTOMER-509: after tablet migration, the destination node

--- a/test/cluster/test_tablets_merge.py
+++ b/test/cluster/test_tablets_merge.py
@@ -34,6 +34,7 @@ async def disable_injection_on(manager, error_name, servers):
     await asyncio.gather(*errs)
 
 
+@pytest.mark.max_running_shards(4)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_tablet_merge_simple(manager: ScyllaClusterManager):
     logger.info("Bootstrapping cluster")
@@ -175,6 +176,7 @@ async def test_tablet_merge_simple(manager: ScyllaClusterManager):
         await check()
 
 # Multiple cycles of split and merge, with topology changes in parallel and RF > 1.
+@pytest.mark.max_running_shards(6)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_tablet_split_and_merge_with_concurrent_topology_changes(manager: ScyllaClusterManager):
     logger.info("Bootstrapping cluster")
@@ -317,6 +319,7 @@ async def test_tablet_split_and_merge_with_concurrent_topology_changes(manager: 
                 await manager.api.keyspace_compaction(server.ip_addr, ks)
             await check()
 
+@pytest.mark.max_running_shards(18)
 @pytest.mark.parametrize("racks", [2, 3])
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_tablet_merge_cross_rack_migrations(manager: ScyllaClusterManager, racks):
@@ -367,6 +370,7 @@ async def test_tablet_merge_cross_rack_migrations(manager: ScyllaClusterManager,
     await wait_for(finished_merging, time.time() + 120)
 
 # Reproduces #23284
+@pytest.mark.max_running_shards(24)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_tablet_split_merge_with_many_tables(build_mode: str, manager: ScyllaClusterManager, racks = 2):
     cmdline = ['--smp', '4', '-m', '2G', '--target-tablet-size-in-bytes', '30000', '--max-task-backlog', '200', '--logger-log-level', 'load_balancer=debug']
@@ -430,6 +434,7 @@ async def test_tablet_split_merge_with_many_tables(build_mode: str, manager: Scy
     await check_logs("after merge completion")
 
 
+@pytest.mark.max_running_shards(2)
 @pytest.mark.parametrize("feature_config", feature_configs(FeatureConfigurations.EVENTUAL_CONSISTENCY,
     FeatureConfigurations.LOGSTOR_EVENTUAL_CONSISTENCY))
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
@@ -497,6 +502,7 @@ async def test_missing_data(manager: ScyllaClusterManager, feature_config: Featu
             pks), f"received {rec_count} records instead of {len(pks)} while querying server {server.server_id}"
 
 
+@pytest.mark.max_running_shards(2)
 @pytest.mark.parametrize("feature_config", feature_configs(FeatureConfigurations.EVENTUAL_CONSISTENCY,
     FeatureConfigurations.LOGSTOR_EVENTUAL_CONSISTENCY))
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
@@ -569,6 +575,7 @@ async def test_merge_with_drop(manager: ScyllaClusterManager, feature_config: Fe
         await drop_table_fut
 
 
+@pytest.mark.max_running_shards(2)
 @pytest.mark.parametrize("feature_config", feature_configs(FeatureConfigurations.EVENTUAL_CONSISTENCY,
     FeatureConfigurations.LOGSTOR_EVENTUAL_CONSISTENCY))
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
@@ -646,6 +653,7 @@ async def test_background_merge_deadlock(manager: ScyllaClusterManager, feature_
     await manager.server_stop(servers[0].server_id, convict=False)
 
 
+@pytest.mark.max_running_shards(2)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_gc_sstable_release_during_tablet_merge(manager: ScyllaClusterManager):
     """

--- a/test/cluster/test_tablets_migration.py
+++ b/test/cluster/test_tablets_migration.py
@@ -37,6 +37,7 @@ async def await_api_task(task, allowed_exception: Optional[Type[Exception]]=None
             raise
 
 
+@pytest.mark.max_running_shards(6)
 @pytest.mark.parametrize("action", ['move', 'add_replica', 'del_replica'])
 async def test_tablet_transition_sanity(manager: ScyllaClusterManager, action):
     logger.info("Bootstrapping cluster")
@@ -159,6 +160,7 @@ def pick_replica_and_free_host_in_rack(replicas, rack_hosts):
     return old_replica, (new_host, 0)
 
 
+@pytest.mark.max_running_shards(6)
 @pytest.mark.parametrize("action", ['add_replica', 'del_replica'])
 @pytest.mark.parametrize("constraint", ['rf_rack_valid', 'views', 'rack_list'])
 async def test_tablet_replica_change_requires_force_with_rack_constraints(manager: ScyllaClusterManager, action, constraint):
@@ -211,6 +213,7 @@ async def test_tablet_replica_change_requires_force_with_rack_constraints(manage
         assert sorted(r[0] for r in await get_single_tablet_replicas(manager, servers[0], ks)) == expected_replicas
 
 
+@pytest.mark.max_running_shards(6)
 async def test_tablet_replica_change_without_rack_constraints(manager: ScyllaClusterManager):
     """When the keyspace neither uses rack lists nor is required to be RF-rack-valid, adding
     and removing tablet replicas is allowed. Adding a replica to a rack which already holds
@@ -248,6 +251,7 @@ async def test_tablet_replica_change_without_rack_constraints(manager: ScyllaClu
                sorted([h for h in replica_hosts if h != old_replica[0]] + [new_replica[0]])
 
 
+@pytest.mark.max_running_shards(10)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_bootstrap_starts_while_tablet_migration_is_blocked(manager: ScyllaClusterManager, scale_timeout):
     cfg = {'enable_user_defined_functions': False, 'tablets_mode_for_new_keyspaces': 'enabled'}
@@ -308,6 +312,7 @@ async def test_bootstrap_starts_while_tablet_migration_is_blocked(manager: Scyll
         await wait_for_no_pending_topology_transition(manager, time.time() + scale_timeout(60))
 
 
+@pytest.mark.max_running_shards(12)
 @pytest.mark.parametrize("feature_config", feature_configs(FeatureConfigurations.EVENTUAL_CONSISTENCY,
     FeatureConfigurations.LOGSTOR_EVENTUAL_CONSISTENCY))
 @pytest.mark.parametrize("fail_replica", ["source", "destination"])
@@ -476,6 +481,7 @@ async def test_node_failure_during_tablet_migration(manager: ScyllaClusterManage
         await reconnect_driver(manager)
 
 
+@pytest.mark.max_running_shards(4)
 @pytest.mark.parametrize("feature_config", feature_configs(FeatureConfigurations.EVENTUAL_CONSISTENCY,
     FeatureConfigurations.LOGSTOR_EVENTUAL_CONSISTENCY))
 async def test_tablet_back_and_forth_migration(manager: ScyllaClusterManager, feature_config: FeatureConfig):
@@ -528,6 +534,7 @@ async def test_tablet_back_and_forth_migration(manager: ScyllaClusterManager, fe
         await cql.run_async(f"INSERT INTO {ks}.test (pk, c) VALUES ({3}, {3});")
         await assert_rows(3)
 
+@pytest.mark.max_running_shards(4)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_staging_backlog_is_preserved_with_file_based_streaming(manager: ScyllaClusterManager):
     logger.info("Bootstrapping cluster")
@@ -623,6 +630,7 @@ async def test_staging_backlog_is_preserved_with_file_based_streaming(manager: S
 
         await check(keys)
 
+@pytest.mark.max_running_shards(4)
 @pytest.mark.parametrize("migration_stage_and_injection", [("cleanup", "cleanup_tablet_wait"), ("end_migration", "handle_tablet_migration_end_migration")], ids=["cleanup", "end_migration"])
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_restart_leaving_replica_during_cleanup(manager: ScyllaClusterManager, migration_stage_and_injection):
@@ -707,6 +715,7 @@ async def test_restart_leaving_replica_during_cleanup(manager: ScyllaClusterMana
         await wait_for(tablets_merged, time.time() + 60)
 
 
+@pytest.mark.max_running_shards(4)
 @pytest.mark.parametrize("feature_config", feature_configs(FeatureConfigurations.EVENTUAL_CONSISTENCY,
     FeatureConfigurations.STRONG_CONSISTENCY, FeatureConfigurations.LOGSTOR_EVENTUAL_CONSISTENCY,
     FeatureConfigurations.LOGSTOR_STRONG_CONSISTENCY))

--- a/test/cluster/test_tablets_parallel_decommission.py
+++ b/test/cluster/test_tablets_parallel_decommission.py
@@ -25,6 +25,7 @@ async def count_requests_queued(manager: ScyllaClusterManager, coord_srv: Server
     return len(list(filter(lambda t: t['type'] == request_type, tasks)))
 
 
+@pytest.mark.max_running_shards(8)
 @pytest.mark.skip_mode('release', 'error injections are not supported in release mode')
 async def test_tablets_are_drained_in_parallel(manager: ScyllaClusterManager):
     """
@@ -83,6 +84,7 @@ async def test_tablets_are_drained_in_parallel(manager: ScyllaClusterManager):
         await decomm_task2
 
 
+@pytest.mark.max_running_shards(10)
 @pytest.mark.parametrize("same_rack", [False, True])
 @pytest.mark.skip_mode('release', 'error injections are not supported in release mode')
 async def test_tablets_are_rebuilt_in_parallel(manager: ScyllaClusterManager, same_rack):
@@ -158,6 +160,7 @@ async def test_tablets_are_rebuilt_in_parallel(manager: ScyllaClusterManager, sa
         await gather_safely(*tasks)
 
 
+@pytest.mark.max_running_shards(4)
 @pytest.mark.skip_mode('release', 'error injections are not supported in release mode')
 async def test_decommission_can_be_canceled(manager: ScyllaClusterManager):
     """
@@ -234,6 +237,7 @@ async def test_decommission_can_be_canceled(manager: ScyllaClusterManager):
         assert load[decomm_hostid] == 0
 
 
+@pytest.mark.max_running_shards(6)
 @pytest.mark.skip_mode('release', 'error injections are not supported in release mode')
 async def test_decommission_is_rejected_when_another_one_is_still_pending(manager: ScyllaClusterManager):
     """
@@ -278,6 +282,7 @@ async def test_decommission_is_rejected_when_another_one_is_still_pending(manage
         await decomm_task
 
 
+@pytest.mark.max_running_shards(10)
 @pytest.mark.skip_mode('release', 'error injections are not supported in release mode')
 async def test_remove_is_canceled_if_there_is_node_down(manager: ScyllaClusterManager):
     """
@@ -330,6 +335,7 @@ async def test_remove_is_canceled_if_there_is_node_down(manager: ScyllaClusterMa
             await remove_task
 
 
+@pytest.mark.max_running_shards(4)
 @pytest.mark.skip_mode('release', 'error injections are not supported in release mode')
 async def test_decommission_start_time_is_stable(manager: ScyllaClusterManager):
     """
@@ -376,6 +382,7 @@ async def test_decommission_start_time_is_stable(manager: ScyllaClusterManager):
         assert task2['start_time'] == task['start_time']
 
 
+@pytest.mark.max_running_shards(4)
 @pytest.mark.skip_mode('release', 'error injections are not supported in release mode')
 async def test_decommission_can_not_be_canceled_once_running(manager: ScyllaClusterManager):
     """
@@ -421,6 +428,7 @@ async def test_decommission_can_not_be_canceled_once_running(manager: ScyllaClus
         assert load[decomm_hostid] == 0
 
 
+@pytest.mark.max_running_shards(6)
 @pytest.mark.skip_mode('release', 'error injections are not supported in release mode')
 async def test_decommission_fails_if_capacity_is_gone_during_draining(manager: ScyllaClusterManager):
     """
@@ -466,6 +474,7 @@ async def test_decommission_fails_if_capacity_is_gone_during_draining(manager: S
             await decomm_task
 
 
+@pytest.mark.max_running_shards(4)
 @pytest.mark.skip_mode('release', 'error injections are not supported in release mode')
 async def test_node_lost_during_decommission_drain(manager: ScyllaClusterManager):
     """

--- a/test/cluster/test_tablets_removenode.py
+++ b/test/cluster/test_tablets_removenode.py
@@ -29,6 +29,7 @@ async def run_async_cl_all(cql, query: str):
     return await cql.run_async(stmt)
 
 
+@pytest.mark.max_running_shards(6)
 async def test_removenode_with_coordinator_restart(manager: ScyllaClusterManager):
     """
     Verifies that removenode can proceed when the coordinator is restarted
@@ -60,6 +61,7 @@ async def test_removenode_with_coordinator_restart(manager: ScyllaClusterManager
     await manager.remove_node(servers[1].server_id, servers[2].server_id)
 
 
+@pytest.mark.max_running_shards(6)
 async def test_replace(manager: ScyllaClusterManager):
     logger.info("Bootstrapping cluster")
     cmdline = [
@@ -140,6 +142,7 @@ async def test_replace(manager: ScyllaClusterManager):
     await check_ks(ks3)
 
 
+@pytest.mark.max_running_shards(8)
 async def test_removenode(manager: ScyllaClusterManager):
     logger.info("Bootstrapping cluster")
     cmdline = ['--logger-log-level', 'storage_service=trace']
@@ -202,6 +205,7 @@ async def test_removenode(manager: ScyllaClusterManager):
     await check()
 
 
+@pytest.mark.max_running_shards(10)
 async def test_removenode_with_ignored_node(manager: ScyllaClusterManager):
     logger.info("Bootstrapping cluster")
     cmdline = [

--- a/test/cluster/test_tls.py
+++ b/test/cluster/test_tls.py
@@ -16,6 +16,7 @@ logger = logging.getLogger(__name__)
 pytestmark = pytest.mark.prepare_3_racks_cluster
 
 
+@pytest.mark.max_running_shards(6)
 async def test_upgrade_to_ssl(manager: ScyllaClusterManager) -> None:
     """Tests rolling upgrade/downgrade from non-SSL to SSL and back
     """

--- a/test/cluster/test_tombstone_gc.py
+++ b/test/cluster/test_tombstone_gc.py
@@ -26,6 +26,7 @@ def check_tombstone_gc_mode(cql, table, mode):
     assert f"'mode': '{mode}'" in s
 
 
+@pytest.mark.max_running_shards(4)
 @pytest.mark.parametrize("rf", [1, 2])
 @pytest.mark.parametrize("tablets", [True, False])
 async def test_default_tombstone_gc(manager: ScyllaClusterManager, rf: int, tablets: bool):
@@ -37,6 +38,7 @@ async def test_default_tombstone_gc(manager: ScyllaClusterManager, rf: int, tabl
             check_tombstone_gc_mode(cql, table, "repair")
 
 
+@pytest.mark.max_running_shards(4)
 @pytest.mark.parametrize("rf", [1, 2])
 @pytest.mark.parametrize("tablets", [True, False])
 async def test_default_tombstone_gc_does_not_override(manager: ScyllaClusterManager, rf: int, tablets: bool):
@@ -49,6 +51,7 @@ async def test_default_tombstone_gc_does_not_override(manager: ScyllaClusterMana
             check_tombstone_gc_mode(cql, table, "disabled")
 
 
+@pytest.mark.max_running_shards(6)
 async def test_group0_tombstone_gc(manager: ScyllaClusterManager):
     """
     Regression test for #15607.
@@ -261,6 +264,7 @@ async def test_group0_tombstone_gc(manager: ScyllaClusterManager):
                 await delete_raft_group_data(first_group0_id, cql, h)
 
 
+@pytest.mark.max_running_shards(2)
 @pytest.mark.skip_mode(mode='release', reason="test only needs to run once - allowing only the 'dev' mode")
 @pytest.mark.skip_mode(mode='debug', reason="test only needs to run once - allowing only the 'dev' mode")
 async def test_group0_state_id_failure(manager: ScyllaClusterManager):
@@ -293,6 +297,7 @@ async def test_group0_state_id_failure(manager: ScyllaClusterManager):
     assert not matches, "The 'endpoint_state_map does not contain endpoint' warning appeared in the log"
 
 
+@pytest.mark.max_running_shards(4)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 @pytest.mark.parametrize("tablets", (True, False))
 async def test_tombstone_gc_rf_one(manager: ScyllaClusterManager, tablets: bool):

--- a/test/cluster/test_tools_perf.py
+++ b/test/cluster/test_tools_perf.py
@@ -32,12 +32,14 @@ def scylla_path(build_mode):
     return path_to(build_mode, "scylla")
 
 
+@pytest.mark.max_running_shards(2)
 @pytest.mark.parametrize("mode", ["read"])
 async def test_perf_simple_query(scylla_path, mode, tmp_path):
     args = [scylla_path, "perf-simple-query", "--duration", "1", "--partitions", "1000", "--stop-on-error", "false", "--memory", "2G", "--smp", "2", "--overprovisioned"]
     await run(args)
 
 
+@pytest.mark.max_running_shards(2)
 @pytest.mark.parametrize("workload", ["read", "write"])
 async def test_perf_cql_raw(scylla_path, tmp_path, workload):
     hosts = HostRegistry()
@@ -65,6 +67,7 @@ async def test_perf_cql_raw(scylla_path, tmp_path, workload):
          await hosts.release_host(host)
 
 
+@pytest.mark.max_running_shards(2)
 @pytest.mark.parametrize("workload", ["write", "batch_read"])
 async def test_perf_alternator(scylla_path, tmp_path, workload):
     hosts = HostRegistry()
@@ -95,6 +98,7 @@ async def test_perf_alternator(scylla_path, tmp_path, workload):
          await hosts.release_host(host)
 
 
+@pytest.mark.max_running_shards(2)
 @pytest.mark.parametrize("workload", ["read"])
 async def test_perf_cql_raw_remote(scylla_path, tmp_path, workload, manager):
     await manager.server_add()
@@ -115,6 +119,7 @@ async def test_perf_cql_raw_remote(scylla_path, tmp_path, workload, manager):
     await run(client_cmd)
 
 
+@pytest.mark.max_running_shards(2)
 @pytest.mark.parametrize("workload", ["read", "batch_read"])
 async def test_perf_alternator_remote(scylla_path, tmp_path, workload, manager):
     server = await manager.server_add(cmdline=[

--- a/test/cluster/test_topology_failure_recovery.py
+++ b/test/cluster/test_topology_failure_recovery.py
@@ -50,6 +50,7 @@ async def remove_error_on(manager: ScyllaClusterManager, error_name: str, server
     await asyncio.gather(*errs)
 
 
+@pytest.mark.max_running_shards(6)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_tablet_drain_failure_during_decommission(manager: ScyllaClusterManager):
     cfg = {'enable_user_defined_functions': False, 'tablets_mode_for_new_keyspaces': 'enabled'}
@@ -73,6 +74,7 @@ async def test_tablet_drain_failure_during_decommission(manager: ScyllaClusterMa
         assert node.draining == False and node.excluded == False and node.status == 'NORMAL'
 
 
+@pytest.mark.max_running_shards(8)
 @pytest.mark.prepare_3_nodes_cluster
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_topology_streaming_failure(request, manager: ScyllaClusterManager):

--- a/test/cluster/test_topology_ops.py
+++ b/test/cluster/test_topology_ops.py
@@ -18,6 +18,7 @@ import logging
 logger = logging.getLogger(__name__)
 
 
+@pytest.mark.max_running_shards(10)
 @pytest.mark.parametrize("tablets_enabled", [True, False])
 async def test_topology_ops(request, manager: ScyllaClusterManager, tablets_enabled: bool):
     """Test basic topology operations using the topology coordinator."""

--- a/test/cluster/test_topology_ops_encrypted.py
+++ b/test/cluster/test_topology_ops_encrypted.py
@@ -18,6 +18,7 @@ import logging
 
 logger = logging.getLogger(__name__)
 
+@pytest.mark.max_running_shards(10)
 @pytest.mark.parametrize("tablets_enabled", [True, False])
 async def test_topology_ops_encrypted(request, manager: ScyllaClusterManager, tablets_enabled: bool, tmp_path):
     """Test basic topology operations using the topology coordinator. But encrypted."""

--- a/test/cluster/test_topology_ops_with_rf_rack_valid.py
+++ b/test/cluster/test_topology_ops_with_rf_rack_valid.py
@@ -14,6 +14,7 @@ import pytest
 logger = logging.getLogger(__name__)
 
 
+@pytest.mark.max_running_shards(10)
 @pytest.mark.parametrize("enforce", [True, False])
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_add_node_in_new_rack_violating_rf_rack(manager: ScyllaClusterManager, enforce: bool):
@@ -58,6 +59,7 @@ async def test_add_node_in_new_rack_violating_rf_rack(manager: ScyllaClusterMana
         assert any(matches)
 
 
+@pytest.mark.max_running_shards(12)
 @pytest.mark.parametrize("enforce", [True, False])
 @pytest.mark.parametrize("op", ["remove", "decommission"])
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
@@ -119,6 +121,7 @@ async def test_remove_node_violating_rf_rack(manager: ScyllaClusterManager, enfo
         assert any(matches)
 
 
+@pytest.mark.max_running_shards(10)
 @pytest.mark.parametrize("injection", ["before_bootstrap", "after_bootstrap"])
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_keyspace_creation_during_node_join(manager: ScyllaClusterManager, injection: str):
@@ -224,6 +227,7 @@ async def test_keyspace_creation_during_node_join(manager: ScyllaClusterManager,
         await add_node2_task
 
 
+@pytest.mark.max_running_shards(6)
 @pytest.mark.parametrize("op", ["remove", "decommission"])
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_keyspace_creation_during_node_remove(manager: ScyllaClusterManager, op: str):
@@ -289,6 +293,7 @@ async def test_keyspace_creation_during_node_remove(manager: ScyllaClusterManage
     await node_op_task
 
 
+@pytest.mark.max_running_shards(10)
 @pytest.mark.parametrize("op", ["remove", "decommission"])
 async def test_remove_node_violating_rf_rack_with_rack_list(manager: ScyllaClusterManager, op: str):
     """
@@ -337,6 +342,7 @@ async def test_remove_node_violating_rf_rack_with_rack_list(manager: ScyllaClust
     await remove_node(servers[2])
 
 
+@pytest.mark.max_running_shards(6)
 @pytest.mark.parametrize("op", ["remove", "decommission"])
 @pytest.mark.parametrize("scenario", ["last_in_dc", "last_in_rack"])
 async def test_remove_last_node_in_dc_violating_rf_rack(manager: ScyllaClusterManager, op: str, scenario: str):

--- a/test/cluster/test_topology_rejoin.py
+++ b/test/cluster/test_topology_rejoin.py
@@ -12,6 +12,7 @@ import pytest
 pytestmark = pytest.mark.prepare_3_racks_cluster
 
 
+@pytest.mark.max_running_shards(6)
 async def test_start_after_sudden_stop(manager: ScyllaClusterManager, random_tables) -> None:
     """Tests a server can rejoin the cluster after being stopped suddenly"""
     servers = await manager.running_servers()

--- a/test/cluster/test_topology_remove_decom.py
+++ b/test/cluster/test_topology_remove_decom.py
@@ -23,6 +23,7 @@ logger = logging.getLogger(__name__)
 pytestmark = pytest.mark.prepare_3_racks_cluster
 
 
+@pytest.mark.max_running_shards(8)
 async def test_remove_node_add_column(manager: ScyllaClusterManager, random_tables: RandomTables):
     """Add a node, remove an original node, add a column"""
     servers = await manager.running_servers()
@@ -35,6 +36,7 @@ async def test_remove_node_add_column(manager: ScyllaClusterManager, random_tabl
     await random_tables.verify_schema()
 
 
+@pytest.mark.max_running_shards(8)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_decommission_node_add_column(manager: ScyllaClusterManager, random_tables: RandomTables):
     """Add a node, remove an original node, add a column"""
@@ -132,12 +134,14 @@ async def test_remove_node_with_concurrent_ddl(manager: ScyllaClusterManager, ra
         await ddl_task
         logger.debug("ddl fiber done, finished")
 
+@pytest.mark.max_running_shards(6)
 async def test_rebuild_node(manager: ScyllaClusterManager, random_tables: RandomTables):
     """rebuild a node"""
     servers = await manager.running_servers()
     await manager.rebuild_node(servers[0].server_id)
     await check_token_ring_and_group0_consistency(manager)
 
+@pytest.mark.max_running_shards(6)
 async def test_concurrent_removenode_two_initiators_one_dead_node(manager: ScyllaClusterManager):
     servers = await manager.running_servers()
     assert len(servers) >= 3
@@ -152,6 +156,7 @@ async def test_concurrent_removenode_two_initiators_one_dead_node(manager: Scyll
     else:
         raise Exception("concurrent removenode request should result in a failure, but unexpectedly succeeded")
 
+@pytest.mark.max_running_shards(10)
 async def test_concurrent_removenode_one_initiator_two_dead_nodes(manager: ScyllaClusterManager):
     """
     Tests the execution flow in case of performing remove node
@@ -170,6 +175,7 @@ async def test_concurrent_removenode_one_initiator_two_dead_nodes(manager: Scyll
     await asyncio.gather(*[manager.remove_node(servers[0].server_id, servers[2].server_id, ignore_dead=ignore_nodes),
             manager.remove_node(servers[0].server_id, servers[1].server_id, ignore_dead=ignore_nodes)])
 
+@pytest.mark.max_running_shards(10)
 async def test_concurrent_removenode_two_initiators_two_dead_nodes(manager: ScyllaClusterManager):
     """
     Tests the execution flow in case of performing remove node
@@ -189,6 +195,7 @@ async def test_concurrent_removenode_two_initiators_two_dead_nodes(manager: Scyl
     await asyncio.gather(*[manager.remove_node(servers[0].server_id, servers[2].server_id, ignore_dead=ignore_nodes),
             manager.remove_node(servers[3].server_id, servers[1].server_id, ignore_dead=ignore_nodes)])
 
+@pytest.mark.max_running_shards(8)
 @pytest.mark.skip_mode(mode='release', reason='error injection is not supported in release mode')
 async def test_decommission_left_token_ring_retry(manager: ScyllaClusterManager):
     """

--- a/test/cluster/test_topology_schema.py
+++ b/test/cluster/test_topology_schema.py
@@ -13,6 +13,7 @@ import pytest
 pytestmark = pytest.mark.prepare_3_racks_cluster
 
 
+@pytest.mark.max_running_shards(8)
 async def test_topology_schema_changes(manager, random_tables):
     """Test schema consistency with restart, add, and sudden stop of servers"""
     table = await random_tables.add_table(ncolumns=5)

--- a/test/cluster/test_topology_smp.py
+++ b/test/cluster/test_topology_smp.py
@@ -20,6 +20,7 @@ logger = logging.getLogger(__name__)
 
 
 # Checks basic functionality on the cluster with different values of the --smp parameter on the nodes.
+@pytest.mark.max_running_shards(12)
 async def test_nodes_with_different_smp(request: FixtureRequest, manager: ScyllaClusterManager, build_mode) -> None:
     # In this test it's more convenient to start with a fresh cluster.
 

--- a/test/cluster/test_truncate_concurrent_writes.py
+++ b/test/cluster/test_truncate_concurrent_writes.py
@@ -19,6 +19,7 @@ import os
 
 logger = logging.getLogger(__name__)
 
+@pytest.mark.max_running_shards(6)
 async def test_validate_truncate_with_concurrent_writes(manager: ScyllaClusterManager):
 
     # This test validates that all the data before a truncate started has been deleted,

--- a/test/cluster/test_truncate_with_drop.py
+++ b/test/cluster/test_truncate_with_drop.py
@@ -14,6 +14,7 @@ import pytest
 
 logger = logging.getLogger(__name__)
 
+@pytest.mark.max_running_shards(2)
 async def test_truncation_on_drop(manager: ScyllaClusterManager):
     await manager.server_add()
     cql = manager.get_cql()
@@ -38,6 +39,7 @@ async def test_truncation_on_drop(manager: ScyllaClusterManager):
         row = await cql.run_async(SimpleStatement(f'SELECT COUNT(*) FROM system.truncated where table_uuid={table_id}'))
         assert row[0].count == 0
 
+@pytest.mark.max_running_shards(2)
 async def test_truncation_records_pruned_on_dirty_restart(manager: ScyllaClusterManager):
     server = await manager.server_add()
     cql = manager.get_cql()

--- a/test/cluster/test_truncate_with_tablets.py
+++ b/test/cluster/test_truncate_with_tablets.py
@@ -20,6 +20,7 @@ import asyncio
 logger = logging.getLogger(__name__)
 
 
+@pytest.mark.max_running_shards(4)
 @pytest.mark.parametrize("feature_config", feature_configs(FeatureConfigurations.EVENTUAL_CONSISTENCY,
                                                            FeatureConfigurations.LOGSTOR_EVENTUAL_CONSISTENCY))
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
@@ -76,6 +77,7 @@ async def get_raft_leader_and_log(manager: ScyllaClusterManager, servers):
     return (raft_leader, raft_leader_log)
 
 
+@pytest.mark.max_running_shards(6)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_truncate_with_concurrent_drop(manager: ScyllaClusterManager):
 
@@ -126,6 +128,7 @@ async def test_truncate_with_concurrent_drop(manager: ScyllaClusterManager):
             await trunc_future
 
 
+@pytest.mark.max_running_shards(6)
 @pytest.mark.parametrize("feature_config", feature_configs(FeatureConfigurations.EVENTUAL_CONSISTENCY,
                                                            FeatureConfigurations.LOGSTOR_EVENTUAL_CONSISTENCY,
                                                            FeatureConfigurations.STRONG_CONSISTENCY,
@@ -180,6 +183,7 @@ async def test_truncate_while_node_restart(manager: ScyllaClusterManager, featur
                                 query_template="SELECT COUNT(*) FROM {ks}.{table}", ks=ks, table='test', keys=keys, partition_key='pk') == 0
 
 
+@pytest.mark.max_running_shards(4)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_truncate_with_coordinator_crash(manager: ScyllaClusterManager):
 
@@ -225,6 +229,7 @@ async def test_truncate_with_coordinator_crash(manager: ScyllaClusterManager):
         assert row[0].count == 0
 
 
+@pytest.mark.max_running_shards(4)
 @pytest.mark.parametrize("feature_config", feature_configs(FeatureConfigurations.EVENTUAL_CONSISTENCY,
                                                            FeatureConfigurations.LOGSTOR_EVENTUAL_CONSISTENCY))
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
@@ -278,6 +283,7 @@ async def test_truncate_while_truncate_already_waiting(manager: ScyllaClusterMan
                                 query_template="SELECT COUNT(*) FROM {ks}.{table}", ks=ks, table='test', keys=keys, partition_key='pk') == 0
 
 # Reproduces https://github.com/scylladb/scylladb/issues/23771.
+@pytest.mark.max_running_shards(1)
 @pytest.mark.parametrize("feature_config", feature_configs(FeatureConfigurations.EVENTUAL_CONSISTENCY,
                                                            FeatureConfigurations.LOGSTOR_EVENTUAL_CONSISTENCY,
                                                            FeatureConfigurations.STRONG_CONSISTENCY,
@@ -319,6 +325,7 @@ async def test_replay_position_check_during_truncate(manager, feature_config: Fe
         await truncate_task
 
 
+@pytest.mark.max_running_shards(4)
 @pytest.mark.parametrize("feature_config", feature_configs(FeatureConfigurations.EVENTUAL_CONSISTENCY,
                                                            FeatureConfigurations.LOGSTOR_EVENTUAL_CONSISTENCY))
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
@@ -369,6 +376,7 @@ async def test_parallel_truncate(manager: ScyllaClusterManager, feature_config: 
         assert await count_rows(cql, feature_config,
                                 query_template="SELECT COUNT(*) FROM {ks}.{table}", ks=ks, table='test1', keys=keys, partition_key='pk') == 0
 
+@pytest.mark.max_running_shards(2)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_split_emitted_during_truncate(manager: ScyllaClusterManager):
     """Tests that truncation handles new compaction groups introduced by tablet
@@ -444,6 +452,7 @@ async def test_split_emitted_during_truncate(manager: ScyllaClusterManager):
         await wait_for(finished_splitting, time.time() + 120)
 
 
+@pytest.mark.max_running_shards(6)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_truncate_by_stale_coordinator_with_foreign_session(manager: ScyllaClusterManager):
     """A coordinator which loses leadership while parked in handle_topology_ordered_op()

--- a/test/cluster/test_ttl_row.py
+++ b/test/cluster/test_ttl_row.py
@@ -49,6 +49,7 @@ async def get_cpu_metrics(manager: ScyllaClusterManager):
     return (ms_streaming, ms_statement, items_deleted)
 
 
+@pytest.mark.max_running_shards(6)
 async def test_row_ttl_scheduling_group(manager: ScyllaClusterManager):
     """Verify that the expiration scans and deletion operations done by the
        per-row TTL feature are done entirely in the "streaming" scheduling
@@ -149,6 +150,7 @@ async def test_row_ttl_scheduling_group(manager: ScyllaClusterManager):
     assert ms_streaming > 0, f'expected some streaming-group work, got 0 (statement: {ms_statement} ms)'
     assert ms_statement < ms_streaming * 0.1, f'expected negligible statement-group work, got {ms_statement} ms (streaming: {ms_streaming} ms)'
 
+@pytest.mark.max_running_shards(6)
 @pytest.mark.parametrize("with_down_node", [False, True], ids=["all_nodes_up", "one_node_down"])
 async def test_row_ttl_multinode_expiration(manager: ScyllaClusterManager, with_down_node):
     """When the cluster has multiple nodes, different nodes are responsible
@@ -205,6 +207,7 @@ async def test_row_ttl_multinode_expiration(manager: ScyllaClusterManager, with_
                 time.sleep(0.1)
             assert 0 == len(list(await cql.run_async(SimpleStatement(f'SELECT p FROM {table}', consistency_level=ConsistencyLevel.QUORUM))))
 
+@pytest.mark.max_running_shards(6)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_row_ttl_upgrade(manager: ScyllaClusterManager):
     """This test verifies that a rolling upgrade works as designed for the
@@ -289,6 +292,7 @@ async def test_row_ttl_upgrade(manager: ScyllaClusterManager):
     assert 0 == len(list(await cql.run_async(SimpleStatement(f'SELECT p FROM ks.tbl2', consistency_level=ConsistencyLevel.QUORUM))))
 
 
+@pytest.mark.max_running_shards(12)
 async def test_row_ttl_multi_dc(manager: ScyllaClusterManager):
     """Check that the TTL feature works correctly on a setup with multiple
        data centers. Rows added in one DC will, of course, get copied to all

--- a/test/cluster/test_unfinished_writes_during_shutdown.py
+++ b/test/cluster/test_unfinished_writes_during_shutdown.py
@@ -23,6 +23,7 @@ from cassandra.cluster import ConnectionException, NoHostAvailable  # type: igno
 
 logger = logging.getLogger(__name__)
 
+@pytest.mark.max_running_shards(6)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_unfinished_writes_during_shutdown(request: pytest.FixtureRequest, manager: ScyllaClusterManager) -> None:
     """ Test a simultaneous topology change and write query during shutdown,

--- a/test/cluster/test_uninitialized_conns_semaphore.py
+++ b/test/cluster/test_uninitialized_conns_semaphore.py
@@ -14,6 +14,7 @@ CQL_PORT = 9042
 SHARD_AWARE_PORT = 19042
 
 
+@pytest.mark.max_running_shards(2)
 async def test_uninitialized_conns_sempahore_one(manager: ScyllaClusterManager):
     """Verify that CQL queries work when uninitialized_connections_semaphore_cpu_concurrency is set to 1."""
     config = {

--- a/test/cluster/test_vector_store.py
+++ b/test/cluster/test_vector_store.py
@@ -20,6 +20,7 @@ logger = logging.getLogger(__name__)
 # 
 # In this test, we check that creating a vector index without
 # rf_rack_valid_keyspaces being set is possible.
+@pytest.mark.max_running_shards(2)
 async def test_vector_store_can_be_created_without_rf_rack_valid(manager: ScyllaClusterManager):
     # Explicitly disable the rf_rack_valid_keyspaces option.
     config = {"rf_rack_valid_keyspaces": False}

--- a/test/cluster/test_view_build_status.py
+++ b/test/cluster/test_view_build_status.py
@@ -58,6 +58,7 @@ async def wait_for_view_build_status(cql, ks_name, view_name, status, node_count
 # Create a materialized view and check that the view's build status
 # is stored in view_build_status_v2 and all nodes see all the other
 # node's statuses.
+@pytest.mark.max_running_shards(6)
 async def test_view_build_status_v2_table(manager: ScyllaClusterManager):
     node_count = 3
     servers = await manager.servers_add(node_count)
@@ -77,6 +78,7 @@ async def test_view_build_status_v2_table(manager: ScyllaClusterManager):
 # The table system_distributed.view_build_status is set to be a virtual table reading
 # from system.view_build_status_v2, so verify that reading from each of them provides
 # the same output.
+@pytest.mark.max_running_shards(6)
 async def test_view_build_status_virtual_table(manager: ScyllaClusterManager):
     node_count = 3
     servers = await manager.servers_add(node_count)
@@ -153,6 +155,7 @@ async def test_view_build_status_virtual_table(manager: ScyllaClusterManager):
 # Cluster with 3 nodes.
 # Create materialized views. Start new server and it should get a snapshot on bootstrap.
 # Stop 3 `old` servers and query the new server to validate if it has the same view build status.
+@pytest.mark.max_running_shards(8)
 async def test_view_build_status_snapshot(manager: ScyllaClusterManager):
     servers = await manager.servers_add(3)
     cql, _ = await manager.get_ready_cql(servers)
@@ -188,6 +191,7 @@ async def test_view_build_status_snapshot(manager: ScyllaClusterManager):
 
 # Test that when removing a node from the cluster, we clean its rows from
 # the view build status table.
+@pytest.mark.max_running_shards(8)
 async def test_view_build_status_cleanup_on_remove_node(manager: ScyllaClusterManager):
     node_count = 4
     servers = await manager.servers_add(node_count)
@@ -211,6 +215,7 @@ async def test_view_build_status_cleanup_on_remove_node(manager: ScyllaClusterMa
 
 # Replace a node and verify that the view_build_status has rows for the new node and
 # no rows for the old node
+@pytest.mark.max_running_shards(8)
 async def test_view_build_status_with_replace_node(manager: ScyllaClusterManager):
     node_count = 4
     servers = await manager.servers_add(node_count)
@@ -253,6 +258,7 @@ async def test_view_build_status_with_replace_node(manager: ScyllaClusterManager
     await wait_for(node_rows_replaced, time.time() + 60)
 
 # Test that when removing the view, its build status is cleaned from the status table
+@pytest.mark.max_running_shards(8)
 async def test_view_build_status_cleanup_on_drop_view(manager: ScyllaClusterManager):
     node_count = 4
     servers = await manager.servers_add(node_count)
@@ -267,6 +273,7 @@ async def test_view_build_status_cleanup_on_drop_view(manager: ScyllaClusterMana
         await wait_for_view_build_status(cql, ks, "vt1", "SUCCESS", 0)
 
 # Test that when removing the view, its build status is cleaned from the status table
+@pytest.mark.max_running_shards(10)
 async def test_view_build_status_extended_on_added_node(manager: ScyllaClusterManager):
     node_count = 4
     servers = await manager.servers_add(node_count)
@@ -281,6 +288,7 @@ async def test_view_build_status_extended_on_added_node(manager: ScyllaClusterMa
         await wait_for_view_build_status(cql, ks, "vt1", "SUCCESS", node_count+1)
 
 # Test that when removing the view, its build status is cleaned from the status table
+@pytest.mark.max_running_shards(10)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_view_build_status_marked_started_on_node_added_during_building(manager: ScyllaClusterManager):
     node_count = 4

--- a/test/cluster/test_view_building_coordinator.py
+++ b/test/cluster/test_view_building_coordinator.py
@@ -93,6 +93,7 @@ async def check_view_contents(cql: Session, ks: str, table: str, view: str, part
 ### TESTS ###
 #############
 
+@pytest.mark.max_running_shards(6)
 async def test_build_no_data(manager: ScyllaClusterManager):
     node_count = 3
     servers = await manager.servers_add(node_count, cmdline=cmdline_loggers, property_file=[
@@ -108,6 +109,7 @@ async def test_build_no_data(manager: ScyllaClusterManager):
         await wait_for_view(cql, 'mv_cf_view', node_count)
         await check_view_contents(cql, ks, "tab", "mv_cf_view")
 
+@pytest.mark.max_running_shards(6)
 async def test_build_one_view(manager: ScyllaClusterManager):
     node_count = 3
     servers = await manager.servers_add(node_count, cmdline=cmdline_loggers, property_file=[
@@ -125,6 +127,7 @@ async def test_build_one_view(manager: ScyllaClusterManager):
         await wait_for_view(cql, 'mv_cf_view', node_count)
         await check_view_contents(cql, ks, "tab", "mv_cf_view")
 
+@pytest.mark.max_running_shards(6)
 async def test_build_filtered_view(manager: ScyllaClusterManager):
     node_count = 3
     servers = await manager.servers_add(node_count, cmdline=cmdline_loggers)
@@ -139,6 +142,7 @@ async def test_build_filtered_view(manager: ScyllaClusterManager):
         await check_view_contents(cql, ks, "tab", "mv_cf_view", partition_list=[1, 4, 9])
 
 
+@pytest.mark.max_running_shards(6)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_build_two_views(manager: ScyllaClusterManager):
     node_count = 3
@@ -168,6 +172,7 @@ async def test_build_two_views(manager: ScyllaClusterManager):
         await check_view_contents(cql, ks, "tab", "mv_cf_view1")
         await check_view_contents(cql, ks, "tab", "mv_cf_view2")
 
+@pytest.mark.max_running_shards(6)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_add_view_while_build_in_progress(manager: ScyllaClusterManager):
     node_count = 3
@@ -201,6 +206,7 @@ async def test_add_view_while_build_in_progress(manager: ScyllaClusterManager):
         await check_view_contents(cql, ks, "tab", "mv_cf_view1")
         await check_view_contents(cql, ks, "tab", "mv_cf_view2")
 
+@pytest.mark.max_running_shards(2)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_add_view_after_view_build_flush_races_with_delete(manager: ScyllaClusterManager):
     server = await manager.server_add(cmdline=cmdline_loggers, property_file={"dc": "dc1", "rack": "r1"})
@@ -236,6 +242,7 @@ async def test_add_view_after_view_build_flush_races_with_delete(manager: Scylla
         await check_view_contents(cql, ks, "tab", "mv_cf_view1")
         await check_view_contents(cql, ks, "tab", "mv_cf_view2")
 
+@pytest.mark.max_running_shards(6)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_remove_some_view_while_build_in_progress(manager: ScyllaClusterManager):
     node_count = 3
@@ -264,6 +271,7 @@ async def test_remove_some_view_while_build_in_progress(manager: ScyllaClusterMa
         await wait_for_view(cql, 'mv_cf_view1', node_count)
         await check_view_contents(cql, ks, "tab", "mv_cf_view1")
 
+@pytest.mark.max_running_shards(6)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_abort_building_by_remove_view(manager: ScyllaClusterManager):
     node_count = 3
@@ -290,6 +298,7 @@ async def test_abort_building_by_remove_view(manager: ScyllaClusterManager):
         views = await cql.run_async(f"SELECT * FROM system_schema.views WHERE keyspace_name = '{ks}'")
         assert len(views) == 0
 
+@pytest.mark.max_running_shards(6)
 @pytest.mark.parametrize("change", ["add", "rename"])
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_alter_base_schema_while_build_in_progress(manager: ScyllaClusterManager, change: str):
@@ -325,6 +334,7 @@ async def test_alter_base_schema_while_build_in_progress(manager: ScyllaClusterM
         elif change == "rename":
             await check_view_contents(cql, ks, "tab", "mv_cf_view", clustering_key="renamed_c")
 
+@pytest.mark.max_running_shards(6)
 @pytest.mark.parametrize("change", ["increase", "decrease"])
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_change_rf_while_build_in_progress(manager: ScyllaClusterManager, change: str):
@@ -366,6 +376,7 @@ async def test_change_rf_while_build_in_progress(manager: ScyllaClusterManager, 
         await wait_for_view(cql, 'mv_cf_view', node_count)
         await check_view_contents(cql, ks, "tab", "mv_cf_view")
 
+@pytest.mark.max_running_shards(8)
 @pytest.mark.parametrize("operation", ["add", "remove", "decommission", "replace"])
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_node_operation_during_view_building(manager: ScyllaClusterManager, operation: str):
@@ -417,6 +428,7 @@ async def test_node_operation_during_view_building(manager: ScyllaClusterManager
         await wait_for_view(cql, 'mv_cf_view', node_count)
         await check_view_contents(cql, ks, "tab", "mv_cf_view")
 
+@pytest.mark.max_running_shards(6)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_leader_change_while_building(manager: ScyllaClusterManager):
     node_count = 3
@@ -450,6 +462,7 @@ async def test_leader_change_while_building(manager: ScyllaClusterManager):
         await wait_for_view(cql, 'mv_cf_view1', node_count)
         await check_view_contents(cql, ks, "tab", "mv_cf_view1")
 
+@pytest.mark.max_running_shards(6)
 @pytest.mark.xfail
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_truncate_while_building(manager: ScyllaClusterManager):
@@ -481,6 +494,7 @@ async def test_truncate_while_building(manager: ScyllaClusterManager):
         await wait_for_view(cql, 'mv_cf_view1', node_count)
         await check_view_contents(cql, ks, "tab", "mv_cf_view1")
 
+@pytest.mark.max_running_shards(6)
 @pytest.mark.parametrize("view_action", ["finish_build", "drop_while_building"])
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_scylla_views_builds_in_progress(manager: ScyllaClusterManager, view_action):
@@ -528,6 +542,7 @@ async def test_scylla_views_builds_in_progress(manager: ScyllaClusterManager, vi
 
         await check_scylla_views_builds_in_progress(expect_zero_rows=True)
 
+@pytest.mark.max_running_shards(4)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_view_building_while_tablet_streaming_fail(manager: ScyllaClusterManager):
     servers = [await manager.server_add(cmdline=cmdline_loggers)]
@@ -558,6 +573,7 @@ async def test_view_building_while_tablet_streaming_fail(manager: ScyllaClusterM
         await wait_for_view(cql, 'mv_cf_view', 2)
         await check_view_contents(cql, ks, "tab", "mv_cf_view")
 
+@pytest.mark.max_running_shards(6)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_view_building_failure(manager: ScyllaClusterManager):
     node_count = 3
@@ -585,6 +601,7 @@ async def test_view_building_failure(manager: ScyllaClusterManager):
         await check_view_contents(cql, ks, "tab", "mv_cf_view")
 
 # Reproduces scylladb/scylladb#25912
+@pytest.mark.max_running_shards(12)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_concurrent_tablet_migrations(manager: ScyllaClusterManager):
     """
@@ -690,6 +707,7 @@ async def assert_row_count_on_host(cql, host, ks, table, row_count):
 # Staging sstables are created by removing table's normal sstables and repairing it.
 # Then processing staging sstables is prevented using error injection and the tablet is
 # migrated to a new node, which will receive the staging sstables via file streaming.
+@pytest.mark.max_running_shards(6)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_file_streaming(manager: ScyllaClusterManager):
     node_count = 2
@@ -825,6 +843,7 @@ async def test_file_streaming(manager: ScyllaClusterManager):
 #   However after tablet merge, view building tasks of those sstables are merged into one task,
 #   but the map stays the same, so one sstable won't be processed
 #   because last token after tablet merge = last token of tablet2 before merge
+@pytest.mark.max_running_shards(6)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_staging_sstables_with_tablet_merge(manager: ScyllaClusterManager):
     node_count = 2
@@ -932,6 +951,7 @@ async def test_staging_sstables_with_tablet_merge(manager: ScyllaClusterManager)
         await assert_row_count_on_host(cql, new_hosts[0], ks, "mv", 1000)
         await manager.server_start(servers[1].server_id)
 
+@pytest.mark.max_running_shards(4)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_tablet_migration_during_view_building(manager: ScyllaClusterManager):
     node_count = 1
@@ -962,6 +982,7 @@ async def test_tablet_migration_during_view_building(manager: ScyllaClusterManag
         await wait_for_view(cql, 'mv_cf_view1', 2)
         await check_view_contents(cql, ks, "tab", "mv_cf_view1")
 
+@pytest.mark.max_running_shards(6)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_tablet_merge_during_view_building(manager: ScyllaClusterManager):
     node_count = 3
@@ -1015,6 +1036,7 @@ async def test_tablet_merge_during_view_building(manager: ScyllaClusterManager):
 #
 # We check that the observed bad behavior no longer occurs by checking that
 # the view_building_state_observer no longer prints warnings.
+@pytest.mark.max_running_shards(4)
 async def test_all_good_on_node_restart(manager: ScyllaClusterManager):
     node_count = 2
     servers = await manager.servers_add(node_count, cmdline=cmdline_loggers, property_file=[
@@ -1040,6 +1062,7 @@ async def test_all_good_on_node_restart(manager: ScyllaClusterManager):
 # Test that view building does not trigger tombstone_warn_threshold warnings.
 # Uses a high tablet count (2048) to create many tasks, which produces many
 # tombstones when tasks are cleaned up. Verifies no warnings appear in logs.
+@pytest.mark.max_running_shards(2)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_tombstone_warn_threshold(manager: ScyllaClusterManager):
     node_count = 1
@@ -1070,6 +1093,7 @@ async def test_tombstone_warn_threshold(manager: ScyllaClusterManager):
 
 # Test that in presence of view update hints, view building will not be marked as finished
 # Migrated from dtest materialized_views_test.py::TestMaterializedViews::test_do_not_finish_view_building_with_hints
+@pytest.mark.max_running_shards(6)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_do_not_finish_view_building_with_hints(manager: ScyllaClusterManager):
     node_count = 3
@@ -1123,6 +1147,7 @@ async def test_do_not_finish_view_building_with_hints(manager: ScyllaClusterMana
 # - the task cleaning fiber removes the finished task - this indirectly triggers broadcast on the CV by commiting to group0
 # before unpausing the coordinator (`view_building_coordinator_wait_before_await_event`)
 # Reproduces scylladb/scylladb#27298
+@pytest.mark.max_running_shards(2)
 @pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_coordinator_misses_cv_broadcast(manager: ScyllaClusterManager):
@@ -1167,6 +1192,7 @@ async def test_coordinator_misses_cv_broadcast(manager: ScyllaClusterManager):
 # `_staging_sstables` and creates a `process_staging` task. That task tries to link() the TOC file
 # which no longer exists, hitting ENOENT, and retries indefinitely.
 # Reproduces SCYLLADB-2312
+@pytest.mark.max_running_shards(8)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_staging_registration_race_with_tablet_migration(manager: ScyllaClusterManager):
     node_count = 2

--- a/test/cluster/test_vnodes_to_tablets_migration.py
+++ b/test/cluster/test_vnodes_to_tablets_migration.py
@@ -235,6 +235,7 @@ async def verify_migration_status(manager: ScyllaClusterManager, server: ServerI
                 raise
 
 
+@pytest.mark.max_running_shards(3)
 async def test_migration(manager: ScyllaClusterManager):
     """Verify vnodes-to-tablets migration for a single table on a single-node cluster.
 
@@ -364,6 +365,7 @@ async def test_migration(manager: ScyllaClusterManager):
         await wait_for_pow2_convergence(manager, server, ks, 'test')
 
 
+@pytest.mark.max_running_shards(3)
 async def test_migration_rollback(manager: ScyllaClusterManager):
     """Verify rollback of vnodes-to-tablets migration on a single-node cluster.
 
@@ -482,6 +484,7 @@ async def test_migration_rollback(manager: ScyllaClusterManager):
         await verify_data_integrity(cql, ks, "test", num_keys)
 
 
+@pytest.mark.max_running_shards(6)
 async def test_migration_multinode(manager: ScyllaClusterManager):
     """Verify vnodes-to-tablets migration for a single table on a multi-node cluster with rolling restarts.
 
@@ -632,6 +635,7 @@ async def test_migration_multinode(manager: ScyllaClusterManager):
         await wait_for_pow2_convergence(manager, servers[0], ks, 'test')
 
 
+@pytest.mark.max_running_shards(6)
 async def test_migration_multidc(manager: ScyllaClusterManager):
     """Verify vnodes-to-tablets migration on a multi-DC cluster with asymmetric RF.
 
@@ -797,6 +801,7 @@ async def setup_single_node(manager: ScyllaClusterManager):
     return server, cql
 
 
+@pytest.mark.max_running_shards(2)
 async def test_migration_nonexistent_keyspace(manager: ScyllaClusterManager):
     """Verify that migration APIs fail on a non-existent keyspace."""
     server, cql = await setup_single_node(manager)
@@ -809,6 +814,7 @@ async def test_migration_nonexistent_keyspace(manager: ScyllaClusterManager):
         await manager.api.finalize_vnode_tablet_migration(server.ip_addr, "ks")
 
 
+@pytest.mark.max_running_shards(2)
 async def test_migration_already_tablets(manager: ScyllaClusterManager):
     """Verify that starting migration on a keyspace that already uses tablets fails."""
     server, cql = await setup_single_node(manager)
@@ -818,6 +824,7 @@ async def test_migration_already_tablets(manager: ScyllaClusterManager):
             await manager.api.create_vnode_tablet_migration(server.ip_addr, ks_tablets)
 
 
+@pytest.mark.max_running_shards(2)
 async def test_migration_empty_keyspace(manager: ScyllaClusterManager):
     """Verify that starting migration on a keyspace with no tables fails."""
     server, cql = await setup_single_node(manager)
@@ -827,6 +834,7 @@ async def test_migration_empty_keyspace(manager: ScyllaClusterManager):
             await manager.api.create_vnode_tablet_migration(server.ip_addr, ks_empty)
 
 
+@pytest.mark.max_running_shards(2)
 async def test_migration_finalize_without_migration(manager: ScyllaClusterManager):
     """Verify that finalizing migration without starting one first fails."""
     server, cql = await setup_single_node(manager)
@@ -837,6 +845,7 @@ async def test_migration_finalize_without_migration(manager: ScyllaClusterManage
             await manager.api.finalize_vnode_tablet_migration(server.ip_addr, ks_vnodes)
 
 
+@pytest.mark.max_running_shards(2)
 async def test_migration_upgrade_without_migration(manager: ScyllaClusterManager):
     """Verify that upgrading a node to tablets without an active migration fails."""
     server, cql = await setup_single_node(manager)
@@ -845,6 +854,7 @@ async def test_migration_upgrade_without_migration(manager: ScyllaClusterManager
         await manager.api.upgrade_node_to_tablets(server.ip_addr)
 
 
+@pytest.mark.max_running_shards(2)
 async def test_migration_overlapping_migrations(manager: ScyllaClusterManager):
     """Verify that starting a second migration while one is already in progress fails."""
     server, cql = await setup_single_node(manager)
@@ -865,6 +875,7 @@ async def test_migration_overlapping_migrations(manager: ScyllaClusterManager):
         await manager.api.finalize_vnode_tablet_migration(server.ip_addr, ks1)
 
 
+@pytest.mark.max_running_shards(2)
 async def test_migration_finalize_before_upgrade(manager: ScyllaClusterManager):
     """Verify that finalizing migration before the node has finished upgrading fails."""
     server, cql = await setup_single_node(manager)
@@ -883,6 +894,7 @@ async def test_migration_finalize_before_upgrade(manager: ScyllaClusterManager):
         await manager.api.finalize_vnode_tablet_migration(server.ip_addr, ks)
 
 
+@pytest.mark.max_running_shards(2)
 async def test_migration_task_not_abortable(manager: ScyllaClusterManager):
     """Verify that aborting a vnodes-to-tablets migration task via the task manager fails."""
     server, cql = await setup_single_node(manager)
@@ -908,6 +920,7 @@ async def test_migration_task_not_abortable(manager: ScyllaClusterManager):
         await manager.api.finalize_vnode_tablet_migration(server.ip_addr, ks)
 
 
+@pytest.mark.max_running_shards(2)
 async def test_migration_wait_task(manager: ScyllaClusterManager):
     """Verify that the task manager "wait" API works for vnodes-to-tablets migration tasks.
 
@@ -982,6 +995,7 @@ async def test_migration_wait_task(manager: ScyllaClusterManager):
         assert wait_status.progress_completed == 1, f"Expected 1 upgraded node for completed migration, got {wait_status.progress_completed}"
 
 
+@pytest.mark.max_running_shards(3)
 async def test_migration_multiple_keyspaces(manager: ScyllaClusterManager):
     """Verify that two keyspaces can be migrated from vnodes to tablets simultaneously."""
     num_shards = 3
@@ -1052,6 +1066,7 @@ async def test_migration_multiple_keyspaces(manager: ScyllaClusterManager):
                     f"intended_storage_mode should be cleared for node {row.host_id} after all migrations are done, got '{row.intended_storage_mode}'"
 
 
+@pytest.mark.max_running_shards(3)
 @pytest.mark.asyncio
 async def test_migration_multiple_tables(manager: ScyllaClusterManager):
     """Verify vnodes-to-tablets migration on keyspace with multiple tables.
@@ -1106,6 +1121,7 @@ async def test_migration_multiple_tables(manager: ScyllaClusterManager):
         await wait_for_pow2_convergence(manager, server, ks, 't2')
 
 
+@pytest.mark.max_running_shards(3)
 @pytest.mark.asyncio
 async def test_tablet_status_in_migration_api(manager: ScyllaClusterManager):
     """"Verify the ?include=tablet_status query parameter in the migration API.
@@ -1218,6 +1234,7 @@ async def test_tablet_status_in_migration_api(manager: ScyllaClusterManager):
                 f"Tablet count {tablet_count} for table {t['table']} is not a power of two"
 
 
+@pytest.mark.max_running_shards(3)
 @pytest.mark.asyncio
 async def test_pow2_convergence_virtual_task(manager: ScyllaClusterManager):
     """Verify that pow2 convergence is tracked via a virtual task.
@@ -1362,6 +1379,7 @@ async def test_pow2_convergence_virtual_task(manager: ScyllaClusterManager):
             f"Expected no convergence tasks after completion, got {len(convergence_tasks)}"
 
 
+@pytest.mark.max_running_shards(4)
 async def test_migration_with_zero_token_node(manager: ScyllaClusterManager):
     """Verify vnodes-to-tablets migration succeeds in the presence of zero-token nodes (arbiter DCs).
 

--- a/test/cluster/test_write_query_during_cql_server_shutdown.py
+++ b/test/cluster/test_write_query_during_cql_server_shutdown.py
@@ -18,6 +18,7 @@ from cassandra.cluster import ConnectionException, NoHostAvailable  # type: igno
 
 logger = logging.getLogger(__name__)
 
+@pytest.mark.max_running_shards(6)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_write_query_during_cql_server_shutdown(request: pytest.FixtureRequest, manager: ScyllaClusterManager) -> None:
     """

--- a/test/cluster/test_writes_to_previous_cdc_generations.py
+++ b/test/cluster/test_writes_to_previous_cdc_generations.py
@@ -42,6 +42,7 @@ async def wait_for_publishing_generations(cql: Session, servers: list[ServerInfo
     return gen_timestamps
 
 
+@pytest.mark.max_running_shards(6)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_writes_to_recent_previous_cdc_generations(request, manager: ScyllaClusterManager):
     """
@@ -90,6 +91,7 @@ async def test_writes_to_recent_previous_cdc_generations(request, manager: Scyll
             await do_write(ts - 1)
 
 
+@pytest.mark.max_running_shards(4)
 @pytest.mark.skip_mode(mode='debug', reason='test requires nodes to be started quickly')
 async def test_writes_to_old_previous_cdc_generation(request, manager: ScyllaClusterManager):
     """

--- a/test/cluster/test_zero_token_nodes_multidc.py
+++ b/test/cluster/test_zero_token_nodes_multidc.py
@@ -15,6 +15,7 @@ from test.pylib.util import unique_name
 from test.cluster.util import create_new_test_keyspace
 
 
+@pytest.mark.max_running_shards(8)
 @pytest.mark.parametrize('zero_token_nodes', [1, 2])
 @pytest.mark.parametrize('rf_rack_valid_keyspaces', [False, True])
 async def test_zero_token_nodes_multidc_basic(manager: ScyllaClusterManager, zero_token_nodes: int, rf_rack_valid_keyspaces: bool):

--- a/test/cluster/test_zero_token_nodes_no_replication.py
+++ b/test/cluster/test_zero_token_nodes_no_replication.py
@@ -15,6 +15,7 @@ from test.pylib.util import unique_name
 from test.cluster.util import create_new_test_keyspace
 
 
+@pytest.mark.max_running_shards(6)
 async def test_zero_token_nodes_no_replication(manager: ScyllaClusterManager):
     """
     Test that zero-token nodes aren't replicas in all non-local replication strategies with and without tablets.

--- a/test/cluster/test_zero_token_nodes_topology_ops.py
+++ b/test/cluster/test_zero_token_nodes_topology_ops.py
@@ -15,6 +15,7 @@ from test.pylib.util import wait_for_cql_and_get_hosts
 from test.cluster.util import check_node_log_for_failed_mutations, start_writes
 
 
+@pytest.mark.max_running_shards(10)
 @pytest.mark.parametrize('tablets_enabled', [True, False])
 async def test_zero_token_nodes_topology_ops(manager: ScyllaClusterManager, tablets_enabled: bool):
     """

--- a/test/cql/conftest.py
+++ b/test/cql/conftest.py
@@ -77,3 +77,8 @@ async def output_path(suite_log_dir: Path, testpy_uname: str) -> Path:
     """A file to collect real output of test's CQL queries to compare with .result file."""
 
     return suite_log_dir / f"{testpy_uname}.reject"
+
+# The .cql tests run their statements through the `cql` fixture, so they need
+# the module's server: one cluster of cluster.initial_size (default 1) at
+# --smp 2, unchanged throughout.
+pytestmark = pytest.mark.max_running_shards(2)

--- a/test/cqlpy/conftest.py
+++ b/test/cqlpy/conftest.py
@@ -309,3 +309,8 @@ def _vector_store_mock_session(cql):
 def vector_store_mock(_vector_store_mock_session):
     _vector_store_mock_session.reset()
     yield _vector_store_mock_session
+
+# Every test here shares one cluster, created per module from
+# cluster.initial_size (which defaults to 1) at --smp 2, and no test changes
+# it -- so the claim is a constant of the suite, not something to measure.
+pytestmark = pytest.mark.max_running_shards(2)

--- a/test/cqlpy/strong_consistency/conftest.py
+++ b/test/cqlpy/strong_consistency/conftest.py
@@ -1,0 +1,10 @@
+#
+# Copyright (C) 2026-present ScyllaDB
+#
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
+#
+import pytest
+
+# As in the parent suite: one cluster per module of
+# cluster.initial_size (default 1) at --smp 2, unchanged throughout.
+pytestmark = pytest.mark.max_running_shards(2)

--- a/test/nodetool/conftest.py
+++ b/test/nodetool/conftest.py
@@ -228,3 +228,9 @@ def nodetool(request, jmx, nodetool_path, rest_api_mock_server):
             return res
 
     return invoker
+
+# These tests start no cluster: each invocation runs `scylla nodetool`,
+# and a scylla *tool* runs on one shard by design -- configure_tool_mode() in
+# tools/utils.cc sets smp to 1 -- against a Python REST-API mock.  Not free,
+# but one shard's worth, and a constant.
+pytestmark = pytest.mark.max_running_shards(1)

--- a/test/pylib/db/model.py
+++ b/test/pylib/db/model.py
@@ -62,3 +62,28 @@ class Test:
     mode: str
     run_id: int
     test_name: str
+
+
+@define
+class ClusterMetric:
+    """Per-test cluster capacity: what the test's cluster actually ran.
+
+    `nodeid` is here alongside the `tests` row it points at because it is the
+    key the backfill script needs -- it names the class and the parameters of
+    the source function to mark, which `tests.test_name` does not carry.
+    """
+    test_id: int
+    host_id: str
+    nodeid: str
+    max_running_shards: int
+    # How the test ended, the same value test_metrics gets.  Here as well
+    # because tests.id is shared by every run of a test with the same name,
+    # mode and run id, so a join on it cannot tell one run's rows from
+    # another's -- and only the run that finished measured the whole test.
+    status: str
+    # The claim in force while this was measured, or None if none was.  Without
+    # it a row is not interpretable: a claim caps the peak (see
+    # RunningShards.reserve), so `max_running_shards` from an enforced run is
+    # the smaller of what the test used and what it was allowed.  Only a row
+    # with no claim reports what the test would use unrestricted.
+    claim: int | None

--- a/test/pylib/db/writer.py
+++ b/test/pylib/db/writer.py
@@ -20,6 +20,7 @@ TESTS_TABLE = 'tests'
 METRICS_TABLE = 'test_metrics'
 SYSTEM_RESOURCE_METRICS_TABLE = 'system_resource_metrics'
 CGROUP_MEMORY_METRICS_TABLE = 'cgroup_memory_metrics'
+CLUSTER_METRICS_TABLE = 'cluster_metrics'
 HOST_INFO_TABLE = 'host_info'
 DEFAULT_DB_NAME = f'sqlite_{HOST_ID}.db'
 DATE_TIME_TEMPLATE = '%Y-%m-%d %H:%M:%S.%f'
@@ -95,8 +96,53 @@ create_table = [
         FOREIGN KEY(test_id) REFERENCES {TESTS_TABLE}(id),
         FOREIGN KEY(host_id) REFERENCES {HOST_INFO_TABLE}(host_id)
     );
+    ''',
+
+    f'''
+    CREATE TABLE IF NOT EXISTS {CLUSTER_METRICS_TABLE} (
+        id INTEGER PRIMARY KEY,
+        test_id INT NOT NULL,
+        host_id VARCHAR(5) NOT NULL,
+        nodeid TEXT NOT NULL,
+        max_running_shards INTEGER NOT NULL,
+        status VARCHAR(15),
+        claim INTEGER,
+        FOREIGN KEY(test_id) REFERENCES {TESTS_TABLE}(id),
+        FOREIGN KEY(host_id) REFERENCES {HOST_INFO_TABLE}(host_id)
+    );
     '''
 ]
+
+# Columns added to a table after it first shipped.  The database outlives a run
+# -- prepare_dirs() clears *.log from the tmpdir but not sqlite_*.db, and a host
+# with SCYLLA_TEST_HOST_ID set keeps the same filename -- so CREATE TABLE IF NOT
+# EXISTS silently leaves an older file a column short and every insert then
+# fails.  Applied idempotently at open, in order.
+add_column = [
+    (CLUSTER_METRICS_TABLE, 'claim', 'INTEGER'),
+    (CLUSTER_METRICS_TABLE, 'status', 'VARCHAR(15)'),
+]
+
+
+def add_missing_columns(cursor) -> None:
+    """Bring an existing database up to the schema above.
+
+    Runs after create_table, so every table it names exists.  The check cannot
+    be atomic: every xdist worker shares one database file and builds a writer
+    per test, so two can both find a column missing.  The one that loses that
+    race carries on, since another worker adding the column is the outcome it
+    wanted -- and the schema is read again to make sure that is what happened.
+    """
+    for table, column, decl in add_column:
+        cursor.execute(f"PRAGMA table_info({table})")
+        if column not in {row[1] for row in cursor.fetchall()}:
+            try:
+                cursor.execute(f"ALTER TABLE {table} ADD COLUMN {column} {decl}")
+            except sqlite3.OperationalError:
+                cursor.execute(f"PRAGMA table_info({table})")
+                if column not in {row[1] for row in cursor.fetchall()}:
+                    raise
+
 
 def adapt_datetime_iso(val):
     """Adapt datetime.datetime to timezone-naive ISO 8601 date."""
@@ -127,6 +173,7 @@ class SQLiteWriter:
             cursor.execute('PRAGMA synchronous=off')
             for table in create_table:
                 cursor.execute(table)
+            add_missing_columns(cursor)
             conn.commit()
 
     @contextmanager

--- a/test/pylib/marker_index.py
+++ b/test/pylib/marker_index.py
@@ -1,0 +1,96 @@
+#
+# Copyright (C) 2026-present ScyllaDB
+#
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
+#
+"""The selected tests and the markers they carry, from one collect-only pass.
+
+Only pytest knows what a test ends up carrying: markers come from decorators,
+`pytestmark` in a module or a conftest, parametrize and collection hooks.
+
+    from test.pylib.marker_index import build_index
+    tests = build_index(["--mode", "dev", "test/cluster"], tmpdir)
+
+The same module is the plugin doing the collecting, so it also works as
+`python -m pytest --collect-only -p test.pylib.marker_index --marker-index=out.json`
+(as a module, so that `-p` can import it before any conftest runs).
+The index is uninterpreted on purpose, so a scheduler can weigh tests by any
+marker without this module knowing about it.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from test import TOP_SRC_DIR
+from test.pylib.running_shards import MARKER as MAX_RUNNING_SHARDS, claimed_shards
+
+
+INDEX_OPTION = "--marker-index"
+
+# How the collect-only pass loads this module with -p.
+PLUGIN = "test.pylib.marker_index"
+
+
+def index_item(item: pytest.Item) -> dict:
+    """One test's entry: what it is, and what it declares."""
+    markers = {}
+    for marker in item.iter_markers():
+        # A name can repeat (parametrize, stacked skip_mode); iter_markers
+        # yields the closest first, which is the one that counts.
+        markers.setdefault(marker.name, {"args": marker.args, "kwargs": marker.kwargs})
+
+    return {
+        "nodeid": item.nodeid,
+        "markers": markers,
+        # Lifted out of `markers` for the one consumer that exists today; the
+        # marker itself stays in `markers` for everyone else.
+        MAX_RUNNING_SHARDS: claimed_shards(item),
+    }
+
+
+def pytest_addoption(parser: pytest.Parser) -> None:
+    parser.addoption(INDEX_OPTION, action="store", default=None, metavar="PATH",
+                     help="Write the selected tests and their markers to PATH as JSON "
+                          "(see test/pylib/marker_index.py)")
+
+
+def pytest_collection_finish(session: pytest.Session) -> None:
+    if out := session.config.getoption(INDEX_OPTION, default=None):
+        index = {"tests": [index_item(item) for item in session.items]}
+        # default=repr: a marker may carry anything, and an index that fails on
+        # one such argument is useless.
+        Path(out).write_text(json.dumps(index, indent=1, sort_keys=True, default=repr) + "\n")
+
+
+def build_index(pytest_args, tmpdir: Path) -> list[dict]:
+    """Collect in a subprocess and return the index.
+
+    A subprocess, not pytest.main(): the caller can be a running pytest
+    session, and a nested session in the same interpreter would share plugin
+    and fixture state with the outer one.
+    """
+    out = tmpdir / "marker_index.json"
+    argv = [sys.executable, "-m", "pytest", "--collect-only", "-q",
+            "-p", PLUGIN, f"{INDEX_OPTION}={out}", f"--tmpdir={tmpdir}", *pytest_args]
+    # PYTEST_XDIST*: without dropping it the runner plugin would take the
+    # nested collection for a worker of the outer run and skip creating its log
+    # directory, as test_no_bare_skips.py found.  PYTEST_ADDOPTS: a -k or
+    # --ignore in the caller's environment would narrow this collection, and
+    # what is decided from a narrowed one is wrong.
+    env = {name: value for name, value in os.environ.items()
+           if not name.startswith(("PYTEST_XDIST", "PYTEST_ADDOPTS"))}
+    done = subprocess.run(argv, capture_output=True, text=True, cwd=TOP_SRC_DIR, env=env)
+    # A collection that fails part-way still reaches pytest_collection_finish,
+    # so the index can exist and be quietly short.  Anything decided from a
+    # short index is wrong, so a bad exit means no index at all.
+    if done.returncode != 0 or not out.exists():
+        raise RuntimeError(f"collection failed (exit {done.returncode}).\n"
+                           f"$ {' '.join(argv)}\n{done.stdout}\n{done.stderr}")
+    return json.loads(out.read_text())["tests"]

--- a/test/pylib/resource_gather.py
+++ b/test/pylib/resource_gather.py
@@ -26,9 +26,10 @@ import psutil
 
 from threading import Event
 from test import HOST_ID, TOP_SRC_DIR
-from test.pylib.db.model import HostInfo, Metric, SystemResourceMetric, CgroupMetric, Test
+from test.pylib.db.model import ClusterMetric, HostInfo, Metric, SystemResourceMetric, CgroupMetric, Test
 from test.pylib.db.writer import (
     CGROUP_MEMORY_METRICS_TABLE,
+    CLUSTER_METRICS_TABLE,
     DEFAULT_DB_NAME,
     HOST_INFO_TABLE,
     METRICS_TABLE,
@@ -82,6 +83,10 @@ class ResourceGather(ABC):
     def write_metrics_to_db(self, metrics: Metric, success: bool = False) -> None:
         pass
 
+    def write_cluster_metrics(self, nodeid: str, max_running_shards: int, claim: int | None,
+                              status: str) -> None:
+        pass
+
     def teardown_test_tracking(self) -> None:
         pass
 
@@ -130,6 +135,26 @@ class ResourceGatherRecord(ResourceGather):
     def write_metrics_to_db(self, metrics: Metric, success: bool = False) -> None:
         metrics.success = success
         self.sqlite_writer.write_row(metrics, METRICS_TABLE)
+
+    def write_cluster_metrics(self, nodeid: str, max_running_shards: int, claim: int | None,
+                              status: str) -> None:
+        """Record the peak shard count the test's cluster ran.
+
+        Written for every test that leased a cluster, claim or not: this is what
+        the marker backfill reads.  `claim` is what was in force, and bounds the
+        peak -- so only a row without one reports unrestricted usage.  `status`
+        says whether the test got far enough for the peak to be its own.
+        """
+        self.sqlite_writer.write_row(
+            ClusterMetric(
+                test_id=self.test_id,
+                host_id=HOST_ID,
+                nodeid=nodeid,
+                max_running_shards=max_running_shards,
+                status=status,
+                claim=claim,
+            ),
+            CLUSTER_METRICS_TABLE)
 
     def teardown_test_tracking(self) -> None:
         self.sqlite_writer.close()

--- a/test/pylib/runner.py
+++ b/test/pylib/runner.py
@@ -68,6 +68,10 @@ REPEATING_FILES = pytest.StashKey[set[pathlib.Path]]()
 BUILD_MODE = pytest.StashKey[str]()
 RUN_ID = pytest.StashKey[int]()
 PYTEST_LOG_FILE = pytest.StashKey[str]()
+# Peak shards the test's cluster ran, and the claim in force while it did,
+# published by the manager fixture for pytest_runtest_protocol to record.
+MAX_RUNNING_SHARDS = pytest.StashKey[int]()
+MAX_RUNNING_SHARDS_CLAIM = pytest.StashKey[int | None]()
 
 EXIT_MAXFAIL_REACHED = 11
 
@@ -283,6 +287,16 @@ def pytest_runtest_protocol(item, nextitem):
                     metrics=test_metrics,
                     success=success
                 )
+                peak = item.stash.get(MAX_RUNNING_SHARDS, None)
+                if peak is not None:
+                    # nodeid without the ".mode.run_id" suffix modify_pytest_item()
+                    # appended, so --repeat copies and modes share one key.
+                    resource_gather.write_cluster_metrics(
+                        nodeid=item.nodeid.removesuffix(f".{test_mock.mode}.{test_mock.id}"),
+                        max_running_shards=peak,
+                        claim=item.stash.get(MAX_RUNNING_SHARDS_CLAIM, None),
+                        status=status,
+                    )
             finally:
                 resource_gather.teardown_test_tracking()
 

--- a/test/pylib/runner.py
+++ b/test/pylib/runner.py
@@ -12,6 +12,7 @@ import os
 import pathlib
 import platform
 import random
+import shlex
 import shutil
 import sys
 import time
@@ -44,7 +45,8 @@ from test.pylib.host_registry import HostRegistry
 from test.pylib.s3_proxy import S3ProxyServer
 from test.pylib.s3_server_mock import MockS3Server
 from test.pylib.scylla_cluster import ScyllaCluster
-from test.pylib.scylla_server import merge_cmdline_options
+from test.pylib.running_shards import claimed_shards
+from test.pylib.scylla_server import merge_cmdline_options, specifies_shards
 from test.pylib.skip_reason_plugin import skip_marker
 from test.pylib.util import get_modes_to_run, scale_timeout_by_mode, get_xdist_worker_id, LogPrefixAdapter
 from test.pylib.version_fetch_utils import fetch_and_install_scylla_version
@@ -85,6 +87,10 @@ def pytest_addoption(parser: pytest.Parser) -> None:
                      help="Specific byte limit for failure injection (random by default)")
     parser.addoption("--gather-metrics", action=BooleanOptionalAction, default=False,
                      help='Switch on gathering cgroup metrics')
+    parser.addoption("--measure-running-shards", action='store_true', default=False,
+                     help="Ignore every max_running_shards claim and record the peak each test "
+                          "reaches unrestricted. Only for re-measuring a test that already has a "
+                          "claim: an unclaimed test is unrestricted anyway")
     parser.addoption('--random-seed', action="store",
                      help="Random number generator seed to be used by boost tests")
 
@@ -323,6 +329,27 @@ def scale_timeout(build_mode: str) -> Callable[[int | float], int | float]:
     return scale_timeout_inner
 
 
+@cache
+def _ignore_claims(config: pytest.Config) -> bool:
+    """Whether this run's max_running_shards claims do not apply to it.
+
+    True in measurement mode.  Also true when the run resizes the servers
+    itself: that override beats every other source (see
+    ScyllaCluster.add_server), so the servers are not the size the claims
+    describe, and every test would fail for an unrelated reason.  Cached, so
+    the warning is logged once per run.
+    """
+    if config.getoption("--measure-running-shards"):
+        return True
+    extra = shlex.split(config.getoption("--extra-scylla-cmdline-options", default="") or "")
+    if specifies_shards(extra):
+        logger.warning(
+            "not enforcing max_running_shards: --extra-scylla-cmdline-options %s changes the "
+            "servers' shard count, so the claims no longer describe this run", extra)
+        return True
+    return False
+
+
 @pytest.fixture(scope="module")
 def testpy_cluster_factory(request: pytest.FixtureRequest,
                            build_mode: str,
@@ -357,6 +384,10 @@ def testpy_cluster_factory(request: pytest.FixtureRequest,
             scylla_exe=scylla_binary,
             save_log_on_success=options.save_log_on_success,
         )
+        # Set the claim before anything can start a server.  A test with no
+        # marker is not restricted, so a new test can run before it is
+        # measured.
+        cluster.shard_usage.claim = None if _ignore_claims(request.config) else claimed_shards(node)
         testpy_logger.info("Created Scylla cluster %s for test %s", cluster, test_name)
         try:
             yield cluster
@@ -783,6 +814,7 @@ def modify_pytest_item(item: pytest.Item, run_ids: defaultdict[tuple[str, str], 
 
     item._nodeid = f"{item._nodeid}{suffix}"
     item.name = f"{item.name}{suffix}"
+    claimed_shards(item)  # a malformed claim fails collection, not one test
     skip_marks = [
         mark for mark in item.iter_markers("skip_mode")
         if mark.name == "skip_mode"

--- a/test/pylib/runner.py
+++ b/test/pylib/runner.py
@@ -72,6 +72,7 @@ PYTEST_LOG_FILE = pytest.StashKey[str]()
 # published by the manager fixture for pytest_runtest_protocol to record.
 MAX_RUNNING_SHARDS = pytest.StashKey[int]()
 MAX_RUNNING_SHARDS_CLAIM = pytest.StashKey[int | None]()
+CONFTEST_MARKERS_APPLIED = pytest.StashKey[bool]()
 
 EXIT_MAXFAIL_REACHED = 11
 
@@ -441,6 +442,7 @@ async def scylla_cluster(request: pytest.FixtureRequest,
 def pytest_collection_modifyitems(items: list[pytest.Item], config: pytest.Config) -> None:
     run_ids = defaultdict(lambda: count(start=int(config.getoption("--run_id") or 1)))
     for item in items:
+        apply_conftest_markers(item)
         modify_pytest_item(item=item, run_ids=run_ids)
 
     suites_order = defaultdict(count().__next__)  # number suites in order of appearance
@@ -814,6 +816,27 @@ def get_params_stash(node: _pytest.nodes.Node) -> pytest.Stash | None:
     if parent is None:
         return None
     return parent.stash
+
+
+def apply_conftest_markers(item: pytest.Item) -> None:
+    """Apply the `pytestmark` of every conftest that covers this item.
+
+    pytest honours it in a test module but not in a conftest, so a suite has no
+    other way to say "this goes for every test here".  On the file node, and
+    nearest conftest first, so the usual precedence holds: test beats module
+    beats closest conftest beats outer one.  Once per file.
+
+    _getconftestmodules() is pytest-internal and the only way to ask which
+    conftests cover a path, so it stays here.
+    """
+    node = item.getparent(pytest.File)
+    if node is None or node.stash.get(CONFTEST_MARKERS_APPLIED, False):
+        return
+    node.stash[CONFTEST_MARKERS_APPLIED] = True
+    for conftest in reversed(item.config.pluginmanager._getconftestmodules(item.path)):
+        marks = getattr(conftest, "pytestmark", [])
+        for mark in marks if isinstance(marks, (list, tuple)) else [marks]:
+            node.add_marker(mark)
 
 
 def modify_pytest_item(item: pytest.Item, run_ids: defaultdict[tuple[str, str], count]) -> None:

--- a/test/pylib/runner.py
+++ b/test/pylib/runner.py
@@ -45,8 +45,8 @@ from test.pylib.host_registry import HostRegistry
 from test.pylib.s3_proxy import S3ProxyServer
 from test.pylib.s3_server_mock import MockS3Server
 from test.pylib.scylla_cluster import ScyllaCluster
-from test.pylib.running_shards import claimed_shards
-from test.pylib.scylla_server import merge_cmdline_options, specifies_shards
+from test.pylib.running_shards import MARKER as MAX_RUNNING_SHARDS_MARKER, claimed_shards
+from test.pylib.scylla_server import merge_cmdline_options, shards_of, specifies_shards
 from test.pylib.skip_reason_plugin import skip_marker
 from test.pylib.util import get_modes_to_run, scale_timeout_by_mode, get_xdist_worker_id, LogPrefixAdapter
 from test.pylib.version_fetch_utils import fetch_and_install_scylla_version
@@ -198,7 +198,7 @@ def _build_test_mock(item: pytest.Item) -> SimpleNamespace:
     Works for both Python test items and C++ CppTestCase items, providing a
     unified interface for the resource-gather subsystem.
     """
-    from test.pylib.cpp.base import CppTestCase
+    from test.pylib.cpp.base import CppTestCase   # imported here: cpp.base imports this module
 
     params_stash = get_params_stash(node=item)
     build_mode = params_stash[BUILD_MODE] if params_stash else item.config.build_modes[0]
@@ -840,6 +840,8 @@ def apply_conftest_markers(item: pytest.Item) -> None:
 
 
 def modify_pytest_item(item: pytest.Item, run_ids: defaultdict[tuple[str, str], count]) -> None:
+    from test.pylib.cpp.base import CppTestCase
+
     params_stash = get_params_stash(node=item)
 
     if RUN_ID not in params_stash:
@@ -851,6 +853,14 @@ def modify_pytest_item(item: pytest.Item, run_ids: defaultdict[tuple[str, str], 
 
     item._nodeid = f"{item._nodeid}{suffix}"
     item.name = f"{item.name}{suffix}"
+    # A C++ case starts no cluster, but it is not free. It runs one Seastar
+    # process, and its shard count is the -c we pass. So the claim is that
+    # number, and nothing has to declare it.
+    if isinstance(item, CppTestCase) and item.get_closest_marker(MAX_RUNNING_SHARDS_MARKER) is None:
+        # The same option lists run_exe() passes, in the same order, so a
+        # per-case override from `custom_args` wins here as it does at run time.
+        shards = shards_of([*item.parent.test_args, *item.test_custom_args])
+        item.add_marker(getattr(pytest.mark, MAX_RUNNING_SHARDS_MARKER)(shards))
     claimed_shards(item)  # a malformed claim fails collection, not one test
     skip_marks = [
         mark for mark in item.iter_markers("skip_mode")

--- a/test/pylib/running_shards.py
+++ b/test/pylib/running_shards.py
@@ -1,0 +1,70 @@
+#
+# Copyright (C) 2026-present ScyllaDB
+#
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
+#
+"""The peak cluster capacity a test uses, counted in shards.
+
+``@pytest.mark.max_running_shards(n)`` limits how many Scylla shards a test
+runs at the same time.  It is enforced: the cluster refuses the server that
+would break the claim, before that server exists.
+
+Shards, not servers: one server with ``--smp 8`` costs much more than one with
+``--smp 1``.  A test without the marker is not restricted, so a new test can
+run before anyone measures it.  What a claim means for scheduling is up to the
+scheduler that reads it.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+MARKER = "max_running_shards"
+
+
+class RunningShardsExceeded(Exception):
+    """A test tried to run more shards at once than it claimed."""
+
+
+def claimed_shards(item: pytest.Item) -> int | None:
+    """The test's claim, or None if it has no marker.
+
+    Raises if the marker is not one positive whole number, so a typo fails the
+    run instead of quietly meaning nothing.
+    """
+    marker = item.get_closest_marker(MARKER)
+    if marker is None:
+        return None
+    amount = marker.args[0] if marker.args else marker.kwargs.get("amount")
+    if len(marker.args) + len(marker.kwargs) != 1 or type(amount) is not int or amount < 1:
+        raise ValueError(f"{item.nodeid}: bad {MARKER} marker, "
+                         f"write it as @pytest.mark.{MARKER}(6)")
+    return amount
+
+
+class RunningShards:
+    """A cluster's claim, and the peak it actually ran.
+
+    A cluster belongs to one test, so the claim is set when the cluster is
+    created and never changed again.
+    """
+
+    def __init__(self) -> None:
+        self.claim: int | None = None
+        self.high_water_mark = 0
+
+    def reserve(self, running: int, adding: int, what: str) -> None:
+        """Account for `adding` shards about to start on top of `running`.
+
+        Raises before any of them starts.  So a refused reservation leaves
+        nothing to undo, and never puts the shards on the machine at all.  That
+        is what stops a broken claim from taking the whole run down.
+        """
+        total = running + adding
+        if self.claim is not None and total > self.claim:
+            raise RunningShardsExceeded(
+                f"{what} would run {total} shards at once ({running} + {adding}), over this "
+                f"test's claim of {MARKER}={self.claim}. Keep the test within its claim, or "
+                f"raise the claim to @pytest.mark.{MARKER}({total})")
+        self.high_water_mark = max(self.high_water_mark, total)

--- a/test/pylib/scylla_cluster.py
+++ b/test/pylib/scylla_cluster.py
@@ -21,6 +21,7 @@ import psutil
 from test.pylib.host_registry import Host, HostRegistry
 from test.pylib.internal_types import ServerNum, IPAddress, HostID, ServerInfo, ServerUpState
 from test.pylib.rest_client import ScyllaRESTAPIClient
+from test.pylib.running_shards import RunningShards
 from test.pylib.scylla_server import (
     SCYLLA_CMDLINE_OPTIONS,
     ScyllaServer,
@@ -28,6 +29,7 @@ from test.pylib.scylla_server import (
     get_current_version_description,
     make_scylla_conf,
     merge_cmdline_options,
+    shards_of,
 )
 from test.pylib.util import gather_safely, graceful_stop_timeout
 
@@ -85,6 +87,10 @@ class ScyllaCluster:
         self.servers = ChainMap(self.running, self.stopped)
         self.removed: Set[ServerNum] = set()                    # removed servers (might be running)
         self.starting: Dict[ServerNum, ScyllaServer] = {}       # servers starting right now, not yet running (and not included in "servers").
+        # This cluster's shard claim and peak.  No claim until whoever builds
+        # the cluster sets one (see the cluster factory); until then it only
+        # counts and limits nothing.
+        self.shard_usage = RunningShards()
         # The first IP assigned to a server added to the cluster.
         self.initial_seed: Optional[IPAddress] = None
         # cluster is started (but it might not have running servers);
@@ -225,6 +231,12 @@ class ScyllaCluster:
                 self.cmdline_options_override,
             ])
 
+            if start:
+                # Only a server that will run takes shards.  With start=False it
+                # is just installed and left in self.stopped.  server_start()
+                # reserves for it if the test starts it later.
+                self._reserve_shards(shards_of(cmdline_options), "adding a server")
+
             # Sum of the basic server configuration and the user-provided
             # config options, with increasing priority (if two sources provide
             # the same option, the higher priority one wins):
@@ -356,6 +368,26 @@ class ScyllaCluster:
         return [server.server_info() for server in self.running.values()
                 if server.server_id not in self.removed]
 
+    @property
+    def running_shards(self) -> int:
+        """Shards the cluster is running right now.
+
+        Servers that are starting count too.  They already use the machine, and
+        a parallel servers_add() has to see the shards its siblings are taking.
+        A server marked removed also counts, because marking it does not stop
+        the process.
+        """
+        return sum(server.shards for server in (*self.running.values(), *self.starting.values()))
+
+    def _reserve_shards(self, shards: int, what: str) -> None:
+        """Account for `shards` about to start, and refuse to break the claim.
+
+        Call it before holding anything, so raising leaves no server started,
+        and with no await before the registration it guards, or a parallel add
+        would reserve against a stale count.
+        """
+        self.shard_usage.reserve(running=self.running_shards, adding=shards, what=what)
+
     def all_servers(self) -> list[ServerInfo]:
         """Get a list of tuples of server id and IP address of all servers"""
         return [server.server_info() for server in self.servers.values()]
@@ -411,7 +443,14 @@ class ScyllaCluster:
         if server_id in self.running:
             return
         assert server_id in self.stopped, f"Server {server_id} unknown"
-        server = self.stopped.pop(server_id)
+        server = self.stopped[server_id]
+        # cmdline_options_override replaces the server's whole command line
+        # (see ScyllaServer.start), so it also decides how many shards it runs.
+        # Recorded before reserving, so that every later reservation counts this
+        # server as the size the override made it, not as it was installed.
+        server.running_cmdline_options = cmdline_options_override
+        self._reserve_shards(server.shards, f"starting server {server_id}")
+        del self.stopped[server_id]
         self.logger.info("Cluster %s starting server %s ip %s", self,
                          server_id, server.ip_addr)
         if not seeds:

--- a/test/pylib/scylla_cluster_manager.py
+++ b/test/pylib/scylla_cluster_manager.py
@@ -387,6 +387,8 @@ class ScyllaClusterManager:
             "cluster_str": str(self.cluster),
             "tasks_leaked": bool(tasks_leaked),
             "message": tasks_leaked,
+            "max_running_shards": self.cluster.shard_usage.high_water_mark,
+            "claim": self.cluster.shard_usage.claim,
         }
 
     @manager_op

--- a/test/pylib/scylla_server.py
+++ b/test/pylib/scylla_server.py
@@ -224,6 +224,45 @@ async def get_scylla_2026_1_description(build_mode: str) -> ScyllaVersionDescrip
         argv=[],
     )
 
+
+# Seastar spells the shard count both `--smp` and `-c`.
+SMP_OPTIONS = ('--smp', '-c')
+
+
+def specifies_shards(cmdline_options: List[str]) -> bool:
+    """Whether these options set a shard count at all, in any spelling."""
+    return any(name.partition('=')[0] in SMP_OPTIONS
+               or (name.startswith('-c') and name[2:].isdigit())
+               for name in cmdline_options)
+
+
+def shards_of(cmdline_options: List[str]) -> int:
+    """Number of shards a process started with these options runs.
+
+    Its effective `--smp`, or `-c`, which Seastar takes as the same option:
+    servers get the long spelling, C++ test cases the short one.  Last spelling
+    wins.  Without one Seastar takes a shard per core, which this reports --
+    loudly, since no test means to ask for that.
+    """
+    smp: Optional[str] = None
+    rest = list(cmdline_options)
+    while rest:
+        name, sep, attached = rest.pop(0).partition('=')
+        if name in SMP_OPTIONS:
+            if sep:
+                smp = attached                       # --smp=2
+            elif rest and not rest[0].startswith('-'):
+                smp = rest.pop(0)                    # --smp 2 / -c 2
+        elif name.startswith('-c') and name[2:].isdigit():
+            smp = name[2:]                           # -c2, value attached
+    if smp is None:
+        cores = os.cpu_count() or 1
+        logging.getLogger(__name__).warning(
+            "no --smp/-c in %s, counting %d shards -- a core each, as Seastar would",
+            cmdline_options, cores)
+        return cores
+    return int(smp)
+
 # [--smp, 1], [--smp, 2] -> [--smp, 2]
 # [--smp, 1], [--smp] -> [--smp]
 # [--smp, 1], [--smp, __missing__] -> [--smp]
@@ -359,6 +398,9 @@ class ScyllaServer:
         # `cmdline` it was given, i.e. everything in `cmdline_options` above except
         # SCYLLA_CMDLINE_OPTIONS, the version's argv, and the cluster-level options.
         self._per_server_cmdline_options: List[str] = []
+        # What a per-start cmdline_options_override replaced them with, if any:
+        # that is the command line the process runs (see start() and shards).
+        self.running_cmdline_options: Optional[List[str]] = None
         self.auth_provider: Optional[AuthProvider] = None
         self.cmd: Optional[Process] = None
         self.start_stop_lock = asyncio.Lock()
@@ -445,7 +487,18 @@ class ScyllaServer:
         if self.property_file and "rack" in self.property_file:
             return self.property_file["rack"]
         return "DEFAULT_RACK"
-    
+
+    @property
+    def shards(self) -> int:
+        """Number of shards this server runs.
+
+        From the command line the process runs, which is the override when a
+        start was given one.  Recomputed rather than remembered, because
+        update_cmdline() can change --smp while the server is stopped.
+        """
+        return shards_of(self.cmdline_options if self.running_cmdline_options is None
+                         else self.running_cmdline_options)
+
     def server_info(self) -> ServerInfo:
         pid = self.cmd.pid if self.cmd else None
         return ServerInfo(self.server_id, self.ip_addr, self.rpc_address, self.datacenter, self.rack, pid)

--- a/test/pylib/update_max_running_shards_markers.py
+++ b/test/pylib/update_max_running_shards_markers.py
@@ -1,0 +1,300 @@
+#! /usr/bin/env python3
+
+#
+# Copyright (C) 2026-present ScyllaDB
+#
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
+#
+
+"""Backfill `max_running_shards` markers from measured runs.
+
+Run the test, then let what it actually did write the marker:
+
+    ./test.py --mode dev test/cluster/my_new_test.py
+    ./test/pylib/update_max_running_shards_markers.py testlog/sqlite_*.db
+
+No flag needed: an unmarked test has no claim, so nothing caps what is
+recorded.  Re-measuring one that already has a claim needs
+`pytest --measure-running-shards` -- see measured_shards().
+
+Idempotent: it writes a missing marker, raises one that is too low, and leaves
+the rest alone, a claim being an upper bound.
+"""
+
+import argparse
+import ast
+import sqlite3
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+# Run directly, sys.path[0] is this directory, so `test` is not importable yet.
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from test import TEST_DIR
+from test.pylib.db.writer import CLUSTER_METRICS_TABLE
+from test.pylib.running_shards import MARKER
+
+
+def parse_nodeid(nodeid):
+    """(file, class or None, function) for a nodeid, parameters stripped.
+
+    One function carries one marker, so parametrized cases fold together.
+    Raises ValueError for a nodeid this cannot place in the source, e.g. one
+    naming a nested class.
+    """
+    file_name, *rest = nodeid.split("::")
+    if not rest:
+        raise ValueError("no test in the nodeid")
+    *class_name, func_name = rest
+    if len(class_name) > 1:
+        raise ValueError("nested classes are not supported")
+    func_name = func_name.split("[", maxsplit=1)[0]  # drop the parameters
+    return Path(file_name), (class_name[0] if class_name else None), func_name
+
+
+def measured_shards(db_paths, headroom):
+    """Peak shards measured for each test that passed, with no claim in force.
+
+    Returns file -> class (or None) -> function -> shards.  Takes the maximum
+    over every row that maps to one marker: modes, hosts, --repeat copies and
+    parameters.
+
+    Only runs that passed outright, with no claim, count.  A test that failed,
+    was skipped part-way or xfailed stopped before its peak, and a run with a
+    claim cannot exceed it, so all of them report too little.  Writing such a
+    value as a claim makes the test fail on its own claim later.  That is why
+    raising a claim needs --measure-running-shards.
+
+    Both facts are read off the row itself: tests.id is shared by every run of
+    the same test, so a join through it would let one run's outcome vouch for
+    another run's peak.
+    """
+    per_test = {}
+
+    for db_path in db_paths:
+        if not db_path.exists():
+            raise FileNotFoundError(f"Database file not found at: {db_path}")
+        conn = sqlite3.connect(db_path)
+        try:
+            rows = conn.execute(
+                f"SELECT nodeid, MAX(max_running_shards) FROM {CLUSTER_METRICS_TABLE} "
+                f"WHERE status IN ('passed', 'xpassed') AND claim IS NULL GROUP BY nodeid"
+            ).fetchall()
+        finally:
+            conn.close()
+
+        for nodeid, shards in rows:
+            try:
+                key = parse_nodeid(nodeid)
+            except ValueError as err:
+                print(f"Skipping {nodeid}: {err}")
+                continue
+            per_test[key] = max(per_test.get(key, 0), shards)
+
+    by_file = defaultdict(lambda: defaultdict(dict))
+    for (file_name, class_name, func_name), shards in per_test.items():
+        if not shards:
+            # It leased a cluster but started no server, so it has nothing to
+            # claim.  A marker of 0 would also break the first time it did
+            # start one.
+            continue
+        by_file[file_name][class_name][func_name] = shards + headroom
+    return by_file
+
+
+def find_marker(func_node: ast.FunctionDef | ast.AsyncFunctionDef) -> ast.Call | None:
+    """The max_running_shards decorator on `func_node`, if any.
+
+    Any spelling of it, `@pt.mark.max_running_shards(2)` included.  Only
+    written_as_pytest_mark() can be rewritten, but one this did not see at all
+    would get a second marker added above it -- and the one below, being
+    closer to the test, is the one that counts.
+    """
+    for decorator in func_node.decorator_list:
+        match decorator:
+            case ast.Call(func=ast.Attribute(attr=str(attr))) if attr == MARKER:
+                return decorator
+    return None
+
+
+def written_as_pytest_mark(marker: ast.Call) -> bool:
+    """Whether the marker is spelled `pytest.mark.<MARKER>`, the only spelling this writes."""
+    match marker.func:
+        case ast.Attribute(value=ast.Attribute(value=ast.Name(id="pytest"), attr="mark")):
+            return True
+    return False
+
+
+def claim_of(marker: ast.Call) -> int | None:
+    """The shard count an existing marker claims, or None if it is not a plain literal.
+
+    A computed or non-integer claim is left for a human: this script must not
+    guess at what it meant.
+    """
+    args = list(marker.args) + [kw.value for kw in marker.keywords if kw.arg == "amount"]
+    match args:
+        case [ast.Constant(value=int(claim))] if not isinstance(claim, bool):
+            return claim
+    return None
+
+
+class MarkerEditor(ast.NodeVisitor):
+    """Collects the line edits that bring one file's markers up to date."""
+
+    def __init__(self, tests: dict[str | None, dict[str, int]], file_path: Path) -> None:
+        self.tests = tests
+        self.file_path = file_path
+        # Line inserts and whole-line replacements, both 0-based, applied in
+        # reverse so earlier edits do not shift later ones.
+        self.inserts: list[tuple[int, str]] = []
+        self.replacements: list[tuple[int, int, str]] = []
+        self._class_name: str | None = None
+        # Only a module-level function, or a method of one class, is a test that
+        # a nodeid can name.  Anything deeper is a helper defined inside one.
+        self._depth = 0
+
+    def visit_ClassDef(self, node: ast.ClassDef) -> None:
+        outer, self._class_name = self._class_name, node.name
+        self.generic_visit(node)
+        self._class_name = outer
+
+    def visit_FunctionDef(self, node: ast.FunctionDef | ast.AsyncFunctionDef) -> None:
+        shards = self.tests.get(self._class_name, {}).get(node.name)
+        if shards is not None and not self._depth:
+            self._update(node, shards)
+        self._depth += 1
+        self.generic_visit(node)
+        self._depth -= 1
+
+    visit_AsyncFunctionDef = visit_FunctionDef
+
+    def _update(self, node: ast.FunctionDef | ast.AsyncFunctionDef, shards: int) -> None:
+        where = f"{self.file_path.name}::{node.name}"
+        marker = find_marker(node)
+        if marker is None:
+            indent = " " * node.col_offset
+            # Above the whole decorator stack, so the claim is the first thing
+            # read about the test.  AST lines are 1-based, list indices are not.
+            first = min([node.lineno] + [d.lineno for d in node.decorator_list]) - 1
+            self.inserts.append((first, f"{indent}@pytest.mark.{MARKER}({shards})"))
+            return
+
+        claim = claim_of(marker)
+        if claim is None or not written_as_pytest_mark(marker):
+            print(f"Skipping {where}: cannot read or rewrite its {MARKER} marker, measured {shards}")
+        elif claim < shards:
+            indent = " " * (marker.col_offset - 1)  # the '@' sits one column left
+            self.replacements.append(
+                (marker.lineno - 1, marker.end_lineno - 1,
+                 f"{indent}@pytest.mark.{MARKER}({shards})"))
+            print(f"Raising {where}: {MARKER} {claim} -> {shards}")
+
+
+def module_binds_pytest(tree: ast.Module, above: int) -> bool:
+    """Whether `import pytest` runs at module level before line `above`.
+
+    Where a decorator reads the name: an import inside a helper, under another
+    name, or below the marker leaves it unbound at collection time.
+    """
+    return any(node.lineno <= above and isinstance(node, ast.Import)
+               and any(a.name == "pytest" and a.asname in (None, "pytest") for a in node.names)
+               for node in tree.body)
+
+
+def module_body_start(tree: ast.Module) -> int:
+    """The line a module's own code starts on, past its docstring."""
+    return tree.body[0].end_lineno if ast.get_docstring(tree) else tree.body[0].lineno - 1
+
+
+def update_file(file_path: Path, tests: dict[str | None, dict[str, int]]) -> bool:
+    """Bring one file's markers up to date. Returns whether it was changed."""
+    if not file_path.exists():
+        print(f"Warning: test file not found, skipping: {file_path}")
+        return False
+
+    source = file_path.read_text()
+    try:
+        tree = ast.parse(source)
+    except SyntaxError as err:
+        print(f"Error parsing {file_path}: {err}")
+        return False
+
+    editor = MarkerEditor(tests, file_path)
+    editor.visit(tree)
+    if not editor.inserts and not editor.replacements:
+        return False
+
+    # split("\n") round-trips exactly: splitlines() also breaks on form feeds
+    # and U+2028, and re-joining would rewrite those lines.  A file ending in a
+    # newline yields a final "" here, so the join restores it as it was.
+    lines = source.split("\n")
+    # One pass, bottom-up, treating an insert as a replacement of zero lines.
+    # Every position comes from the original AST.  Replacing a marker written
+    # over several lines with one line changes the line count, so it must not
+    # run before the edits below it are applied.
+    edits = [(start, end + 1, marker) for start, end, marker in editor.replacements]
+    edits += [(line, line, marker) for line, marker in editor.inserts]
+    for start, end, marker in sorted(edits, reverse=True):
+        lines[start:end] = [marker]
+
+    first_marker = min((line for line, _ in editor.inserts), default=0)
+    if editor.inserts and not module_binds_pytest(tree, above=first_marker):
+        # A marker we write needs the name.  After the last import above it, so
+        # it lands below the licence header and the docstring; with no such
+        # import, at the top of the module body, which is above the marker
+        # whether the test is a function or a method of a class.
+        above = [node.end_lineno for node in tree.body
+                 if isinstance(node, (ast.Import, ast.ImportFrom)) and node.end_lineno <= first_marker]
+        if above:
+            lines.insert(max(above), "import pytest")
+        else:
+            at = module_body_start(tree)
+            lines[at:at] = ["import pytest", ""]
+        print(f"Adding 'import pytest' to {file_path}")
+
+    print(f"Updating {file_path}: {len(editor.inserts)} new, {len(editor.replacements)} raised")
+    file_path.write_text("\n".join(lines))
+    return True
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=f"Write {MARKER} markers into the test sources from measured runs.",
+        epilog="Produce the measurements with ./test.py --measure-running-shards.",
+    )
+    parser.add_argument("db_path", nargs="+", type=Path,
+                        help="SQLite .db file(s) written by a measurement run, e.g. testlog/sqlite_*.db")
+    parser.add_argument("--path", type=Path,
+                        help="only update files under PATH")
+    parser.add_argument("--headroom-shards", type=int, default=0, metavar="N",
+                        help="claim N shards more than measured. A claim is an upper bound, so "
+                             "headroom keeps a test that varies its cluster from failing on the "
+                             "run where it uses most (default: 0, claim exactly what was measured)")
+    args = parser.parse_args()
+    if args.headroom_shards < 0:
+        # A negative value would write a claim below the measured peak, and far
+        # enough below it a zero or negative marker.  claimed_shards() rejects
+        # those, so the tool would write source that fails collection.
+        parser.error("--headroom-shards cannot be negative")
+
+    by_file = measured_shards(db_paths=args.db_path, headroom=args.headroom_shards)
+    if not by_file:
+        print(f"No unrestricted {CLUSTER_METRICS_TABLE} rows found. A claim caps the peak "
+              f"recorded under it, so measuring takes --measure-running-shards -- was the "
+              f"run made with it, and did any cluster test pass?")
+        return 1
+
+    changed = 0
+    for file_rel_path, tests in sorted(by_file.items()):
+        file_abs_path = TEST_DIR / file_rel_path
+        if args.path and not file_abs_path.is_relative_to(args.path.absolute()):
+            continue
+        changed += update_file(file_abs_path, tests)
+
+    print(f"{changed} file(s) updated.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/test/pylib_test/test_max_running_shards_declared.py
+++ b/test/pylib_test/test_max_running_shards_declared.py
@@ -1,0 +1,72 @@
+#
+# Copyright (C) 2026-present ScyllaDB
+#
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
+#
+"""Every cluster test must say how much of the machine it uses.
+
+test/cluster is the one suite where a claim can go missing: everywhere else it
+is a constant applied at collection, from a conftest's pytestmark or a C++
+case's own `-c`.  A cluster test's claim is a marker somebody wrote, and a
+scheduler reading the markers is only as good as their coverage.
+
+It asks pytest what exists rather than reading the source, since only
+collection sees every marker.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from test import ALL_MODES
+from test.pylib.marker_index import build_index
+from test.pylib.running_shards import MARKER
+
+
+# No scheduler will place these.  A skipped test never reaches the manager
+# fixture (skip is also what skip_mode, skip_bug and skip_env apply), CI does
+# not run non_gating at all, and no_parallel gets a step of its own.  skipif is
+# not here: its condition is evaluated at setup, so the marker alone does not
+# say whether the test runs.
+EXEMPT_MARKERS = frozenset({"skip", "non_gating", "no_parallel"})
+
+
+# The suite pins some tests to one mode (run_in_release, run_in_debug), so a
+# single collection does not see them all -- and a mode this does not look at is
+# a mode where a claim can go missing.  Every mode --mode accepts, for that
+# reason.  Collection needs no build, so asking for a mode is fine even though
+# CI runs the framework tests before building.
+MODES = sorted(ALL_MODES)
+
+
+@pytest.fixture(scope="module", params=MODES)
+def cluster_test_index(request: pytest.FixtureRequest, tmp_path_factory: pytest.TempPathFactory):
+    """The tests under test/cluster in one mode, and the markers they carry.
+
+    The selection is fixed here rather than taken from the run, so narrowing the
+    outer run with -k cannot narrow what this checks.
+    """
+    return build_index(["--mode", request.param, "test/cluster"],
+                       tmpdir=tmp_path_factory.mktemp(f"marker_index_{request.param}"))
+
+
+def test_the_index_is_not_empty(cluster_test_index):
+    """Guard the guard: an empty collection would make everything below vacuous."""
+    assert len(cluster_test_index) > 100, \
+        f"only {len(cluster_test_index)} tests collected from test/cluster -- collection is broken, " \
+        f"so the check below proves nothing"
+
+
+def test_every_cluster_test_declares_max_running_shards(cluster_test_index):
+    missing = sorted(test["nodeid"] for test in cluster_test_index
+                     if test[MARKER] is None and not EXEMPT_MARKERS & set(test["markers"]))
+    assert not missing, (
+        f"{len(missing)} test(s) under test/cluster do not declare {MARKER}:\n"
+        + "\n".join(f"    {nodeid}" for nodeid in missing)
+        + f"\n\nEvery cluster test has to state the peak shards it runs, so a scheduler can\n"
+          f"weigh it. Add @pytest.mark.{MARKER}(n), or let the test itself write it:\n"
+          f"    ./test.py --mode dev <the test>\n"
+          f"    ./test/pylib/update_max_running_shards_markers.py testlog/sqlite_*.db\n"
+          f"See docs/dev/testing.md."
+    )
+

--- a/test/pylib_test/test_running_shards.py
+++ b/test/pylib_test/test_running_shards.py
@@ -5,14 +5,19 @@
 #
 """Tests for max_running_shards: the marker, and the claim it makes true."""
 
+import ast
 import asyncio
 import logging
+import shlex
 import sqlite3
+import sys
+import textwrap
 from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
 
+from test.pylib.cpp.base import DEFAULT_CUSTOM_ARGS, DEFAULT_SCYLLA_ARGS
 from test.pylib.db import writer
 from test.pylib.db.writer import (
     CLUSTER_METRICS_TABLE,
@@ -29,12 +34,18 @@ from test.pylib.running_shards import (
     claimed_shards,
 )
 from test.pylib.scylla_cluster import ScyllaCluster
-from test.pylib.scylla_server import ScyllaServer
 from test.pylib.scylla_server import (
     SCYLLA_CMDLINE_OPTIONS,
+    ScyllaServer,
     merge_cmdline_options,
     shards_of,
     specifies_shards,
+)
+from test.pylib.update_max_running_shards_markers import (
+    main,
+    measured_shards,
+    parse_nodeid,
+    update_file,
 )
 
 
@@ -173,6 +184,331 @@ def test_claim_exceeded_is_refused_before_anything_starts():
 
     # The mark did not move: those shards were never put on the machine.
     assert shards.high_water_mark == 2
+
+
+# --- the backfill -----------------------------------------------------------
+
+@pytest.mark.parametrize("nodeid,expected", [
+    ("cluster/test_x.py::test_y", (Path("cluster/test_x.py"), None, "test_y")),
+    ("cluster/test_x.py::TestC::test_y", (Path("cluster/test_x.py"), "TestC", "test_y")),
+    ("cluster/test_x.py::test_y[3-True]", (Path("cluster/test_x.py"), None, "test_y")),
+])
+def test_parse_nodeid(nodeid, expected):
+    assert parse_nodeid(nodeid) == expected
+
+
+@pytest.mark.parametrize("nodeid", ["cluster/test_x.py", "a.py::A::B::test_y"])
+def test_parse_nodeid_rejects(nodeid):
+    with pytest.raises(ValueError):
+        parse_nodeid(nodeid)
+
+
+def make_db(tmp_path: Path, rows: list[tuple[str, int]], *,
+            status: str = "passed", claim: int | None = None) -> Path:
+    """A measurements DB holding `rows` as (nodeid, shards), one row each.
+
+    `claim` is what was in force while they were measured; None -- the default --
+    is a --measure-running-shards run, the only kind the backfill trusts.
+    """
+    db_path = tmp_path / "measurements.db"
+    conn = sqlite3.connect(db_path)
+    with conn:
+        conn.execute(f"CREATE TABLE {CLUSTER_METRICS_TABLE} "
+                     "(id INTEGER PRIMARY KEY, test_id INT, nodeid TEXT, "
+                     "max_running_shards INTEGER, status VARCHAR(15), claim INTEGER)")
+        for test_id, (nodeid, shards) in enumerate(rows):
+            conn.execute(f"INSERT INTO {CLUSTER_METRICS_TABLE} "
+                         "(test_id, nodeid, max_running_shards, status, claim) VALUES (?, ?, ?, ?, ?)",
+                         (test_id, nodeid, shards, status, claim))
+    conn.close()
+    return db_path
+
+
+def test_measured_shards_folds_repeats_modes_and_params(tmp_path):
+    """One function carries one marker, so everything folding into it takes the max."""
+    db_path = make_db(tmp_path, [
+        ("cluster/test_x.py::test_y[1]", 2),
+        ("cluster/test_x.py::test_y[2]", 6),   # the heaviest parameter wins
+        ("cluster/test_x.py::test_y[2]", 4),   # a --repeat copy of the same one
+        ("cluster/test_x.py::TestC::test_y", 8),
+    ])
+    assert measured_shards([db_path], headroom=0) == {
+        Path("cluster/test_x.py"): {None: {"test_y": 6}, "TestC": {"test_y": 8}},
+    }
+
+
+def test_measured_shards_ignores_tests_that_started_nothing(tmp_path):
+    """A test that leased a cluster but ran no server has nothing to claim.
+
+    A marker of 0 would be a claim it breaks the first time it does start one,
+    and claimed_shards() rejects it anyway.
+    """
+    db_path = make_db(tmp_path, [("cluster/test_x.py::test_y", 0)])
+    assert measured_shards([db_path], headroom=0) == {}
+
+
+def test_measured_shards_ignores_runs_held_to_a_claim(tmp_path):
+    """A claim caps the peak recorded under it, so such a row proves nothing new."""
+    db_path = make_db(tmp_path, [("cluster/test_x.py::test_y", 6)], claim=6)
+    assert measured_shards([db_path], headroom=0) == {}
+
+
+def test_measured_shards_ignores_failed_runs(tmp_path):
+    """A test that failed part-way never reached its peak, so it makes no claim."""
+    db_path = make_db(tmp_path, [("cluster/test_x.py::test_y", 2)], status="failed")
+    assert measured_shards([db_path], headroom=0) == {}
+
+
+def test_measured_shards_does_not_let_one_run_vouch_for_another(tmp_path):
+    """Two runs of one test share a tests.id, so the outcome has to be per row.
+
+    Here the run that measured 2 failed, and the run that passed was held to a
+    claim.  Neither says what the test uses, and joining them would say 2.
+    """
+    db_path = tmp_path / "two_runs.db"
+    conn = sqlite3.connect(db_path)
+    with conn:
+        conn.execute(f"CREATE TABLE {CLUSTER_METRICS_TABLE} "
+                     "(id INTEGER PRIMARY KEY, test_id INT, nodeid TEXT, "
+                     "max_running_shards INTEGER, status VARCHAR(15), claim INTEGER)")
+        for shards, status, claim in [(2, "failed", None), (6, "passed", 6)]:
+            conn.execute(f"INSERT INTO {CLUSTER_METRICS_TABLE} "
+                         "(test_id, nodeid, max_running_shards, status, claim) VALUES (1, ?, ?, ?, ?)",
+                         ("cluster/test_x.py::test_y", shards, status, claim))
+    conn.close()
+    assert measured_shards([db_path], headroom=0) == {}
+
+
+@pytest.mark.parametrize("status", ["skipped", "xfailed"])
+def test_measured_shards_ignores_runs_that_stopped_early(tmp_path, status):
+    """These are recorded as successes, but the test did not run to the end.
+
+    A mid-test skip or an xfail leaves the peak short of what the test does
+    when it runs through, and a claim written from that fails the test later.
+    """
+    db_path = make_db(tmp_path, [("cluster/test_x.py::test_y", 2)], status=status)
+    assert measured_shards([db_path], headroom=0) == {}
+
+
+def test_negative_headroom_is_refused(monkeypatch, tmp_path, capsys):
+    """It would write a claim below the measured peak, and at enough below it a
+    zero or negative one that claimed_shards() rejects."""
+    db = make_db(tmp_path, [("cluster/test_x.py::test_y", 6)])
+    monkeypatch.setattr(sys, "argv", ["update_max_running_shards_markers",
+                                      str(db), "--headroom-shards", "-1"])
+    with pytest.raises(SystemExit) as refused:
+        main()
+    assert refused.value.code != 0
+    assert "cannot be negative" in capsys.readouterr().err
+
+
+def test_measured_shards_headroom(tmp_path):
+    db_path = make_db(tmp_path, [("cluster/test_x.py::test_y", 6)])
+    assert measured_shards([db_path], headroom=2)[Path("cluster/test_x.py")][None]["test_y"] == 8
+
+
+SOURCE = textwrap.dedent(f'''\
+    import pytest
+
+
+    async def test_plain(manager):
+        pass
+
+
+    @pytest.mark.asyncio
+    async def test_decorated(manager):
+        pass
+
+
+    @pytest.mark.{MARKER}(2)
+    async def test_claims_too_little(manager):
+        pass
+
+
+    @pytest.mark.{MARKER}(100)
+    async def test_claims_plenty(manager):
+        pass
+
+
+    class TestC:
+        async def test_method(self, manager):
+            pass
+    ''')
+
+
+def write_source(tmp_path: Path, source: str = SOURCE) -> Path:
+    path = tmp_path / "test_x.py"
+    path.write_text(source)
+    return path
+
+
+TESTS = {
+    None: {
+        "test_plain": 4,
+        "test_decorated": 4,
+        "test_claims_too_little": 6,
+        "test_claims_plenty": 6,
+    },
+    "TestC": {"test_method": 8},
+}
+
+
+def test_update_file_writes_and_raises_claims(tmp_path):
+    path = write_source(tmp_path)
+    assert update_file(path, TESTS)
+    updated = path.read_text()
+
+    assert f"@pytest.mark.{MARKER}(4)\nasync def test_plain" in updated
+    # Above the whole decorator stack, not between it and the function.
+    assert f"@pytest.mark.{MARKER}(4)\n@pytest.mark.asyncio\nasync def test_decorated" in updated
+    # Too low, so raised in place; already generous, so left alone.
+    assert f"@pytest.mark.{MARKER}(6)\nasync def test_claims_too_little" in updated
+    assert f"@pytest.mark.{MARKER}(100)\nasync def test_claims_plenty" in updated
+    # Methods keep their indentation.
+    assert f"    @pytest.mark.{MARKER}(8)\n    async def test_method" in updated
+
+
+def test_update_file_is_idempotent(tmp_path):
+    path = write_source(tmp_path)
+    assert update_file(path, TESTS)
+    once = path.read_text()
+
+    assert not update_file(path, TESTS), "a second run should find nothing to change"
+    assert path.read_text() == once
+
+
+def test_update_file_adds_the_pytest_import(tmp_path):
+    path = write_source(tmp_path, textwrap.dedent('''\
+        from test.pylib.manager_client import ManagerClient
+
+
+        async def test_plain(manager):
+            pass
+        '''))
+    assert update_file(path, {None: {"test_plain": 4}})
+    updated = path.read_text()
+    assert "import pytest" in updated
+    assert updated.index("import pytest") < updated.index(f"@pytest.mark.{MARKER}(4)")
+
+
+@pytest.mark.parametrize("source", [
+    "import pytest as pt\n\n\n@pt.mark.asyncio\nasync def test_plain(manager):\n    pass\n",
+    "def helper():\n    import pytest\n\n\nasync def test_plain(manager):\n    pass\n",
+    "async def test_plain(manager):\n    pass\n",
+], ids=["aliased-import", "import-inside-a-helper", "no-imports-at-all"])
+def test_update_file_adds_the_pytest_import_when_the_name_is_not_bound(tmp_path, source):
+    """The marker needs `pytest` bound at module level, above it."""
+    path = write_source(tmp_path, source)
+    assert update_file(path, {None: {"test_plain": 4}})
+    updated = path.read_text().splitlines()
+    assert "import pytest" in updated, "the marker would fail with NameError without it"
+    assert updated.index("import pytest") < next(i for i, line in enumerate(updated) if MARKER in line)
+    ast.parse("\n".join(updated))
+
+
+def test_update_file_adds_the_pytest_import_above_a_class(tmp_path):
+    """An import cannot be indented into the class body the method lives in."""
+    path = write_source(tmp_path, "class TestX:\n    async def test_plain(self, manager):\n        pass\n")
+    assert update_file(path, {"TestX": {"test_plain": 4}})
+    updated = path.read_text()
+    assert updated.index("import pytest") < updated.index("class TestX")
+    ast.parse(updated)
+
+
+def test_update_file_leaves_a_marker_it_cannot_rewrite(tmp_path):
+    """A second marker would sit above the first, and the first is the one that counts."""
+    source = "import pytest as pt\n\n\n@pt.mark.max_running_shards(2)\nasync def test_plain(manager):\n    pass\n"
+    path = write_source(tmp_path, source)
+    assert not update_file(path, {None: {"test_plain": 6}})
+    assert path.read_text() == source
+
+
+@pytest.mark.parametrize("trailing", ["\n", ""], ids=["final-newline", "no-final-newline"])
+def test_update_file_changes_only_the_markers(tmp_path, trailing):
+    """Whatever else the file has, only the marker lines may move.
+
+    The rewrite has to round-trip the source exactly: a file that ended without
+    a newline must not gain one, and a form feed must not become a line break.
+    """
+    source = ("import pytest\n"
+              "\n"
+              "PAGE = 'a\fb'  # a form feed, which splitlines() would break on\n"
+              "\n"
+              "\n"
+              "async def test_plain(manager):\n"
+              "    pass" + trailing)
+    path = write_source(tmp_path, source)
+    assert update_file(path, {None: {"test_plain": 4}})
+
+    updated = path.read_text()
+    assert updated == source.replace("async def test_plain",
+                                     f"@pytest.mark.{MARKER}(4)\nasync def test_plain")
+
+
+def test_update_file_ignores_a_function_nested_in_a_test(tmp_path):
+    """Only a test gets a marker, not a helper that happens to share its name."""
+    source = textwrap.dedent("""\
+        import pytest
+
+
+        async def test_plain(manager):
+            def test_plain():   # a helper, not a test
+                pass
+            test_plain()
+        """)
+    path = write_source(tmp_path, source)
+    assert update_file(path, {None: {"test_plain": 4}})
+    updated = path.read_text()
+    assert updated.count(f"@pytest.mark.{MARKER}(4)") == 1
+    assert updated.startswith("import pytest\n\n\n"
+                              f"@pytest.mark.{MARKER}(4)\nasync def test_plain(manager):")
+
+
+def test_update_file_raises_a_multi_line_claim_without_moving_the_rest(tmp_path):
+    """Replacing a marker spelled across several lines shortens the file.
+
+    Every edit position comes from the original AST, so if that replacement ran
+    before an insert below it, the insert would land at a stale index -- the
+    marker for the second test ended up after it, as invalid Python.
+    """
+    source = textwrap.dedent(f"""\
+        import pytest
+
+
+        @pytest.mark.{MARKER}(
+            2
+        )
+        async def test_first(manager):
+            pass
+
+
+        async def test_second(manager):
+            pass
+        """)
+    path = write_source(tmp_path, source)
+    assert update_file(path, {None: {"test_first": 6, "test_second": 4}})
+
+    updated = path.read_text()
+    assert f"@pytest.mark.{MARKER}(6)\nasync def test_first" in updated
+    assert f"@pytest.mark.{MARKER}(4)\nasync def test_second" in updated
+    ast.parse(updated)   # and it is still Python
+
+
+def test_update_file_leaves_a_computed_claim_alone(tmp_path):
+    """A claim this script cannot read is a human's to change."""
+    source = textwrap.dedent(f'''\
+        import pytest
+
+        SHARDS = 2
+
+
+        @pytest.mark.{MARKER}(SHARDS)
+        async def test_plain(manager):
+            pass
+        ''')
+    path = write_source(tmp_path, source)
+    assert not update_file(path, {None: {"test_plain": 6}})
+    assert path.read_text() == source
 
 
 # --- the cluster's side of the claim ----------------------------------------
@@ -432,8 +768,4 @@ def test_writer_reports_a_migration_that_really_failed(tmp_path, monkeypatch):
 
 def test_shards_of_cpp_defaults():
     """The command line every C++ test case gets by default claims two shards."""
-    import shlex
-
-    from test.pylib.cpp.base import DEFAULT_CUSTOM_ARGS, DEFAULT_SCYLLA_ARGS
-
     assert shards_of([*DEFAULT_SCYLLA_ARGS, *shlex.split(DEFAULT_CUSTOM_ARGS[0])]) == 2

--- a/test/pylib_test/test_running_shards.py
+++ b/test/pylib_test/test_running_shards.py
@@ -10,6 +10,7 @@ import asyncio
 import logging
 import shlex
 import sqlite3
+import subprocess
 import sys
 import textwrap
 from pathlib import Path
@@ -27,6 +28,7 @@ from test.pylib.db.writer import (
 )
 from test.pylib.host_registry import Host
 from test.pylib.internal_types import ServerNum
+from test.pylib.marker_index import build_index
 from test.pylib.running_shards import (
     MARKER,
     RunningShards,
@@ -685,6 +687,26 @@ def test_a_start_stop_cycle_does_not_accumulate(tmp_path):
         del cluster.running[ServerNum(1)]       # the test stops it again
 
     assert cluster.shard_usage.high_water_mark == 2
+
+# --- the marker index -------------------------------------------------------
+
+def test_build_index_ignores_the_callers_pytest_options(tmp_path, monkeypatch):
+    """A -k in PYTEST_ADDOPTS would silently narrow what the index covers."""
+    captured: dict[str, str] = {}
+
+    def fake_run(argv, **kwargs):
+        captured.update(kwargs["env"])
+        (tmp_path / "marker_index.json").write_text('{"tests": []}')
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setenv("PYTEST_ADDOPTS", "-k nothing_matches")
+    monkeypatch.setenv("PYTEST_XDIST_WORKER", "gw3")
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    assert build_index(["test/cluster"], tmpdir=tmp_path) == []
+    assert "PYTEST_ADDOPTS" not in captured
+    assert "PYTEST_XDIST_WORKER" not in captured
+
 
 # --- the metrics database outlives a run ------------------------------------
 

--- a/test/pylib_test/test_running_shards.py
+++ b/test/pylib_test/test_running_shards.py
@@ -1,0 +1,343 @@
+#
+# Copyright (C) 2026-present ScyllaDB
+#
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
+#
+"""Tests for max_running_shards: the marker, and the claim it makes true."""
+
+import asyncio
+import logging
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from test.pylib.host_registry import Host
+from test.pylib.internal_types import ServerNum
+from test.pylib.running_shards import (
+    MARKER,
+    RunningShards,
+    RunningShardsExceeded,
+    claimed_shards,
+)
+from test.pylib.scylla_cluster import ScyllaCluster
+from test.pylib.scylla_server import ScyllaServer
+from test.pylib.scylla_server import (
+    SCYLLA_CMDLINE_OPTIONS,
+    merge_cmdline_options,
+    shards_of,
+    specifies_shards,
+)
+
+
+# --- the shard count a command line asks for --------------------------------
+
+@pytest.mark.parametrize("options,expected", [
+    (["--smp", "2"], 2),
+    (["--smp=8"], 8),
+    (["--overprovisioned", "--smp", "1", "--abort-on-ebadf", "1"], 1),
+    # Seastar's short spelling, as the C++ test cases pass it.
+    (["-c2", "-m2G"], 2),
+    (["-c", "4"], 4),
+    (["-c=4"], 4),
+    # A long option merely starting with -c is not one.
+    (["--collectd", "0", "--smp", "3"], 3),
+    # The last spelling wins, whichever it is.
+    (["--smp", "1", "--smp", "4"], 4),
+    (["--smp", "2", "-c1"], 1),
+])
+def test_shards_of(options, expected):
+    assert shards_of(options) == expected
+
+
+def test_shards_of_default_cmdline():
+    """The default every server starts from claims two shards."""
+    assert shards_of(SCYLLA_CMDLINE_OPTIONS) == 2
+
+
+@pytest.mark.parametrize("override", [["--smp", "3"], ["--smp=3"]])
+def test_shards_of_merged_override(override):
+    """A test overriding --smp changes the server's shard count, either spelling."""
+    assert shards_of(merge_cmdline_options(SCYLLA_CMDLINE_OPTIONS, override)) == 3
+
+
+def test_shards_of_without_smp_counts_cores(caplog):
+    """No --smp means a shard per core, and says so -- no test means to ask for that."""
+    import os
+
+    assert shards_of(["--overprovisioned"]) == (os.cpu_count() or 1)
+    assert "no --smp" in caplog.text
+
+
+@pytest.mark.parametrize("base,override,expected", [
+    (["--smp", "1"], ["--smp", "2"], ["--smp", "2"]),
+    (["--smp", "1"], ["--smp"], ["--smp"]),
+    (["--smp", "1"], ["--smp", "__missing__"], ["--smp"]),
+    (["--smp", "1"], ["--smp", "__remove__"], []),
+    (["--smp=1"], ["--smp=2"], ["--smp", "2"]),
+    (["--smp=1"], ["--smp=__remove__"], []),
+    (["--overprovisioned", "--smp=1", "--abort-on-ebadf"], ["--smp=2"],
+     ["--overprovisioned", "--smp", "2", "--abort-on-ebadf"]),
+])
+def test_merge_cmdline_options_documented_cases(base, override, expected):
+    """The cases merge_cmdline_options' own comment promises.
+
+    It had no test of its own, and shards_of() now shares its option parser.
+    """
+    assert merge_cmdline_options(base, override) == expected
+
+
+@pytest.mark.parametrize("options,expected", [
+    ([], False),
+    (["--overprovisioned", "-m2G"], False),
+    (["--collectd", "0"], False),
+    (["--smp", "2"], True),
+    (["-c2"], True),
+])
+def test_specifies_shards(options, expected):
+    assert specifies_shards(options) is expected
+
+
+# --- reading the marker -----------------------------------------------------
+
+def node(*args, **kwargs):
+    """An item carrying one max_running_shards marker, or none at all."""
+    mark = SimpleNamespace(args=args, kwargs=kwargs) if (args or kwargs) else None
+    return SimpleNamespace(nodeid="a_test.py::test_x",
+                           get_closest_marker=lambda name: mark if name == MARKER else None)
+
+
+def test_claimed_shards_absent():
+    assert claimed_shards(SimpleNamespace(get_closest_marker=lambda name: None)) is None
+
+
+@pytest.mark.parametrize("mark", [(6,), {"amount": 6}])
+def test_claimed_shards_either_spelling(mark):
+    item = node(*mark) if isinstance(mark, tuple) else node(**mark)
+    assert claimed_shards(item) == 6
+
+
+@pytest.mark.parametrize("args,kwargs", [
+    ((6,), {"amount": 6}),   # both spellings at once
+    ((1, 2), {}),            # two counts
+    ((), {"shards": 6}),     # unknown keyword
+    (("6",), {}),            # not a number
+    ((True,), {}),           # bool is an int, but not a shard count
+    ((0,), {}),
+    ((-1,), {}),
+])
+def test_claimed_shards_rejects(args, kwargs):
+    with pytest.raises(ValueError, match=MARKER):
+        claimed_shards(node(*args, **kwargs))
+
+
+# --- the claim and the high-water mark --------------------------------------
+
+def test_unclaimed_cluster_runs_unrestricted():
+    """Which is what lets a new test run before anyone has measured it."""
+    shards = RunningShards()                    # claims nothing by default
+    shards.reserve(running=6, adding=100, what="a greedy server")
+    assert shards.high_water_mark == 106
+
+
+def test_high_water_mark_is_the_peak_not_the_last_value():
+    shards = RunningShards()
+    shards.reserve(running=0, adding=6, what="three servers")
+    shards.reserve(running=2, adding=2, what="one more, after two stopped")
+    assert shards.high_water_mark == 6
+
+
+def test_claim_respected():
+    shards = RunningShards()
+    shards.claim = 6
+    shards.reserve(running=0, adding=2, what="a server")
+    shards.reserve(running=2, adding=4, what="two more servers")
+    assert shards.high_water_mark == 6
+
+
+def test_claim_exceeded_is_refused_before_anything_starts():
+    shards = RunningShards()
+    shards.claim = 4
+    shards.reserve(running=0, adding=2, what="a server")
+
+    with pytest.raises(RunningShardsExceeded, match=f"{MARKER}=4"):
+        shards.reserve(running=2, adding=4, what="two more servers")
+
+    # The mark did not move: those shards were never put on the machine.
+    assert shards.high_water_mark == 2
+
+
+# --- the cluster's side of the claim ----------------------------------------
+#
+# No Scylla process is involved: a refused reservation happens before anything
+# is started, which is the property these check.
+
+def make_cluster(tmp_path: Path) -> ScyllaCluster:
+    return ScyllaCluster(
+        logger=logging.getLogger(__name__),
+        vardir=tmp_path,
+        mode="dev",
+        cmdline_options=[],
+        cmdline_options_override=[],
+        config_options={},
+        append_env={},
+        scylla_exe="/nonexistent/scylla",
+    )
+
+
+def test_running_shards_counts_servers_on_their_way_up(tmp_path):
+    """A concurrent servers_add() must see the shards its siblings are taking."""
+    cluster = make_cluster(tmp_path)
+    cluster.running[ServerNum(1)] = SimpleNamespace(shards=2)
+    cluster.running[ServerNum(2)] = SimpleNamespace(shards=1)
+    cluster.starting[ServerNum(3)] = SimpleNamespace(shards=8)
+    assert cluster.running_shards == 11
+
+
+async def test_add_server_refuses_to_break_the_claim(tmp_path, monkeypatch):
+    """Refused before a ScyllaServer exists, so there is nothing to unwind."""
+    cluster = make_cluster(tmp_path)
+    cluster.shard_usage.claim = 4
+
+    leased = set[str]()
+
+    async def lease_host() -> str:
+        leased.add("127.0.0.99")
+        return "127.0.0.99"
+
+    async def release_host(host: Host) -> None:
+        leased.remove(host)
+
+    monkeypatch.setattr(cluster.host_registry, "lease_host", lease_host)
+    monkeypatch.setattr(cluster.host_registry, "release_host", release_host)
+
+    with pytest.raises(RunningShardsExceeded, match="adding a server"):
+        await cluster.add_server(cmdline=["--smp", "8"])
+
+    assert not leased and not cluster.leased_ips, "the address leased for the server leaked"
+    assert not cluster.starting and not cluster.stopped and not cluster.running
+
+
+async def test_add_server_that_will_not_start_takes_no_shards(tmp_path, monkeypatch):
+    """start=False only installs the server and parks it in self.stopped.
+
+    It runs nothing, so it must not be counted against the claim -- a test
+    already at its claim is still allowed to park one.  server_start() reserves
+    for it if the test ever starts it.
+    """
+    cluster = make_cluster(tmp_path)
+    cluster.shard_usage.claim = 2
+    # Already at the claim.  ip_addr because _seeds() reads it off running servers.
+    cluster.running[ServerNum(1)] = SimpleNamespace(shards=2, ip_addr="127.0.0.98")
+
+    async def lease_host() -> str:
+        return "127.0.0.99"
+
+    monkeypatch.setattr(cluster.host_registry, "lease_host", lease_host)
+    monkeypatch.setattr(ScyllaServer, "install", lambda self: asyncio.sleep(0))
+
+    before = cluster.shard_usage.high_water_mark
+    await cluster.add_server(start=False, cmdline=["--smp", "8"])
+
+    assert len(cluster.stopped) == 1, "the server should be parked, not refused"
+    assert cluster.shard_usage.high_water_mark == before, "a parked server runs nothing"
+
+
+async def test_server_start_refuses_to_break_the_claim(tmp_path):
+    """The server stays stopped, rather than being lost between the two dicts."""
+    cluster = make_cluster(tmp_path)
+    cluster.shard_usage.claim = 4
+    cluster.stopped[ServerNum(1)] = SimpleNamespace(shards=8, server_id=ServerNum(1))
+
+    with pytest.raises(RunningShardsExceeded, match="starting server 1"):
+        await cluster.server_start(ServerNum(1))
+
+    assert ServerNum(1) in cluster.stopped and not cluster.running
+
+
+async def park_server(cluster: ScyllaCluster, monkeypatch, cmdline: list[str]) -> ServerNum:
+    """Install a real ScyllaServer into `cluster` and leave it stopped.
+
+    A real one, because ScyllaServer.shards is what these check.  Nothing is
+    started: the process, the config file and the address are all stubbed out.
+    """
+    async def lease_host() -> str:
+        return "127.0.0.99"
+
+    monkeypatch.setattr(cluster.host_registry, "lease_host", lease_host)
+    monkeypatch.setattr(ScyllaServer, "install", lambda self: asyncio.sleep(0))
+    monkeypatch.setattr(ScyllaServer, "_write_config_file", lambda self: None)
+    monkeypatch.setattr(ScyllaServer, "start", lambda self, **kwargs: asyncio.sleep(0))
+    await cluster.add_server(start=False, cmdline=cmdline)
+    return next(iter(cluster.stopped))
+
+
+async def test_server_start_counts_a_cmdline_override(tmp_path, monkeypatch):
+    """cmdline_options_override replaces the whole command line, --smp included."""
+    cluster = make_cluster(tmp_path)
+    server_id = await park_server(cluster, monkeypatch, ["--smp", "2"])
+    cluster.shard_usage.claim = 4
+
+    with pytest.raises(RunningShardsExceeded, match=f"starting server {server_id}"):
+        await cluster.server_start(server_id, cmdline_options_override=["--smp", "8"])
+
+
+async def test_an_override_keeps_counting_while_the_server_runs(tmp_path, monkeypatch):
+    """Reserving for the start is not enough.
+
+    Every later reservation counts the running servers, and this one no longer
+    runs the command line it was installed with.
+    """
+    cluster = make_cluster(tmp_path)
+    server_id = await park_server(cluster, monkeypatch, ["--smp", "2"])
+    cluster.shard_usage.claim = 8
+
+    await cluster.server_start(server_id, cmdline_options_override=["--smp", "6"])
+    assert cluster.running_shards == 6, "the server is the size the override made it"
+
+    with pytest.raises(RunningShardsExceeded, match="adding a server"):
+        await cluster.add_server(cmdline=["--smp", "4"])       # 6 + 4 is over 8
+
+
+async def test_a_restart_without_an_override_counts_the_installed_options(tmp_path, monkeypatch):
+    """The override applied to one start, so it must not outlive it."""
+    cluster = make_cluster(tmp_path)
+    server_id = await park_server(cluster, monkeypatch, ["--smp", "2"])
+    cluster.shard_usage.claim = 8
+
+    await cluster.server_start(server_id, cmdline_options_override=["--smp", "6"])
+    cluster.stopped[server_id] = cluster.running.pop(server_id)   # as server_stop() does
+    await cluster.server_start(server_id)
+
+    assert cluster.running_shards == 2, "back to the command line it was installed with"
+
+
+def test_a_stopped_server_stops_counting(tmp_path):
+    """Nothing decrements: the count is derived, so a stop just is not in it."""
+    cluster = make_cluster(tmp_path)
+    server = SimpleNamespace(shards=2, server_id=ServerNum(1))
+    cluster.running[ServerNum(1)] = server
+    assert cluster.running_shards == 2
+
+    del cluster.running[ServerNum(1)]           # as server_stop() does
+    cluster.stopped[ServerNum(1)] = server
+    assert cluster.running_shards == 0
+
+
+def test_a_start_stop_cycle_does_not_accumulate(tmp_path):
+    """The claim is the peak at once, not the total over the test's life.
+
+    A test that starts a node, stops it, and does that a hundred times peaks at
+    one node -- so it claims one node's worth, not a hundred.  test_commitlog.py
+    is the real thing: one server, two stop/start cycles, measured claim 2.
+    """
+    cluster = make_cluster(tmp_path)
+    cluster.shard_usage.claim = 2               # one server's worth, and no more
+    server = SimpleNamespace(shards=2, server_id=ServerNum(1))
+
+    for _ in range(100):
+        cluster._reserve_shards(server.shards, "starting server 1")   # raises if it accumulated
+        cluster.running[ServerNum(1)] = server
+        del cluster.running[ServerNum(1)]       # the test stops it again
+
+    assert cluster.shard_usage.high_water_mark == 2

--- a/test/pylib_test/test_running_shards.py
+++ b/test/pylib_test/test_running_shards.py
@@ -7,11 +7,19 @@
 
 import asyncio
 import logging
+import sqlite3
 from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
 
+from test.pylib.db import writer
+from test.pylib.db.writer import (
+    CLUSTER_METRICS_TABLE,
+    SQLiteWriter,
+    add_column,
+    add_missing_columns,
+)
 from test.pylib.host_registry import Host
 from test.pylib.internal_types import ServerNum
 from test.pylib.running_shards import (
@@ -341,3 +349,82 @@ def test_a_start_stop_cycle_does_not_accumulate(tmp_path):
         del cluster.running[ServerNum(1)]       # the test stops it again
 
     assert cluster.shard_usage.high_water_mark == 2
+
+# --- the metrics database outlives a run ------------------------------------
+
+def test_writer_adds_a_column_missing_from_an_older_database(tmp_path):
+    """The database is not wiped between runs, so an older one has to be updated.
+
+    prepare_dirs() clears *.log from the tmpdir but not sqlite_*.db, and a host
+    with SCYLLA_TEST_HOST_ID set keeps the same filename -- so a file written
+    before a column existed has to gain it, or every insert into it fails.
+    """
+    db_path = tmp_path / "old.db"
+    conn = sqlite3.connect(db_path)
+    with conn:
+        conn.execute(f"CREATE TABLE {CLUSTER_METRICS_TABLE} ("
+                     "id INTEGER PRIMARY KEY, test_id INT NOT NULL, host_id VARCHAR(5) NOT NULL, "
+                     "nodeid TEXT NOT NULL, max_running_shards INTEGER NOT NULL)")
+    conn.close()
+
+    SQLiteWriter(db_path).close()
+
+    conn = sqlite3.connect(db_path)
+    columns = {row[1] for row in conn.execute(f"PRAGMA table_info({CLUSTER_METRICS_TABLE})")}
+    conn.close()
+    assert {"claim", "status"} <= columns, "every column add_column names has to be applied"
+
+    SQLiteWriter(db_path).close()   # and opening it again is a no-op
+
+
+class LostTheRace:
+    """A cursor whose first look at the schema is one migration out of date.
+
+    What a worker sees when another adds a column between its check and its
+    ALTER: the check says missing, the ALTER says duplicate, and looking again
+    says it is there.  Workers share one database file and build a writer per
+    test, so nothing stops them arriving together.
+    """
+
+    def __init__(self, cursor: sqlite3.Cursor) -> None:
+        self.cursor = cursor
+        self.stale = True
+        self.last = ""
+
+    def execute(self, sql: str, *args):
+        self.last = sql
+        return self.cursor.execute(sql, *args)
+
+    def fetchall(self):
+        rows = self.cursor.fetchall()
+        if not self.stale or not self.last.startswith("PRAGMA table_info"):
+            return rows
+        self.stale = False
+        added = {column for _, column, _ in add_column}
+        return [row for row in rows if row[1] not in added]
+
+
+def test_writer_survives_losing_the_migration_race(tmp_path):
+    """The column being there already is the outcome the migration wanted."""
+    db_path = tmp_path / "current.db"
+    SQLiteWriter(db_path).close()               # a database that is already migrated
+
+    conn = sqlite3.connect(db_path)
+    with conn:
+        add_missing_columns(LostTheRace(conn.cursor()))
+    columns = {row[1] for row in conn.execute(f"PRAGMA table_info({CLUSTER_METRICS_TABLE})")}
+    conn.close()
+    assert {column for _, column, _ in add_column} <= columns
+
+
+def test_writer_reports_a_migration_that_really_failed(tmp_path, monkeypatch):
+    """A refused ALTER is only forgivable when the column ended up there anyway."""
+    db_path = tmp_path / "current.db"
+    SQLiteWriter(db_path).close()
+    # SQLite refuses this one outright: ALTER TABLE cannot add an index.
+    monkeypatch.setattr(writer, "add_column", [(CLUSTER_METRICS_TABLE, "late", "INTEGER UNIQUE")])
+
+    conn = sqlite3.connect(db_path)
+    with pytest.raises(sqlite3.OperationalError):
+        add_missing_columns(conn.cursor())
+    conn.close()

--- a/test/pylib_test/test_running_shards.py
+++ b/test/pylib_test/test_running_shards.py
@@ -428,3 +428,12 @@ def test_writer_reports_a_migration_that_really_failed(tmp_path, monkeypatch):
     with pytest.raises(sqlite3.OperationalError):
         add_missing_columns(conn.cursor())
     conn.close()
+
+
+def test_shards_of_cpp_defaults():
+    """The command line every C++ test case gets by default claims two shards."""
+    import shlex
+
+    from test.pylib.cpp.base import DEFAULT_CUSTOM_ARGS, DEFAULT_SCYLLA_ARGS
+
+    assert shards_of([*DEFAULT_SCYLLA_ARGS, *shlex.split(DEFAULT_CUSTOM_ARGS[0])]) == 2

--- a/test/pytest.ini
+++ b/test/pytest.ini
@@ -34,6 +34,7 @@ markers =
     cluster_options: specify cluster options used to initialize a cluster (dtest only)
     perf: mark for performance tests, these tests will automatically apply non_gating marker
     manual: to mark manual test cases, these tests will automatically apply non_gating marker
+    max_running_shards(amount): peak number of Scylla shards the test may have running at once, counted across every server in its cluster (a server's shards are its effective --smp, 2 by default). Enforced: a server start that would break the claim fails the test. Backfilled by test/pylib/update_max_running_shards_markers.py
     no_parallel: for genuinely heavy tests that must not run in parallel with other tests, they run in a separate step of the Nightly pipeline with parallelization 1, these tests will automatically apply non_gating marker
     non_gating: tests that are not run in CI/Next/Nightly verification, but can be run manually or on special job when needed
     tier2: for tests that are quite old, stable, and test functionality that rather not be changed or affected by other features, are partially covered in other tests, verify non-critical functionality, have not found any issues or regressions, too long to run on every PR,  and can be popped out from the CI run, but will continue run in Next/Nightly verification

--- a/test/rest_api/conftest.py
+++ b/test/rest_api/conftest.py
@@ -98,3 +98,8 @@ def test_keyspace(cql, this_dc):
     cql.execute("CREATE KEYSPACE " + name + " WITH REPLICATION = { 'class' : 'NetworkTopologyStrategy', '" + this_dc + "' : 1 }")
     yield name
     cql.execute("DROP KEYSPACE " + name)
+
+# Every test here shares one cluster, created per module from
+# cluster.initial_size (which defaults to 1) at --smp 2, and no test changes
+# it -- so the claim is a constant of the suite, not something to measure.
+pytestmark = pytest.mark.max_running_shards(2)

--- a/test/scylla_gdb/conftest.py
+++ b/test/scylla_gdb/conftest.py
@@ -75,3 +75,7 @@ def execute_gdb_command(gdb_cmd, scylla_command: str = None, full_command: str =
         command, capture_output=True, text=True, encoding="utf-8", errors="replace"
     )
     return result
+
+# Every test here shares one cluster, created per module from
+# cluster.initial_size (which defaults to 1) at --smp 2, unchanged throughout.
+pytestmark = pytest.mark.max_running_shards(2)


### PR DESCRIPTION
A scheduler cannot pack tests onto machines without knowing how much of a
machine each test uses. This adds that number to the tests, and keeps it
honest.

A test says what it needs with a marker:

    @pytest.mark.max_running_shards(6)
    async def test_something(manager: ScyllaClusterManager):
        await manager.servers_add(3)     # 3 servers x --smp 2 = 6 shards

Shards, not servers, because one server with `--smp 8` is not one server with
`--smp 1`. The number is a peak, not a total: a test that starts two servers,
stops them and starts two more uses 4 shards, not 8.

## The claim is true because it is enforced

Before a server starts, the cluster adds up the shards already running and the
shards this server would add. If that is over the claim, it refuses to start
the server and the test fails there, naming the marker. Nothing is on the
machine yet, so a wrong claim costs the run nothing. This is why a test cannot
quietly drift over its claim, and why a bad claim cannot OOM a whole run.

## Keeping the claim up to date is not a developer chore

Every run with `--gather-metrics` writes the peak each test reached to the
metrics database. A new test has no marker, so nothing limits it, and its
first run measures the truth:

    ./test.py --mode dev --gather-metrics test/cluster/my_new_test.py
    ./test/pylib/update_max_running_shards_markers.py testlog/sqlite_*.db

The second command writes the marker into the source. It adds a missing
marker, raises one that is too low, and leaves everything else alone, so
running it twice makes no diff. Its output is an ordinary diff to review.

Re-measuring a test that already has a claim needs
`pytest --measure-running-shards`, because a claim caps what can be recorded
under it. Every row stores the claim that was in force, so the tool can tell
a real measurement from a capped one and ignores the capped ones.

## Where the numbers come from

- `test/cluster`: 1042 markers in 231 files, all written from measurement.
- Suites whose cluster is fixed for the whole suite: one `pytestmark` in the
  suite `conftest.py` (2 shards, or 1 for nodetool). A marker on a test or its
  module still wins.
- C++ test cases: taken from the `-c` on the case's own command line, so
  `-c1` claims 1 and `-c3` claims 3 with nothing to write down.
- Suites that start no Scylla: nothing to declare.

Only `test/cluster` can forget a claim, since only there is the number a
person writes. A test in `test/pylib_test` collects `test/cluster` in dev,
release and debug and fails the build if a gating test has no claim. It needs
no build, so it runs with the rest of the framework tests. Skipped,
`non_gating` and `no_parallel` tests are exempt: no scheduler places them.

A missing marker means "not limited", so a local run of a brand new test
passes. CI is where the claim becomes mandatory.

## For the scheduler that comes next

`test/pylib/marker_index.py` returns every selected test with the markers it
carries, from one collect-only pass. Markers come from decorators, from
`pytestmark`, from parametrize and from collection hooks, so only pytest knows
the answer. The index keeps the markers uninterpreted, so a scheduler can
weigh tests by any marker without this code knowing about it.

## Testing

- 73 unit tests in `test/pylib_test/test_running_shards.py`, covering the
  shard-count parsing, the marker, enforcement, the backfill and the schema
  migration.
- `pytest test/pylib_test`: 128 passed, 1 skipped.
- Full `test/cluster` with enforcement on, in dev (1390 passed), release (785)
  and debug (1267): no claim violation in any mode. These three runs were made
  before the last rebase onto master.
- Peaks and claims checked against each other over 1279 recorded rows: no row
  with a peak above its claim.
Refs: SCYLLADB-48
Fixes: SCYLLADB-4461

[SCYLLADB-48]: https://scylladb.atlassian.net/browse/SCYLLADB-48?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SCYLLADB-3852]: https://scylladb.atlassian.net/browse/SCYLLADB-3852?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ