### PR TITLE
sstables: standalone fixes from the parquet work

### DIFF
--- a/sstables/file_writer.hh
+++ b/sstables/file_writer.hh
@@ -60,6 +60,14 @@ public:
     // Must be called in a seastar thread.
     void close();
 
+protected:
+    // For derived classes that must close the stream from their own destructor, before their
+    // members die. close() asserts on a double close, so they need to be able to ask first.
+    bool is_closed() const noexcept {
+        return _closed;
+    }
+public:
+
     uint64_t offset() const {
         return _offset.offset;
     }

--- a/sstables/sstable_directory.cc
+++ b/sstables/sstable_directory.cc
@@ -444,12 +444,55 @@ future<> sstable_directory::sstables_registry_components_lister::process(sstable
     });
 }
 
+void validate_restore_toc_names(const std::vector<sstring>& toc_filenames) {
+    for (const auto& toc_filename : toc_filenames) {
+        auto result = sstables::parse_path(std::filesystem::path{toc_filename}, "", "");
+        if (!result) {
+            throw std::invalid_argument(seastar::format(
+                    "restore: '{}' is not a valid sstable TOC object name: {}",
+                    toc_filename, result.error()));
+        }
+        // A well-formed sstable name is not enough: the manifest lists TOC objects, and a Data.db
+        // (or an unrecognised component, which parse_path maps to Unknown rather than rejecting)
+        // would otherwise be accepted here and only fail later, inside the restore.
+        if (result->component != component_type::TOC) {
+            throw std::invalid_argument(seastar::format(
+                    "restore: '{}' is not a TOC object name (component {})",
+                    toc_filename, result->component));
+        }
+    }
+}
+
 future<> sstable_directory::restore_components_lister::process(sstable_directory& directory, process_flags flags) {
+    // These TOC names come from the restore REQUEST -- they are operator input, not a listing of
+    // files Scylla wrote. That distinction decides how a bad one must be reported.
+    //
+    // throw_malformed_sstable_exception() honours abort_on_malformed_sstable_error, which defaults
+    // to true, so it ABORTS THE PROCESS. That is the right policy for corrupt bytes found on disk:
+    // carrying on with data known to be wrong is worse than stopping. It is the wrong policy for a
+    // typo in a request. A blank trailing line in a --sstables-file-list parsed as an sstable named
+    // "", and the node died with "invalid version for file ." -- taking the cluster member down at
+    // exactly the moment an operator is restoring from backup, and reporting it to them as
+    // "Connection reset by peer".
+    //
+    // Validated up front, before any restoring starts, so a bad entry fails the whole operation
+    // cleanly instead of half way through a partially-restored table.
+    validate_restore_toc_names(_toc_filenames);
     co_await coroutine::parallel_for_each(_toc_filenames, [flags, &directory] (sstring toc_filename) -> future<> {
         std::filesystem::path sst_path{toc_filename};
         auto result = sstables::parse_path(sst_path, "", "");
         if (!result) {
-            throw_malformed_sstable_exception(result.error());
+            // Unreachable: every name was parsed above. Kept so this cannot silently become an
+            // abort again if the pre-pass is ever dropped.
+            throw std::invalid_argument(seastar::format(
+                    "restore: '{}' is not a valid sstable TOC object name: {}",
+                    toc_filename, result.error()));
+        }
+        if (result->component != component_type::TOC) {
+            // Likewise unreachable; same belt-and-braces reasoning.
+            throw std::invalid_argument(seastar::format(
+                    "restore: '{}' is not a TOC object name (component {})",
+                    toc_filename, result->component));
         }
         entry_descriptor desc = std::move(*result);
         if (!sstable_generation_generator::maybe_owned_by_this_shard(desc.generation)) {

--- a/sstables/sstable_directory.hh
+++ b/sstables/sstable_directory.hh
@@ -67,6 +67,19 @@ public:
     }
 };
 
+// Reject TOC object names that came from a restore REQUEST, before any restoring starts.
+//
+// Split out of restore_components_lister::process() so it can be tested without standing up a
+// replica::table: the bug it guards -- a malformed name reaching
+// throw_malformed_sstable_exception, which honours abort_on_malformed_sstable_error and so ABORTS
+// THE NODE -- had no test at all, and an abort is not something a caller can catch and assert on.
+//
+// Every name must parse as an sstable component name AND be a TOC: a Data.db, or an unrecognised
+// component, is a well-formed sstable name that is not a TOC object, and is rejected too.
+//
+// Throws std::invalid_argument, which reaches the API caller as an error.
+void validate_restore_toc_names(const std::vector<sstring>& toc_filenames);
+
 // Handles a directory containing SSTables. It could be an auxiliary directory (like upload),
 // or the main directory.
 class sstable_directory {

--- a/sstables/writer.hh
+++ b/sstables/writer.hh
@@ -22,6 +22,8 @@
 
 namespace sstables {
 
+extern logging::logger sstlog;
+
 class index_sampling_state;
 class compression;
 class metadata_collector;
@@ -174,8 +176,40 @@ public:
     // Since we are exposing a reference to _full_checksum, we delete the move
     // constructor.  If it is moved, the reference will refer to the old
     // location.
+    //
+    // Copying is deleted for exactly the same reason, and stated as `= delete` rather than
+    // `= default`: the base holds an output_stream and declares a move constructor, so it is not
+    // copyable and `= default` was already defined-as-deleted. It merely read as though copying
+    // were permitted, which for a class whose sink holds references to its own members is the
+    // wrong thing for it to look like.
     checksummed_file_writer(checksummed_file_writer&&) = delete;
-    checksummed_file_writer(const checksummed_file_writer&) = default;
+    checksummed_file_writer(const checksummed_file_writer&) = delete;
+
+    // Close the stream here, not in ~file_writer().
+    //
+    // _c and _full_checksum are members of THIS class, and the base's output_stream holds
+    // references to both (see the constructors above, and checksummed_file_data_sink_impl). A
+    // derived class's members are destroyed before the base destructor runs, and ~file_writer()
+    // best-effort auto-closes a stream that was never closed -- "close() should be called by the
+    // owner ... it may not be called on exception handling paths". That close flushes, the flush
+    // appends a CRC to _c, and _c is gone: a use-after-free, seen as a near-null write at 0x8
+    // inside chunked_vector::emplace_back when a cancelled compaction destroyed a pq writer
+    // without closing it.
+    //
+    // This destructor body runs BEFORE the members are destroyed, so closing here is safe, and
+    // close() sets _closed so ~file_writer() then does nothing. Callers that close explicitly are
+    // unaffected.
+    virtual ~checksummed_file_writer() {
+        if (is_closed()) {
+            return;
+        }
+        try {
+            file_writer::close();
+        } catch (...) {
+            sstlog.warn("Error while auto-closing checksummed writer: {}. Ignored.",
+                        std::current_exception());
+        }
+    }
 
     checksum& finalize_checksum() {
         return _c;
@@ -184,6 +218,12 @@ public:
         return _full_checksum;
     }
 };
+
+// The sink holds references to _c and _full_checksum, so a copy or move would leave those
+// references pointing into the old object. Asserted rather than trusted: both were already
+// unavailable via the base, and an assertion says so where a reader will see it.
+static_assert(!std::is_copy_constructible_v<checksummed_file_writer<adler32_utils, true>>);
+static_assert(!std::is_move_constructible_v<checksummed_file_writer<adler32_utils, true>>);
 
 using adler32_checksummed_file_writer = checksummed_file_writer<adler32_utils, true>;
 using crc32_checksummed_file_writer = checksummed_file_writer<crc32_utils, true>;

--- a/test/boost/sstable_datafile_test.cc
+++ b/test/boost/sstable_datafile_test.cc
@@ -51,6 +51,8 @@
 #include <boost/icl/interval_map.hpp>
 #include "test/lib/sstable_utils.hh"
 #include "test/lib/random_utils.hh"
+#include "sstables/writer.hh"
+#include <seastar/core/fstream.hh>
 #include "test/lib/test_utils.hh"
 #include "test/lib/cql_test_env.hh"
 #include "readers/from_mutations.hh"
@@ -3556,4 +3558,53 @@ SEASTAR_THREAD_TEST_CASE(test_small_sstable_has_reasonable_memory_usage) {
     // pools can absorb the batch and a growth of 0 is legitimate.
     BOOST_REQUIRE_LT(growth, upper_bound);
 #endif
+}
+
+// ---------------------------------------------------------------------------------------------
+// A regression test for a defect that had none. It lives here rather than in a writer-focused file
+// because sstable_datafile_test is a standalone binary that can actually be built and run in this
+// configuration; other regression tests live in files that are compiled into test/boost/combined_tests.
+// ---------------------------------------------------------------------------------------------
+
+// Destroying a checksummed_file_writer WITHOUT calling close() must not fault.
+//
+// The class keeps `checksum _c` and `uint32_t _full_checksum` as DERIVED members while the base
+// file_writer owns the output_stream whose sink holds references to both. Derived members are
+// destroyed before the base destructor runs, and ~file_writer() best-effort auto-closes an unclosed
+// stream -- so the flush appended a CRC to a checksum struct that was already gone. A cancelled
+// compaction destroying an unclosed writer hit exactly this, as a near-null write at 0x8 inside
+// chunked_vector::emplace_back.
+//
+// HONEST LIMITATION, checked rather than assumed: in dev mode this test PASSES with the fix
+// reverted. It was run that way. The bug is undefined behaviour, not a null dereference -- freeing a
+// small chunked_vector and then appending to it touches memory that has not been reused yet, so
+// nothing faults. That is precisely why the original reproduction needed 7.7 M rows of allocation
+// churn, and it means this test is NOT a regression guard on its own in dev.
+//
+// It is a real guard where it matters: seastar turns ASAN on by default for the Debug and Sanitize
+// build types, and ASAN reports a use-after-free here deterministically regardless of size. So this
+// exists to be run under those, and in dev it is a smoke test that the path is exercised at all.
+//
+// There must be BUFFERED DATA at destruction, or the auto-close has nothing to flush and the test
+// cannot detect anything even under a sanitizer.
+SEASTAR_THREAD_TEST_CASE(test_checksummed_file_writer_destroyed_without_close) {
+    tmpdir tmp;
+    auto path = tmp.path() / "unclosed";
+
+    {
+        auto f = open_file_dma(path.native(),
+                               open_flags::wo | open_flags::create | open_flags::truncate).get();
+        auto sink = make_file_data_sink(std::move(f), file_output_stream_options{}).get();
+        // The two-argument overload: component_name holds an sstable reference and cannot be
+        // default-constructed, and naming a component is irrelevant to what this test exercises.
+        sstables::crc32_checksummed_file_writer w(std::move(sink), 4096);
+        // Enough to be buffered but not enough to have been flushed on its own.
+        sstring payload(1024, 'x');
+        w.write(payload.c_str(), payload.size());
+        BOOST_REQUIRE_EQUAL(w.offset(), payload.size());
+        // Deliberately NO w.close(). Leaving this scope is the whole test.
+    }
+
+    // Surviving to here is the assertion. Anything else is a crash, not a failure.
+    BOOST_REQUIRE(file_exists(path.native()).get());
 }

--- a/test/boost/sstable_directory_test.cc
+++ b/test/boost/sstable_directory_test.cc
@@ -1016,3 +1016,66 @@ SEASTAR_TEST_CASE(sstable_directory_test_reshard_vnodes) {
 }
 
 BOOST_AUTO_TEST_SUITE_END()
+
+// ---------------------------------------------------------------------------------------------
+// Regression test for scylladb/scylladb#31589 (series tracking: #31556).
+//
+// The restore-manifest defect. Reached via test/boost/combined_tests, which is
+// what this file compiles into -- there is no standalone sstable_directory_test binary, which is
+// why an earlier attempt to build one "failed" and the test was parked in sstable_datafile_test.
+// ---------------------------------------------------------------------------------------------
+// A malformed name in a restore manifest must be REJECTED, not abort the node.
+//
+// A blank trailing line in a --sstables-file-list parsed as an sstable named "", reached
+// throw_malformed_sstable_exception, and because that honours abort_on_malformed_sstable_error
+// (default true) it took the node down -- the operator saw "Connection reset by peer" from the very
+// node they were restoring with. Aborting is right for corrupt bytes found on disk and wrong for
+// operator input on a recovery path.
+//
+// This asserts on the EXCEPTION, because an abort cannot be caught and asserted on at all, which is
+// exactly why the behaviour went untested.
+SEASTAR_THREAD_TEST_CASE(test_restore_rejects_malformed_toc_names) {
+    BOOST_REQUIRE_NO_THROW(sstables::validate_restore_toc_names(
+            {"me-3h39_0jv6_26nsg2gplzfjtup6vf-big-TOC.txt"}));
+    BOOST_REQUIRE_NO_THROW(sstables::validate_restore_toc_names({}));
+
+    // The exact trigger, and the same list with a good entry beside it.
+    BOOST_REQUIRE_THROW(sstables::validate_restore_toc_names({""}), std::invalid_argument);
+    BOOST_REQUIRE_THROW(sstables::validate_restore_toc_names(
+            {"me-3h39_0jv6_26nsg2gplzfjtup6vf-big-TOC.txt", ""}), std::invalid_argument);
+
+    // Shapes of nonsense that were never tried when the fix landed.
+    BOOST_REQUIRE_THROW(sstables::validate_restore_toc_names({"not-an-sstable"}),
+                        std::invalid_argument);
+    BOOST_REQUIRE_THROW(sstables::validate_restore_toc_names({"zz-1-big-TOC.txt"}),
+                        std::invalid_argument);
+
+    // Well-formed sstable names that are NOT TOC objects. parse_path accepts both -- a known
+    // non-TOC component, and an unrecognised one, which it maps to component_type::Unknown rather
+    // than rejecting -- so the validator has to check the component itself.
+    BOOST_REQUIRE_THROW(sstables::validate_restore_toc_names(
+            {"me-3h39_0jv6_26nsg2gplzfjtup6vf-big-Data.db"}), std::invalid_argument);
+    BOOST_REQUIRE_THROW(sstables::validate_restore_toc_names(
+            {"me-3h39_0jv6_26nsg2gplzfjtup6vf-big-ReallyBigData.db"}), std::invalid_argument);
+
+    // The message must name the offender, or an operator cannot fix their manifest.
+    auto message_for = [] (std::vector<sstring> names) -> sstring {
+        try {
+            sstables::validate_restore_toc_names(std::move(names));
+        } catch (const std::invalid_argument& e) {
+            return e.what();
+        }
+        BOOST_FAIL("expected std::invalid_argument");
+        return {};
+    };
+    // The empty name: the offender is quoted, so an operator sees the '' and knows to look for a
+    // blank line.
+    BOOST_REQUIRE(message_for({"", "me-3h39_0jv6_26nsg2gplzfjtup6vf-big-TOC.txt"})
+                          .starts_with("restore: '' is not a valid sstable TOC object name"));
+    // A visible offender must appear verbatim, quoted.
+    BOOST_REQUIRE(message_for({"me-3h39_0jv6_26nsg2gplzfjtup6vf-big-TOC.txt", "zz-1-big-TOC.txt"})
+                          .find("'zz-1-big-TOC.txt'") != sstring::npos);
+    // And so must a well-formed name rejected for not being a TOC.
+    BOOST_REQUIRE(message_for({"me-3h39_0jv6_26nsg2gplzfjtup6vf-big-Data.db"})
+                          .find("'me-3h39_0jv6_26nsg2gplzfjtup6vf-big-Data.db'") != sstring::npos);
+}


### PR DESCRIPTION
Part 1/5 of the parquet storage format series (#31556). Independent of it: both are
real bugs in existing code, found while developing the parquet sstable writer, and
mergeable on their own.

* `checksummed_file_writer` keeps its checksum structs as derived members while
  the base `file_writer` owns the stream whose sink references them; the base
  destructor's best-effort auto-close therefore flushed into freed memory when a
  writer was destroyed unclosed - e.g. by a compaction cancelled mid-write. The
  writer now closes itself from the derived destructor, and the copy constructor
  is deleted.

* A malformed TOC object name in a restore request (an empty line in
  `--sstables-file-list` sufficed) threw `malformed_sstable_exception`, which
  with the default `abort_on_malformed_sstable_error=true` aborts the node.
  Restore now validates every name up front and rejects the request with
  `invalid_argument` - a bad argument, not a corrupt sstable.

Testing: regression tests for both. The writer test is deterministic under ASAN
(Debug/Sanitize); in dev mode the use-after-free lands in not-yet-reused memory and
does not fault - verified by reverting the fix. The restore test pins the exact
original trigger and the error message; it could not have existed before the fix,
since the old behavior was a process abort.

Rebased on master a7259e247e.

---
The stack: #31589 (fixes) → #31590 (groundwork) → #31591 (parquet) → #31592 (hooks) → #31593 (docs). Tracking: #31556.

No backport: both fixes are candidates for backport on their own merits, but this
series does not request it; the maintainers can label as they see fit.
