### PR TITLE
test/cluster/conftest: don't evaluate fixture annotations at runtime

### DIFF
--- a/test/cluster/conftest.py
+++ b/test/cluster/conftest.py
@@ -6,6 +6,8 @@
 # This file configures pytest for all tests in this directory, and also
 # defines common test fixtures for all of them to use
 
+from __future__ import annotations
+
 import asyncio
 import sys
 import tempfile


### PR DESCRIPTION
Since #31451 the `manager` fixture is annotated with `ScyllaCluster`, which conftest.py imports only under `TYPE_CHECKING`. With Python 3.14 and pytest older than 8.4.2 registering the fixture fails:
```
  INTERNALERROR>   File "test/cluster/conftest.py", line 149, in __annotate__
  INTERNALERROR>     scylla_cluster: ScyllaCluster,
  INTERNALERROR> NameError: name 'ScyllaCluster' is not defined
```
pytest calls inspect.signature() on the fixture, which on 3.14 evaluates the deferred annotations and hits the missing name. Newer pytest reads signatures with annotation_format=STRING and doesn't trip over it.

Add `from __future__ import annotations`, as the other files under test/ with TYPE_CHECKING-only imports already do, so the annotations stay strings and are never evaluated.

#31451 wasn't backported anywhere, so this patch doesn't need to be either.