### PR TITLE
db/hints: Remove corrupted commitlog segments

### DIFF
--- a/db/hints/internal/hint_sender.cc
+++ b/db/hints/internal/hint_sender.cc
@@ -252,6 +252,15 @@ future<> hint_sender::send_one_mutation(frozen_mutation_and_schema m) {
     host_id_vector_replica_set natural_endpoints = ermp->get_natural_replicas(token);
     host_id_vector_topology_change pending_endpoints  = ermp->get_pending_replicas(token);
 
+    if (utils::get_local_injector().enter("hinted_handoff_fail_hint_send")) {
+        return utils::get_local_injector().inject("hinted_handoff_fail_hint_send",
+                utils::wait_for_message{std::chrono::minutes{5}},
+                /* share_messages */ false).then([] {
+            return make_exception_future<>(std::runtime_error(
+                    "Sending a hint failed due to error injection: hinted_handoff_fail_hint_send"));
+        });
+    }
+
     return futurize_invoke([this, m = std::move(m), ermp = std::move(ermp), &natural_endpoints, &pending_endpoints, &token] () mutable -> future<> {
         // The fact that we send with CL::ALL in both cases below ensures that new hints are not going
         // to be generated as a result of hints sending.
@@ -276,6 +285,7 @@ future<> hint_sender::send_one_mutation(frozen_mutation_and_schema m) {
 }
 
 future<> hint_sender::send_one_hint(lw_shared_ptr<send_one_file_ctx> ctx_ptr, fragmented_temporary_buffer buf, db::replay_position rp, gc_clock::duration secs_since_file_mod, const sstring& fname) {
+    manager_logger.trace("hint_sender[{}]:send_one_hint: Scheduling a hint to be sent", _ep_key);
     return _resource_manager.get_send_units_for(buf.size_bytes()).then([this, secs_since_file_mod, &fname, buf = std::move(buf), rp, ctx_ptr] (auto units) mutable {
         ctx_ptr->mark_hint_as_in_progress(rp);
 
@@ -461,6 +471,7 @@ bool hint_sender::send_one_file(const sstring& fname) {
     timespec last_mod = get_last_file_modification(fname).get();
     gc_clock::duration secs_since_file_mod = std::chrono::seconds(last_mod.tv_sec);
     lw_shared_ptr<send_one_file_ctx> ctx_ptr = make_lw_shared<send_one_file_ctx>(_last_schema_ver_to_column_mapping);
+    bool corrupted_segment = false;
 
     struct canceled_draining_exception {};
 
@@ -512,6 +523,7 @@ bool hint_sender::send_one_file(const sstring& fname) {
         manager_logger.error("hint_sender[{}]:send_one_file: Segment error in {}: {}. Last not complete position={}",
                 _ep_key, fname, ex.what(), _last_not_complete_rp);
         ctx_ptr->segment_replay_failed = false;
+        corrupted_segment = true;
         ++this->shard_stats().corrupted_files;
     } catch  (const canceled_draining_exception&) {
         manager_logger.debug("hint_sender[{}]:send_one_file: Loop in send_one_file finishes due to canceled draining", _ep_key);
@@ -524,6 +536,25 @@ bool hint_sender::send_one_file(const sstring& fname) {
     // wait till all background hints sending is complete
     ctx_ptr->file_send_gate.close().get();
 
+    // Hints are sent asynchronously, so the following scenario could happen:
+    //
+    // 1. N + 1 hints are dispatched to be sent.
+    // 2. N pass through the semaphore, while 1 waits on it. This suspends
+    //    the commitlog::read_log_file loop above.
+    // 3. Those N hints time out and the 1 remaining hint finally gets through.
+    //    The commitlog loop is unblocked. However, since
+    //    ctx_ptr->segment_replay_failed == true, the loop just browses the
+    //    rest of the commitlog, not sending anything. This is not throttled.
+    // 4. The commitlog loop encounters a corrupted entry and throws an exception.
+    //    The exception handler sets ctx_ptr->segment_replay_failed to false.
+    // 5. We block in closing the send gate. That eventually happens when the
+    //    last hint times out. But what it also does is set
+    //    ctx_ptr->segment_replay_failed to true again.
+    //
+    // We must remove the segment, so we cannot return yet. The code below
+    // assumes there was no corruption, so we embrace it with an if.
+    // Refs: SCYLLADB-4294.
+    if (!corrupted_segment) {
     // If draining was canceled, we can't say anything about the segment's state,
     // so return immediately. We return false here because of that reason too.
     if (canceled_draining()) {
@@ -543,7 +574,9 @@ bool hint_sender::send_one_file(const sstring& fname) {
         // the last hint that was successfully sent (last_succeeded_rp).
         _last_not_complete_rp = ctx_ptr->first_failed_rp.value_or(ctx_ptr->last_succeeded_rp.value_or(_last_not_complete_rp));
         manager_logger.debug("hint_sender[{}]:send_one_file: Error while sending hints from {}, last RP is {}", _ep_key, fname, _last_not_complete_rp);
+
         return false;
+    }
     }
 
     // If we got here we are done with the current segment and we can remove it.
@@ -555,7 +588,13 @@ bool hint_sender::send_one_file(const sstring& fname) {
     // clear the replay position - we are going to send the next segment...
     _last_not_complete_rp = replay_position();
     _last_schema_ver_to_column_mapping.clear();
-    manager_logger.debug("hint_sender[{}]:send_one_file: Segment {} has been sent in full and deleted", _ep_key, fname);
+
+    if (corrupted_segment) {
+        manager_logger.info("hint_sender[{}]:send_one_file: Corrupted segment {} has been deleted", _ep_key, fname);
+    } else {
+        manager_logger.debug("hint_sender[{}]:send_one_file: Segment {} has been sent in full and deleted", _ep_key, fname);
+    }
+
     return true;
 }
 

--- a/db/hints/internal/hint_sender.cc
+++ b/db/hints/internal/hint_sender.cc
@@ -555,28 +555,28 @@ bool hint_sender::send_one_file(const sstring& fname) {
     // assumes there was no corruption, so we embrace it with an if.
     // Refs: SCYLLADB-4294.
     if (!corrupted_segment) {
-    // If draining was canceled, we can't say anything about the segment's state,
-    // so return immediately. We return false here because of that reason too.
-    if (canceled_draining()) {
-        return false;
-    }
+        // If draining was canceled, we can't say anything about the segment's state,
+        // so return immediately. We return false here because of that reason too.
+        if (canceled_draining()) {
+            return false;
+        }
 
-    // If we are draining ignore failures and drop the segment even if we failed to send it.
-    if (draining() && ctx_ptr->segment_replay_failed) {
-        manager_logger.debug("hint_sender[{}]:send_one_file: We are draining, so we are going to delete the segment anyway", _ep_key);
-        ctx_ptr->segment_replay_failed = false;
-    }
+        // If we are draining ignore failures and drop the segment even if we failed to send it.
+        if (draining() && ctx_ptr->segment_replay_failed) {
+            manager_logger.debug("hint_sender[{}]:send_one_file: We are draining, so we are going to delete the segment anyway", _ep_key);
+            ctx_ptr->segment_replay_failed = false;
+        }
 
-    // update the next iteration replay position if needed
-    if (ctx_ptr->segment_replay_failed) {
-        // If some hints failed to be sent, first_failed_rp will tell the position of first such hint.
-        // If there was an error thrown by read_log_file function itself, we will retry sending from
-        // the last hint that was successfully sent (last_succeeded_rp).
-        _last_not_complete_rp = ctx_ptr->first_failed_rp.value_or(ctx_ptr->last_succeeded_rp.value_or(_last_not_complete_rp));
-        manager_logger.debug("hint_sender[{}]:send_one_file: Error while sending hints from {}, last RP is {}", _ep_key, fname, _last_not_complete_rp);
+        // update the next iteration replay position if needed
+        if (ctx_ptr->segment_replay_failed) {
+            // If some hints failed to be sent, first_failed_rp will tell the position of first such hint.
+            // If there was an error thrown by read_log_file function itself, we will retry sending from
+            // the last hint that was successfully sent (last_succeeded_rp).
+            _last_not_complete_rp = ctx_ptr->first_failed_rp.value_or(ctx_ptr->last_succeeded_rp.value_or(_last_not_complete_rp));
+            manager_logger.debug("hint_sender[{}]:send_one_file: Error while sending hints from {}, last RP is {}", _ep_key, fname, _last_not_complete_rp);
 
-        return false;
-    }
+            return false;
+        }
     }
 
     // If we got here we are done with the current segment and we can remove it.

--- a/db/hints/internal/hint_sender.cc
+++ b/db/hints/internal/hint_sender.cc
@@ -522,7 +522,6 @@ bool hint_sender::send_one_file(const sstring& fname) {
     } catch (db::commitlog::segment_error& ex) {
         manager_logger.error("hint_sender[{}]:send_one_file: Segment error in {}: {}. Last not complete position={}",
                 _ep_key, fname, ex.what(), _last_not_complete_rp);
-        ctx_ptr->segment_replay_failed = false;
         corrupted_segment = true;
         ++this->shard_stats().corrupted_files;
     } catch  (const canceled_draining_exception&) {
@@ -536,21 +535,6 @@ bool hint_sender::send_one_file(const sstring& fname) {
     // wait till all background hints sending is complete
     ctx_ptr->file_send_gate.close().get();
 
-    // Hints are sent asynchronously, so the following scenario could happen:
-    //
-    // 1. N + 1 hints are dispatched to be sent.
-    // 2. N pass through the semaphore, while 1 waits on it. This suspends
-    //    the commitlog::read_log_file loop above.
-    // 3. Those N hints time out and the 1 remaining hint finally gets through.
-    //    The commitlog loop is unblocked. However, since
-    //    ctx_ptr->segment_replay_failed == true, the loop just browses the
-    //    rest of the commitlog, not sending anything. This is not throttled.
-    // 4. The commitlog loop encounters a corrupted entry and throws an exception.
-    //    The exception handler sets ctx_ptr->segment_replay_failed to false.
-    // 5. We block in closing the send gate. That eventually happens when the
-    //    last hint times out. But what it also does is set
-    //    ctx_ptr->segment_replay_failed to true again.
-    //
     // We must remove the segment, so we cannot return yet. The code below
     // assumes there was no corruption, so we embrace it with an if.
     // Refs: SCYLLADB-4294.

--- a/test/cluster/test_hints.py
+++ b/test/cluster/test_hints.py
@@ -22,7 +22,9 @@ from test.pylib.scylla_cluster import ReplaceConfig
 from test.pylib.util import gather_safely, wait_for
 
 from test.pylib import nodetool
-from test.cluster.util import get_topology_coordinator, keyspace_has_tablets, new_test_keyspace, new_test_table
+from test.cluster.util import (get_commitlog_segment_id, corrupt_commitlog_segment,
+                               get_topology_coordinator, keyspace_has_tablets, new_test_keyspace,
+                               new_test_table)
 
 
 logger = logging.getLogger(__name__)
@@ -1565,3 +1567,131 @@ async def test_hint_retransmission_keeps_column_mappings(manager: ScyllaClusterM
     rows = await cql.run_async(SimpleStatement(f"SELECT pk, v FROM {table}",
                                                 consistency_level=ConsistencyLevel.ONE))
     assert sorted((row.pk, row.v) for row in rows) == [(i, i + 1) for i in range(row_count)]
+
+
+@pytest.mark.skip_mode(mode="release", reason="error injections are not supported in release mode")
+async def test_corrupted_segment_is_removed(manager: ScyllaClusterManager):
+    """
+    Reproducer of SCYLLADB-4294.
+
+    The original problem stemmed from hint sending being an asynchronous operation
+    with relation to reading from the commitlog. If sending a hint failed *after*
+    hint_sender encountered corruption in the segment, it would override the flag
+    both failure scenarios relied on.
+
+    As a result, hint_sender didn't attempt removing the corrupted segment, treating
+    the whole operation as if it *only* failed to apply a hint. When it then entered
+    the function send_one_file() again, it would go through the same corrupted
+    commitlog, potentially running into the same issue.
+
+    This test follows exactly that scenario. More details can be found in Jira.
+    """
+    fail_hint_send_injection = "hinted_handoff_fail_hint_send"
+    # Use one shard so that all hints land in the same segment.
+    # The increased log level is needed for the test to be reliable.
+    cmdline = ["--smp=1", "--logger-log-level", "hints_manager=trace"]
+    # Allow sending one hint at a time. This simplifies the test.
+    config = {"max_hinted_handoff_concurrency": 1}
+
+    node1, node2 = await manager.servers_add(2, cmdline=cmdline, config=config, auto_rack_dc="dc1")
+
+    node2_host_id = await manager.get_host_id(node2.server_id)
+    hints_dir = await get_hints_dir(manager, node1)
+
+    cql = await manager.get_cql_exclusive(node1)
+    await cql.run_async("CREATE KEYSPACE ks WITH replication = "
+                        "{'class': 'NetworkTopologyStrategy', 'replication_factor': 2}")
+    await cql.run_async("CREATE TABLE ks.tbl (pk int PRIMARY KEY, v int)")
+
+    await manager.server_stop_gracefully(node2.server_id)
+    await manager.server_not_sees_other_server(node1.ip_addr, node2.ip_addr)
+
+    stmt = cql.prepare("INSERT INTO ks.tbl (pk, v) VALUES (?, ?)")
+    stmt.consistency_level = ConsistencyLevel.ONE
+
+    # This number of hints should always be enough to cover at least
+    # two commitlog sectors.
+    hint_count = 4000
+    batch_size = 1000
+    for i in range(hint_count // batch_size):
+        start = i * batch_size
+        await gather_safely(*[cql.run_async(stmt, (start + j, start + j)) for j in range(batch_size)])
+
+    await wait_until_hint_writing_settled(manager, [node1])
+    written = await get_hint_metrics(manager.metrics, node1.ip_addr, "written")
+    assert written == hint_count, f"Some hints failed to be written: {written} vs. {hint_count}"
+
+    await manager.server_stop_gracefully(node1.server_id)
+
+    segments = glob.glob(os.path.join(hints_dir, "*", str(node2_host_id), "HintsLog-*.log"))
+    assert segments, f"No hint segments for {node2_host_id} under {hints_dir}"
+    # The oldest segments are replayed first, so damage the one picked up first.
+    damaged_segment = min(segments, key=get_commitlog_segment_id)
+    logger.info(f"Corrupting hint segment {damaged_segment}")
+    corrupt_commitlog_segment(damaged_segment)
+
+    injections = [
+        {"name": fail_hint_send_injection, "one_shot": False},
+        # Speed up the test.
+        {"name": "decrease_hints_flush_period", "one_shot": False}
+    ]
+    await manager.server_update_config(node1.server_id, "error_injections_at_startup", injections)
+    await manager.server_start(node1.server_id)
+
+    log = await manager.server_open_log(node1.server_id)
+    mark = await log.mark()
+
+    await manager.server_start(node2.server_id)
+    await manager.server_sees_other_server(node1.ip_addr, node2.ip_addr)
+
+    segment_name = re.escape(os.path.basename(damaged_segment))
+
+    try:
+        # Wait for the first hint to get stuck at the error injection.
+        await log.wait_for(fail_hint_send_injection, from_mark=mark, timeout=120)
+
+        # In the meantime, the second hint should also be scheduled
+        # by hint_sender::send_one_file, but because of throttling
+        # allowing for one hint to be sent at a time, it'll be
+        # waiting and *not* hit the error injection yet.
+        async def wait_for_second_hint():
+            matches = await log.grep("Scheduling a hint to be sent", from_mark=mark)
+            return True if (len(matches) == 2) else None
+        await wait_for(wait_for_second_hint, deadline=time.time() + 120)
+
+        # Sanity check. Make sure the second hint didn't reach the error
+        # injection yet.
+        matches = await log.grep(fail_hint_send_injection, from_mark=mark)
+        assert len(matches) == 1, f"Expected just one hint being stuck, got: {len(matches)}"
+        mark = await log.mark()
+
+        # With this setup, make the first hint fail. This should trigger
+        # hint_sender::send_one_file to run into the corrupted sector
+        # in the segment.
+        # Note that the second hint will be attempted to be sent now,
+        # but because the injection is still active, it will hang at it.
+        # We can only unblock it *after* we observe the error message
+        # about the corrupted segment.
+        await manager.api.message_injection(node1.ip_addr, fail_hint_send_injection)
+        await log.wait_for(f"Segment error in .*{segment_name}", from_mark=mark, timeout=120)
+        mark = await log.mark()
+    finally:
+        # Don't prolong test teardown if anything inside the try clause fails.
+        await manager.api.disable_injection(node1.ip_addr, fail_hint_send_injection)
+        await manager.api.message_injection(node1.ip_addr, fail_hint_send_injection)
+
+    await log.wait_for(f"Corrupted segment .*{segment_name} has been deleted", from_mark=mark, timeout=120)
+
+    async def wait_for_damaged_segment_removed():
+        return True if (not os.path.exists(damaged_segment)) else None
+    await wait_for(wait_for_damaged_segment_removed, deadline=time.time() + 120)
+
+    # Make sure we *did* try to send something. That was a necessary part of the
+    # trigger of the original problem.
+    send_errors = await get_hint_metrics(manager.metrics, node1.ip_addr, "send_errors")
+    assert send_errors and send_errors >= 1, \
+        "No hint send failed, so the test did not exercise the race it is meant to cover"
+
+    corrupted_files = await get_hint_metrics(manager.metrics, node1.ip_addr, "corrupted_files")
+    assert corrupted_files == 1, \
+        f"The damaged segment was processed {corrupted_files} times, expected exactly once"

--- a/test/cluster/util.py
+++ b/test/cluster/util.py
@@ -10,6 +10,8 @@ import asyncio
 import logging
 import functools
 import operator
+import os
+import struct
 import time
 import re
 from contextlib import asynccontextmanager, contextmanager, suppress
@@ -771,3 +773,62 @@ def get_replica_count(rf: ReplicationOption) -> int:
         get_replica_count(["2"]) == 2
     """
     return len(rf) if type(rf) is list else int(rf)
+
+
+def get_commitlog_segment_id(path: str) -> int:
+    """
+    The id of a commitlog segment, taken from its name: <prefix>-<version>-<id>.log.
+    """
+    return int(os.path.basename(path).removesuffix(".log").split("-")[-1])
+
+
+def get_commitlog_segment_alignment(path: str) -> int:
+    """
+    The sector size of a commitlog segment, read from its header.
+    """
+    segment_header_size = 24
+    segment_magic = b"SCLC"
+
+    with open(path, "rb") as f:
+        header = f.read(segment_header_size)
+
+    assert len(header) == segment_header_size, f"{path} is too short to hold a segment header"
+    magic, _version, _segment_id, alignment, _checksum = struct.unpack(">IIQII", header)
+    assert magic.to_bytes(4, "big") == segment_magic, f"{path} is not a commitlog segment"
+    return alignment
+
+
+def commitlog_sector_has_data(file, sector: int, alignment: int) -> bool:
+    """
+    Whether a sector of an open segment holds anything the reader would look at.
+    """
+    file.seek(sector * alignment)
+    return any(file.read(alignment))
+
+
+def corrupt_commitlog_segment(path: str, sector: int = 1) -> None:
+    """
+    Damage a commitlog segment so that commitlog reports the corruption
+    once it reaches `sector`. It's done via flipping the CRC at the end
+    of the given sector.
+
+    Sector 0 holds the segment header and the first entries. Tests that need
+    the reader to hand out some entries before it fails should leave it alone.
+
+    Inspired by corrupt_segment() from test/boost/commitlog_test.cc.
+    """
+    alignment = get_commitlog_segment_alignment(path)
+    crc_size = 4
+    # The last crc_size bytes of a sector is its CRC.
+    crc_offset = (sector + 1) * alignment - crc_size
+
+    with open(path, "r+b") as f:
+        if not commitlog_sector_has_data(f, sector, alignment):
+            # Technically, flipping the bits in such a segment could work
+            # in some cases, but it's not reliable. Reject it.
+            pytest.fail(f"Sector {sector} of {path} holds no data")
+        f.seek(crc_offset)
+        stored = f.read(crc_size)
+        assert len(stored) == crc_size, f"{path} is shorter than sector {sector}"
+        f.seek(crc_offset)
+        f.write(bytes(b ^ 0xff for b in stored))


### PR DESCRIPTION
The existing logic of sending hints had a bug -- because hints are sent
asynchronously, a failed hint could overwrite a flag the code relied on
to trigger the removal of a corrupted segment. As a result, if a segment
was corrupted, we could process it multiple times -- hitting the
corruption again and again. That's what we observed in our testing too.

We fix it by introducing a separate flag for corruption specifically.

A more detailed scenario looks like this:

1. N + 1 hints are dispatched to be sent.
2. N pass through the semaphore, while 1 waits on it. This suspends
   the commitlog::read_log_file loop above.
3. Those N hints time out and the 1 remaining hint finally gets through.
   The commitlog loop is unblocked. However, since
   ctx_ptr->segment_replay_failed == true, the loop just browses the
   rest of the commitlog, not sending anything. This is not throttled.
4. The commitlog loop encounters a corrupted entry and throws an exception.
   The exception handler sets ctx_ptr->segment_replay_failed to false.
5. We block in closing the send gate. That eventually happens when the
   last hint times out. But what it also does is set
   ctx_ptr->segment_replay_failed to true again.

Instead of removing the segment, we return from the function
and process it again when we enter the function next time.

A reproducer test has been added to validate the solution.
It's deterministic and relies on newly added commitlog helpers.

Fixes: SCYLLADB-4294

The problem is present on all supported versions, so let's
backport the fix to them.