### PR TITLE
alternator/streams: deliver whole CDC batches in GetRecords

### DIFF
--- a/alternator/streams.cc
+++ b/alternator/streams.cc
@@ -1276,7 +1276,7 @@ future<executor::request_return_type> executor::get_records(client_state& client
         | std::ranges::to<attrs_to_get>()
     ;
     // Include all base table columns as values (in case pre or post is enabled).
-    // This will include attributes not stored in the frozen map column
+    // This will include attributes not stored in the :attrs map column
     std::optional<attrs_to_get> attr_names = base->regular_columns()
         // this will include the :attrs column, which we will also force evaluating. 
         // But not having this set empty forces out any cdc columns from actual result 
@@ -1412,16 +1412,13 @@ future<executor::request_return_type> executor::get_records(client_state& client
          * This is pretty much needed, because a CDC row typically
          * encodes ~half the info of an alternator write.
          *
-         * A big, big downside to how alternator records are written
-         * (i.e. CQL), is that the distinction between INSERT and UPDATE
-         * is somewhat lost/unmappable to actual eventName.
-         * A write (currently) always looks like an insert+modify
-         * regardless whether we wrote existing record or not.
-         *
-         * Maybe RMW ops could be done slightly differently so
-         * we can distinguish them here...
-         *
-         * For now, all writes will become MODIFY.
+         * A CQL write does not say by itself whether it created or
+         * overwrote an item, so the event type comes from CDC: it marks
+         * the row insert or update depending on whether a pre-image row
+         * was available, and we map insert to INSERT and update to
+         * MODIFY below. Where no pre-image is read - KEYS_ONLY with
+         * alternator_streams_increased_compatibility off - every write
+         * therefore looks like an INSERT.
          *
          * Note: we do not check the current pre/post
          * flags on CDC log, instead we use data to 
@@ -1490,7 +1487,7 @@ future<executor::request_return_type> executor::get_records(client_state& client
     rjson::add(ret, "Records", std::move(records));
 
     if (timestamp) {
-        // #9642. Set next iterators threshold to > last
+        // #6942. Set next iterators threshold to > last
         shard_iterator next_iter(iter.table, iter.shard, *timestamp, false);
         // Note that here we unconditionally return NextShardIterator,
         // without checking if maybe we reached the end-of-shard. If the

--- a/alternator/streams.cc
+++ b/alternator/streams.cc
@@ -1504,8 +1504,10 @@ future<executor::request_return_type> executor::get_records(client_state& client
         per_table_stats->returned_records += nrecords;
         _stats.operation_sizes.get_records_op_size_kb.add((total_item_bytes + 1023) / 1024);
         per_table_stats->operation_sizes.get_records_op_size_kb.add((total_item_bytes + 1023) / 1024);
-        auto str = rjson::print(std::move(ret));
-        co_return str;
+        if (is_big(ret)) {
+            co_return make_streamed(std::move(ret));
+        }
+        co_return rjson::print(std::move(ret));
     }
 
     // ugh. figure out if we are and end-of-shard

--- a/alternator/streams.cc
+++ b/alternator/streams.cc
@@ -1311,9 +1311,6 @@ future<executor::request_return_type> executor::get_records(client_state& client
     stream_view_type type = cdc_options_to_stream_view_type(base->cdc_options());
 
     auto selection = cql3::selection::selection::for_columns(schema, std::move(columns));
-    auto partition_slice = query::partition_slice(
-        std::move(bounds)
-        , {}, std::move(regular_columns), selection->get_query_options());
 
 	auto& opts = base->cdc_options();
 	auto mul = 2; // key-only, allow for delete + insert
@@ -1323,43 +1320,60 @@ future<executor::request_return_type> executor::get_records(client_state& client
     if (opts.postimage()) {
         ++mul;
     }
-    auto command = ::make_lw_shared<query::read_command>(schema->id(), schema->version(), partition_slice, _proxy.get_max_result_size(partition_slice),
-            query::tombstone_limit(_proxy.get_tombstone_limit()), query::row_limit(limit * mul));
 
-    service::storage_proxy::result<service::storage_proxy::coordinator_query_result> rqr =
-            co_await _proxy.query_result(schema, std::move(command), std::move(partition_ranges), cl, service::storage_proxy::coordinator_query_options(default_timeout(), std::move(permit), client_state));
-    if (!rqr) {
-        co_return create_api_error_from_coordinators_exception(std::move(rqr).assume_error());
+    auto metadata = selection->get_result_metadata();
+    auto index_of = [&] (const bytes& name) {
+        return std::distance(metadata->get_names().begin(),
+            std::find_if(metadata->get_names().begin(), metadata->get_names().end(), [&](const lw_shared_ptr<cql3::column_specification>& cdef) {
+                return cdef->name->name() == name;
+            })
+        );
+    };
+    auto op_index = index_of(op_column_name);
+    auto ts_index = index_of(timestamp_column_name);
+    auto eor_index = index_of(eor_column_name);
+    auto clustering_key_index = clustering_key_column_name ? index_of(*clustering_key_column_name) : 0;
+
+    auto timeout = default_timeout();
+    auto row_limit = query::row_limit(limit * mul);
+    std::unique_ptr<cql3::result_set> result_set;
+
+    // A batch is only emitted once its cdc$end_of_batch row has been read, and a
+    // shard iterator cannot address a position inside a batch, so the first batch
+    // in the window has to be read whole. If the row limit cut it, read that one
+    // batch - a single cdc$time - again, unbounded.
+    for (bool retried = false; ; retried = true) {
+        auto partition_slice = query::partition_slice(
+            bounds
+            , {}, regular_columns, selection->get_query_options());
+
+        auto command = ::make_lw_shared<query::read_command>(schema->id(), schema->version(), partition_slice, _proxy.get_max_result_size(partition_slice),
+                query::tombstone_limit(_proxy.get_tombstone_limit()), row_limit);
+
+        service::storage_proxy::result<service::storage_proxy::coordinator_query_result> rqr =
+                co_await _proxy.query_result(schema, std::move(command), dht::partition_range_vector(partition_ranges), cl, service::storage_proxy::coordinator_query_options(timeout, permit, client_state));
+        if (!rqr) {
+            co_return create_api_error_from_coordinators_exception(std::move(rqr).assume_error());
+        }
+        auto qr = std::move(rqr).assume_value();
+        cql3::selection::result_set_builder builder(*selection, gc_clock::now());
+        query::result_view::consume(*qr.query_result, partition_slice, cql3::selection::result_set_builder::visitor(builder, *schema, *selection));
+
+        result_set = builder.build();
+
+        auto& rows = result_set->rows();
+        if (retried || rows.size() < uint64_t(row_limit) || std::ranges::any_of(rows, [&] (const auto& row) {
+                    return row[eor_index].has_value() && value_cast<bool>(boolean_type->deserialize(*row[eor_index]));
+                })) {
+            break;
+        }
+        auto partial_ts = value_cast<utils::UUID>(data_type_for<utils::UUID>()->deserialize(*rows.back()[ts_index]));
+        bounds = { query::clustering_range::make_singular(clustering_key_prefix::from_exploded(*schema, { partial_ts.serialize() })) };
+        row_limit = query::row_limit::max;
+        result_set.reset();
     }
-    auto qr = std::move(rqr).assume_value();
-    cql3::selection::result_set_builder builder(*selection, gc_clock::now());
-    query::result_view::consume(*qr.query_result, partition_slice, cql3::selection::result_set_builder::visitor(builder, *schema, *selection));
 
-    auto result_set = builder.build();
     auto records = rjson::empty_array();
-
-    auto& metadata = result_set->get_metadata();
-
-    auto op_index = std::distance(metadata.get_names().begin(),
-        std::find_if(metadata.get_names().begin(), metadata.get_names().end(), [](const lw_shared_ptr<cql3::column_specification>& cdef) {
-            return cdef->name->name() == op_column_name;
-        })
-    );
-    auto ts_index = std::distance(metadata.get_names().begin(),
-        std::find_if(metadata.get_names().begin(), metadata.get_names().end(), [](const lw_shared_ptr<cql3::column_specification>& cdef) {
-            return cdef->name->name() == timestamp_column_name;
-        })
-    );
-    auto eor_index = std::distance(metadata.get_names().begin(),
-        std::find_if(metadata.get_names().begin(), metadata.get_names().end(), [](const lw_shared_ptr<cql3::column_specification>& cdef) {
-            return cdef->name->name() == eor_column_name;
-        })
-    );
-    auto clustering_key_index = clustering_key_column_name ? std::distance(metadata.get_names().begin(), 
-        std::find_if(metadata.get_names().begin(), metadata.get_names().end(), [&](const lw_shared_ptr<cql3::column_specification>& cdef) {
-            return cdef->name->name() == *clustering_key_column_name;
-        })
-    ) : 0;
 
     std::optional<utils::UUID> timestamp;
     uint64_t total_item_bytes = 0;

--- a/test/alternator/test_streams.py
+++ b/test/alternator/test_streams.py
@@ -5,6 +5,7 @@
 # Tests for stream operations: ListStreams, DescribeStream, GetShardIterator,
 # GetRecords.
 
+import collections
 import time
 import urllib.request
 from contextlib import contextmanager, ExitStack
@@ -2496,6 +2497,95 @@ def test_streams_multiple_items_one_partition(dynamodb, dynamodbstreams, scylla_
                 table.name: [{'PutRequest': {'Item': {'p': p, 'c': cc, 'x': cc}}} for cc in cs]})
             return [['INSERT', {'p': p, 'c': cc}, None, {'p': p, 'c': cc, 'x': cc}] for cc in cs]
         do_test(stream, dynamodb, dynamodbstreams, do_updates, 'NEW_AND_OLD_IMAGES')
+
+# Read one shard from TRIM_HORIZON with the given Limit until it stops
+# producing records. Returns the records and whether the shard is still open.
+# A GetRecords call which returns no record and the very same iterator it was
+# given cannot make progress, so stop there instead of spinning.
+def read_shard_from_start(dynamodbstreams, arn, shard_id, limit, max_calls=20):
+    iter = dynamodbstreams.get_shard_iterator(StreamArn=arn, ShardId=shard_id,
+        ShardIteratorType='TRIM_HORIZON')['ShardIterator']
+    records = []
+    for _ in range(max_calls):
+        response = dynamodbstreams.get_records(ShardIterator=iter, Limit=limit)
+        records.extend(response['Records'])
+        if 'NextShardIterator' not in response:
+            return records, False
+        if not response['Records'] and response['NextShardIterator'] == iter:
+            return records, True
+        iter = response['NextShardIterator']
+    return records, True
+
+# The sorted range keys of the records of partition p, read from every shard
+# of the stream with the given Limit.
+def read_partition_keys(dynamodbstreams, arn, p, limit):
+    keys = []
+    for shard_id in list_shards(dynamodbstreams, arn):
+        records, _ = read_shard_from_start(dynamodbstreams, arn, shard_id, limit)
+        keys.extend(r['dynamodb']['Keys']['c']['S'] for r in records
+                    if r['dynamodb']['Keys']['p']['S'] == p)
+    return sorted(keys)
+
+# Write two BatchWriteItems of five items each into one partition and wait
+# until all ten show up on the stream. In always_use_lwt write isolation a
+# whole BatchWriteItem is written with one timestamp, so each becomes a single
+# five-row CDC batch - which the caller checks with assert_cdc_batches(),
+# because everything these tests do rests on that.
+def write_two_batches_and_wait(table, dynamodbstreams, arn):
+    table_arn = table.meta.client.describe_table(TableName=table.name)['Table']['TableArn']
+    table.meta.client.tag_resource(ResourceArn=table_arn,
+        Tags=[{'Key': 'system:write_isolation', 'Value': 'always_use_lwt'}])
+    p = random_string()
+    cs = sorted(f'c{b}_{i}' for b in range(2) for i in range(5))
+    for b in range(2):
+        table.meta.client.batch_write_item(RequestItems={
+            table.name: [{'PutRequest': {'Item': {'p': p, 'c': f'c{b}_{i}'}}}
+                         for i in range(5)]})
+    exp = time.time() + 60
+    while read_partition_keys(dynamodbstreams, arn, p, 1000) != cs:
+        assert time.time() < exp, 'the batches never showed up on the stream'
+        time.sleep(0.5)
+    return p, cs
+
+# The tests below are only meaningful if the writes really formed the expected
+# CDC batches: the right number of them, and each one wider than the limit * mul
+# rows GetRecords reads. Neither is visible through the DynamoDB API, so check
+# both in the log table itself.
+def assert_cdc_batches(cql, table, expected, rows_per_batch):
+    ks = 'alternator_' + table.name
+    log = table.name + '_scylla_cdc_log'
+    sizes = collections.Counter(row[0] for row in
+        cql.execute(f'SELECT "cdc$time" FROM "{ks}"."{log}"'))
+    assert sorted(sizes.values()) == [rows_per_batch] * expected, \
+        f'expected {expected} CDC batches of {rows_per_batch} rows, found {sorted(sizes.values())}'
+
+# GetRecords bounds the number of CDC log rows it reads by the requested Limit,
+# but a record can only be emitted once the end-of-batch row of its CDC batch
+# has been read, and a shard iterator cannot point inside a batch. A Limit
+# smaller than the batch therefore used to return no record at all, together
+# with the very same shard iterator - so the consumer polled that position
+# forever and never saw the rest of the shard either.
+# Two batches are written, so the test also covers that the iterator advances
+# past a batch which had to be re-read, and that the second batch, cut by the
+# same row limit, is picked up by the following call.
+# Scylla-only because it needs the write isolation tag.
+@pytest.mark.parametrize('limit', [1, 2, 3])
+def test_streams_get_records_small_limit(dynamodb, dynamodbstreams, cql, scylla_only, limit):
+    with create_table_ss(dynamodb, dynamodbstreams, 'KEYS_ONLY') as (table, arn):
+        p, cs = write_two_batches_and_wait(table, dynamodbstreams, arn)
+        assert_cdc_batches(cql, table, 2, 5)
+        assert read_partition_keys(dynamodbstreams, arn, p, limit) == cs
+
+# The same, on a disabled stream. Its records stay readable (#7239), but all of
+# its shards are closed, so a GetRecords which returns nothing also returns no
+# NextShardIterator and the consumer concludes the shard is drained - the batch
+# is not merely delayed but lost.
+def test_streams_get_records_small_limit_disabled_stream(dynamodb, dynamodbstreams, cql, scylla_only):
+    with create_table_ss(dynamodb, dynamodbstreams, 'KEYS_ONLY') as (table, arn):
+        p, cs = write_two_batches_and_wait(table, dynamodbstreams, arn)
+        assert_cdc_batches(cql, table, 2, 5)
+        disable_stream(dynamodbstreams, table)
+        assert read_partition_keys(dynamodbstreams, arn, p, 1) == cs
 
 # Test the CHILD_SHARDS shard filter. In a simple case where the table
 # hasn't been modified since the stream was created, there is just one

--- a/test/alternator/test_streams_tablets.py
+++ b/test/alternator/test_streams_tablets.py
@@ -7,7 +7,7 @@
 import time, random, collections
 
 import pytest
-from test.alternator.test_streams import create_stream_test_table, wait_for_active_stream
+from test.alternator.test_streams import create_stream_test_table, wait_for_active_stream, read_shard_from_start, write_two_batches_and_wait, assert_cdc_batches
 
 TABLET_TAGS = [{'Key': 'system:initial_tablets', 'Value': '0'}]
 
@@ -543,3 +543,41 @@ def test_get_records_with_alternating_tablets_count(dynamodb, dynamodbstreams, r
                 path = get_path(r)
                 siblings_count = count_map[get_generation_from_shard(r)]
                 assert siblings_count == init_table_count * tablet_multipliers[len(path) - 1]
+
+# A shard closed by a tablet split still has to deliver everything it holds,
+# whatever Limit the client passes. GetRecords reads at most Limit times a
+# small factor of CDC log rows and only emits a record once it has read the
+# end-of-batch row of its batch, so a Limit smaller than the batch used to
+# return no record - and, the shard being closed, no NextShardIterator either,
+# which tells the consumer that the shard is drained.
+def test_get_records_small_limit_on_closed_shard(dynamodb, dynamodbstreams, rest_api, cql):
+    with create_stream_test_table(dynamodb, StreamViewType='KEYS_ONLY', Tags=TABLET_TAGS) as table:
+        (arn, label) = wait_for_active_stream(dynamodbstreams, table)
+        p, cs = write_two_batches_and_wait(table, dynamodbstreams, arn)
+        assert_cdc_batches(cql, table, 2, 5)
+        end_ts = time.time() + 30
+        for shard in iterate_over_describe_stream(dynamodbstreams, arn, end_ts):
+            records, _ = read_shard_from_start(dynamodbstreams, arn, shard['ShardId'], 1000)
+            if any(r['dynamodb']['Keys']['p']['S'] == p for r in records):
+                shard_id = shard['ShardId']
+                break
+        else:
+            pytest.fail(f'no shard holds the records of partition {p}')
+
+        ks = f'alternator_{table.name}'
+        cdc_log_table_name = f'{table.name}_scylla_cdc_log'
+        init_table_count = get_tablet_count_for_base_table_of_table(rest_api, cql, ks, cdc_log_table_name)
+        set_tablet_count_and_wait(rest_api, cql, ks, table.name, cdc_log_table_name, init_table_count * 2, timeout=30)
+
+        end_ts = time.time() + 30
+        while True:
+            assert time.time() < end_ts, f'shard {shard_id} was never reported closed'
+            if any(shard['ShardId'] == shard_id and 'EndingSequenceNumber' in shard['SequenceNumberRange']
+                   for shard in iterate_over_describe_stream(dynamodbstreams, arn, end_ts)):
+                break
+            time.sleep(0.2)
+
+        records, has_next = read_shard_from_start(dynamodbstreams, arn, shard_id, 1)
+        assert not has_next
+        assert sorted(r['dynamodb']['Keys']['c']['S'] for r in records
+                      if r['dynamodb']['Keys']['p']['S'] == p) == cs


### PR DESCRIPTION
`GetRecords` returns no records, and no way to make progress, when the client passes a `Limit` smaller than one CDC batch. On a closed shard or a disabled stream the records are not delayed but lost.

Line numbers are on master, c99402fba7.

## The problem

`get_records` bounds its read of the CDC log to `Limit * mul` rows (`alternator/streams.cc:1327`; `mul` is 2 for KEYS_ONLY, plus one for each of the pre- and post-image). A record is only emitted at the row carrying `cdc$end_of_batch`, and CDC sets that flag on the last row of a batch only (`cdc/log.cc:1175`, re-stamped at `:1791` after the Alternator no-op cleanup removes rows).

A batch cut by the row bound therefore produces nothing at all: `timestamp` stays disengaged, the `NextShardIterator` exit at `:1478` is skipped, and control falls into the end-of-shard block at `:1497-1521`.

| state of the shard | line | what the client gets |
|---|---|---|
| disabled stream | `:1509` | no `NextShardIterator` |
| closed shard | `:1512` | no `NextShardIterator` |
| open shard | `:1517` | the input iterator, returned unchanged |

An open shard stalls: the consumer polls the same position forever, so it never sees the rest of that shard either. The other two tell the consumer the shard is drained, so it checkpoints past the remainder and those records are gone. All three are silent — HTTP 200 with an empty `Records`, no error and no log line, indistinguishable from polling an idle shard.

Nothing exotic is needed to hit it. One `BatchWriteItem` against a table tagged `system:write_isolation=always_use_lwt` is a single LWT, hence a single CDC batch whose rows share one `cdc$time`. With KEYS_ONLY that is one log row per item, so a five-item batch is already undeliverable at `Limit` 1 or 2.

## The fix

A shard iterator addresses a `cdc$time` and nothing finer (`streams.cc:1060-1096`), so a batch cannot be resumed midway: the first batch in the window has to be read whole.

When a read comes back full **and** holds no `cdc$end_of_batch` row anywhere, the first batch is the one that was cut. Narrow the clustering range to its single `cdc$time`, read it again with no row limit, and assemble from that.

That test is exact rather than a heuristic, because of two properties of the log:

1. the clustering key is `(cdc$time, cdc$batch_seq_no)` (`cdc/log.cc:652-653`), so a batch is one contiguous clustering run holding exactly one end-of-batch row, its last;
2. both clustering bounds of the read are one-component `cdc$time` prefixes (`streams.cc:1261-1266`), so a bound can never fall inside a batch.

Together they make "no end-of-batch row in a full result" mean precisely "the first batch in the window was cut" — and every row of such a result belongs to that one batch, so `rows.back()`'s `cdc$time` identifies it.

Only the first batch needs this, which is what bounds the loop at two reads: any complete batch sets `timestamp`, so the response carries an iterator past it and a batch cut later is simply re-read from its start on the next call.

The second read is confined to that one `cdc$time` and is still subject to `max_result_size`, which master already meets on the same batch on every default-`Limit` call. Reaching it at all requires a result that is full with no end-of-batch row — exactly the state in which master returned zero records and no usable iterator, so no call that makes progress today gains a read.

One consequence worth stating: a response may now exceed `Limit` by up to one batch, since an iterator cannot point inside one. The overshoot is not new — the note at `:1466-1468` has described it since 7d404cdd51 — but below the batch width it becomes the normal case.

## Tests

Dev binary from this tree, single node, `SCYLLA=build/dev/scylla ./test/alternator/run`.

Three new tests: an open shard (`test_streams_get_records_small_limit`, `Limit` 1/2/3, vnodes and tablets), a disabled stream (`test_streams_get_records_small_limit_disabled_stream`), and a shard closed by a tablet split (`test_get_records_small_limit_on_closed_shard`). Each writes two five-item batches, so they also cover the iterator advancing past a batch that had to be re-read, and each asserts against the CDC log that the writes really formed two five-row batches.

With the fix: `test_streams.py` + `test_streams_tablets.py` → 178 passed, 9 xfailed. `test_metrics.py`, `test_no_exception.py`, `test_cql_rbac.py` → 127 passed, 3 skipped, 4 xfailed.

With the fix commit reverted, same binary otherwise, `test_streams.py` → 6 failed, 2 passed:

```
FAILED test_streams_get_records_small_limit[using vnodes-1]   AssertionError: assert [] == ['c0_0', ...]
FAILED test_streams_get_records_small_limit[using vnodes-2]
FAILED test_streams_get_records_small_limit[using tablets-1]
FAILED test_streams_get_records_small_limit[using tablets-2]
FAILED test_streams_get_records_small_limit_disabled_stream[using vnodes]
FAILED test_streams_get_records_small_limit_disabled_stream[using tablets]
```

`[]` is zero of the ten written records. The closed-shard test fails on the revert too, with the `assert not has_next` before it passing — the shard really was reported drained while its records were dropped.

Both `Limit=3` legs pass either way, deliberately: their bound is wide enough for the first batch, so they exercise the case the fix leaves alone — a later batch cut by the same bound, picked up by the next call — and they are the only legs where the read comes back full *and* contains an end-of-batch row, which is the condition that stops the retry.

## Commits

1. `alternator/streams: deliver whole CDC batches in GetRecords` — the fix.
2. `alternator/streams: stream large GetRecords responses` — the `is_big()`/`make_streamed()` guard sat only on the exit where `Records` is empty and the response can never reach the threshold; the exit that carries the records printed the whole response into one contiguous string.
3. `alternator/streams: correct stale comments in get_records` — three comments in this function that no longer describe the code.
4. `test/alternator: cover GetRecords with a Limit smaller than a CDC batch`.

Commits 2 and 3 are separable from the fix; happy to drop them if you would rather decide them apart.

Backport to 2026.2 and 2026.3 only: `alternator-streams` is GA (`feature::UNUSED`) there and on master, but still `feature::ALTERNATOR_STREAMS` on 2026.1 and every 2025.x. Both need one hand-edit on commit 1, since those branches still spell the read `_proxy.query(...)` rather than `_proxy.query_result(...)`/`result<>`.

Fixes: SCYLLADB-4350
Refs: SCYLLADB-1661

🤖 Generated with [Claude Code](https://claude.com/claude-code)
