### PR TITLE
[Backport 2026.1] db: fix UB in system.clients row sorting

### DIFF
--- a/db/virtual_tables.cc
+++ b/db/virtual_tables.cc
@@ -832,7 +832,10 @@ class clients_table : public streaming_virtual_table {
             auto& clients = cd_map[dip.ip];
 
             std::ranges::sort(clients, [] (const foreign_ptr<std::unique_ptr<client_data>>& a, const foreign_ptr<std::unique_ptr<client_data>>& b) {
-                return a->port < b->port || a->client_type_str() < b->client_type_str();
+                if (a->port != b->port) {
+                    return a->port < b->port;
+                }
+                return a->client_type_str() < b->client_type_str();
             });
 
             for (const auto& cd : clients) {


### PR DESCRIPTION
The comparator used to sort per-IP client rows was not a strict-weak-ordering (it could return true in both directions for some pairs), which makes `std::ranges::sort` behavior undefined. A concrete pair that breaks it (and is realistic in system.clients):
a = (port=9042, client_type="cql")
b = (port=10000, client_type="alternator")
With the current comparator:
cmp(a,b) = (9042 < 10000) || ("cql" < "alternator") = true || false = true
cmp(b,a) = (10000 < 9042) || ("alternator" < "cql") = false || true = true
So both directions are true, meaning there is no valid ordering that sort can achieve.

The fix is to sort lexicographically by (port, client_type) to match the table's clustering key and ensure deterministic ordering. Can lead to memory corruption / mutation fragment validator failures / performance issues when reading from system.clients.

Fixes SCYLLADB-4235
Refs SCYLLADB-4232

- (cherry picked from commit a31cb18324dbe2fd31a94cb7fa6a97cf0de2c4db)

Parent PR: #28844