### PR TITLE
test: audit: drop plain CQL ports from the CertificateAuthenticator node

### DIFF
--- a/test/cluster/test_auth_certificate_or_password.py
+++ b/test/cluster/test_auth_certificate_or_password.py
@@ -530,15 +530,21 @@ async def _certificate_authenticator_node(manager, tmp_path):
     a test for a refused login needs this authenticator instead.  The manager's own
     driver cannot log into it on the plain port, hence connect_driver=False and an
     admin connection over TLS retried until the listener answers.
+
+    The unencrypted ports are left unset, which keeps the node from opening them
+    at all: this authenticator refuses, and audits under an empty user name, every
+    connection that presents no certificate, so anything reaching a plain port
+    would record the failure these tests attribute to themselves.
     """
     _gen_certs(tmp_path)
-    server = await manager.server_add(
-        config=_server_config(tmp_path, extra_config={
-            'authenticator': 'CertificateAuthenticator',
-            'audit': 'table',
-            'audit_categories': 'AUTH',
-        }),
-        connect_driver=False)
+    config = _server_config(tmp_path, extra_config={
+        'authenticator': 'CertificateAuthenticator',
+        'audit': 'table',
+        'audit_categories': 'AUTH',
+    })
+    del config['native_transport_port']
+    del config['native_shard_aware_transport_port']
+    server = await manager.server_add(config=config, connect_driver=False)
 
     def connect_admin():
         cluster = _make_tls_cluster(

--- a/test/cluster/test_auth_certificate_or_password.py
+++ b/test/cluster/test_auth_certificate_or_password.py
@@ -140,6 +140,9 @@ def _make_tls_cluster(host: str, port: int,
         protocol_version=4,
         connect_timeout=30,
         control_connection_timeout=30,
+        # The driver picks the encrypted shard-aware port only when ssl_options
+        # is set, and these clusters configure TLS with an ssl_context instead.
+        shard_aware_options={'disable_shardaware_port': True},
     )
 
 


### PR DESCRIPTION
Two of the certificate-login audit tests fail whenever another client
has reached their node's plain CQL port before they start. The node
runs the CertificateAuthenticator, which refuses and audits every
connection that presents no certificate, and the tests expect to find
no such record until they cause one themselves. Nothing in these tests
needs the plain ports: the harness does not connect its driver to this
node, and the tests connect over TLS. Leave the ports out of the node's
config, so it never opens them.

Fixes: SCYLLADB-4330
Backport: not needed, as https://github.com/scylladb/scylladb/pull/31319 was not backported