### PR TITLE
[Backport 2026.2] sstables: fix bytes on disk value after component rewrite and reduce test mutation count

### DIFF
--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -1581,8 +1581,14 @@ future<shared_sstable> sstable::link_with_rewritten_component(std::function<shar
         // The rest of the sstable is hard-linked and its scylla_metadata is carried over.
         new_sst->mark_created_by_component_rewrite();
 
-        _storage->link_with_excluded_components(*this, generation, {component, component_type::Scylla}).get();
+        std::unordered_set<component_type> excluded_components = {component, component_type::Scylla};
+        _storage->link_with_excluded_components(*this, generation, excluded_components).get();
         new_sst->copy_components(*this).get();
+
+        new_sst->_metadata_size_on_disk = _metadata_size_on_disk;
+        parallel_for_each(excluded_components, coroutine::lambda([this, new_sst] (component_type type) -> future<> {
+            new_sst->_metadata_size_on_disk -= co_await component_filesize(type);
+        })).get();
 
         modifier(*new_sst);
 
@@ -1630,6 +1636,14 @@ void sstable::write_component_with_metadata(component_type type, scylla_metadata
     // mirroring read_scylla_metadata(). Otherwise a rewritten sstable would
     // report zeroed features (e.g. losing ShadowableTombstones).
     _features = _components->scylla_metadata->get_features();
+}
+
+future<uint64_t> sstable::component_filesize(component_type type) const noexcept {
+    // Open the file, in order to correctly read the size while taking into account
+    // the storage layer and possible encryption.
+    return open_file(type, open_flags::ro).then([] (file f) {
+        return with_closeable(std::move(f), std::mem_fn(&file::size));
+    });
 }
 
 future<> sstable::read_summary() noexcept {

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -1222,6 +1222,8 @@ public:
             bool update_sstable_id);
     // Must be called in a seastar thread
     void write_component_with_metadata(component_type type, scylla_metadata metadata);
+private:
+    future<uint64_t> component_filesize(component_type type) const noexcept;
 };
 
 // Validate checksums

--- a/test/boost/sstable_test.cc
+++ b/test/boost/sstable_test.cc
@@ -478,7 +478,7 @@ static void do_test_link_with_rewritten_component_size(test_env& env) {
     auto random_schema = tests::random_schema{tests::random::get_int<uint32_t>(), *random_spec};
     auto schema = random_schema.schema();
 
-    const auto muts = tests::generate_random_mutations(random_schema, 1000).get();
+    const auto muts = tests::generate_random_mutations(random_schema, 10).get();
     auto sst = make_sstable_containing(env.make_sstable(schema, sstable::version_types::me), muts).get();
 
     auto before_size = calculate_actual_on_disk_size(sst).get();

--- a/test/boost/sstable_test.cc
+++ b/test/boost/sstable_test.cc
@@ -444,6 +444,56 @@ SEASTAR_TEST_CASE(statistics_rewrite) {
     });
 }
 
+static future<uint64_t> calculate_actual_on_disk_size(shared_sstable sst) {
+    return map_reduce(
+        sst->all_components(),
+        [sst] (const auto& p) {
+            return file_size(sst->get_filename(p.first).format());
+        },
+        uint64_t{0},
+        std::plus{}
+    );
+}
+
+static future<shared_sstable> mutate_sstable(test_env& env, shared_sstable sst, std::function<void(sstables::sstable&)> modifier, sstables::component_type type = sstables::component_type::Statistics, bool update_id = false) {
+    auto toc_path = fmt::to_string(sst->toc_filename());
+    auto dir_path = std::filesystem::path(toc_path).parent_path().string();
+
+    auto creator = [&env, &dir_path] (shared_sstable sst) {
+        return env.make_sstable(sst->get_schema(), dir_path, sst->get_version());
+    };
+
+    auto new_sst = co_await sst->link_with_rewritten_component(std::move(creator), type, std::move(modifier), update_id);
+    co_await sst->unlink();
+    co_return new_sst;
+}
+
+static void do_test_link_with_rewritten_component_size(test_env& env) {
+    auto random_spec = tests::make_random_schema_specification(
+        "ks",
+        std::uniform_int_distribution<size_t>(1, 4),
+        std::uniform_int_distribution<size_t>(2, 4),
+        std::uniform_int_distribution<size_t>(2, 8),
+        std::uniform_int_distribution<size_t>(2, 8));
+    auto random_schema = tests::random_schema{tests::random::get_int<uint32_t>(), *random_spec};
+    auto schema = random_schema.schema();
+
+    const auto muts = tests::generate_random_mutations(random_schema, 1000).get();
+    auto sst = make_sstable_containing(env.make_sstable(schema, sstable::version_types::me), muts).get();
+
+    auto before_size = calculate_actual_on_disk_size(sst).get();
+    BOOST_REQUIRE_EQUAL(before_size, sst->bytes_on_disk());
+
+    auto new_sst = mutate_sstable(env, std::move(sst), std::identity{}).get();
+
+    auto after_size = calculate_actual_on_disk_size(new_sst).get();
+    BOOST_REQUIRE_EQUAL(after_size, new_sst->bytes_on_disk());
+}
+
+SEASTAR_TEST_CASE(test_link_with_rewritten_component_bytes_on_disk) {
+    return test_env::do_with_async(do_test_link_with_rewritten_component_size);
+}
+
 // Tests for reading a large partition for which the index contains a
 // "promoted index", i.e., a sample of the column names inside the partition,
 // with which we can avoid reading the entire partition when we look only


### PR DESCRIPTION
This patch backports two PRs at once, as the second one contains a fix for a flaky tests introduced in the first one.

Currently, `link_with_rewritten_component` does not correctly set the `_metadata_size_on_disk` value. 
It is first initialized to 0 when creating a new sstable, then increased by writing the `Scylla` and rewritten components.
Because of this, it does not reflect the real size of non Disk and Index components on disk, which result in an incorrect `sstable::bytes_on_disk()` value.

Set it to the original sstable's value and subtract the rewritten components. Their new size will be added when they are written.
Implement a test to verify that the size is calculated correctly. The test doesn't pass before the changes introduced by this patch.

Fixes: SCYLLADB-4186

backport to versions with `link_with_rewritten_component`

- (cherry picked from commit 5a521290fafc27e7b3f35e5237d76b185aaf8371)
- (cherry picked from commit 6f363e32f9bdda13728952538a137f35de6b870e)

Parent PR: #31522

The `do_test_link_with_rewritten_component_size` helper generated far too many random mutations, and could cause out of memory errors. Reduce the random mutations count.

This impacted CI in #31477 and #17356.

Fixes: SCYLLADB-4329

backport to 2026.03 and 2026.02 where the PR introducing the test was backported

- (cherry picked from commit af8ec3dd4c129200b74771a7df9fef7f50cd0902)

Parent PR: #31316

no backport, this is the oldest version the parent PRs were backported to