### PR TITLE
compaction, replica: register gc sstables as compacting on replacement

### DIFF
--- a/compaction/compaction_descriptor.hh
+++ b/compaction/compaction_descriptor.hh
@@ -44,6 +44,24 @@ struct compaction_completion_desc {
     std::vector<sstables::shared_sstable> new_gc_sstables;
     // Set of compacted partition ranges that should be invalidated in the cache.
     utils::chunked_vector<dht::partition_range> ranges_for_cache_invalidation;
+
+    // Everything this replacement adds to the SSTable set, the regular outputs
+    // followed by the GCed-data ones.
+    //
+    // The two are kept in separate vectors only because
+    // sstable_list_updater::prepare() has to pin the GCed-data SSTables to the
+    // compaction group the compaction runs on, instead of routing them through
+    // the live tablet map like the regular outputs. Every other consumer wants
+    // both, and one that reads new_sstables alone ends up seeing a removal it
+    // was never told to expect, since GCed-data SSTables come back as
+    // old_sstables when they are released.
+    std::vector<sstables::shared_sstable> all_new_sstables() const {
+        std::vector<sstables::shared_sstable> ret;
+        ret.reserve(new_sstables.size() + new_gc_sstables.size());
+        ret.insert(ret.end(), new_sstables.begin(), new_sstables.end());
+        ret.insert(ret.end(), new_gc_sstables.begin(), new_gc_sstables.end());
+        return ret;
+    }
 };
 
 // creates a new SSTable for a given shard

--- a/compaction/compaction_manager.cc
+++ b/compaction/compaction_manager.cc
@@ -426,8 +426,13 @@ future<compaction_result> compaction_task_executor::compact_sstables(compaction_
             co_await handler.wait_for_message(std::chrono::steady_clock::now() + std::chrono::minutes{5});
             cmlog.info("split_pause_before_replacer: released");
         }).get();
-        t.get_compaction_strategy().notify_completion(t, desc.old_sstables, desc.new_sstables);
-        _cm.propagate_replacement(t, desc.old_sstables, desc.new_sstables);
+        // Everything that tracks a replacement has to see the garbage
+        // collected sstables as well as the regular outputs, since both are
+        // attached to the sstable set and both come back as old_sstables when
+        // released. See compaction_completion_desc::all_new_sstables().
+        auto added = desc.all_new_sstables();
+        t.get_compaction_strategy().notify_completion(t, desc.old_sstables, added);
+        _cm.propagate_replacement(t, desc.old_sstables, added);
         // Hold sstable_set_lock while mutating the sstable set and deregistering
         // old sstables.  This serializes with regular compaction's snapshot +
         // filter + registration, preventing the stale-snapshot race.
@@ -445,7 +450,12 @@ future<compaction_result> compaction_task_executor::compact_sstables(compaction_
         // window, where the sstables:
         // - are still in the main set
         // - are not being compacted.
-        on_replace.on_addition(desc.new_sstables);
+        //
+        // This has to cover the garbage collected sstables too. The regular
+        // outputs are shielded twice over, since they carry the output run
+        // identifier this task advertises and get_candidates() filters on it,
+        // but a garbage collected sstable gets a run identifier of its own.
+        on_replace.on_addition(added);
         auto old_sstables = desc.old_sstables;
         _cm.on_compaction_completion(t, std::move(desc), offstrategy).get();
         on_replace.on_removal(old_sstables);

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -2716,6 +2716,12 @@ compaction_group::do_update_sstable_sets_on_compaction_completion(compaction::co
     cache.refresh_snapshot();
 
     _t.rebuild_statistics();
+    // desc.new_gc_sstables are deliberately left out. They hold only data this
+    // compaction is dropping, they exist just long enough to keep a crash from
+    // resurrecting it, and they are released by the same compaction that
+    // created them. Their large-partition, large-row and large-collection
+    // records describe garbage, so feeding them to the guardrail would report
+    // limit violations for data that is on its way out.
     for (auto& sst : desc.new_sstables) {
         _t._large_data_guardrail->register_sstable(sst);
     }
@@ -2729,8 +2735,7 @@ compaction_group::update_sstable_sets_on_compaction_completion(compaction::compa
     // table. By the time this runs the outputs are unreachable through every other channel
     // (finish() already moved them out of the compaction, and they are sealed so ~sstable()
     // won't unlink them either), so a failure here would otherwise leak them on disk forever.
-    auto new_sstables = desc.new_sstables;
-    std::ranges::copy(desc.new_gc_sstables, std::back_inserter(new_sstables));
+    auto new_sstables = desc.all_new_sstables();
     bool attached = false;
     std::exception_ptr ex;
     try {

--- a/test/boost/incremental_compaction_test.cc
+++ b/test/boost/incremental_compaction_test.cc
@@ -5,6 +5,7 @@
  */
 
 #include <boost/test/unit_test.hpp>
+#include <fmt/ranges.h>
 #include <boost/range/iterator_range_core.hpp>
 #include <memory>
 #include <utility>
@@ -530,6 +531,51 @@ SEASTAR_TEST_CASE(gc_tombstone_with_grace_seconds_test) {
     });
 }
 
+// Parameters for add_input_sstable(). The defaults produce the mix the garbage
+// collection tests need: a run in which most keys carry a tombstone that has
+// already expired, so that compacting the run has something to collect.
+struct input_sstable_params {
+    // One key in every live_every holds live data, the rest hold expired
+    // tombstones. Pass 1 for an all-live sstable.
+    int live_every = 4;
+    sstring live_value = "live_data";
+    api::timestamp_type live_ts = 100;
+    // Has to exceed live_ts where the tombstones are meant to shadow live data
+    // held by another sstable.
+    api::timestamp_type tombstone_ts = 100;
+};
+
+// Builds an sstable covering dks[first_key, first_key + nkeys) as described by
+// params, adds it to the table's sstable set and tags it with run_id, so that
+// a compaction over several such sstables takes the incremental, and hence the
+// garbage collecting, path.
+static shared_sstable add_input_sstable(test_env& env, table_for_tests& cf, const schema_ptr& schema,
+        const std::vector<dht::decorated_key>& dks, int first_key, int nkeys,
+        sstables::run_id run_id, input_sstable_params params = {}) {
+    auto& cdef = *schema->get_column_definition("data");
+    utils::chunked_vector<mutation> mutations;
+    for (int j = 0; j < nkeys; j++) {
+        int key_idx = first_key + j;
+        mutation mut(schema, dks.at(key_idx));
+        auto ck = clustering_key::make_empty();
+        if (key_idx % params.live_every == 0) {
+            // Live data. Also what keeps the sstable from being fully expired,
+            // which would take it out of the incremental path entirely.
+            auto live_cell = atomic_cell::make_live(*cdef.type, params.live_ts, serialized(params.live_value));
+            mut.set_clustered_cell(ck, cdef, std::move(live_cell));
+        } else {
+            auto expiration_time = (gc_clock::now() - 2s).time_since_epoch().count();
+            auto tombstone = atomic_cell::make_dead(params.tombstone_ts, gc_clock::time_point(gc_clock::duration(expiration_time)));
+            mut.set_clustered_cell(ck, cdef, std::move(tombstone));
+        }
+        mutations.push_back(std::move(mut));
+    }
+    auto sst = make_sstable_containing(env.make_sst_factory(schema), std::move(mutations)).get();
+    sstables::test(sst).set_run_identifier(run_id);
+    column_family_test(cf).add_sstable(sst).get();
+    return sst;
+}
+
 SEASTAR_TEST_CASE(gc_sstable_incremental_release_test) {
     return test_env::do_with_async([](test_env& env) {
 
@@ -550,35 +596,12 @@ SEASTAR_TEST_CASE(gc_sstable_incremental_release_test) {
         table_for_tests cf = env.make_table_for_tests(schema);
         auto close_cf = deferred_stop(cf);
 
-        auto make_mutation = [&] (size_t key_index, bool insert_tombstones) {
-            mutation mut(schema, dks.at(key_index));
-            auto ck = clustering_key::make_empty();
-            auto& cdef = *schema->get_column_definition("data");
-            if (insert_tombstones) {
-                auto expiration_time = (gc_clock::now() - 2s).time_since_epoch().count();
-                auto tombstone = atomic_cell::make_dead(ts, gc_clock::time_point(gc_clock::duration(expiration_time)));
-                mut.set_clustered_cell(ck, cdef, std::move(tombstone));
-            } else {
-                auto live_cell = atomic_cell::make_live(*cdef.type, ts, serialized("live_data"));
-                mut.set_clustered_cell(ck, cdef, std::move(live_cell));
-            }
-            return mut;
-        };
-
+        // 3/4th of the keys are expired tombstones.
         const auto run_id = sstables::run_id::create_random_id();
         std::vector<shared_sstable> input_sstables;
         for (int i = 0; i < num_sstables; i++) {
-            utils::chunked_vector<mutation> mutations;
-            for (int j = 0; j < keys_per_sstable; j++) {
-                int key_idx = i * keys_per_sstable + j;
-                // 3/4th of the keys are expired tombstones
-                bool expired = (key_idx % 4) == 0;
-                mutations.push_back(make_mutation(key_idx, !expired));
-            }
-            auto sst = make_sstable_containing(env.make_sst_factory(schema), std::move(mutations)).get();
-            sstables::test(sst).set_run_identifier(run_id);
-            column_family_test(cf).add_sstable(sst).get();
-            input_sstables.push_back(std::move(sst));
+            input_sstables.push_back(add_input_sstable(env, cf, schema, dks, i * keys_per_sstable, keys_per_sstable,
+                    run_id, {.live_ts = ts, .tombstone_ts = ts}));
         }
 
         // Track GC sstables and their release order
@@ -592,8 +615,7 @@ SEASTAR_TEST_CASE(gc_sstable_incremental_release_test) {
                 }
             }
 
-            auto new_sstables = desc.new_sstables;
-            std::ranges::copy(desc.new_gc_sstables, std::back_inserter(new_sstables));
+            auto new_sstables = desc.all_new_sstables();
             column_family_test(cf).rebuild_sstable_list(cf.as_compaction_group_view(), new_sstables, desc.old_sstables).get();
             env.test_compaction_manager().propagate_replacement(cf.as_compaction_group_view(), desc.old_sstables, std::move(new_sstables));
         };
@@ -651,47 +673,15 @@ SEASTAR_TEST_CASE(gc_sstable_no_premature_release_with_overlapping_inputs_test) 
         // GC sstables whose tombstones shadow data in the still-alive wide sstable.
 
         // Create narrow sstables, each with 3/4 tombstones and 1/4 live data.
+        // The tombstones shadow data held by the wide sstable below.
         for (int i = 0; i < num_narrow; i++) {
-            utils::chunked_vector<mutation> mutations;
-            for (int j = 0; j < narrow_keys; j++) {
-                int key_idx = i * narrow_keys + j;
-                mutation mut(schema, dks.at(key_idx));
-                auto ck = clustering_key::make_empty();
-                auto& cdef = *schema->get_column_definition("data");
-                if ((key_idx % 4) != 0) {
-                    // 3/4 of keys: expired tombstones that shadow data in the wide sstable
-                    auto expiration_time = (gc_clock::now() - 2s).time_since_epoch().count();
-                    auto tombstone = atomic_cell::make_dead(tombstone_ts, gc_clock::time_point(gc_clock::duration(expiration_time)));
-                    mut.set_clustered_cell(ck, cdef, std::move(tombstone));
-                } else {
-                    // 1/4 of keys: live data (prevents the sstable from being fully expired)
-                    auto live_cell = atomic_cell::make_live(*cdef.type, live_ts, serialized("narrow_live"));
-                    mut.set_clustered_cell(ck, cdef, std::move(live_cell));
-                }
-                mutations.push_back(std::move(mut));
-            }
-            auto sst = make_sstable_containing(env.make_sst_factory(schema), std::move(mutations)).get();
-            sstables::test(sst).set_run_identifier(run_id);
-            column_family_test(cf).add_sstable(sst).get();
-            input_sstables.push_back(std::move(sst));
+            input_sstables.push_back(add_input_sstable(env, cf, schema, dks, i * narrow_keys, narrow_keys, run_id,
+                    {.live_value = "narrow_live", .live_ts = live_ts, .tombstone_ts = tombstone_ts}));
         }
 
         // Create 1 wide sstable covering ALL keys [0, 1600) with live data.
-        {
-            utils::chunked_vector<mutation> mutations;
-            for (int j = 0; j < total_keys; j++) {
-                mutation mut(schema, dks.at(j));
-                auto ck = clustering_key::make_empty();
-                auto& cdef = *schema->get_column_definition("data");
-                auto live_cell = atomic_cell::make_live(*cdef.type, live_ts, serialized("wide_live"));
-                mut.set_clustered_cell(ck, cdef, std::move(live_cell));
-                mutations.push_back(std::move(mut));
-            }
-            auto sst = make_sstable_containing(env.make_sst_factory(schema), std::move(mutations)).get();
-            sstables::test(sst).set_run_identifier(run_id);
-            column_family_test(cf).add_sstable(sst).get();
-            input_sstables.push_back(std::move(sst));
-        }
+        input_sstables.push_back(add_input_sstable(env, cf, schema, dks, 0, total_keys, run_id,
+                {.live_every = 1, .live_value = "wide_live", .live_ts = live_ts}));
 
         // Track whether any GC sstable was released while input sstables remain.
         // A GC sstable must not be released if it overlaps with any remaining input sstable.
@@ -727,8 +717,7 @@ SEASTAR_TEST_CASE(gc_sstable_no_premature_release_with_overlapping_inputs_test) 
                 std::erase(alive_inputs, old_sst);
             }
 
-            auto new_sstables = desc.new_sstables;
-            std::ranges::copy(desc.new_gc_sstables, std::back_inserter(new_sstables));
+            auto new_sstables = desc.all_new_sstables();
             column_family_test(cf).rebuild_sstable_list(cf.as_compaction_group_view(), new_sstables, desc.old_sstables).get();
             env.test_compaction_manager().propagate_replacement(cf.as_compaction_group_view(), desc.old_sstables, std::move(new_sstables));
         };
@@ -741,5 +730,157 @@ SEASTAR_TEST_CASE(gc_sstable_no_premature_release_with_overlapping_inputs_test) 
         // released while the wide sstable is alive. GC sstables should only be
         // released at the very end (or not incrementally at all).
         BOOST_CHECK_MESSAGE(!premature_gc_release, "GC sstable was released while overlapping input sstables were still alive");
+    });
+}
+
+// Reproducer for SCYLLADB-4014.
+//
+// An incremental compaction hands the garbage-collected (GC) sstables it
+// produces to the replacer in compaction_completion_desc::new_gc_sstables, and
+// sstable_list_updater::prepare() attaches them to the compaction's own group.
+// They stay in the table's sstable set until every overlapping input has been
+// exhausted, and are then released by the same compaction as old_sstables.
+//
+// While they are attached they must be announced through
+// compaction_task_executor::on_replacement::on_addition(), whose contract is
+// "the new sstables to be added to the table's sstable set", because that is
+// what registers them as compacting.  The compaction manager's replacer spells
+// out why right above the call: a regular compaction skips the sstables that
+// are being compacted, so an sstable sitting in the main set unregistered can
+// be picked up by another compaction and compacted away.  The owning
+// compaction then fails to remove it and aborts with
+// "Unable to remove input SSTable ... that belongs to group id N".
+//
+// The regular outputs are shielded twice over, because they also inherit the
+// descriptor's run identifier, which the running task advertises through
+// output_run_id() and get_candidates() filters on.  GC sstables get a run
+// identifier of their own, so on_addition() is the only thing protecting them.
+//
+// This test runs a real compaction through
+// compaction_task_executor::compact_sstables(), i.e. through the compaction
+// manager's own replacer, records everything the replacer announces, and
+// checks after every replacement that each GC sstable in the group's sstable
+// set has been announced.
+class gc_sstable_registration_task : public compaction::compaction_task_executor {
+public:
+    // Called after each replacement, with the sstables announced so far.
+    using check_fn = std::function<void(const std::unordered_set<shared_sstable>&)>;
+
+private:
+    compaction::compaction_descriptor _descriptor;
+    check_fn _check_after_replacement;
+    gate::holder _hold;
+
+    // Stands in for compacting_sstable_registration::update_me, which is
+    // private to compaction_manager.cc.  It is handed exactly what production
+    // hands the real one.
+    class announcement_recorder : public on_replacement {
+        std::unordered_set<shared_sstable> _announced;
+        check_fn& _check;
+    public:
+        explicit announcement_recorder(check_fn& check) noexcept : _check(check) {}
+
+        void on_addition(const std::vector<shared_sstable>& sstables) override {
+            _announced.insert(sstables.begin(), sstables.end());
+        }
+
+        void on_removal(const std::vector<shared_sstable>& sstables) override {
+            // The sstable set has been updated by now, so this is the state a
+            // concurrent compaction would observe.
+            _check(_announced);
+            for (auto& sst : sstables) {
+                _announced.erase(sst);
+            }
+        }
+    };
+
+public:
+    gc_sstable_registration_task(compaction::compaction_manager& cm, compaction::compaction_group_view& table_s,
+                                 compaction::compaction_descriptor descriptor, check_fn check)
+        : compaction::compaction_task_executor(cm, compaction::throw_if_stopping::no, &table_s,
+                compaction::compaction_type::Compaction, "GC sstable registration test")
+        , _descriptor(std::move(descriptor))
+        , _check_after_replacement(std::move(check))
+        , _hold(_compaction_state.gate.hold())
+    {}
+
+protected:
+    virtual future<compaction::compaction_manager::compaction_stats_opt> do_run() override {
+        // Advertises the output run identifier, so that the compaction behaves
+        // the way a regular compaction does.
+        setup_new_compaction(_descriptor.run_identifier);
+        announcement_recorder on_replace(_check_after_replacement);
+        co_await compact_sstables(std::move(_descriptor), _compaction_data, on_replace);
+        finish_compaction();
+        co_return std::nullopt;
+    }
+};
+
+SEASTAR_TEST_CASE(gc_sstables_are_announced_to_the_compacting_registration_test) {
+    return test_env::do_with_async([](test_env& env) {
+        auto schema = schema_builder(this_smp_shard_count(), "ks", "gc_sstable_registration_test")
+                .with_column("pk", utf8_type, column_kind::partition_key)
+                .with_column("data", utf8_type)
+                .with_tombstone_gc_options(tombstone_gc_options{tombstone_gc_mode::immediate})
+                .build();
+
+        constexpr int num_sstables = 16;
+        constexpr int keys_per_sstable = 100;
+        constexpr api::timestamp_type ts = 100;
+
+        auto dks = tests::generate_partition_keys(num_sstables * keys_per_sstable, schema, local_shard_only::yes);
+
+        table_for_tests cf = env.make_table_for_tests(schema);
+        auto close_cf = deferred_stop(cf);
+
+        // Same shape as gc_sstable_incremental_release_test: 3/4 of the keys
+        // are expired tombstones, so the compaction produces GC sstables, and
+        // the inputs share a run identifier so that the incremental, and hence
+        // the garbage collecting, writer is enabled.
+        const auto run_id = sstables::run_id::create_random_id();
+        std::vector<shared_sstable> input_sstables;
+        for (int i = 0; i < num_sstables; i++) {
+            input_sstables.push_back(add_input_sstable(env, cf, schema, dks, i * keys_per_sstable, keys_per_sstable,
+                    run_id, {.live_ts = ts, .tombstone_ts = ts}));
+        }
+
+        auto& table_s = cf.as_compaction_group_view();
+
+        auto is_gc_sstable = [] (const shared_sstable& sst) {
+            return sst->get_origin() == "garbage_collection";
+        };
+
+        size_t max_attached_gc_sstables = 0;
+        std::unordered_set<shared_sstable> unannounced_gc_sstables;
+
+        auto check = [&] (const std::unordered_set<shared_sstable>& announced) {
+            auto main_set = table_s.main_sstable_set().get();
+            size_t attached = 0;
+            for (auto& sst : *main_set->all()) {
+                if (!is_gc_sstable(sst)) {
+                    continue;
+                }
+                ++attached;
+                if (!announced.contains(sst)) {
+                    unannounced_gc_sstables.insert(sst);
+                }
+            }
+            max_attached_gc_sstables = std::max(max_attached_gc_sstables, attached);
+        };
+
+        auto descriptor = compaction::compaction_descriptor(std::move(input_sstables), 1, 512);
+        auto& tcm = env.test_compaction_manager();
+        auto task = make_shared<gc_sstable_registration_task>(tcm.get_compaction_manager(), table_s,
+                std::move(descriptor), check);
+        tcm.perform_compaction(task).get();
+
+        // Guard against the test passing because no GC sstable was ever
+        // attached, which would make the check above vacuous.
+        BOOST_REQUIRE_GT(max_attached_gc_sstables, 0u);
+
+        BOOST_REQUIRE_MESSAGE(unannounced_gc_sstables.empty(),
+                seastar::format("{} GC sstable(s) were attached to the sstable set without being announced to "
+                        "the compacting registration, so a concurrent compaction could remove them: [{}]",
+                        unannounced_gc_sstables.size(), fmt::join(unannounced_gc_sstables, ", ")));
     });
 }


### PR DESCRIPTION
b65caf79a4 ("replica: fix 'Unable to remove input SSTable' crash for GC sstables during tablet merge") moved the garbage collected sstables of an incremental compaction out of `compaction_completion_desc::new_sstables` into a vector of their own, `new_gc_sstables`, so that `sstable_list_updater::prepare()` can pin them to the compaction group the compaction runs on rather than routing them through the live tablet map.

The compaction manager was not updated to match. Its replacer still passes only `desc.new_sstables` to `on_replacement::on_addition()`, so a garbage collected sstable now enters the group's main sstable set without ever being registered in `_compacting_sstables`. The comment right above that call states the invariant it breaks: a regular compaction skips the sstables that are being compacted, so one that sits in the main set unregistered can be picked up by another compaction and compacted away. The compaction that created it then fails to remove it on release and aborts with

```
Unable to remove input SSTable [...] that belongs to group id N for compaction of type unknown
```

The regular outputs survive this because they are shielded twice over: they carry the descriptor's run identifier, which the running task advertises through `output_run_id()`, and `get_candidates()` filters on it. A garbage collected sstable gets a run identifier of its own, so the registration was the only thing protecting it.

The same omission left `notify_completion()` and `propagate_replacement()` seeing a removal they were never told to expect, since the garbage collected sstables do come back as `old_sstables` when released. Build the added list once and hand it to all three, which is what they saw before the sstables were split into a second vector.

The large data guardrail keeps ignoring them, and now says why: they hold only the data the compaction is dropping.

A new unit test drives a compaction through `compaction_task_executor::compact_sstables()`, and so through the manager's own replacer, and checks after every replacement that each garbage collected sstable in the group's sstable set was announced. It fails on the unfixed code.

Fixes: https://scylladb.atlassian.net/browse/SCYLLADB-4014

## Backport considerations

Needs to go to 2026.1. The regression reached that branch through https://github.com/scylladb/scylladb/pull/31595, the [SCYLLADB-3896](https://scylladb.atlassian.net/browse/SCYLLADB-3896)) backport of [SCYLLADB-3595](https://scylladb.atlassian.net/browse/SCYLLADB-3595), and the abort has already been reported on 2026.3.1 builds. The patch applies to the same replacer and carries no dependency on anything newer.

Earlier branches are unaffected: they predate the split into `new_gc_sstables`, so their garbage collected sstables still travel inside `new_sstables` and are registered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[SCYLLADB-3895]: https://scylladb.atlassian.net/browse/SCYLLADB-3895?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[SCYLLADB-3896]: https://scylladb.atlassian.net/browse/SCYLLADB-3896?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ