### PR TITLE
dist: run journald in scylla-helper.slice, pin the slice to spare CPUs

### DIFF
--- a/dist/common/scripts/scylla_post_install.py
+++ b/dist/common/scripts/scylla_post_install.py
@@ -1,0 +1,264 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2019-present ScyllaDB
+#
+
+#
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
+#
+"""Machine-dependent systemd drop-ins for the units shipped with Scylla.
+
+Run from the RPM %post, the Debian postinst and the offline installer, through
+the scylla_post_install.sh wrapper. Must never fail the package transaction:
+every step is best-effort and main() always returns 0.
+"""
+
+import argparse
+import logging
+import platform
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+from scylla_util import parse_cpu_list, cpu_list_to_str, parse_cpuset_conf
+
+HELPER_SLICE = 'scylla-helper.slice'
+JOURNALD_SERVICE = 'systemd-journald.service'
+
+# Below this, Scylla's 7% reservation hits seastar's 1.5GB floor, so the helper
+# slice uses fixed limits rather than percentages.
+MEMORY_PERCENT_THRESHOLD_BYTES = 23008753371
+
+# CAP_PERFMON is only available on linux-5.8+
+PERFMON_KERNEL_VERSION = (5, 8)
+
+# AllowedCPUs= requires systemd v244 and the unified cgroup hierarchy.
+ALLOWED_CPUS_SYSTEMD_VERSION = 244
+
+logger = logging.getLogger('scylla_post_install')
+
+
+def parse_version(version):
+    """Leading dotted numeric components of a version string, as a tuple."""
+    match = re.match(r'(\d+(?:\.\d+)*)', version)
+    if not match:
+        return ()
+    return tuple(int(x) for x in match.group(1).split('.'))
+
+
+class PostInstall:
+    """Post-install actions. Every path is rooted at `root`, so tests can drive
+    this against a scratch directory."""
+
+    def __init__(self, root='/', kernel_version=None):
+        self.root = Path(root)
+        self.systemd_dir = self.root / 'etc/systemd/system'
+        self.cpuset_conf = self.root / 'etc/scylla.d/cpuset.conf'
+        self.meminfo = self.root / 'proc/meminfo'
+        self.cpu_online = self.root / 'sys/devices/system/cpu/online'
+        self.cgroup_controllers = self.root / 'sys/fs/cgroup/cgroup.controllers'
+        self.kernel_version = kernel_version if kernel_version is not None else platform.release()
+        self.changed = set()   # drop-ins this run actually changed
+
+    # ---- system probing ---------------------------------------------------
+
+    def total_memory(self):
+        """MemTotal in bytes, or None if it cannot be determined."""
+        match = re.search(r'^MemTotal:\s*(\d+) kB$', self.meminfo.read_text(), re.MULTILINE)
+        if not match:
+            return None
+        return int(match.group(1)) * 1024
+
+    def online_cpus(self):
+        """The CPUs present on this machine, per sysfs."""
+        return parse_cpu_list(self.cpu_online.read_text().strip())
+
+    def scylla_cpus(self):
+        """The CPUs dedicated to Scylla, or None when it is not pinned."""
+        return parse_cpuset_conf(self.cpuset_conf)['cpuset']
+
+    def free_cpus(self):
+        """CPUs the helpers may use. Empty when Scylla is unpinned (it may then
+        use every CPU) or when its cpuset covers the whole machine."""
+        scylla_cpus = self.scylla_cpus()
+        if not scylla_cpus:
+            return set()
+        return self.online_cpus() - scylla_cpus
+
+    def has_cgroup_cpuset(self):
+        """True on a unified (v2) hierarchy that exposes the cpuset controller."""
+        if not self.cgroup_controllers.exists():
+            return False
+        return 'cpuset' in self.cgroup_controllers.read_text().split()
+
+    def systemd_version(self):
+        """Version of the running systemd, or None if it cannot be determined."""
+        res = self.run_systemctl(['--version'], capture=True)
+        if res is None:
+            return None
+        match = re.search(r'^systemd\s+(\d+)', res, re.MULTILINE)
+        return int(match.group(1)) if match else None
+
+    def supports_allowed_cpus(self):
+        if not self.has_cgroup_cpuset():
+            logger.info('cgroup v2 cpuset controller not available, skipping AllowedCPUs')
+            return False
+        version = self.systemd_version()
+        if version is None or version < ALLOWED_CPUS_SYSTEMD_VERSION:
+            logger.info('systemd %s does not support AllowedCPUs (needs %s), skipping',
+                        version, ALLOWED_CPUS_SYSTEMD_VERSION)
+            return False
+        return True
+
+    # ---- systemctl --------------------------------------------------------
+
+    def run_systemctl(self, args, capture=False):
+        """Returns stdout when `capture`, True on success, None on failure -
+        systemd problems must not fail the install."""
+        cmd = ['systemctl'] + args
+        try:
+            res = subprocess.run(cmd, capture_output=True, encoding='utf-8', check=True)
+        except (subprocess.CalledProcessError, OSError) as e:
+            logger.warning('%s failed: %s', ' '.join(cmd), e)
+            return None
+        return res.stdout if capture else True
+
+    # ---- drop-in files ----------------------------------------------------
+
+    def write_dropin(self, unit, name, content):
+        """Create a drop-in for `unit`. Returns True if its content changed."""
+        path = self.systemd_dir / '{}.d'.format(unit) / name
+        if path.exists() and path.read_text() == content:
+            return False
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content)
+        path.chmod(0o644)
+        logger.info('wrote %s', path)
+        self.changed.add(path)
+        return True
+
+    def remove_dropin(self, unit, name):
+        """Drop one left behind by an earlier install. True if it was there."""
+        path = self.systemd_dir / '{}.d'.format(unit) / name
+        if not path.exists():
+            return False
+        path.unlink()
+        logger.info('removed %s', path)
+        self.changed.add(path)
+        return True
+
+    # ---- individual configuration steps -----------------------------------
+
+    def setup_capabilities(self):
+        """Grant CAP_PERFMON to scylla-server where the kernel supports it."""
+        if parse_version(self.kernel_version) < PERFMON_KERNEL_VERSION:
+            return
+        self.write_dropin('scylla-server.service', 'capabilities.conf',
+                          '[Service]\nAmbientCapabilities=CAP_PERFMON\n')
+
+    def setup_helper_slice_memory(self):
+        """Replace the slice's percentage-based limits with fixed ones where
+        there is not a lot of memory to take a percentage of."""
+        memtotal = self.total_memory()
+        if memtotal is None:
+            logger.warning('could not read MemTotal from %s, leaving slice memory limits alone',
+                           self.meminfo)
+            return
+        if memtotal >= MEMORY_PERCENT_THRESHOLD_BYTES:
+            return
+        self.write_dropin(HELPER_SLICE, 'memory.conf',
+                          '[Slice]\nMemoryHigh=1200M\nMemoryMax=1400M\n')
+
+    def setup_helper_slice_cpuset(self):
+        """Keep the helpers off the cores Scylla has to itself.
+
+        With no spare core to give, no drop-in is installed - and a stale one is
+        removed, so the slice is not left pinned to cores Scylla has since
+        taken over.
+        """
+        free_cpus = self.free_cpus()
+        if not free_cpus or not self.supports_allowed_cpus():
+            self.remove_dropin(HELPER_SLICE, 'cpuset.conf')
+            return
+        self.write_dropin(HELPER_SLICE, 'cpuset.conf',
+                          '[Slice]\nAllowedCPUs={}\n'.format(cpu_list_to_str(free_cpus)))
+
+    def setup_journald_slice(self):
+        """Run journald in the helper slice, so its memory, IO and CPU are
+        capped alongside Scylla's other companions instead of competing with
+        the database."""
+        self.write_dropin(JOURNALD_SERVICE, 'scylla-helper-slice.conf',
+                          '[Service]\nSlice={}\n'.format(HELPER_SLICE))
+
+    def setup_limitnofile(self):
+        """Retire a per-machine LimitNOFILE drop-in left by an older install.
+
+        scylla-server.service now ships LimitNOFILE=infinity. An existing
+        drop-in would keep overriding it, so rewrite rather than remove it: a
+        downgrade then ends up with more file descriptors, not fewer.
+        """
+        path = self.systemd_dir / 'scylla-server.service.d/limitnofile.conf'
+        if not path.exists():
+            return
+        self.write_dropin('scylla-server.service', 'limitnofile.conf',
+                          '[Service]\nLimitNOFILE=infinity\n')
+
+    def setup_coredump_timeout(self):
+        """Let a coredump of a Scylla-sized process run to completion."""
+        path = self.systemd_dir / 'systemd-coredump@.service.d/timeout.conf'
+        if not path.exists() or 'RuntimeMaxSec' in path.read_text():
+            return
+        self.write_dropin('systemd-coredump@.service', 'timeout.conf',
+                          '[Service]\nRuntimeMaxSec=infinity\nTimeoutSec=infinity\n')
+
+    # ---- applying the configuration ---------------------------------------
+
+    def apply(self):
+        """Make the drop-ins written by this run take effect.
+
+        daemon-reload re-realizes the cgroup attributes of active units, so the
+        slice limits apply to the running helpers without restarting them. Only
+        journald needs more than that: a running unit cannot change slice, so
+        its new Slice= takes effect on restart.
+        """
+        # Unconditional, as in the shell version: the package manager has just
+        # laid down the unit files themselves, and systemd has to hear about
+        # those even when no drop-in of ours changed.
+        self.run_systemctl(['daemon-reload'])
+        if any(p.parent.name == '{}.d'.format(JOURNALD_SERVICE) for p in self.changed):
+            logger.info('restarting %s', JOURNALD_SERVICE)
+            self.run_systemctl(['try-restart', JOURNALD_SERVICE])
+
+    def run(self):
+        for step in (self.setup_capabilities,
+                     self.setup_helper_slice_memory,
+                     self.setup_helper_slice_cpuset,
+                     self.setup_journald_slice,
+                     self.setup_limitnofile,
+                     self.setup_coredump_timeout):
+            try:
+                step()
+            except Exception:
+                logger.warning('%s failed', step.__name__, exc_info=True)
+        self.apply()
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description='Configure the systemd units shipped with Scylla.')
+    parser.add_argument('--root', default='/',
+                        help='prefix every configured path with this directory')
+    args = parser.parse_args(argv)
+
+    logging.basicConfig(level=logging.INFO, format='scylla_post_install: %(levelname)s: %(message)s')
+    try:
+        PostInstall(root=args.root).run()
+    except Exception:
+        # A broken post-install must not break the package transaction.
+        logger.warning('post-install configuration failed', exc_info=True)
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/dist/common/scripts/scylla_util.py
+++ b/dist/common/scripts/scylla_util.py
@@ -183,6 +183,60 @@ def hex2list(hex_str):
     return ",".join(cpu_list)
 
 
+def parse_cpu_list(cpu_list):
+    """Expand a cpu list like '0,2-7,17-24' into a set of CPU ids."""
+    cpus = set()
+    for group in cpu_list.split(','):
+        group = group.strip()
+        if not group:
+            continue
+        if '-' in group:
+            beg, end = group.split('-', 1)
+            cpus.update(range(int(beg), int(end) + 1))
+        else:
+            cpus.add(int(group))
+    return cpus
+
+def cpu_list_to_str(cpus):
+    """Collapse a set of CPU ids into a range list like '0,2-7,17-24'."""
+    groups = []
+    for cpu in sorted(cpus):
+        if groups and groups[-1][1] == cpu - 1:
+            groups[-1][1] = cpu
+        else:
+            groups.append([cpu, cpu])
+    return ','.join(str(beg) if beg == end else '{}-{}'.format(beg, end) for beg, end in groups)
+
+# Matches CPUSET="--cpuset 0 --smp 1", CPUSET="--cpuset 2-23,26-47 " and so on;
+# both options are optional. _nocomment skips commented-out lines.
+_nocomment = r"^\s*(?!#)"
+_scyllaeq = r"(?:\s*|=)"
+_cpuset_re = r"(?:\s*--cpuset" + _scyllaeq + r"(?P<cpuset>\d+(?:[-,]\d+)*))?"
+_smp_re = r"(?:\s*--smp" + _scyllaeq + r"(?P<smp>\d+))?"
+_cpuset_conf_pattern = re.compile(
+    _nocomment + r"CPUSET=\s*\"" + _cpuset_re + _smp_re + r"\s*\"")
+
+def parse_cpuset_conf(conf_file):
+    """Parse cpuset.conf into {'cpuset': set of CPU ids or None, 'smp': int or None}.
+
+    A None cpuset means the file is absent or holds no live CPUSET line (the
+    shipped one only has a commented-out example), i.e. Scylla is not pinned.
+    """
+    d = {"cpuset": None, "smp": None}
+    path = Path(conf_file)
+    if not path.exists():
+        return d
+    # The file may hold several CPUSET lines; the last one wins.
+    matches = [m for m in (_cpuset_conf_pattern.match(x) for x in path.read_text().splitlines()) if m]
+    if matches:
+        d = matches[-1].groupdict()
+    if d["cpuset"]:
+        d["cpuset"] = parse_cpu_list(d["cpuset"])
+    if d["smp"]:
+        d["smp"] = int(d["smp"])
+    return d
+
+
 SYSTEM_PARTITION_UUIDS = [
         '21686148-6449-6e6f-744e-656564454649', # BIOS boot partition
         'c12a7328-f81f-11d2-ba4b-00a0c93ec93b', # EFI system partition

--- a/dist/debian/debian/scylla-server.postrm
+++ b/dist/debian/debian/scylla-server.postrm
@@ -5,6 +5,10 @@ set -e
 case "$1" in
     purge|remove)
         rm -rf /etc/systemd/system/scylla-helper.slice.d/
+        # Only our own drop-in: the directory may hold drop-ins from the distro.
+        rm -f /etc/systemd/system/systemd-journald.service.d/scylla-helper-slice.conf
+        rmdir --ignore-fail-on-non-empty /etc/systemd/system/systemd-journald.service.d/ 2>/dev/null || true
+        JOURNALD_MOVED=1
         # We need to keep dependencies.conf and sysconfdir.conf on 'remove',
         # otherwise it will be missing after rollback.
         if [ "$1" = "purge" ]; then
@@ -17,6 +21,10 @@ esac
 
 if [ -d /run/systemd/system ]; then
     systemctl --system daemon-reload >/dev/null || true
+    if [ -n "$JOURNALD_MOVED" ]; then
+        # scylla-helper.slice is gone, so move journald back out of it.
+        systemctl --system try-restart systemd-journald.service >/dev/null || true
+    fi
 fi
 
 #DEBHELPER#

--- a/dist/redhat/scylla.spec
+++ b/dist/redhat/scylla.spec
@@ -107,6 +107,10 @@ fi
 
 %postun server
 /usr/bin/systemctl daemon-reload ||:
+if [ $1 -eq 0 ] ; then
+    # scylla-helper.slice is gone on erase, so move journald back out of it.
+    /usr/bin/systemctl try-restart systemd-journald.service ||:
+fi
 
 %posttrans server
 if  [ -d /tmp/%{name}-%{version}-%{release} ]; then
@@ -156,6 +160,8 @@ ln -sfT /etc/scylla /var/lib/scylla/conf
 %attr(0755,scylla,scylla) %dir %{_sharedstatedir}/scylla-housekeeping
 %ghost /etc/systemd/system/scylla-helper.slice.d/
 %ghost /etc/systemd/system/scylla-helper.slice.d/memory.conf
+%ghost /etc/systemd/system/scylla-helper.slice.d/cpuset.conf
+%ghost /etc/systemd/system/systemd-journald.service.d/scylla-helper-slice.conf
 %ghost /etc/systemd/system/scylla-server.service.d/capabilities.conf
 %ghost /etc/systemd/system/scylla-server.service.d/mounts.conf
 %ghost /etc/systemd/system/scylla-server.service.d/limitnofile.conf

--- a/scylla_post_install.sh
+++ b/scylla_post_install.sh
@@ -7,62 +7,19 @@
 # SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
 #
 
+# Entry point for the RPM %post, the Debian postinst and the offline installer.
+# The logic lives in the Python script next to this one.
+
+# Nothing to configure without systemd running - notably in the container image
+# build, which installs the packages without booting systemd.
 if [ ! -d /run/systemd/system ]; then
     exit 0
 fi
 
-version_ge() {
-    [  "$2" = "`echo -e "$1\n$2" | sort -V | head -n1`" ]
-}
+SCRIPT_DIR=$(dirname "$(readlink -f "$0")")
 
-# Install capabilities.conf when AmbientCapabilities supported
-. /etc/os-release
+# Never fail the package transaction: the Debian postinst runs under 'set -e'.
+"$SCRIPT_DIR"/scylla_post_install.py "$@" || \
+    echo "scylla_post_install: warning: post-install configuration failed" >&2
 
-KERNEL_VER=$(uname -r)
-
-# CAP_PERFMON is only available on linux-5.8+
-if version_ge $KERNEL_VER 5.8; then
-    AMB_CAPABILITIES="$AMB_CAPABILITIES CAP_PERFMON"
-    mkdir -p /etc/systemd/system/scylla-server.service.d/
-    cat << EOS > /etc/systemd/system/scylla-server.service.d/capabilities.conf
-[Service]
-AmbientCapabilities=CAP_PERFMON
-EOS
-fi
-
-# For systems with not a lot of memory, override default reservations for the slices
-# seastar has a minimum reservation of 1.5GB that kicks in, and 21GB * 0.07 = 1.5GB.
-# So for anything smaller than that we will not use percentages in the helper slice
-MEMTOTAL=$(cat /proc/meminfo |grep -e "^MemTotal:"|sed -s 's/^MemTotal:\s*\([0-9]*\) kB$/\1/')
-MEMTOTAL_BYTES=$(($MEMTOTAL * 1024))
-if [ $MEMTOTAL_BYTES -lt 23008753371 ]; then
-    mkdir -p /etc/systemd/system/scylla-helper.slice.d/
-    cat << EOS > /etc/systemd/system/scylla-helper.slice.d/memory.conf
-[Slice]
-MemoryHigh=1200M
-MemoryMax=1400M
-EOS
-fi
-
-# Old installs sized LimitNOFILE via this drop-in, which would keep overriding
-# the LimitNOFILE=infinity default. Rewrite it instead of removing it, so a
-# downgrade ends up with more file descriptors, not fewer.
-if [ -f /etc/systemd/system/scylla-server.service.d/limitnofile.conf ]; then
-    cat << EOS > /etc/systemd/system/scylla-server.service.d/limitnofile.conf
-[Service]
-LimitNOFILE=infinity
-EOS
-fi
-
-if [ -e /etc/systemd/system/systemd-coredump@.service.d/timeout.conf ]; then
-    COREDUMP_RUNTIME_MAX=$(grep RuntimeMaxSec /etc/systemd/system/systemd-coredump@.service.d/timeout.conf)
-    if [ -z $COREDUMP_RUNTIME_MAX ]; then
-    cat << EOS > /etc/systemd/system/systemd-coredump@.service.d/timeout.conf
-[Service]
-RuntimeMaxSec=infinity
-TimeoutSec=infinity
-EOS
-    fi
-fi
-
-systemctl --system daemon-reload >/dev/null || true
+exit 0

--- a/test/dist_test/test_scylla_post_install.py
+++ b/test/dist_test/test_scylla_post_install.py
@@ -1,0 +1,399 @@
+#
+# Copyright (C) 2026-present ScyllaDB
+#
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
+#
+import importlib.util
+import os
+import sys
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Load the real production script by path, as test_coredump_setup.py does.
+# It imports scylla_util (which imports scylla_sysconfdir), so dist/common/
+# scripts has to go on sys.path first.
+# ---------------------------------------------------------------------------
+
+_SCRIPTS_DIR = os.path.normpath(os.path.join(
+    os.path.dirname(__file__), '..', '..', 'dist', 'common', 'scripts',
+))
+_POST_INSTALL_PATH = os.path.join(_SCRIPTS_DIR, 'scylla_post_install.py')
+
+
+def _load_post_install():
+    if _SCRIPTS_DIR not in sys.path:
+        sys.path.insert(0, _SCRIPTS_DIR)
+    spec = importlib.util.spec_from_file_location('scylla_post_install', _POST_INSTALL_PATH)
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+scylla_post_install = _load_post_install()
+scylla_util = sys.modules['scylla_util']
+
+HELPER_SLICE_D = 'etc/systemd/system/scylla-helper.slice.d'
+JOURNALD_D = 'etc/systemd/system/systemd-journald.service.d'
+
+BIG_MEMORY = 64 * 1024 * 1024   # kB (64GiB) - above the percentage threshold
+SMALL_MEMORY = 8 * 1024 * 1024  # kB (8GiB) - below it
+
+
+class FakeSystemctl:
+    """Stands in for the systemctl binary, recording what was asked of it."""
+
+    def __init__(self, version=254):
+        self.version = version
+        self.calls = []
+
+    def __call__(self, args, capture=False):
+        self.calls.append(list(args))
+        if args == ['--version']:
+            return 'systemd {} ({}.5-1)\n+PAM +AUDIT +SELINUX\n'.format(self.version, self.version)
+        return True
+
+    def restarted(self):
+        return [c[1] for c in self.calls if c[0] == 'try-restart']
+
+    def reloaded(self):
+        return ['daemon-reload'] in self.calls
+
+
+def make_post_install(tmp_path, *, memory_kb=BIG_MEMORY, online_cpus='0-3',
+                      cpuset=None, cgroup_controllers='cpuset cpu io memory pids',
+                      kernel_version='6.1.0', systemctl=None):
+    """Build a PostInstall rooted at tmp_path, with a fake machine underneath."""
+    (tmp_path / 'proc').mkdir(exist_ok=True)
+    (tmp_path / 'proc/meminfo').write_text(
+        'MemFree:         1000 kB\nMemTotal:       {} kB\n'.format(memory_kb))
+
+    cpu_dir = tmp_path / 'sys/devices/system/cpu'
+    cpu_dir.mkdir(parents=True, exist_ok=True)
+    (cpu_dir / 'online').write_text(online_cpus + '\n')
+
+    if cgroup_controllers is not None:
+        cgroup_dir = tmp_path / 'sys/fs/cgroup'
+        cgroup_dir.mkdir(parents=True, exist_ok=True)
+        (cgroup_dir / 'cgroup.controllers').write_text(cgroup_controllers + '\n')
+
+    scylla_d = tmp_path / 'etc/scylla.d'
+    scylla_d.mkdir(parents=True, exist_ok=True)
+    if cpuset is not None:
+        (scylla_d / 'cpuset.conf').write_text(cpuset)
+
+    post_install = scylla_post_install.PostInstall(root=tmp_path, kernel_version=kernel_version)
+    post_install.run_systemctl = systemctl if systemctl is not None else FakeSystemctl()
+    return post_install
+
+
+CPUSET_PINNED = '''# DO NO EDIT
+# This file should be automatically configure by scylla_cpuset_setup
+#
+# CPUSET="--cpuset 0 --smp 1"
+CPUSET="--cpuset 2-3 "
+'''
+
+CPUSET_COMMENTED_ONLY = '''# DO NO EDIT
+#
+# CPUSET="--cpuset 0 --smp 1"
+'''
+
+
+class TestCpuListHelpers:
+    """The cpu list helpers shared with scylla_io_setup."""
+
+    @pytest.mark.parametrize('text,cpus', [
+        ('0', {0}),
+        ('0-1', {0, 1}),
+        ('2-3,6', {2, 3, 6}),
+        ('2-23,26-47', set(range(2, 24)) | set(range(26, 48))),
+        ('0,2,4', {0, 2, 4}),
+    ])
+    def test_parse_cpu_list(self, text, cpus):
+        assert scylla_util.parse_cpu_list(text) == cpus
+
+    @pytest.mark.parametrize('text', ['0', '0-1', '2-3,6', '2-23,26-47', '0,2,4'])
+    def test_cpu_list_round_trip(self, text):
+        assert scylla_util.cpu_list_to_str(scylla_util.parse_cpu_list(text)) == text
+
+    def test_parse_cpu_list_ignores_blanks(self):
+        assert scylla_util.parse_cpu_list(' 0, 2-3 ,') == {0, 2, 3}
+
+    def test_cpu_list_to_str_empty(self):
+        assert scylla_util.cpu_list_to_str(set()) == ''
+
+
+class TestParseCpusetConf:
+    """Parsing the forms /etc/scylla.d/cpuset.conf takes in the wild."""
+
+    def _parse(self, tmp_path, content):
+        path = tmp_path / 'cpuset.conf'
+        path.write_text(content)
+        return scylla_util.parse_cpuset_conf(path)
+
+    def test_cpuset_with_trailing_whitespace(self, tmp_path):
+        d = self._parse(tmp_path, 'CPUSET="--cpuset 2-23,26-47 "\n')
+        assert d['cpuset'] == set(range(2, 24)) | set(range(26, 48))
+        assert d['smp'] is None
+
+    def test_cpuset_with_smp(self, tmp_path):
+        d = self._parse(tmp_path, 'CPUSET="--cpuset 0 --smp 1"\n')
+        assert d['cpuset'] == {0}
+        assert d['smp'] == 1
+
+    def test_cpuset_range(self, tmp_path):
+        assert self._parse(tmp_path, 'CPUSET="--cpuset 0-1"\n')['cpuset'] == {0, 1}
+
+    def test_commented_example_is_ignored(self, tmp_path):
+        assert self._parse(tmp_path, CPUSET_COMMENTED_ONLY)['cpuset'] is None
+
+    def test_live_line_wins_over_comment(self, tmp_path):
+        assert self._parse(tmp_path, CPUSET_PINNED)['cpuset'] == {2, 3}
+
+    def test_last_line_wins(self, tmp_path):
+        content = 'CPUSET="--cpuset 0-1"\nCPUSET="--cpuset 2-3"\n'
+        assert self._parse(tmp_path, content)['cpuset'] == {2, 3}
+
+    def test_missing_file(self, tmp_path):
+        assert scylla_util.parse_cpuset_conf(tmp_path / 'nope.conf') == {'cpuset': None, 'smp': None}
+
+
+class TestFreeCpus:
+    def test_free_cpus_is_the_complement(self, tmp_path):
+        p = make_post_install(tmp_path, online_cpus='0-3', cpuset=CPUSET_PINNED)
+        assert p.free_cpus() == {0, 1}
+
+    def test_no_free_cpus_when_scylla_owns_all(self, tmp_path):
+        p = make_post_install(tmp_path, online_cpus='0-3', cpuset='CPUSET="--cpuset 0-3"\n')
+        assert p.free_cpus() == set()
+
+    def test_no_free_cpus_when_unpinned(self, tmp_path):
+        p = make_post_install(tmp_path, online_cpus='0-3', cpuset=CPUSET_COMMENTED_ONLY)
+        assert p.free_cpus() == set()
+
+    def test_no_free_cpus_without_cpuset_conf(self, tmp_path):
+        p = make_post_install(tmp_path, online_cpus='0-3', cpuset=None)
+        assert p.free_cpus() == set()
+
+
+class TestMemoryDropin:
+    def test_written_on_a_small_machine(self, tmp_path):
+        make_post_install(tmp_path, memory_kb=SMALL_MEMORY).run()
+        content = (tmp_path / HELPER_SLICE_D / 'memory.conf').read_text()
+        assert 'MemoryHigh=1200M' in content
+        assert 'MemoryMax=1400M' in content
+
+    def test_absent_on_a_large_machine(self, tmp_path):
+        make_post_install(tmp_path, memory_kb=BIG_MEMORY).run()
+        assert not (tmp_path / HELPER_SLICE_D / 'memory.conf').exists()
+
+
+class TestCapabilitiesDropin:
+    def test_written_on_a_recent_kernel(self, tmp_path):
+        make_post_install(tmp_path, kernel_version='5.8.0-1.el8.x86_64').run()
+        capabilities = tmp_path / 'etc/systemd/system/scylla-server.service.d/capabilities.conf'
+        assert 'AmbientCapabilities=CAP_PERFMON' in capabilities.read_text()
+
+    def test_absent_on_an_old_kernel(self, tmp_path):
+        make_post_install(tmp_path, kernel_version='5.4.0-99-generic').run()
+        assert not (tmp_path / 'etc/systemd/system/scylla-server.service.d/capabilities.conf').exists()
+
+
+class TestAllowedCpusDropin:
+    def test_written_when_scylla_has_dedicated_cores(self, tmp_path):
+        make_post_install(tmp_path, online_cpus='0-3', cpuset=CPUSET_PINNED).run()
+        assert (tmp_path / HELPER_SLICE_D / 'cpuset.conf').read_text() == \
+            '[Slice]\nAllowedCPUs=0-1\n'
+
+    def test_skipped_when_there_are_no_free_cores(self, tmp_path):
+        make_post_install(tmp_path, online_cpus='0-3', cpuset='CPUSET="--cpuset 0-3"\n').run()
+        assert not (tmp_path / HELPER_SLICE_D / 'cpuset.conf').exists()
+
+    def test_skipped_on_cgroup_v1(self, tmp_path):
+        make_post_install(tmp_path, cpuset=CPUSET_PINNED, cgroup_controllers=None).run()
+        assert not (tmp_path / HELPER_SLICE_D / 'cpuset.conf').exists()
+
+    def test_skipped_without_the_cpuset_controller(self, tmp_path):
+        make_post_install(tmp_path, cpuset=CPUSET_PINNED, cgroup_controllers='cpu io memory').run()
+        assert not (tmp_path / HELPER_SLICE_D / 'cpuset.conf').exists()
+
+    def test_skipped_on_old_systemd(self, tmp_path):
+        make_post_install(tmp_path, cpuset=CPUSET_PINNED,
+                          systemctl=FakeSystemctl(version=239)).run()
+        assert not (tmp_path / HELPER_SLICE_D / 'cpuset.conf').exists()
+
+    def test_stale_dropin_is_removed(self, tmp_path):
+        """A node reconfigured to give Scylla every core must not stay pinned."""
+        stale = tmp_path / HELPER_SLICE_D / 'cpuset.conf'
+        stale.parent.mkdir(parents=True)
+        stale.write_text('[Slice]\nAllowedCPUs=0-1\n')
+        make_post_install(tmp_path, online_cpus='0-3', cpuset='CPUSET="--cpuset 0-3"\n').run()
+        assert not stale.exists()
+
+
+class TestJournaldDropin:
+    def test_journald_joins_the_helper_slice(self, tmp_path):
+        make_post_install(tmp_path, cpuset=CPUSET_PINNED).run()
+        assert (tmp_path / JOURNALD_D / 'scylla-helper-slice.conf').read_text() == \
+            '[Service]\nSlice=scylla-helper.slice\n'
+
+    def test_written_even_without_free_cores(self, tmp_path):
+        """Containment is worth having even with no core to spare."""
+        make_post_install(tmp_path, online_cpus='0-3', cpuset='CPUSET="--cpuset 0-3"\n').run()
+        assert (tmp_path / JOURNALD_D / 'scylla-helper-slice.conf').exists()
+
+    def test_journald_is_restarted(self, tmp_path):
+        systemctl = FakeSystemctl()
+        make_post_install(tmp_path, cpuset=CPUSET_PINNED, systemctl=systemctl).run()
+        assert systemctl.reloaded()
+        assert 'systemd-journald.service' in systemctl.restarted()
+
+
+class TestLimitNofile:
+    """An older install's per-machine LimitNOFILE drop-in is retired, not left
+    to override the LimitNOFILE=infinity the unit now ships."""
+
+    def test_existing_dropin_is_rewritten(self, tmp_path):
+        limitnofile = tmp_path / 'etc/systemd/system/scylla-server.service.d/limitnofile.conf'
+        limitnofile.parent.mkdir(parents=True)
+        limitnofile.write_text('[Service]\nLimitNOFILE=800000\n')
+        make_post_install(tmp_path).run()
+        assert limitnofile.read_text() == '[Service]\nLimitNOFILE=infinity\n'
+
+    def test_not_created_when_absent(self, tmp_path):
+        make_post_install(tmp_path).run()
+        assert not (tmp_path / 'etc/systemd/system/scylla-server.service.d'
+                    / 'limitnofile.conf').exists()
+
+    def test_already_infinity_is_not_rewritten(self, tmp_path):
+        limitnofile = tmp_path / 'etc/systemd/system/scylla-server.service.d/limitnofile.conf'
+        limitnofile.parent.mkdir(parents=True)
+        limitnofile.write_text('[Service]\nLimitNOFILE=infinity\n')
+        p = make_post_install(tmp_path)
+        p.run()
+        assert limitnofile not in p.changed
+
+
+class TestCoredumpTimeout:
+    def test_rewritten_when_runtimemaxsec_is_missing(self, tmp_path):
+        timeout = tmp_path / 'etc/systemd/system/systemd-coredump@.service.d/timeout.conf'
+        timeout.parent.mkdir(parents=True)
+        timeout.write_text('[Service]\n')
+        make_post_install(tmp_path).run()
+        assert 'RuntimeMaxSec=infinity' in timeout.read_text()
+        assert 'TimeoutSec=infinity' in timeout.read_text()
+
+    def test_left_alone_when_already_set(self, tmp_path):
+        timeout = tmp_path / 'etc/systemd/system/systemd-coredump@.service.d/timeout.conf'
+        timeout.parent.mkdir(parents=True)
+        original = '[Service]\nRuntimeMaxSec=120\n'
+        timeout.write_text(original)
+        make_post_install(tmp_path).run()
+        assert timeout.read_text() == original
+
+    def test_not_created_when_absent(self, tmp_path):
+        make_post_install(tmp_path).run()
+        assert not (tmp_path / 'etc/systemd/system/systemd-coredump@.service.d').exists()
+
+
+class TestApply:
+    def test_idempotent_second_run_restarts_nothing(self, tmp_path):
+        """A re-run must not disturb running processes. daemon-reload still
+        happens, as in the shell version."""
+        make_post_install(tmp_path, cpuset=CPUSET_PINNED).run()
+
+        systemctl = FakeSystemctl()
+        p = make_post_install(tmp_path, cpuset=CPUSET_PINNED, systemctl=systemctl)
+        p.run()
+        assert p.changed == set()
+        assert systemctl.reloaded()
+        assert systemctl.restarted() == []
+
+    def test_only_journald_is_restarted(self, tmp_path):
+        """The slice limits apply live on daemon-reload, so the other members
+        must be left running."""
+        systemctl = FakeSystemctl()
+        make_post_install(tmp_path, online_cpus='0-3', cpuset=CPUSET_PINNED,
+                          systemctl=systemctl).run()
+        assert systemctl.restarted() == ['systemd-journald.service']
+
+    def test_cpuset_removal_alone_restarts_nothing(self, tmp_path):
+        """Dropping the pinning reverts on daemon-reload; nothing needs a kick."""
+        make_post_install(tmp_path, online_cpus='0-3', cpuset=CPUSET_PINNED).run()
+
+        systemctl = FakeSystemctl()
+        make_post_install(tmp_path, online_cpus='0-3', cpuset='CPUSET="--cpuset 0-3"\n',
+                          systemctl=systemctl).run()
+        assert not (tmp_path / HELPER_SLICE_D / 'cpuset.conf').exists()
+        assert systemctl.restarted() == []
+
+
+class TestRobustness:
+    """Post-install must never fail the package transaction."""
+
+    def test_unreadable_meminfo_does_not_stop_the_other_steps(self, tmp_path):
+        p = make_post_install(tmp_path, cpuset=CPUSET_PINNED)
+        (tmp_path / 'proc/meminfo').unlink()
+        p.run()
+        assert (tmp_path / JOURNALD_D / 'scylla-helper-slice.conf').exists()
+        assert (tmp_path / HELPER_SLICE_D / 'cpuset.conf').exists()
+
+    def test_missing_sysfs_does_not_stop_the_other_steps(self, tmp_path):
+        p = make_post_install(tmp_path, memory_kb=SMALL_MEMORY, cpuset=CPUSET_PINNED)
+        (tmp_path / 'sys/devices/system/cpu/online').unlink()
+        p.run()
+        assert (tmp_path / HELPER_SLICE_D / 'memory.conf').exists()
+        assert (tmp_path / JOURNALD_D / 'scylla-helper-slice.conf').exists()
+
+    def test_main_returns_zero_on_a_broken_root(self, tmp_path, monkeypatch):
+        """main() swallows everything - and must never reach the host's systemd."""
+        calls = []
+
+        def fake_systemctl(self, args, capture=False):
+            calls.append(list(args))
+            return True
+
+        monkeypatch.setattr(scylla_post_install.PostInstall, 'run_systemctl', fake_systemctl)
+        assert scylla_post_install.main(['--root', str(tmp_path / 'nonexistent')]) == 0
+        assert all(c[0] in ('daemon-reload', 'try-restart') for c in calls), calls
+
+
+class TestSystemdVersion:
+    """systemd_version() parses the real `systemctl --version` banner."""
+
+    @pytest.mark.parametrize('banner,expected', [
+        ('systemd 249 (249.11-0ubuntu3.12)\n+PAM +AUDIT +SELINUX\n', 249),
+        ('systemd 239 (239-78.el8)\n+PAM +AUDIT\n', 239),
+        ('systemd 254 (254.5-1.fc39)\n', 254),
+        ('systemd 257 (257.4-1)\n+PAM\n', 257),
+        ('not a systemd banner\n', None),
+    ])
+    def test_parses_the_banner(self, tmp_path, banner, expected):
+        p = make_post_install(tmp_path)
+        p.run_systemctl = lambda args, capture=False: banner
+        assert p.systemd_version() == expected
+
+    def test_none_when_systemctl_is_missing(self, tmp_path):
+        p = make_post_install(tmp_path)
+        p.run_systemctl = lambda args, capture=False: None
+        assert p.systemd_version() is None
+
+
+class TestParseVersion:
+    @pytest.mark.parametrize('text,expected', [
+        ('5.8.0-1.el8.x86_64', (5, 8, 0)),
+        ('6.1.0', (6, 1, 0)),
+        ('5.4', (5, 4)),
+        ('unknown', ()),
+    ])
+    def test_parse_version(self, text, expected):
+        assert scylla_post_install.parse_version(text) == expected
+
+    def test_perfmon_threshold(self):
+        assert scylla_post_install.parse_version('5.8.0') >= \
+            scylla_post_install.PERFMON_KERNEL_VERSION
+        assert scylla_post_install.parse_version('5.4.0') < \
+            scylla_post_install.PERFMON_KERNEL_VERSION


### PR DESCRIPTION
When a node dedicates cores to Scylla via /etc/scylla.d/cpuset.conf, the remaining cores are the ones reserved for network interrupts and housekeeping. Set AllowedCPUs on scylla-helper.slice to the complement of the cpuset, so the helpers stay off the shards rather than relying on CPUWeight alone. The drop-in is written only where systemd can honour it (unified cgroup hierarchy with the cpuset controller, systemd v244+) and only when a spare core exists.

journald is the one companion process that can grow unbounded on a busy node, and it ran in system.slice, outside the containment scylla-helper provides. Give it a Slice= drop-in so its memory, IO and CPU are capped alongside Scylla's other companions.

Fixes: CLOUDEVOPS-2311
