### PR TITLE
alternator: floor the GetRecords row scan at one full batch

### DIFF
--- a/alternator/streams.cc
+++ b/alternator/streams.cc
@@ -1324,7 +1324,7 @@ future<executor::request_return_type> executor::get_records(client_state& client
         ++mul;
     }
     auto command = ::make_lw_shared<query::read_command>(schema->id(), schema->version(), partition_slice, _proxy.get_max_result_size(partition_slice),
-            query::tombstone_limit(_proxy.get_tombstone_limit()), query::row_limit(limit * mul));
+            query::tombstone_limit(_proxy.get_tombstone_limit()), query::row_limit(std::max<uint64_t>(limit, db.get_config().alternator_max_items_in_batch_write() + 1) * mul));
 
     service::storage_proxy::result<service::storage_proxy::coordinator_query_result> rqr =
             co_await _proxy.query_result(schema, std::move(command), std::move(partition_ranges), cl, service::storage_proxy::coordinator_query_options(default_timeout(), std::move(permit), client_state));

--- a/test/alternator/test_streams.py
+++ b/test/alternator/test_streams.py
@@ -2497,6 +2497,45 @@ def test_streams_multiple_items_one_partition(dynamodb, dynamodbstreams, scylla_
             return [['INSERT', {'p': p, 'c': cc}, None, {'p': p, 'c': cc, 'x': cc}] for cc in cs]
         do_test(stream, dynamodb, dynamodbstreams, do_updates, 'NEW_AND_OLD_IMAGES')
 
+# GetRecords must deliver every record in a shard regardless of the client's
+# Limit. Under always-LWT write isolation a BatchWriteItem lands all its items
+# in one CDC batch that shares a timestamp and a single end-of-batch row, and
+# the reader can only emit the batch once it has read that row. GetRecords
+# bounded the CDC row scan at Limit*mul rows, so a Limit smaller than the batch
+# cut the scan short: the batch was silently dropped, no NextShardIterator
+# advanced, and the shard stayed head-of-line blocked forever (SCYLLADB-4395).
+# Draining with a tiny Limit must still surface every item -- DynamoDB parcels
+# the batch out across calls, Alternator returns it whole. The defect is
+# storage-independent, so this overrides the module's vnodes/tablets fixture.
+@pytest.mark.parametrize('tags_param', [[{'Key': 'system:initial_tablets', 'Value': 'none'}]], indirect=True, ids=[''])
+def test_get_records_small_limit_delivers_whole_batch(dynamodb, dynamodbstreams):
+    tags = TAGS + [{'Key': 'system:write_isolation', 'Value': 'always'}]
+    with create_stream_test_table(dynamodb, StreamViewType='KEYS_ONLY', Tags=tags) as table:
+        (arn, label) = wait_for_active_stream(dynamodbstreams, table)
+        p = random_string()
+        cs = ['c0', 'c1', 'c2']
+        with table.batch_writer() as batch:
+            for c in cs:
+                batch.put_item(Item={'p': p, 'c': c})
+        iterators = [dynamodbstreams.get_shard_iterator(StreamArn=arn, ShardId=s,
+                        ShardIteratorType='TRIM_HORIZON')['ShardIterator']
+                     for s in list_shards(dynamodbstreams, arn)]
+        seen = set()
+        deadline = time.time() + 60
+        while time.time() < deadline and seen != set(cs):
+            next_iterators = []
+            for it in iterators:
+                response = dynamodbstreams.get_records(ShardIterator=it, Limit=1)
+                for record in response['Records']:
+                    seen.add(record['dynamodb']['Keys']['c']['S'])
+                if 'NextShardIterator' in response:
+                    next_iterators.append(response['NextShardIterator'])
+            iterators = next_iterators
+            if not iterators:
+                break
+            time.sleep(1)
+        assert seen == set(cs)
+
 # Test the CHILD_SHARDS shard filter. In a simple case where the table
 # hasn't been modified since the stream was created, there is just one
 # generation so asking for child shards of the only shard returns nothing.


### PR DESCRIPTION
Line numbers are on master, fe6582f73f.

## The problem

`GetRecords` never delivers a CDC batch that is larger than the client's
`Limit`. Alternator merges the CDC rows that share a timestamp into stream
records and only emits them once it reads the batch's end-of-batch row. The
read that feeds this loop is bounded at `Limit * mul` rows, where `mul`
(2..4) estimates the rows per record. A `BatchWriteItem` under always-LWT
write isolation writes all of its items into one such batch, so when `Limit`
is smaller than the batch, `Limit * mul` rows stop short of the end-of-batch
row: the batch is never emitted, no timestamp is recorded, and the function
hands the caller back its own shard iterator unchanged. The shard is then
head-of-line blocked at that `Limit` forever, and on a closed or disabled
shard no `NextShardIterator` is returned at all, so a checkpointing consumer
treats the shard as drained. Either way the records are lost to that consumer.

## The fix

Floor the row scan at one full batch:

| | before | after |
|---|---|---|
| row scan bound | `Limit * mul` | `max(Limit, alternator_max_items_in_batch_write + 1) * mul` |

The first batch in the read window is the only fatal cut -- a later batch is
re-read from its start on the next call -- and the floor guarantees it fits,
because a batch cannot hold more than `alternator_max_items_in_batch_write`
items and each item contributes at most `mul` rows. The floor never lowers
the existing `Limit * mul` bound, and the default-`Limit` path (1000) already
reads well past it, so nothing that works today reads fewer rows. A batch
whose serialized rows exceed the read's `max_result_size` is a separate,
pre-existing limit shared with the default-`Limit` path and is unchanged.

## Tests

`test/alternator/test_streams.py::test_get_records_small_limit_delivers_whole_batch`
writes a three-item batch and drains it at `Limit=1`, asserting every item is
surfaced. It fails on an unpatched build (the shard delivers nothing) and
passes with the fix; the completeness it checks holds on real DynamoDB too,
which parcels the batch out across calls. Storage-independent, so it runs
once. Full `test_streams.py`: 167 passed, 8 xfailed.

## Commits

1. `test/alternator: cover small-Limit GetRecords batch delivery`
2. `alternator: floor the GetRecords row scan at one full batch`

Backport: branch-2026.2 and branch-2026.3 (Alternator Streams went GA in 2026.2).

Fixes: SCYLLADB-4395
Refs: SCYLLADB-1661

🤖 Generated with [Claude Code](https://claude.com/claude-code)
