### PR TITLE
alternator: reject a too-short stream id in ShardId/ShardIterator

### DIFF
--- a/alternator/streams.cc
+++ b/alternator/streams.cc
@@ -298,7 +298,11 @@ shard_id::shard_id(const sstring& s) {
     }
 
     time = db_clock::time_point(db_clock::duration(std::stoull(s.substr(1, i - 1), nullptr, 16)));
-    id = cdc::stream_id(from_hex(s.substr(i + 1)));
+    auto id_bytes = from_hex(s.substr(i + 1));
+    if (id_bytes.size() != 2 * sizeof(int64_t)) {
+        throw api_error::validation(fmt::format("Invalid ShardId: {}", s));
+    }
+    id = cdc::stream_id(std::move(id_bytes));
 }
 
 struct sequence_number {

--- a/cdc/generation.cc
+++ b/cdc/generation.cc
@@ -116,6 +116,9 @@ stream_id::stream_id(bytes b)
 {
     // this is not a very solid check. Id:s previous to GA/versioned id:s
     // have fully random bits in low qword, so this could go either way...
+    if (_value.size() < 2 * sizeof(int64_t)) {
+        throw std::invalid_argument("Malformed CDC stream id");
+    }
     if (version() > version_1) {
         throw std::invalid_argument("Unknown CDC stream id version");
     }

--- a/test/alternator/test_streams.py
+++ b/test/alternator/test_streams.py
@@ -629,6 +629,29 @@ def test_get_shard_iterator_for_nonexistent_shard(dynamodb, dynamodbstreams):
                     StreamArn=arn, ShardId='adfasdasdasdasdasdasdasdasdasasdasd', ShardIteratorType='LATEST'
                 )
 
+# A malformed ShardId or ShardIterator must be a client error, never a node abort:
+# on Scylla the stream-id part used to decode to a blob shorter than a CDC stream id
+# and trip a SCYLLA_ASSERT (SCYLLADB-4383). GetShardIterator and GetRecords parse it
+# through the same code. The ShardId is padded past DynamoDB's 28-char minimum so both
+# back ends answer ResourceNotFoundException; a corrupted ShardIterator gives
+# ValidationException. Error codes confirmed against DynamoDB. The crash is storage-
+# independent, so this overrides the module's vnodes/tablets fixture to run once.
+@pytest.mark.parametrize('tags_param', [[{'Key': 'system:initial_tablets', 'Value': 'none'}]], indirect=True, ids=[''])
+def test_get_shard_iterator_malformed_shard_id(dynamodb, dynamodbstreams):
+    with create_stream_test_table(dynamodb, StreamViewType='KEYS_ONLY') as table:
+        (arn, label) = wait_for_active_stream(dynamodbstreams, table)
+        with pytest.raises(ClientError, match='ResourceNotFoundException'):
+            dynamodbstreams.get_shard_iterator(
+                    StreamArn=arn, ShardId='H0000000000000000000000000:00', ShardIteratorType='LATEST')
+        # A real iterator with its trailing stream-id replaced by '00'.
+        desc = dynamodbstreams.describe_stream(StreamArn=arn)
+        good_shard = desc['StreamDescription']['Shards'][0]['ShardId']
+        it = dynamodbstreams.get_shard_iterator(
+                StreamArn=arn, ShardId=good_shard, ShardIteratorType='TRIM_HORIZON')['ShardIterator']
+        bad_it = it[:it.rfind(':') + 1] + '00'
+        with pytest.raises(ClientError, match='ValidationException'):
+            dynamodbstreams.get_records(ShardIterator=bad_it)
+
 def test_get_records(dynamodb, dynamodbstreams):
     # TODO: add tests for storage/transactionable variations and global/local index
     with create_stream_test_table(dynamodb, StreamViewType='NEW_AND_OLD_IMAGES') as table:


### PR DESCRIPTION
A `GetShardIterator` `ShardId`, or a `GetRecords` `ShardIterator`, whose stream-id part is valid even-length hex but shorter than a real CDC stream id aborts the node while the request is being parsed.

Line numbers are on master, fe6582f73f.

## The problem

Both operations build an `alternator::shard_id`, whose constructor decodes the id part with `from_hex` and hands the bytes straight to `cdc::stream_id` (`alternator/streams.cc:301`). `from_hex` (`bytes.cc:36`) accepts any even-length hex, so `"00"` yields a one-byte blob. Every `cdc::stream_id` accessor unpacks two 8-byte qwords and begins with `SCYLLA_ASSERT(b.size() >= offset + sizeof(int64_t))` (`cdc/generation.cc:129`), and `SCYLLA_ASSERT` is an unconditional `abort()`, active in every build mode (`utils/assert.hh:8-9`), so a shorter blob terminates the process. `GetRecords` reaches the same parser because `shard_iterator`'s constructor builds its `shard` member from the tail of the iterator string (`alternator/streams.cc:1093`). The `catch (...)` around the `GetShardIterator` parse (`streams.cc:1136`) cannot intercept an `abort()`.

## The fix

Validate the decoded length before the stream id is constructed, in two places:

| site | guard | on failure |
|---|---|---|
| `alternator::shard_id` (`streams.cc`) | id part must be a full stream id (`2 * sizeof(int64_t)` bytes) | `api_error::validation` |
| `cdc::stream_id(bytes)` (`generation.cc`) | blob must be at least the two qwords it unpacks | `std::invalid_argument` |

The first turns the malformed request into a client error — `ResourceNotFoundException` from `GetShardIterator`, `ValidationException` from `GetRecords`. The second is a root-cause guard so no caller of `stream_id(bytes)` can trip the assert.

## Tests

`test/alternator/test_streams.py::test_get_shard_iterator_malformed_shard_id` drives both entry points: a `ShardId` padded past DynamoDB's 28-char minimum, and a real `ShardIterator` with its trailing stream-id replaced by `00`. On an unpatched build both abort the node (`cdc/generation.cc:129`); with the fix `GetShardIterator` returns `ResourceNotFoundException` and `GetRecords` returns `ValidationException` — both codes confirmed against real DynamoDB. The crash is storage-independent, so the test overrides the module's vnodes/tablets fixture to run once.

`test_streams.py` regression: 168 passed, 8 xfailed.

## Commits

1. `test/alternator: cover malformed ShardId/ShardIterator in the stream APIs`
2. `alternator: reject a too-short stream id in ShardId/ShardIterator`
3. `cdc: reject an undersized blob in stream_id(bytes)`

Backport targets and per-branch mechanics are on the tracker issue.

Fixes: SCYLLADB-4383
Refs: SCYLLADB-1661

🤖 Generated with [Claude Code](https://claude.com/claude-code)
