### PR TITLE
repair: fix dead error-flag check in repair_get_full_row_hashes_with_rpc_stream_handler

### DIFF
--- a/repair/row_level.cc
+++ b/repair/row_level.cc
@@ -2593,10 +2593,10 @@ static future<> repair_get_full_row_hashes_with_rpc_stream_handler(
         uint32_t repair_meta_id,
         rpc::sink<repair_hash_with_cmd> sink,
         rpc::source<repair_stream_cmd> source) {
+    bool error = false;
     std::exception_ptr outer_exception;
     try {
         while (std::optional<std::tuple<repair_stream_cmd>> status_opt = co_await source()) {
-            bool error = false;
             std::exception_ptr ep;
             try {
                 if (error) {


### PR DESCRIPTION
\`error\` was declared inside the receive loop and reset to \`false\` every
iteration, so \`if (error) continue;\` could never observe a prior
iteration's failure — it was dead code. Moved the declaration to function
scope, matching two sibling handlers in the same file that already do this
correctly, so a thrown exception now causes the rest of the stream to be
drained instead of reprocessed.

Found while reviewing PR #31041 — pre-existing on master, unrelated to that
PR's batching work, so split out as its own fix.

## Test plan
- `combined_tests --run_test=repair_test`: 6/6 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)