### PR TITLE
tasks: release the generic task resources on failure

### DIFF
--- a/api/task_manager_test.cc
+++ b/api/task_manager_test.cc
@@ -38,7 +38,7 @@ static future<tasks::task_id> make_test_task(tasks::task_manager& task_manager, 
                     .set_table(std::move(table))
                     .set_entity(std::move(entity))
                     .set_is_user_task(user_task)
-                    .set_finalizer([module_ptr, task_id] {
+                    .set_finalizer([module_ptr, task_id] () noexcept {
                         module_ptr->erase_finalization(task_id);
                         return make_ready_future<>();
                     });

--- a/tasks/task_manager.cc
+++ b/tasks/task_manager.cc
@@ -8,6 +8,7 @@
 
 
 #include <seastar/core/on_internal_error.hh>
+#include <seastar/coroutine/as_future.hh>
 #include <seastar/coroutine/parallel_for_each.hh>
 #include <seastar/core/abort_source.hh>
 #include <seastar/core/gate.hh>
@@ -460,14 +461,30 @@ void task_manager::generic_task_impl::abort() noexcept {
 }
 
 future<> task_manager::generic_task_impl::release_resources() noexcept {
-    _cached_progress = co_await get_progress();
-    _cached_workload = co_await expected_total_workload();
-    co_await (_finalizer ? _finalizer() : task::impl::release_resources());
-    _finalizer = {};
-    _action = {};
-    _progress_fn = {};
-    _workload_fn = {};
-    _abort_fn = {};
+    auto clear_callables = defer([this] () noexcept {
+        _finalizer = {};
+        _action = {};
+        _progress_fn = {};
+        _workload_fn = {};
+        _abort_fn = {};
+    });
+    auto progress_f = co_await coroutine::as_future(get_progress());
+    if (progress_f.failed()) {
+        tmlogger.warn("Failed to cache the progress of task {}: {}", _status.id, progress_f.get_exception());
+        _cached_progress = task::progress{};
+    } else {
+        _cached_progress = progress_f.get();
+    }
+    auto workload_f = co_await coroutine::as_future(expected_total_workload());
+    if (workload_f.failed()) {
+        tmlogger.warn("Failed to cache the workload of task {}: {}", _status.id, workload_f.get_exception());
+    } else {
+        _cached_workload = workload_f.get();
+    }
+    auto finalize_f = co_await coroutine::as_future(_finalizer ? _finalizer() : task::impl::release_resources());
+    if (finalize_f.failed()) {
+        tmlogger.warn("Failed to finalize task {}: {}", _status.id, finalize_f.get_exception());
+    }
 }
 
 future<> task_manager::generic_task_impl::run() {

--- a/tasks/task_manager.hh
+++ b/tasks/task_manager.hh
@@ -280,7 +280,7 @@ public:
         using progress_fn = noncopyable_function<future<task::progress> ()>;
         using workload_fn = noncopyable_function<future<std::optional<double>> ()>;
         using abort_fn = noncopyable_function<void (seastar::abort_source&)>;
-        using finalize_fn = noncopyable_function<future<> ()>;
+        using finalize_fn = noncopyable_function<future<> () noexcept>;
     private:
         std::string _type;
         tasks::is_abortable _is_abortable;


### PR DESCRIPTION
If caching the progress or the workload, or the finalizer, threw, the callbacks were never cleared, so their captures were retained until the task was unregistered, and the failure was silently swallowed by the caller. Clear the callbacks on every exit path and handle each step's failure independently, so one failing step does not skip the others.

Make the finalizer noexcept, so that all its failures arrive through the returned future.

A task whose progress could not be cached reports empty progress afterwards.

No backport, no release affected