### PR TITLE
logalloc: don't prime the segment pool in default-allocator builds

### DIFF
--- a/utils/logalloc.cc
+++ b/utils/logalloc.cc
@@ -1425,6 +1425,16 @@ segment_pool::segment_pool(tracker::impl& tracker)
 }
 
 void segment_pool::prime(size_t available_memory, size_t min_free_memory) {
+#ifdef SEASTAR_DEFAULT_ALLOCATOR
+    // Occupying the top part of memory only means something with seastar's
+    // allocator, where segments come out of the shard's preallocated arena and
+    // claiming them costs nothing. With the standard allocator every segment is
+    // a separate allocation from the system, so priming would really take
+    // _std_memory_available (1G) per shard and hold it for the lifetime of the
+    // process. Let segments be allocated on demand instead. The emergency
+    // reserve is refilled by allocating_section::reserve() when needed.
+    return;
+#endif
     auto old_emergency_reserve = std::exchange(_emergency_reserve_max, std::numeric_limits<size_t>::max());
     try {
         // Allocate all of memory so that we occupy the top part. Afterwards, we'll start


### PR DESCRIPTION
segment_pool::prime() allocates every segment it can get and then frees
the low part again, so that LSA ends up occupying the top of memory and
the general-purpose allocator works below it. That layout is the whole
point of the exercise, and it only means something with seastar's own
allocator: there the segments come out of the shard's preallocated
arena, so claiming all of them costs nothing, the memory is already
reserved for this shard and nobody else can use it anyway.

Builds that define SEASTAR_DEFAULT_ALLOCATOR (debug and sanitize) have
no such arena. Every segment is a separate aligned_alloc() from
the system allocator, and the amount priming takes is the emulated
_std_memory_available, i.e. 1GB per shard, which the pool then sits on
for the lifetime of the process. At the same time there is no arena
whose layout could be improved, so the trick buys exactly nothing.

Skip priming in those builds and let segments be allocated on demand.
Nothing depends on the primed free list: the emergency reserve is 30
segments and allocating_section::reserve() refills it when a section
needs it. Besides, segment_pool::allocate_segment() already falls back
to the system allocator whenever the free list cannot satisfy a request.

Without this change, a `--smp 2` Scylla node built in debug mode uses
~1.3 GB memory. The change decreases that by ~50%. For example, the
total memory used in debug mode by `test_crash_coordinator_before_streaming`
which runs up to 6 nodes drops from ~8GB to ~3.6GB.

8GB exceeds the limit for a test in debug mode assumed by
ThreadsCalculator -- max_test_memory * debug_test_memory_multiplier =
= 5 GB * 1.5 = 7.5 GB. Hence, running this test (and some other tests
that start many nodes) many times with the default concurrency can lead
to the machine going out of memory. That causes shards to make no
progress for seconds and eventually the test fails (e.g. because a
failure detector marks another node down). Such test failures were
observed many times in CI and on dev machines. With this change, tests
will be much more stable and a bit faster in debug mode.

We might also decrease the per-test memory limits assumed by
ThreadsCalculator to run more tests concurrently.

Fixes: SCYLLADB-4397

No backport: we could backport this PR for CI stability, but on the other hand,
if it causes a regression, it's better to have it only in master.