### PR TITLE
Validate GCS resumable uploads in tests

### DIFF
--- a/test/lib/gcs_fixture.cc
+++ b/test/lib/gcs_fixture.cc
@@ -162,9 +162,12 @@ seastar::future<> gcs_fixture::impl::teardown() {
         }
     }
 
+    // Reset it, so that a teardown from a failed setup does not leave a second
+    // one re-terminating an already reaped process.
     if (fake_gcs_server) {
         fake_gcs_server->terminate();
         co_await fake_gcs_server->wait();
+        fake_gcs_server.reset();
     }
 
     if (client) {

--- a/test/lib/gcs_fixture.cc
+++ b/test/lib/gcs_fixture.cc
@@ -8,7 +8,10 @@
 
 #include <string>
 #include <memory>
+#include <regex>
+#include <iostream>
 
+#include <seastar/core/shared_ptr.hh>
 #include <seastar/core/with_timeout.hh>
 #include <seastar/core/reactor.hh>
 #include <seastar/core/sleep.hh>
@@ -63,9 +66,112 @@ static future<std::tuple<tp::process_fixture, int>> start_fake_gcs_server(const 
     );
 }
 
+// fake-gcs-server accepts any Content-Range at all -- it stores the body and
+// derives the object size from it -- so protocol level upload bugs are invisible
+// when testing against it (SCYLLADB-3889). Put a validator in front of it that
+// tracks each upload session and rejects ranges real GCS would reject.
+static future<std::tuple<tp::process_fixture, int>> start_upload_validator(int upstream_port) {
+    auto pyexec = tp::find_file_in_path("python3");
+    if (pyexec.empty()) {
+        pyexec = tp::find_file_in_path("python");
+    }
+    if (pyexec.empty()) {
+        throw std::runtime_error("Could not find python3 or python.");
+    }
+
+    // Resolved against the working directory, as the tests are run from the
+    // source root. Check it here so a bad cwd says so, rather than surfacing
+    // as the validator dying without ever printing a port.
+    static const std::string script = "test/pylib/gcs_upload_validator.py";
+    if (!fs::exists(script)) {
+        throw std::runtime_error(fmt::format("Could not find {} (cwd={}). Tests are expected to run from the source root."
+            , script, fs::current_path().string()));
+    }
+
+    // Held by pointer rather than moved into the handler below: create() takes
+    // the handler by value into its coroutine frame, so a spawn failure would
+    // destroy the promise and leave port_future failed with broken_promise.
+    // Nothing consumes it on that path, and the seastar test runner turns an
+    // abandoned failed future into exit code 3 on top of the real error.
+    auto port_promise = make_lw_shared<promise<int>>();
+    auto port_future = port_promise->get_future();
+
+    auto python = co_await tp::process_fixture::create(pyexec
+        , { // args
+            pyexec.string(),
+            script,
+            "--upstream-port", std::to_string(upstream_port),
+        }
+        , {} // env
+        , tp::process_fixture::create_copy_handler(std::cout) // stdout
+        , [port_promise, matched = false](std::string_view line) mutable -> future<consumption_result<char>> {
+            static std::regex port_ex(R"foo(Starting GCS upload validator on \('[^']+', (\d+)\))foo");
+
+            std::match_results<typename std::string_view::const_iterator> m;
+            if (!matched && std::regex_search(line.begin(), line.end(), m, port_ex)) {
+                port_promise->set_value(std::stoi(m[1].str()));
+                matched = true;
+            } else {
+                // surface rejections in the test log, they explain the failure
+                BOOST_TEST_MESSAGE(std::string(line));
+            }
+            co_return continue_consuming{};
+        }
+    );
+
+    // From here on the fixture must not go out of scope with the process still
+    // running: the stdout/stderr consumers hold its gate until stream EOF, and
+    // ~gate() asserts when it is still held, which would abort the test binary
+    // instead of reporting the failure. Reap it first, as start_docker_service
+    // does on its own error path.
+    std::exception_ptr failure;
+    int port = 0;
+
+    try {
+        port = co_await with_timeout(std::chrono::steady_clock::now() + 20s, std::move(port_future));
+        if (port <= 0) {
+            throw std::runtime_error("Invalid upload validator port");
+        }
+
+        std::exception_ptr last;
+        for (size_t retry = 0;; ++retry) {
+            try {
+                auto c = co_await with_timeout(std::chrono::steady_clock::now() + 20s
+                    , seastar::connect(socket_address(net::inet_address("127.0.0.1"), port)));
+                c.shutdown_output();
+                last = {};
+                break;
+            } catch (...) {
+                last = std::current_exception();
+            }
+            if (retry == 4) {
+                break;
+            }
+            co_await sleep(100ms);
+        }
+        if (last) {
+            // Publishing an endpoint nothing serves would turn every later request
+            // into an unrelated connection error, so give up here instead.
+            throw std::runtime_error(fmt::format("GCS upload validator on port {} never accepted a connection: {}"
+                , port, last));
+        }
+    } catch (...) {
+        failure = std::current_exception();
+    }
+
+    if (failure) {
+        python.terminate();
+        co_await python.wait();
+        std::rethrow_exception(failure);
+    }
+
+    co_return std::make_tuple(std::move(python), port);
+}
+
 class gcs_fixture::impl {
 public:
     std::optional<tp::process_fixture> fake_gcs_server;
+    std::optional<tp::process_fixture> upload_validator;
     std::optional<google_credentials> creds;
 
     std::vector<std::string> objects_to_delete;
@@ -104,6 +210,30 @@ seastar::future<> gcs_fixture::impl::setup() {
         auto [proc, port] = co_await start_fake_gcs_server(tmp);
         fake_gcs_server.emplace(std::move(proc));
         endpoint = "http://127.0.0.1:" + std::to_string(port);
+
+        // Unless explicitly disabled, talk to the mock through a validator that
+        // enforces the resumable upload rules the mock itself ignores.
+        if (getenv_or_default("GCP_STORAGE_SKIP_UPLOAD_VALIDATOR").empty()) {
+            std::exception_ptr p;
+            try {
+                auto [vproc, vport] = co_await start_upload_validator(port);
+                upload_validator.emplace(std::move(vproc));
+                endpoint = "http://127.0.0.1:" + std::to_string(vport);
+                BOOST_TEST_MESSAGE(fmt::format("Validating uploads to fake gcs server on port {}", port));
+            } catch (...) {
+                p = std::current_exception();
+            }
+            if (p) {
+                // The mock is up by now and nothing else would stop it, the
+                // same reason create_bucket below tears down on failure.
+                try {
+                    co_await teardown();
+                } catch (...) {
+                }
+                std::rethrow_exception(p);
+            }
+        }
+
         BOOST_TEST_MESSAGE(fmt::format("Test server endpoint {}", endpoint));
         user_1_creds = "none";
     } else {
@@ -162,8 +292,14 @@ seastar::future<> gcs_fixture::impl::teardown() {
         }
     }
 
-    // Reset it, so that a teardown from a failed setup does not leave a second
-    // one re-terminating an already reaped process.
+    // Reset both, so that a teardown from a failed setup does not leave a
+    // second one re-terminating an already reaped process.
+    if (upload_validator) {
+        upload_validator->terminate();
+        co_await upload_validator->wait();
+        upload_validator.reset();
+    }
+
     if (fake_gcs_server) {
         fake_gcs_server->terminate();
         co_await fake_gcs_server->wait();

--- a/test/pylib/gcs_upload_validator.py
+++ b/test/pylib/gcs_upload_validator.py
@@ -1,0 +1,453 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2026-present ScyllaDB
+#
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
+#
+"""
+A strict resumable-upload validator that sits in front of fake-gcs-server.
+
+fake-gcs-server does not check resumable-upload Content-Range headers at all:
+it stores whatever body arrives and derives the object size from it.  Sending
+"bytes 500-999/1000" with a 3 byte body stores a 3 byte object and returns 200,
+and "bytes 0-0/0" -- a range naming a byte that cannot exist in an object
+declared to be empty -- is likewise accepted.  Real GCS rejects both with 400.
+
+That blind spot hid SCYLLADB-3889, where every object storage sstable failed to
+write its zero length refs/nodes/<host_id>/<gen> marker against real GCS while
+the whole *_gcs test suite stayed green.
+
+This proxy tracks the state of each upload session and computes what the next
+Content-Range must be, rejecting anything inconsistent with 400 before it
+reaches the mock.  Everything else is forwarded untouched, so tests observe the
+same behaviour they always did apart from the added checks.
+
+A chunk is validated from its Content-Length before any payload is read, so
+bodies stream through in both directions rather than being buffered.  The tests
+using this move real sstables around and must not pay for a copy per request.
+
+See https://cloud.google.com/storage/docs/performing-resumable-uploads
+"""
+
+import argparse
+import contextlib
+import http.client
+import json
+import re
+import sys
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from urllib.parse import urlparse, parse_qs
+
+# "bytes <first>-<last>/<total>", "bytes */<total>" or "bytes */*"
+CONTENT_RANGE_RE = re.compile(r"^bytes (?:(\d+)-(\d+)|\*)/(?:(\d+)|\*)$")
+# a 308 reply reports what the server holds as "bytes=<first>-<last>"
+REPLY_RANGE_RE = re.compile(r"^bytes=(\d+)-(\d+)$")
+
+HOP_BY_HOP = {"connection", "keep-alive", "proxy-authenticate", "proxy-authorization",
+              "te", "trailers", "transfer-encoding", "upgrade"}
+
+BLOCK = 128 * 1024
+
+
+class session:
+    """State of one resumable upload session."""
+
+    def __init__(self):
+        self.received = 0          # bytes the server has committed so far
+        self.total = None          # final size, once the client declares it
+        self.finalized = False
+        # held across validate -> forward -> commit for this session
+        self.lock = threading.Lock()
+
+
+class registry:
+    def __init__(self):
+        self._lock = threading.Lock()
+        self._sessions = {}
+
+    def get(self, upload_id):
+        with self._lock:
+            return self._sessions.setdefault(upload_id, session())
+
+    def drop(self, upload_id):
+        with self._lock:
+            self._sessions.pop(upload_id, None)
+
+
+SESSIONS = registry()
+
+# One upstream connection per serving thread. ThreadingHTTPServer gives each
+# client connection its own thread, so this pairs them up. Reconnecting per
+# request instead costs a TCP handshake every time, which showed up as a ~15x
+# slowdown of the delete storms these tests end with.
+THREAD_STATE = threading.local()
+
+
+class limited_reader:
+    """Hands http.client exactly `remaining` bytes off a socket, no buffering."""
+
+    def __init__(self, src, remaining):
+        self._src = src
+        self._remaining = remaining
+
+    def read(self, size=-1):
+        if self._remaining <= 0:
+            return b""
+        if size is None or size < 0:
+            size = self._remaining
+        buf = self._src.read(min(size, self._remaining))
+        self._remaining -= len(buf)
+        return buf
+
+
+def upload_id_of(path):
+    return (parse_qs(urlparse(path).query).get("upload_id") or [None])[0]
+
+
+def check(content_range, body_len, s):
+    """Validate content_range against session state.
+
+    Returns an error string, or None when the header is acceptable.
+    """
+    m = CONTENT_RANGE_RE.match(content_range)
+    if not m:
+        return f"malformed Content-Range {content_range!r}"
+
+    first, last, total = m.group(1), m.group(2), m.group(3)
+
+    if total is not None and s.total is not None and int(total) != s.total:
+        return (f"Content-Range {content_range!r} declares a total of {total} bytes, but this "
+                f"upload was already declared to be {s.total}")
+
+    if first is None:
+        # "bytes */<total>" finalizes the session, "bytes */*" queries it.
+        # Neither carries a payload. Both stay legal once finalized.
+        if body_len:
+            return (f"Content-Range {content_range!r} carries no byte range but the "
+                    f"request body is {body_len} bytes")
+        if total is not None and int(total) != s.received:
+            return (f"Content-Range {content_range!r} finalizes the upload at {total} bytes "
+                    f"but {s.received} bytes have been received; expected "
+                    f"'bytes */{s.received}'")
+        return None
+
+    if s.finalized:
+        return (f"Content-Range {content_range!r} sends more data to an upload already "
+                f"finalized at {s.total} bytes")
+
+    first, last = int(first), int(last)
+
+    if first > last:
+        return f"Content-Range {content_range!r} has first byte {first} past last byte {last}"
+
+    declared = last - first + 1
+    if declared != body_len:
+        return (f"Content-Range {content_range!r} declares {declared} bytes but the "
+                f"request body is {body_len} bytes")
+
+    if total is not None and last >= int(total):
+        # The whole point of the check: a chunk can never name a byte at or past
+        # the declared total size. For an empty object there is no valid
+        # <first>-<last> at all, only 'bytes */0'.
+        expected = f"bytes */{total}" if int(total) == s.received else \
+                   f"a last byte below {total}"
+        return (f"Content-Range {content_range!r} names last byte {last} in an object "
+                f"declared to be {total} bytes (valid byte indices are 0..{int(total) - 1}); "
+                f"expected {expected}")
+
+    if total is None and s.total is not None and last >= s.total:
+        return (f"Content-Range {content_range!r} names last byte {last} in an object declared "
+                f"to be {s.total} bytes (valid byte indices are 0..{s.total - 1})")
+
+    if first != s.received:
+        return (f"Content-Range {content_range!r} starts at {first} but {s.received} bytes "
+                f"have been received; expected a chunk starting at {s.received}")
+
+    return None
+
+
+def commit(content_range, reply_range, s):
+    """Advance session state after the upstream accepted a chunk."""
+    m = CONTENT_RANGE_RE.match(content_range)
+    if not m:
+        return
+    first, last, total = m.group(1), m.group(2), m.group(3)
+
+    if first is None:
+        # A 308 answer to 'bytes */*' or 'bytes */<total>' reports what the
+        # server actually holds, and is the only way to resync after a chunk
+        # whose reply never reached us.
+        if reply_range:
+            rm = REPLY_RANGE_RE.match(reply_range)
+            if rm:
+                s.received = int(rm.group(2)) + 1
+        if total is not None:
+            s.total = int(total)
+            # Only a complete upload is finalized. A 'bytes */<total>' answered
+            # 308 is still short of its total, and finalizing here would reject
+            # the resume chunk that follows it.
+            s.finalized = s.received == int(total)
+        return
+
+    # Prefer what the server says it holds, fall back to what we sent.
+    s.received = int(last) + 1
+    if reply_range:
+        rm = REPLY_RANGE_RE.match(reply_range)
+        if rm:
+            s.received = int(rm.group(2)) + 1
+    if total is not None:
+        s.total = int(total)
+        if s.received == s.total:
+            s.finalized = True
+
+
+class handler(BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"
+    # Headers and body go out as separate writes, so without this every response
+    # pays a delayed-ACK stall of ~40ms, which is enough to push the bounded
+    # retry cleanup loops in the tests over their budget.
+    disable_nagle_algorithm = True
+
+    # keep the test log readable; rejections are reported explicitly below
+    def log_message(self, fmt, *args):
+        pass
+
+    def _note(self, msg):
+        sys.stderr.write(f"gcs-upload-validator: {msg}\n")
+        sys.stderr.flush()
+
+    def _upstream(self):
+        conn = getattr(THREAD_STATE, "conn", None)
+        if conn is None:
+            conn = http.client.HTTPConnection(self.server.upstream_host,
+                                              self.server.upstream_port, timeout=600)
+            THREAD_STATE.conn = conn
+        return conn
+
+    def _drop_upstream(self):
+        conn = getattr(THREAD_STATE, "conn", None)
+        THREAD_STATE.conn = None
+        if conn is not None:
+            try:
+                conn.close()
+            except Exception:
+                pass
+
+    def finish(self):
+        # the serving thread ends with the client connection, so its upstream
+        # connection goes too
+        self._drop_upstream()
+        super().finish()
+
+    def _body_length(self):
+        """Length of the request body, or None when it is chunked."""
+        if "Content-Length" in self.headers:
+            return int(self.headers["Content-Length"])
+        if self.headers.get("Transfer-Encoding", "").lower() == "chunked":
+            return None
+        return 0
+
+    def _read_chunked(self):
+        chunks = []
+        while True:
+            size = int(self.rfile.readline().strip().split(b";")[0], 16)
+            if size == 0:
+                self.rfile.readline()
+                break
+            chunks.append(self.rfile.read(size))
+            self.rfile.readline()
+        return b"".join(chunks)
+
+    def _reject(self, message, body_len):
+        self._note(f"REJECT {self.command} {self.path}: {message}")
+        # drain whatever the client is sending so the reply is not mistaken for
+        # a response to a later request, then drop the connection
+        if body_len:
+            remaining = body_len
+            while remaining > 0:
+                got = self.rfile.read(min(BLOCK, remaining))
+                if not got:
+                    break
+                remaining -= len(got)
+        self.close_connection = True
+
+        payload = json.dumps({
+            "error": {
+                "code": 400,
+                "message": message,
+                "errors": [{"domain": "global", "reason": "badRequest", "message": message}],
+            }
+        }).encode()
+        self.send_response(400)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(payload)))
+        self.send_header("Connection", "close")
+        self.end_headers()
+        self.wfile.write(payload)
+
+    def _proxy(self):
+        body_len = self._body_length()
+        buffered = None
+        if body_len is None:
+            # chunked: no length up front, so this one has to be collected
+            buffered = self._read_chunked()
+            body_len = len(buffered)
+
+        upload_id = upload_id_of(self.path)
+        content_range = self.headers.get("Content-Range")
+        s = SESSIONS.get(upload_id) if upload_id else None
+
+        # Validating, forwarding and committing have to be one step: two
+        # requests on the same session would otherwise both pass check()
+        # against the same received count before either of them commits.
+        # A cancelling DELETE joins them, so that dropping the session cannot
+        # land between a chunk's check() and its commit() and leave a later
+        # chunk holding a different session object for the same upload.
+        # Requests carrying no range (the object reads and deletes that make up
+        # most of the traffic) take no lock at all.
+        needs_lock = s is not None and (content_range is not None or self.command == "DELETE")
+        guard = s.lock if needs_lock else contextlib.nullcontext()
+        with guard:
+            self._serve(body_len, buffered, upload_id, content_range, s)
+
+    def _serve(self, body_len, buffered, upload_id, content_range, s):
+        if content_range is not None and s is not None:
+            err = check(content_range, body_len, s)
+            if err:
+                self._reject(err, 0 if buffered is not None else body_len)
+                return
+
+        headers = {k: v for k, v in self.headers.items() if k.lower() not in HOP_BY_HOP}
+        headers["Host"] = f"{self.server.upstream_host}:{self.server.upstream_port}"
+        headers["Content-Length"] = str(body_len)
+
+        body = buffered if buffered is not None else limited_reader(self.rfile, body_len)
+        # A streamed body is consumed as it is sent, so it cannot be replayed on
+        # a second attempt; a buffered or empty one can. Covering the empty case
+        # is what lets the retry below fire for the object reads and deletes
+        # that make up most of the traffic.
+        replayable = buffered is not None or body_len == 0
+
+        for attempt in (0, 1):
+            conn = self._upstream()
+            try:
+                conn.request(self.command, self.path, body=body, headers=headers)
+                reply = conn.getresponse()
+                break
+            except (http.client.HTTPException, OSError):
+                # the pooled connection went stale, drop it and try once more
+                self._drop_upstream()
+                if attempt or not replayable:
+                    raise
+
+        if content_range is not None and s is not None and reply.status < 400:
+            # Real GCS reports a Range only on a 308, meaning "resume
+            # incomplete". fake-gcs-server also sends one on the 200 that
+            # completes an upload, and its value is off by one, so honouring it
+            # there would leave the session a byte ahead of the object and
+            # reject the next perfectly legal status query.
+            reply_range = reply.getheader("Range") if reply.status == 308 else None
+            commit(content_range, reply_range, s)
+
+        # GCS answers a successful cancel with 499, not a 2xx -- see
+        # remove_upload() in utils/gcp/object_storage.cc, which treats 499 as
+        # the success case and everything else as a failure.
+        cancelled = reply.status == 499 or reply.status < 400
+        if self.command == "DELETE" and upload_id and cancelled:
+            # a failed cancel leaves the upload alive upstream, so dropping our
+            # state would let a later chunk restart the accounting from zero
+            SESSIONS.drop(upload_id)
+
+        reply_len = reply.getheader("Content-Length")
+        self.send_response(reply.status)
+        for k, v in reply.getheaders():
+            if k.lower() in HOP_BY_HOP or k.lower() == "content-length":
+                continue
+            if k.lower() == "location":
+                # make the client come back through us for the rest of the session
+                v = v.replace(f"{self.server.upstream_host}:{self.server.upstream_port}",
+                              f"{self.server.public_host}:{self.server.server_address[1]}")
+            self.send_header(k, v)
+
+        truncated = False
+        if reply_len is not None:
+            # stream it through, downloads here can be whole sstables
+            self.send_header("Content-Length", reply_len)
+            self.end_headers()
+            if self.command == "HEAD":
+                # No body to forward, but http.client only marks a response
+                # closed once read() has returned empty. Leaving it unread keeps
+                # it attached to the pooled connection, and the next request on
+                # this thread reaches upstream and then fails locally with
+                # ResponseNotReady -- executed once, answered never.
+                reply.read()
+            else:
+                remaining = int(reply_len)
+                while remaining > 0:
+                    buf = reply.read(min(BLOCK, remaining))
+                    if not buf:
+                        # upstream gave us less than it promised, so we have
+                        # under-delivered against the length already sent
+                        truncated = True
+                        break
+                    self.wfile.write(buf)
+                    remaining -= len(buf)
+        else:
+            payload = reply.read()
+            self.send_header("Content-Length", str(len(payload)))
+            self.end_headers()
+            if self.command != "HEAD":
+                self.wfile.write(payload)
+
+        if truncated or reply.will_close:
+            # anything left unread would be picked up as the next reply
+            self._drop_upstream()
+        if truncated:
+            self.close_connection = True
+
+    do_GET = do_PUT = do_POST = do_DELETE = do_HEAD = do_PATCH = _proxy
+
+
+class validating_server(ThreadingHTTPServer):
+    daemon_threads = True
+    # socketserver defaults to 5, which the client's connection bursts overflow;
+    # the dropped SYNs are then retried a second later, and a handful of those
+    # stalls is enough to push the tests' cleanup budgets over.
+    request_queue_size = 128
+
+    def handle_error(self, request, client_address):
+        exc = sys.exc_info()[1]
+        if isinstance(exc, (ConnectionResetError, BrokenPipeError, ConnectionAbortedError)):
+            # a client going away mid request is routine during teardown, and
+            # a traceback per occurrence only makes the test log harder to read
+            return
+        super().handle_error(request, client_address)
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--upstream-host", default="127.0.0.1")
+    ap.add_argument("--upstream-port", type=int, required=True,
+                    help="port of the fake-gcs-server to forward to")
+    ap.add_argument("--bind-host", default="127.0.0.1",
+                    help="address to listen on")
+    ap.add_argument("--port", type=int, default=0,
+                    help="port to listen on, 0 to pick a free one")
+    args = ap.parse_args()
+
+    srv = validating_server((args.bind_host, args.port), handler)
+    srv.upstream_host = args.upstream_host
+    srv.upstream_port = args.upstream_port
+    srv.public_host = args.bind_host
+
+    # the fixtures grep stderr for this line to learn the port
+    sys.stderr.write(f"Starting GCS upload validator on {srv.server_address} "
+                     f"-> ('{args.upstream_host}', {args.upstream_port})\n")
+    sys.stderr.flush()
+
+    srv.serve_forever()
+
+
+if __name__ == "__main__":
+    main()

--- a/test/pylib/object_storage.py
+++ b/test/pylib/object_storage.py
@@ -10,12 +10,17 @@ Classes, factory functions, and shared pytest fixtures used by
 test/cluster/object_store/ and test/cqlpy/ tests.
 """
 
+import asyncio
+import contextlib
 import logging
 import os
 import re
+import sys
 import uuid
 from collections.abc import Awaitable, Callable
 from operator import attrgetter
+from pathlib import Path
+from types import SimpleNamespace
 from typing import Literal
 
 import boto3
@@ -240,10 +245,117 @@ class GSFront:
         pass
 
 
+VALIDATOR_PORT_RE = re.compile(r"Starting GCS upload validator on \('[^']+', (\d+)\)")
+
+
+async def start_gcs_upload_validator(upstream_host, upstream_port, log_dir, timeout=30):
+    """Run test/pylib/gcs_upload_validator.py in front of a fake-gcs-server.
+
+    Returns (handle, port). See the script for what it enforces and why.
+    """
+    script = Path(__file__).parent / 'gcs_upload_validator.py'
+    logf = None
+    if log_dir:
+        # log_dir is the shared suite log dir and this fixture is per test, so
+        # the name has to be unique or parallel tests truncate each other's log
+        # -- DockerizedServer does the same for the mock's own log.
+        logpath = Path(log_dir) / f'gcs-upload-validator-{uuid.uuid4()}.log'
+        logging.info('GCS upload validator log: %s', logpath)
+        logf = open(logpath, 'wb')
+
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            sys.executable, str(script),
+            '--upstream-host', str(upstream_host),
+            '--upstream-port', str(upstream_port),
+            '--bind-host', str(upstream_host),
+            '--port', '0',
+            stdout=asyncio.subprocess.DEVNULL,
+            stderr=asyncio.subprocess.PIPE,
+        )
+    except BaseException:
+        if logf:
+            logf.close()
+        raise
+
+    async def read_port():
+        while True:
+            line = await proc.stderr.readline()
+            if not line:
+                raise RuntimeError('GCS upload validator exited before reporting a port')
+            if logf:
+                logf.write(line)
+            m = VALIDATOR_PORT_RE.search(line.decode(errors='replace'))
+            if m:
+                return int(m.group(1))
+
+    try:
+        port = await asyncio.wait_for(read_port(), timeout)
+    except BaseException:
+        # BaseException, not Exception: a cancelled setup would otherwise leave
+        # the validator running, and the caller cannot clean it up either since
+        # it never got the handle.
+        # The validator has usually exited on its own here -- that is what this
+        # path is for -- and terminating a reaped process raises
+        # ProcessLookupError, which would replace the error that actually
+        # explains the failure and skip the cleanup below.
+        try:
+            if proc.returncode is None:
+                with contextlib.suppress(ProcessLookupError):
+                    proc.terminate()
+                await proc.wait()
+        finally:
+            if logf:
+                logf.close()
+        raise
+
+    async def drain():
+        # keep the pipe empty and the rejections in the log
+        while True:
+            line = await proc.stderr.readline()
+            if not line:
+                return
+            if logf:
+                logf.write(line)
+                logf.flush()
+            if b'REJECT' in line:
+                logging.error('%s', line.decode(errors='replace').rstrip())
+
+    handle = SimpleNamespace(proc=proc, drain=asyncio.create_task(drain()), logf=logf)
+    logging.info('GCS upload validator listening on %s:%s -> %s:%s',
+                 upstream_host, port, upstream_host, upstream_port)
+    return handle, port
+
+
+async def stop_gcs_upload_validator(handle):
+    try:
+        if handle.proc.returncode is None:
+            handle.proc.terminate()
+            try:
+                await asyncio.wait_for(handle.proc.wait(), 10)
+            except asyncio.TimeoutError:
+                handle.proc.kill()
+                await handle.proc.wait()
+        handle.drain.cancel()
+        try:
+            await handle.drain
+        except asyncio.CancelledError:
+            pass
+    finally:
+        # A cancelled teardown has to release these too -- the callback is
+        # popped once, so nothing retries it. Cancelling before the close is
+        # race-free: drain only runs while this coroutine is suspended, so it
+        # cannot be part-way through a write here.
+        handle.drain.cancel()
+        if handle.logf:
+            handle.logf.close()
+
+
 class GSServerImpl(GSFront):
     def __init__(self, log_dir):
         super(GSServerImpl, self).__init__(None, 'testbucket', None)
         self.server = None
+        self.validator = None
         self.host = None
         self.port = None
         self.oldvars = {}
@@ -285,6 +397,24 @@ class GSServerImpl(GSFront):
         await self.server.start()
         self.port = self.server.port
         self.host = self.server.host
+
+        # fake-gcs-server accepts any Content-Range it is given, so protocol
+        # level upload bugs are invisible when testing against it
+        # (SCYLLADB-3889). Unless disabled, front it with a validator that
+        # enforces what real GCS enforces, and hand its address out instead.
+        if not os.environ.get('GCP_STORAGE_SKIP_UPLOAD_VALIDATOR'):
+            try:
+                self.validator, validator_port = await start_gcs_upload_validator(
+                    self.host, self.port, self.log_dir)
+            except BaseException:
+                # Nothing frees the server until make_object_storage() has
+                # registered its teardown callback, which happens only once
+                # start() returns, so the container is ours to clean up here.
+                await self.server.stop()
+                self.server = None
+                raise
+            self.port = validator_port
+
         self.publish()
 
 
@@ -324,12 +454,24 @@ class GSServerImpl(GSFront):
         self.bucket_name = None
 
     async def stop(self):
-        if self.server:
-            # Dropped only on success, so that a retry still has a server to
-            # stop.
-            await self.server.stop()
-            self.server = None
-        self.unpublish()
+        # This runs as a cluster teardown callback, and those have their
+        # exceptions swallowed. Nesting the steps keeps a failure in one from
+        # stranding the container or leaving GS_SERVER_ADDRESS_FOR_TEST pointed
+        # at a dead validator, which every later gs test in this worker would
+        # then pick up.
+        try:
+            if self.validator:
+                await stop_gcs_upload_validator(self.validator)
+                self.validator = None
+        finally:
+            try:
+                if self.server:
+                    # Dropped only on success, so that a retry still has a
+                    # server to stop.
+                    await self.server.stop()
+                    self.server = None
+            finally:
+                self.unpublish()
 
 
 # Keep the old name as an alias for backward compatibility (conftest.py imports it)


### PR DESCRIPTION
> This PR hijacks #31241 by Łukasz Paszkowski, who is unavailable now while that branch conflicts
> with master. The four commits are his, cherry-picked onto current master with authorship
> preserved. The only change is the import block of `test/pylib/object_storage.py`, which upstream
> `b41becb06e1` reordered; the rest of the diff is identical to #31241.

`fake-gcs-server` does not validate resumable-upload `Content-Range` headers — it stores whatever body arrives and derives the size from it. `bytes 0-0/0`, a range naming a byte that cannot exist in an object declared empty, returns 200; real GCS returns 400.

That is how SCYLLADB-3889 reached 2026.3 rc0. The coverage was never missing: `compact_gcs_test` walks the exact failing path — every object-storage sstable first writes an empty refs/nodes/<host_id>/<gen> marker — it just could not observe the defect.

This series adds a validator in front of the mock. It tracks each upload session, computes what the next `Content-Range` must be, and rejects what real GCS would reject; everything else is forwarded untouched. Chunks are validated from `Content-Length` before any payload is read, so bodies stream through. Both provisioning paths are wired up: `gcs_fixture` (boost) and `GSServerImpl` (test/cluster/object_store, test/cqlpy), the latter covering 40 tests that run against both backends.

Verified with the SCYLLADB-3889 fix present: 17 boost cases, the *_gcs sstable tests, and 141 cluster tests pass with no rejections logged. With the fix reverted, compact_gcs_test and test_basic[gs-normal-1] fail on the empty marker.

GCP_STORAGE_SKIP_UPLOAD_VALIDATOR=1 bypasses it; real GCP endpoints never start it.

**Test improvement to increase coverage. No backport needed**

---

Rebase of #31241 (@paszkow). Approvals there: @elcallio (2026-08-24) and @kreuzerkrieg (2026-09-03).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
