### PR TITLE
tasks: abort the children of a generic task with a custom abort callback

### DIFF
--- a/tasks/task_manager.cc
+++ b/tasks/task_manager.cc
@@ -456,7 +456,14 @@ tasks::is_user_task task_manager::generic_task_impl::is_user_task() const noexce
 }
 
 void task_manager::generic_task_impl::abort() noexcept {
-    _abort_fn ? _abort_fn(_as) : task::impl::abort();
+    if (!_as.abort_requested()) {
+        _as.request_abort();
+
+        if (_abort_fn) {
+            _abort_fn(_as);
+        }
+        (void)abort_children(_module, _status.id);
+    }
 }
 
 future<> task_manager::generic_task_impl::release_resources() noexcept {

--- a/tasks/task_manager.hh
+++ b/tasks/task_manager.hh
@@ -279,7 +279,7 @@ public:
         using action_fn = noncopyable_function<future<> (task::impl&)>;
         using progress_fn = noncopyable_function<future<task::progress> ()>;
         using workload_fn = noncopyable_function<future<std::optional<double>> ()>;
-        using abort_fn = noncopyable_function<void (seastar::abort_source&)>;
+        using abort_fn = noncopyable_function<void (seastar::abort_source&) noexcept>;
         using finalize_fn = noncopyable_function<future<> ()>;
     private:
         std::string _type;


### PR DESCRIPTION
The abort callback replaced the whole default abort, including the cascade to the task's children. The callback cannot abort the children itself: it only receives the abort source. Cascade to the children in the framework after invoking the callback.

No backport; no release branch affected